### PR TITLE
fix: improve Agent-first experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "7598ac44e6c67362709592aa17cb7e1477dce72a"
-  version "1.0.0"
+      revision: "d8ad68ca046348dead2d11f410838f521fd5cbe0"
+  version "1.0.1"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.0.0", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.0.1", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The agent then calls the `skillroster` CLI and returns an evidence-backed plan f
 
 ```bash
 skillroster scan --json
-skillroster report --json
+skillroster report --summary --json
+skillroster report --finding <finding-id> --json
 skillroster find "database migration" --json
 skillroster plan --stdin --json
 skillroster apply <plan-id> --json
@@ -44,6 +45,8 @@ commands never change Agent files. Plan stores an immutable preview, while Apply
 and Undo use fingerprints, journals, receipts, and recovery blocking.
 See [docs/local-data-lifecycle.md](docs/local-data-lifecycle.md) before purging
 Plan/Receipt history or deleting the local database.
+See [docs/installation.md](docs/installation.md) for verified Release, Cargo,
+and Homebrew installation paths.
 
 Agent-authored Plans are declarative: they reference the latest Snapshot and
 Evidence IDs, then request Roster states, managed/hosted Library placement, or a

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -144,7 +144,8 @@ Machine results should expose facts, not preformatted prose:
 
 - `primary_metrics` with value, unit, coverage, and comparison baseline;
 - Findings with stable ID, category, severity, Evidence quality, impact fields, and affected IDs;
-- Plan deltas for current and proposed state;
+- a bounded `report --summary --json` first view with no more than three Findings, plus explicit placement paths and Evidence facts from `report --finding ID --json`;
+- Plan `change_summary` counts and `impact` deltas for current and proposed state; source-update line details remain in `diff_summary`;
 - affected Agents, Skills, placements, operation groups, exclusions, and deletion count;
 - risk, reversibility, drift, confirmation, and recovery state;
 - typed `suggested_actions` containing argv, mutation status, confirmation requirement, and reason code.

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -89,6 +89,11 @@ Show Agent coverage as it progresses, then independent Skill count, placement co
 
 Lead with four counts: independent Skills, placements, default exposure, and observed-use coverage. Show the three highest-priority Findings, then category totals. Evidence detail remains behind `report --finding`.
 
+Agent callers use `report --summary --json` by default. The compact payload
+contains those four metrics, total Finding count, category totals, and at most
+three complete Finding summaries. Full `report --json` is an explicit
+exhaustive view, not the bootstrap workflow default.
+
 ### `find`
 
 Show ranked matches with Skill name, current Roster state, source, and concise match reasons. Empty results are calm, successful output. Find never implies activation.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,9 +23,21 @@ sha256sum -c skillroster-*.sha256     # Linux
 shasum -a 256 -c skillroster-*.sha256 # macOS
 ```
 
+On macOS or Linux, the archive contains a versioned directory. Extract it and
+install the binary from that directory (not from the current directory):
+
+```sh
+SKILLROSTER_VERSION=1.0.1
+SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
+tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
+install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
+  "$HOME/.local/bin/skillroster"
+skillroster --version
+```
+
 On Windows, compare `Get-FileHash .\skillroster-*.zip -Algorithm SHA256` with
-the checksum file. Extract the archive, then place `skillroster` (or
-`skillroster.exe`) in a directory on `PATH`.
+the checksum file. Extract the archive, open its versioned directory, then
+place `skillroster.exe` in a directory on `PATH`.
 
 ## Build or install from source
 

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -9,11 +9,11 @@ Use the local `skillroster` binary as the deterministic source of facts. Invoke 
 
 ## Inspect and propose
 
-1. Run `skillroster scan --json`, then `skillroster report --json`.
+1. Run `skillroster scan --json`, then `skillroster report --summary --json`. Use the compact result for the first user-facing diagnosis; do not request the full report unless exhaustive Finding enumeration is necessary.
 2. Distinguish observed, inferred, and unknown usage. Missing evidence does not mean unused.
-3. Use stable Finding and Evidence IDs for follow-up questions. Run `report --finding ID --json` against the same Snapshot rather than silently rescanning.
+3. Use stable Finding and Evidence IDs for follow-up questions. Run `report --finding ID --json` against the same Snapshot rather than silently rescanning. Explain its returned placement paths, link targets, and Evidence records; do not make the user infer them from opaque IDs.
 4. Make semantic governance choices in the conversation, then submit declarative target states to `skillroster plan --stdin --json`. Set request `schema_version` to `1`, include the latest `scan_id` and one or more relevant `evidence_ids`, and submit only the supported governance fields.
-5. Present the validated Plan in one viewport: diagnosis, four core metrics, three main Findings, before/after counts, affected Agents, uncertainty, canonical deletion count, reversibility, and Plan ID.
+5. Present the validated Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `impact` before/after facts, affected Agents, uncertainty, canonical deletion count, reversibility, and Plan ID. The source-oriented `diff_summary` may be empty for ordinary Roster or Library Plans; do not treat that as a missing Plan delta.
 
 Use only these Plan request families:
 
@@ -37,6 +37,6 @@ Use `skillroster status --json` for pending Plans, the last Receipt, retention, 
 
 ## Find an on-demand Skill
 
-Run `skillroster find "TASK" --json`. Explain the top matches and evidence, then read the selected `SKILL.md` directly from its returned path. Finding a Skill does not activate or install it.
+Run `skillroster find "TASK" --json`. Explain the top matches and evidence, then read the selected `SKILL.md` directly from its returned path. If the lexical matches are clearly about another domain, retry once with concrete tool or operation terms already implied by the task (for example, `MySQL DDL` for a database migration); do not present an irrelevant top result as confidence. Finding a Skill does not activate or install it.
 
 Never parse styled terminal output, invent a health score, infer token savings, or claim files changed without a successful Receipt.

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,11 +59,13 @@ pub fn run(cli: Cli) -> Result<Output> {
     }
     std::fs::create_dir_all(&state_dir)
         .with_context(|| format!("cannot create {}", state_dir.display()))?;
-    // Every command opens the same SQLite database, so even nominally read-only
-    // commands must serialize with lifecycle delete on platforms that forbid
-    // deleting an open database handle. Mutating change APIs use their locked
-    // variants below because this guard covers the full SQLite/filesystem unit.
-    let _write_lock = change::WriteLock::acquire(&state_dir)?;
+    // Shared guards let Agent read/analysis commands run concurrently while
+    // still excluding lifecycle deletion and filesystem mutations on Windows.
+    let _state_lock = if command_requires_exclusive_state_lock(cli.command.as_ref()) {
+        change::StateLock::acquire_exclusive(&state_dir)?
+    } else {
+        change::StateLock::acquire_shared(&state_dir)?
+    };
     let store = StateStore::open(&database_path)?;
 
     let (command, result, warnings, actions) = match cli.command {
@@ -99,7 +101,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                 warnings,
                 vec![action(
                     "report",
-                    &["report", "--json"],
+                    &["report", "--summary", "--json"],
                     false,
                     false,
                     "scan_complete",
@@ -108,7 +110,7 @@ pub fn run(cli: Cli) -> Result<Output> {
         }
         Some(Command::Report(args)) => (
             "report",
-            report_command(&store, args.finding.as_deref())?,
+            report_command(&store, args.finding.as_deref(), args.summary)?,
             vec![],
             vec![action(
                 "plan",
@@ -258,6 +260,16 @@ pub fn run(cli: Cli) -> Result<Output> {
         json: serde_json::to_string(&envelope)?,
         human: crate::present::human(command, &result),
     })
+}
+
+fn command_requires_exclusive_state_lock(command: Option<&Command>) -> bool {
+    matches!(
+        command,
+        Some(Command::Apply(_) | Command::Undo(_))
+            | Some(Command::Lifecycle(crate::cli::LifecycleArgs {
+                command: LifecycleCommand::Purge(_),
+            }))
+    )
 }
 
 pub fn error_json(command: &str, error: &(dyn std::error::Error + 'static)) -> String {
@@ -973,7 +985,7 @@ fn scan_command(
     ))
 }
 
-fn report_command(store: &StateStore, finding: Option<&str>) -> Result<Value> {
+fn report_command(store: &StateStore, finding: Option<&str>, summary_only: bool) -> Result<Value> {
     if let Some(id) = finding {
         let id = FindingId::parse(id.to_string())?;
         let stored = store
@@ -983,13 +995,60 @@ fn report_command(store: &StateStore, finding: Option<&str>) -> Result<Value> {
         if let Some(object) = details.as_object_mut() {
             object.insert("report_id".into(), json!(stored.report_id));
             object.insert("evidence_ids".into(), json!(stored.evidence_ids));
+            let report = store
+                .get_report(&stored.report_id)?
+                .ok_or_else(|| anyhow!("Report {} does not exist", stored.report_id))?;
+            let scan: ScanResult = store
+                .scan_payload(&report.scan_id)?
+                .ok_or_else(|| anyhow!("Snapshot {} is no longer retained", report.scan_id))?;
+            let affected_placement_ids = object
+                .get("affected_placement_ids")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            let placements = scan
+                .placements
+                .iter()
+                .filter(|placement| {
+                    affected_placement_ids
+                        .iter()
+                        .any(|id| id.as_str() == Some(&placement.id))
+                })
+                .map(|placement| {
+                    json!({
+                        "id": placement.id,
+                        "skill_id": placement.skill_id,
+                        "agent": placement.agent.map(AgentKind::id),
+                        "path": placement.entrypoint,
+                        "root": placement.root,
+                        "link_target": placement.link_target,
+                        "link_status": placement.link_status,
+                        "default_exposed": placement.default_exposed,
+                        "content_digest": placement.content_digest
+                    })
+                })
+                .collect::<Vec<_>>();
+            let evidence = stored
+                .evidence_ids
+                .iter()
+                .map(|id| store.get_evidence(id))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+            object.insert("placements".into(), json!(placements));
+            object.insert("evidence".into(), json!(evidence));
         }
         return Ok(details);
     }
     let (scan_id, scan): (ScanId, ScanResult) = latest_scan(store)?;
     if let Some(existing) = store.latest_report()? {
         if existing.scan_id == scan_id {
-            return Ok(existing.summary);
+            return Ok(if summary_only {
+                compact_report(&existing.summary)
+            } else {
+                existing.summary
+            });
         }
     }
     let report = crate::query::build_report(&scan);
@@ -1072,7 +1131,29 @@ fn report_command(store: &StateStore, finding: Option<&str>) -> Result<Value> {
         },
         &findings,
     )?;
-    Ok(value)
+    Ok(if summary_only {
+        compact_report(&value)
+    } else {
+        value
+    })
+}
+
+fn compact_report(report: &Value) -> Value {
+    let findings = report["findings"].as_array().cloned().unwrap_or_default();
+    json!({
+        "report_id": report["report_id"],
+        "snapshot_id": report["snapshot_id"],
+        "skill_count": report["skill_count"],
+        "placement_count": report["placement_count"],
+        "default_exposure": report["default_exposure"],
+        "observed_use_agent_count": report["observed_use_agent_count"],
+        "coverage_reliable_agent_count": report["coverage_reliable_agent_count"],
+        "primary_metrics": report["primary_metrics"],
+        "finding_count": findings.len(),
+        "findings": findings.into_iter().take(3).collect::<Vec<_>>(),
+        "category_counts": report["category_counts"],
+        "files_changed": false
+    })
 }
 
 fn finding_json(
@@ -1234,25 +1315,20 @@ fn current_readable_skill_paths(
 
     let mut paths = Vec::new();
     let mut seen = std::collections::HashSet::new();
-    let mut rejected_existing = false;
     for path in candidates {
         if !seen.insert(path.clone()) || !path.exists() {
             continue;
         }
         let Ok(resolved) = std::fs::canonicalize(&path) else {
-            rejected_existing = true;
             continue;
         };
         if !resolved.is_file() || !approved_roots.iter().any(|root| resolved.starts_with(root)) {
-            rejected_existing = true;
             continue;
         }
         let Ok((actual_id, actual_fingerprint)) = scan::inspect_skill_identity(&path) else {
-            rejected_existing = true;
             continue;
         };
         if actual_id != skill.id || actual_fingerprint != skill.content_digest {
-            rejected_existing = true;
             continue;
         }
         paths.push(path.display().to_string());
@@ -1260,7 +1336,7 @@ fn current_readable_skill_paths(
     paths.sort();
     paths.dedup();
     Ok(CurrentSkillPaths {
-        drifted: rejected_existing || paths.is_empty(),
+        drifted: paths.is_empty(),
         paths,
     })
 }
@@ -1925,13 +2001,13 @@ fn prepare_plan(
     {
         bail!("Plan has no effective Roster state change");
     }
-    store.save_plan(&plan_record(
-        &prepared,
-        input,
-        roster_before,
-        library_before,
-    )?)?;
-    let impact = if matches!(effective_origin, PlanOrigin::RosterGovernance) {
+    let change_summary = json!({
+        "operation_count": prepared.operations.len(),
+        "roster_change_count": prepared.roster_changes.len(),
+        "library_change_count": prepared.library_changes.len(),
+        "source_update_count": prepared.source_updates.len()
+    });
+    let mut impact = if matches!(effective_origin, PlanOrigin::RosterGovernance) {
         source_update_diffs
             .first()
             .cloned()
@@ -1939,6 +2015,29 @@ fn prepare_plan(
     } else {
         json!(source_update_diffs)
     };
+    if let Some(object) = impact.as_object_mut() {
+        object.insert(
+            "roster".into(),
+            json!({
+                "before": roster_before,
+                "after": prepared.roster_changes
+            }),
+        );
+        object.insert(
+            "library".into(),
+            json!({
+                "before": library_before,
+                "after": prepared.library_changes
+            }),
+        );
+        object.insert("operation_count".into(), json!(prepared.operations.len()));
+    }
+    store.save_plan(&plan_record(
+        &prepared,
+        input,
+        roster_before.clone(),
+        library_before.clone(),
+    )?)?;
     Ok(json!({
         "plan_id": prepared.id,
         "snapshot_id": prepared.scan_id,
@@ -1949,6 +2048,7 @@ fn prepare_plan(
         "evidence_ids": prepared.evidence_ids,
         "source_updates": prepared.source_updates,
         "library_changes": prepared.library_changes,
+        "change_summary": change_summary,
         "diff_summary": if matches!(effective_origin, PlanOrigin::SourceUpdate) {
             json!(source_update_diffs)
         } else {
@@ -2197,12 +2297,13 @@ fn setup_command(store: &StateStore, home: &Path, state_dir: &Path) -> Result<Va
         json!({"schema_version": 1, "scan_id": snapshot.id, "operations": operations}),
         PlanOrigin::BootstrapSetup,
     )?;
+    let operation_count = plan["operations"].as_array().map_or(0, Vec::len);
     Ok(json!({
         "detected_agents": detected,
         "plan_id": plan["plan_id"],
         "state": "preview_ready",
         "bootstrap_skill": "skillroster",
-        "operations": plan["operations"],
+        "operation_count": operation_count,
         "canonical_deletion_count": 0,
         "confirmation_required": true,
         "files_changed": false
@@ -3027,6 +3128,50 @@ fn action(
 mod recovery_tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn readable_skill_path_ignores_stale_alternatives_when_a_valid_copy_exists() {
+        let temp = TempDir::new().unwrap();
+        let first_root = temp.path().join("first");
+        let second_root = temp.path().join("second");
+        for (root, description) in [
+            (&first_root, "Current database migration helper"),
+            (&second_root, "Older unrelated helper"),
+        ] {
+            let directory = root.join("example");
+            std::fs::create_dir_all(&directory).unwrap();
+            std::fs::write(
+                directory.join("SKILL.md"),
+                format!("---\nname: example\ndescription: {description}\n---\n"),
+            )
+            .unwrap();
+        }
+        let mut options = ScanOptions::for_home(temp.path().join("home"));
+        options.explicit_skill_roots = vec![
+            ExplicitSkillRoot {
+                agent: AgentKind::Codex,
+                path: first_root.clone(),
+            },
+            ExplicitSkillRoot {
+                agent: AgentKind::ClaudeCode,
+                path: second_root,
+            },
+        ];
+        options.include_session_evidence = false;
+        let scan = scan::scan(&options).unwrap();
+        let skill_id = scan
+            .placements
+            .iter()
+            .find(|placement| placement.root == first_root)
+            .unwrap()
+            .skill_id
+            .clone();
+
+        let current = current_readable_skill_paths(&scan, temp.path(), &skill_id).unwrap();
+
+        assert!(!current.drifted);
+        assert_eq!(current.paths.len(), 1);
+    }
 
     #[test]
     fn orphan_applied_journal_is_listed_and_blocks_the_next_write() {

--- a/src/change.rs
+++ b/src/change.rs
@@ -1816,10 +1816,19 @@ fn reject_unresolved_recovery_except(state_dir: &Path, except: &str) -> Result<(
     Ok(())
 }
 
-pub(crate) struct WriteLock(File);
+#[derive(Debug)]
+pub(crate) struct StateLock(File);
 
-impl WriteLock {
-    pub(crate) fn acquire(state_dir: &Path) -> Result<Self> {
+impl StateLock {
+    pub(crate) fn acquire_shared(state_dir: &Path) -> Result<Self> {
+        Self::acquire(state_dir, false)
+    }
+
+    pub(crate) fn acquire_exclusive(state_dir: &Path) -> Result<Self> {
+        Self::acquire(state_dir, true)
+    }
+
+    fn acquire(state_dir: &Path, exclusive: bool) -> Result<Self> {
         let path = state_dir.join("write.lock");
         let file = OpenOptions::new()
             .read(true)
@@ -1827,11 +1836,19 @@ impl WriteLock {
             .create(true)
             .truncate(false)
             .open(&path)
-            .map_err(|e| ChangeError::io("open write lock", &path, e))?;
-        file.try_lock_exclusive().map_err(|error| {
+            .map_err(|e| ChangeError::io("open state lock", &path, e))?;
+        let result = if exclusive {
+            FileExt::try_lock_exclusive(&file)
+        } else {
+            FileExt::try_lock_shared(&file)
+        };
+        result.map_err(|error| {
             let mut result = ChangeError::new(
                 "write_locked",
-                format!("another Apply or Undo holds {}: {error}", path.display()),
+                format!(
+                    "another SkillRoster command is using local state guarded by {}: {error}",
+                    path.display()
+                ),
             );
             result.retryable = true;
             result
@@ -1840,9 +1857,19 @@ impl WriteLock {
     }
 }
 
-impl Drop for WriteLock {
+impl Drop for StateLock {
     fn drop(&mut self) {
         let _ = FileExt::unlock(&self.0);
+    }
+}
+
+pub(crate) struct WriteLock {
+    _guard: StateLock,
+}
+
+impl WriteLock {
+    pub(crate) fn acquire(state_dir: &Path) -> Result<Self> {
+        StateLock::acquire_exclusive(state_dir).map(|guard| Self { _guard: guard })
     }
 }
 
@@ -1858,6 +1885,21 @@ mod tests {
         fs::create_dir(&root).unwrap();
         fs::create_dir(&state).unwrap();
         (temp, root, state)
+    }
+
+    #[test]
+    fn state_lock_allows_concurrent_readers_but_excludes_writers() {
+        let (_temp, _root, state) = fixture();
+        let first_reader = StateLock::acquire_shared(&state).unwrap();
+        let second_reader = StateLock::acquire_shared(&state).unwrap();
+        let blocked_writer = StateLock::acquire_exclusive(&state).unwrap_err();
+        assert_eq!(blocked_writer.code, "write_locked");
+        drop(second_reader);
+        drop(first_reader);
+        let writer = StateLock::acquire_exclusive(&state).unwrap();
+        let blocked_reader = StateLock::acquire_shared(&state).unwrap_err();
+        assert_eq!(blocked_reader.code, "write_locked");
+        drop(writer);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,10 @@ pub enum Command {
 pub struct ReportArgs {
     #[arg(long)]
     pub finding: Option<String>,
+
+    /// Return core metrics and the three highest-priority Findings.
+    #[arg(long)]
+    pub summary: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -959,14 +959,19 @@ pub(crate) fn find_matching(
                 .to_lowercase();
             let triggers = skill.metadata.triggers.join(" ").to_lowercase();
             let all_text = skill_search_text(skill).to_lowercase();
-            let haystack_tokens = tokens(&all_text);
-            let overlap = query_tokens.intersection(&haystack_tokens).count();
-            let mut score = overlap as f64 * 8.0;
+            let name_overlap = query_tokens.intersection(&tokens(&name)).count();
+            let trigger_overlap = query_tokens.intersection(&tokens(&triggers)).count();
+            let description_overlap = query_tokens.intersection(&tokens(&description)).count();
+            let overlap = query_tokens.intersection(&tokens(&all_text)).count();
+            let mut score = name_overlap as f64 * 24.0
+                + trigger_overlap as f64 * 18.0
+                + description_overlap as f64 * 12.0
+                + overlap as f64 * 3.0;
             let mut reasons = Vec::new();
             if name == query {
                 score += 100.0;
                 reasons.push("exact_name".into());
-            } else if name.contains(&query) || query.contains(&name) {
+            } else if name.contains(&query) {
                 score += 45.0;
                 reasons.push("name_phrase".into());
             }
@@ -978,8 +983,17 @@ pub(crate) fn find_matching(
                 score += 25.0;
                 reasons.push("description_phrase".into());
             }
+            if name_overlap > 0 {
+                reasons.push(format!("name_tokens:{name_overlap}"));
+            }
+            if trigger_overlap > 0 {
+                reasons.push(format!("trigger_tokens:{trigger_overlap}"));
+            }
+            if description_overlap > 0 {
+                reasons.push(format!("description_tokens:{description_overlap}"));
+            }
             if overlap > 0 {
-                reasons.push(format!("token_overlap:{overlap}"));
+                reasons.push(format!("all_text_tokens:{overlap}"));
             }
             let observed_usage = scan.usage.iter().any(|usage| {
                 usage.skill_id == skill.id && usage.quality == EvidenceQuality::Observed
@@ -1276,6 +1290,54 @@ mod tests {
                 .contains(&"declared_trigger".into())
         );
         assert_eq!(matches[0].paths.len(), 2);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn find_prefers_task_terms_in_name_over_incidental_body_mentions() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("skillroster-routing-fields-{nonce}"));
+        for (directory, contents) in [
+            (
+                "aaa-general-agent",
+                "---\nname: aaa-general-agent\ndescription: General coding assistant\n---\nCan also discuss database migration among many unrelated tasks.",
+            ),
+            (
+                "database-migration",
+                "---\nname: database-migration\ndescription: Plan and review safe schema changes\n---\nUse for production data changes.",
+            ),
+            (
+                "review",
+                "---\nname: review\ndescription: Review code\n---\nGeneric review helper.",
+            ),
+            (
+                "github-code-review",
+                "---\nname: github-code-review\ndescription: Review pull requests and publish inline comments\n---\nInspect a pull request diff.",
+            ),
+        ] {
+            let path = root.join(directory);
+            fs::create_dir_all(&path).unwrap();
+            fs::write(path.join("SKILL.md"), contents).unwrap();
+        }
+        let mut options = ScanOptions::for_home(root.join("home"));
+        options
+            .explicit_skill_roots
+            .push(crate::scan::ExplicitSkillRoot {
+                agent: crate::harness::AgentKind::Codex,
+                path: root.clone(),
+            });
+        options.include_session_evidence = false;
+        let scan = scan(&options).unwrap();
+
+        let matches = find(&scan, "database migration", 2);
+
+        assert_eq!(matches[0].name, "database-migration");
+        assert!(matches[0].match_reasons.contains(&"name_tokens:2".into()));
+        let review_matches = find(&scan, "review a pull request", 2);
+        assert_eq!(review_matches[0].name, "github-code-review");
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -302,6 +302,18 @@ impl StateStore {
             .transpose()
     }
 
+    pub fn scan_payload<T: DeserializeOwned>(&self, id: &ScanId) -> StorageResult<Option<T>> {
+        self.connection
+            .query_row(
+                "SELECT payload_json FROM scan_payloads WHERE scan_id = ?1",
+                [id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|payload| from_json(&payload))
+            .transpose()
+    }
+
     pub fn latest_report(&self) -> StorageResult<Option<ReportRecord>> {
         let stored = self
             .connection
@@ -612,6 +624,59 @@ impl StateStore {
         Ok(count == 1)
     }
 
+    pub fn get_evidence(&self, id: &EvidenceId) -> StorageResult<Option<EvidenceRecord>> {
+        let stored = self
+            .connection
+            .query_row(
+                "SELECT scan_id, kind, quality, subject_type, subject_id, path, digest,
+                        details_json, observed_at
+                 FROM evidence WHERE id = ?1",
+                [id.as_str()],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, Option<String>>(5)?,
+                        row.get::<_, Option<String>>(6)?,
+                        row.get::<_, String>(7)?,
+                        row.get::<_, i64>(8)?,
+                    ))
+                },
+            )
+            .optional()?;
+        stored
+            .map(
+                |(
+                    scan_id,
+                    kind,
+                    quality,
+                    subject_type,
+                    subject_id,
+                    path,
+                    digest,
+                    details,
+                    observed_at,
+                )| {
+                    Ok(EvidenceRecord {
+                        id: id.clone(),
+                        scan_id: ScanId::parse(scan_id).map_err(invalid_id)?,
+                        kind: enum_from_text(&kind)?,
+                        quality: enum_from_text(&quality)?,
+                        subject_type,
+                        subject_id,
+                        path,
+                        digest,
+                        details: from_json(&details)?,
+                        observed_at,
+                    })
+                },
+            )
+            .transpose()
+    }
+
     pub fn save_roster_entry(&self, entry: &RosterEntry) -> StorageResult<()> {
         self.connection.execute(
             "INSERT INTO roster_entries (agent_id, skill_id, state, updated_at)
@@ -719,11 +784,26 @@ impl StateStore {
              ORDER BY bm25(skills_fts, 0.0, 8.0, 5.0, 6.0, 1.0), skill_id
              LIMIT ?2",
         )?;
-        let ids = statement
+        let mut ids = statement
             .query_map(params![expression, limit as i64], |row| {
                 row.get::<_, String>(0)
             })?
             .collect::<Result<Vec<_>, _>>()?;
+        if ids.is_empty() {
+            let mut fallback = self.connection.prepare(
+                "SELECT skill_id FROM skills_fts
+                 WHERE instr(lower(name), lower(?1)) > 0
+                    OR instr(lower(description), lower(?1)) > 0
+                    OR instr(lower(triggers), lower(?1)) > 0
+                    OR instr(lower(body), lower(?1)) > 0
+                 ORDER BY skill_id LIMIT ?2",
+            )?;
+            ids = fallback
+                .query_map(params![task.trim(), limit as i64], |row| {
+                    row.get::<_, String>(0)
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+        }
         ids.into_iter()
             .map(|id| SkillId::parse(id).map_err(invalid_id))
             .collect()
@@ -1847,6 +1927,26 @@ mod tests {
             2
         );
         assert!(store.search_skill_ids("\" OR *", 5).unwrap().is_empty());
+    }
+
+    #[test]
+    fn search_falls_back_to_unicode_phrase_matching() {
+        let store = StateStore::open_in_memory().unwrap();
+        let skill = SkillId::parse("skill_database").unwrap();
+        store
+            .index_skill(
+                &skill,
+                "dms-mysql",
+                "MySQL 数据库管理和表结构查询",
+                "",
+                "执行查询",
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.search_skill_ids("数据库管理", 5).unwrap(),
+            vec![skill]
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -64,6 +64,13 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
         "---\nname: example\ndescription: Example task helper\ntriggers: [example]\n---\n",
     )
     .unwrap();
+    let second_skill = home.join(".claude/skills/example");
+    fs::create_dir_all(&second_skill).unwrap();
+    fs::write(
+        second_skill.join("SKILL.md"),
+        "---\nname: example\ndescription: Example task helper\ntriggers: [example]\n---\n",
+    )
+    .unwrap();
     let session_root = home.join(".codex/sessions");
     fs::create_dir_all(&session_root).unwrap();
     fs::write(
@@ -103,7 +110,9 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
     assert_eq!(initial_status["result"]["retention"]["raw_usage_days"], 180);
     assert_eq!(initial_status["result"]["pending_plan_count"], 0);
 
-    let report = json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let report_output = run(&[&common[..], &["report"]].concat(), None);
+    let report_output_len = report_output.stdout.len();
+    let report = json_output(&report_output);
     assert_eq!(report["ok"], true);
     assert!(report["result"]["findings"].is_array());
     assert!(report["result"]["primary_metrics"].is_object());
@@ -112,7 +121,34 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
         repeated_report["result"]["report_id"],
         report["result"]["report_id"]
     );
-    let finding_id = report["result"]["findings"][0]["id"].as_str().unwrap();
+    let summary_report_output = run(&[&common[..], &["report", "--summary"]].concat(), None);
+    let summary_report_output_len = summary_report_output.stdout.len();
+    let summary_report = json_output(&summary_report_output);
+    assert_eq!(
+        summary_report["result"]["finding_count"],
+        report["result"]["findings"].as_array().unwrap().len()
+    );
+    assert!(
+        summary_report["result"]["findings"]
+            .as_array()
+            .unwrap()
+            .len()
+            <= 3
+    );
+    assert!(summary_report_output_len < report_output_len);
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| {
+            finding["affected_placement_count"]
+                .as_u64()
+                .unwrap_or_default()
+                > 0
+        })
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
     let finding = json_output(&run(
         &[&common[..], &["report", "--finding", finding_id]].concat(),
         None,
@@ -122,6 +158,15 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
     assert!(finding["result"]["affected_placement_ids"].is_array());
     assert!(finding["result"]["impact"].is_object());
     assert!(finding["result"]["coverage"].is_object());
+    assert!(
+        finding["result"]["placements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|placement| placement["path"].as_str()
+                == Some(skill.join("SKILL.md").to_str().unwrap()))
+    );
+    assert!(!finding["result"]["evidence"].as_array().unwrap().is_empty());
     for evidence_id in finding["result"]["evidence_ids"].as_array().unwrap() {
         let exists: i64 = database
             .query_row(
@@ -149,6 +194,9 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
 
     let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     let setup_plan = setup["result"]["plan_id"].as_str().unwrap();
+    assert!(setup["result"]["operation_count"].as_u64().unwrap() > 0);
+    assert!(setup["result"].get("operations").is_none());
+    assert!(!setup["result"].to_string().contains("## Safety boundaries"));
     let setup_applied = json_output(&run(&[&common[..], &["apply", setup_plan]].concat(), None));
     assert!(skill_root.join("skillroster/SKILL.md").is_file());
     let setup_receipt = setup_applied["result"]["receipt_id"].as_str().unwrap();
@@ -176,6 +224,11 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
     ));
     assert_eq!(plan["result"]["files_changed"], false);
     assert_eq!(plan["result"]["evidence_ids"][0], evidence_id);
+    assert_eq!(plan["result"]["change_summary"]["roster_change_count"], 1);
+    assert_eq!(
+        plan["result"]["impact"]["roster"]["after"][0]["state"],
+        "on_demand"
+    );
     let plan_id = plan["result"]["plan_id"].as_str().unwrap();
 
     let agent_id: String = database
@@ -257,6 +310,24 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
     ));
     assert_eq!(purged["result"]["plans_or_receipts_changed"], false);
     assert_eq!(purged["result"]["agent_files_changed"], false);
+
+    let shared_lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(state.join("write.lock"))
+        .unwrap();
+    FileExt::try_lock_shared(&shared_lock).unwrap();
+    let concurrent_status = run(&[&common[..], &["status"]].concat(), None);
+    assert!(concurrent_status.status.success());
+    let blocked_purge = run(
+        &[&common[..], &["lifecycle", "purge", "--raw-days", "180"]].concat(),
+        None,
+    );
+    assert!(!blocked_purge.status.success());
+    FileExt::unlock(&shared_lock).unwrap();
+    drop(shared_lock);
 
     let write_lock = OpenOptions::new()
         .read(true)


### PR DESCRIPTION
## Problem

Real Agent-first use against 180 local Skills exposed four usability defects: the default report JSON was 673,833 bytes, setup repeated the full bootstrap Skill per Agent, read-only commands contended on one exclusive lock, and Finding drill-down returned opaque IDs without paths or Evidence facts. Lexical routing also over-weighted generic names and reported false rescan requirements when one valid placement coexisted with a stale alternative.

## Solution

- add `report --summary --json` with four metrics, category totals, total Finding count, and at most three Findings;
- return concrete placement paths, link targets, and Evidence records from `report --finding`;
- compact setup previews and add structured Plan `change_summary` and `impact` facts;
- allow concurrent shared state readers while preserving exclusive mutation and lifecycle-delete safety;
- weight Find name, trigger, description, and body matches separately, remove generic short-name dominance, and add Unicode phrase fallback;
- treat a Skill as drifted only when no current identity-and-fingerprint-valid path remains;
- update the bootstrap Skill and installation instructions for the Release archive's versioned directory.

## Real experience evidence

- full report: 673,833 bytes; default summary: 8,448 bytes;
- setup preview: 377 bytes with no repeated Skill body;
- six concurrent status/report/find calls: 6/6 successful;
- `review a pull request`: `github-code-review` moved to rank 1;
- `数据库管理`: `dms-mysql` returned at rank 1;
- escaping-link Finding: 16 placements and 16 Evidence records now directly inspectable;
- no Agent files changed during the real-home replay.

## Checks

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (64 unit + 6 acceptance + 13 CLI)
- bootstrap Skill validator: `Skill is valid!`
- `git diff --check`
