### PR TITLE
fix: prioritize actionable diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "d8ad68ca046348dead2d11f410838f521fd5cbe0"
-  version "1.0.1"
+      revision: "2dcd14ebec60c9c2db4424e9665165bf6138a79e"
+  version "1.0.2"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.0.1", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.0.2", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ The agent then calls the `skillroster` CLI and returns an evidence-backed plan f
 
 ```bash
 skillroster scan --json
+skillroster --source-root /absolute/trusted/source scan --json
 skillroster report --summary --json
-skillroster report --finding <finding-id> --json
+skillroster report --finding <finding-id> --limit 20 --json
 skillroster find "database migration" --json
 skillroster plan --stdin --json
 skillroster apply <plan-id> --json
@@ -47,6 +48,11 @@ See [docs/local-data-lifecycle.md](docs/local-data-lifecycle.md) before purging
 Plan/Receipt history or deleting the local database.
 See [docs/installation.md](docs/installation.md) for verified Release, Cargo,
 and Homebrew installation paths.
+
+`--root AGENT=PATH` adds an Agent placement root and therefore contributes to
+that Agent's default exposure. `--source-root PATH` approves a non-exposed
+canonical source directory for the current Scan. Neither option crawls outside
+the exact supplied path.
 
 Agent-authored Plans are declarative: they reference the latest Snapshot and
 Evidence IDs, then request Roster states, managed/hosted Library placement, or a

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -144,7 +144,7 @@ Machine results should expose facts, not preformatted prose:
 
 - `primary_metrics` with value, unit, coverage, and comparison baseline;
 - Findings with stable ID, category, severity, Evidence quality, impact fields, and affected IDs;
-- a bounded `report --summary --json` first view with no more than three Findings, plus explicit placement paths and Evidence facts from `report --finding ID --json`;
+- a bounded `report --summary --json` first view with no more than three Findings and one primary Evidence reference, plus paged placement paths and Evidence facts from `report --finding ID --json`;
 - Plan `change_summary` counts and `impact` deltas for current and proposed state; source-update line details remain in `diff_summary`;
 - affected Agents, Skills, placements, operation groups, exclusions, and deletion count;
 - risk, reversibility, drift, confirmation, and recovery state;
@@ -165,6 +165,13 @@ The Agent reports that no change is justified and does not create artificial arc
 ### Partial Evidence
 
 The Agent distinguishes “not observed” from “unused,” names missing coverage, and avoids a destructive recommendation.
+
+### External canonical source
+
+The Agent leaves an escaping link unread, shows its target, and asks whether
+the source is intentional. A confirmed source is rescanned through
+`--source-root` without increasing any Agent's default exposure; unconfirmed
+sources remain excluded.
 
 ### One-confirmation Apply
 

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -94,6 +94,12 @@ contains those four metrics, total Finding count, category totals, and at most
 three complete Finding summaries. Full `report --json` is an explicit
 exhaustive view, not the bootstrap workflow default.
 
+`report --finding ID --json` returns at most 20 affected IDs, placements, and
+Evidence records per collection. Its `page.next_offset` is the only pagination
+cursor; callers request another page only when the decision still lacks
+relevant evidence. Counts and `primary_evidence_id` remain available in the
+compact first view.
+
 ### `find`
 
 Show ranked matches with Skill name, current Roster state, source, and concise match reasons. Empty results are calm, successful output. Find never implies activation.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.0.1
+SKILLROSTER_VERSION=1.0.2
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -28,7 +28,7 @@ The first complete release directly supports:
 
 Supported platforms are macOS, Linux, and Windows. WSL is treated as Linux. A platform or Agent is not declared supported until its adapter passes fixtures and a real-environment acceptance run.
 
-SkillRoster scans only known directories for these eight Agents plus paths explicitly provided by the user. It never crawls the entire home directory by default. Every Scan reports included, excluded, missing, and inaccessible roots.
+SkillRoster scans only known directories for these eight Agents plus paths explicitly provided by the user. It never crawls the entire home directory by default. Every Scan reports included, excluded, missing, and inaccessible roots. `--root AGENT=PATH` is an Agent placement root and contributes to exposure; `--source-root PATH` is an approved canonical source with no Agent identity and no default exposure. Source trust is explicit and scoped to the supplied path.
 
 ## 3. Primary interaction
 

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -11,7 +11,7 @@ Use the local `skillroster` binary as the deterministic source of facts. Invoke 
 
 1. Run `skillroster scan --json`, then `skillroster report --summary --json`. Use the compact result for the first user-facing diagnosis; do not request the full report unless exhaustive Finding enumeration is necessary.
 2. Distinguish observed, inferred, and unknown usage. Missing evidence does not mean unused.
-3. Use stable Finding and Evidence IDs for follow-up questions. Run `report --finding ID --json` against the same Snapshot rather than silently rescanning. Explain its returned placement paths, link targets, and Evidence records; do not make the user infer them from opaque IDs.
+3. Use stable Finding and Evidence IDs for follow-up questions. The summary exposes one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when the exact paths or Evidence affect the decision. Finding detail is paged. Continue with `--offset NEXT_OFFSET --limit 20` only until the requested decision has enough relevant evidence, and keep the same Snapshot rather than silently rescanning.
 4. Make semantic governance choices in the conversation, then submit declarative target states to `skillroster plan --stdin --json`. Set request `schema_version` to `1`, include the latest `scan_id` and one or more relevant `evidence_ids`, and submit only the supported governance fields.
 5. Present the validated Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `impact` before/after facts, affected Agents, uncertainty, canonical deletion count, reversibility, and Plan ID. The source-oriented `diff_summary` may be empty for ordinary Roster or Library Plans; do not treat that as a missing Plan delta.
 
@@ -21,9 +21,17 @@ Use only these Plan request families:
 - `library_changes`: `skill_id`, `canonical_placement_id`, the complete `placement_ids` set returned by the Snapshot, and `requested_state` (`managed` or `hosted`).
 - `source_updates`: the latest Skill/placement/source/revision/fingerprint facts plus upstream content and SHA-256 digest. If local content changed, include the user's explicit `choice`: `retain_local`, `adopt_upstream`, or `preserve_both`.
 
-Keep source updates and Library changes in separate Plans. Treat a rejected stale Snapshot, Evidence ID, fingerprint, incomplete placement set, or source revision as a reason to rescan or ask the user—not as permission to weaken the request.
+Keep source updates and Library changes in separate Plans. Cite Evidence returned by the relevant Finding page; a convenient but unrelated Evidence ID is not support for a governance change. Treat a rejected stale Snapshot, Evidence ID, fingerprint, incomplete placement set, or source revision as a reason to rescan or ask the user—not as permission to weaken the request.
 
 State explicitly that inspection and planning changed no Agent files. When evidence cannot justify a change, recommend keeping the current state.
+
+For `Skill links escape an approved root`, load one Finding page and show the
+link targets. Treat each target as unread until the user confirms that its
+source directory is intentional and trusted. After confirmation, rescan with
+one repeatable `--source-root ABSOLUTE_PATH` per canonical source directory;
+this approves reading without adding Agent exposure. Then prefer a reviewed
+Hosted or Managed Library Plan so future Scans no longer depend on the
+temporary source-root arguments. Keep unconfirmed targets unread.
 
 ## Apply or undo
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -93,8 +93,12 @@ pub fn run(cli: Cli) -> Result<Output> {
             ("status", result, vec![], actions)
         }
         Some(Command::Scan) => {
-            let (result, warnings) =
-                scan_command(&store, &home, parse_explicit_roots(&cli.roots)?)?;
+            let (result, warnings) = scan_command(
+                &store,
+                &home,
+                parse_explicit_roots(&cli.roots)?,
+                parse_source_roots(&cli.source_roots)?,
+            )?;
             (
                 "scan",
                 result,
@@ -110,7 +114,13 @@ pub fn run(cli: Cli) -> Result<Output> {
         }
         Some(Command::Report(args)) => (
             "report",
-            report_command(&store, args.finding.as_deref(), args.summary)?,
+            report_command(
+                &store,
+                args.finding.as_deref(),
+                args.summary,
+                usize::from(args.limit),
+                usize::try_from(args.offset)?,
+            )?,
             vec![],
             vec![action(
                 "plan",
@@ -493,6 +503,18 @@ fn parse_explicit_roots(values: &[String]) -> Result<Vec<ExplicitSkillRoot>> {
             Ok(ExplicitSkillRoot { agent, path })
         })
         .collect()
+}
+
+fn parse_source_roots(values: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut roots = values.to_vec();
+    for path in &roots {
+        if !path.is_absolute() {
+            bail!("source root must be absolute: {}", path.display());
+        }
+    }
+    roots.sort();
+    roots.dedup();
+    Ok(roots)
 }
 
 fn parse_agent_kind(value: &str) -> Result<AgentKind> {
@@ -907,6 +929,7 @@ fn scan_command(
     store: &StateStore,
     home: &Path,
     explicit: Vec<ExplicitSkillRoot>,
+    source_roots: Vec<PathBuf>,
 ) -> Result<(Value, Vec<String>)> {
     let started = Utc::now().timestamp();
     let id = ScanId::new();
@@ -919,6 +942,7 @@ fn scan_command(
     })?;
     let mut options = ScanOptions::for_home(home);
     options.explicit_skill_roots = explicit;
+    options.explicit_source_roots = source_roots;
     options.excluded_session_agents = store
         .evidence_exclusions()?
         .iter()
@@ -971,6 +995,7 @@ fn scan_command(
         .filter_map(|root| root.agent)
         .collect::<std::collections::BTreeSet<_>>()
         .len();
+    let warnings = compact_scan_warnings(result.warnings);
     Ok((
         json!({
             "snapshot_id": id,
@@ -981,11 +1006,33 @@ fn scan_command(
             "coverage": result.coverage,
             "files_changed": false
         }),
-        result.warnings,
+        warnings,
     ))
 }
 
-fn report_command(store: &StateStore, finding: Option<&str>, summary_only: bool) -> Result<Value> {
+fn compact_scan_warnings(warnings: Vec<String>) -> Vec<String> {
+    let (unsafe_links, mut remaining): (Vec<_>, Vec<_>) = warnings
+        .into_iter()
+        .partition(|warning| warning.starts_with("did not read unsafe Skill link "));
+    if !unsafe_links.is_empty() {
+        remaining.insert(
+            0,
+            format!(
+                "{} unsafe Skill links were not read; inspect the layout Finding for paths and link targets",
+                unsafe_links.len()
+            ),
+        );
+    }
+    remaining
+}
+
+fn report_command(
+    store: &StateStore,
+    finding: Option<&str>,
+    summary_only: bool,
+    detail_limit: usize,
+    detail_offset: usize,
+) -> Result<Value> {
     if let Some(id) = finding {
         let id = FindingId::parse(id.to_string())?;
         let stored = store
@@ -994,23 +1041,47 @@ fn report_command(store: &StateStore, finding: Option<&str>, summary_only: bool)
         let mut details = stored.details;
         if let Some(object) = details.as_object_mut() {
             object.insert("report_id".into(), json!(stored.report_id));
-            object.insert("evidence_ids".into(), json!(stored.evidence_ids));
             let report = store
                 .get_report(&stored.report_id)?
                 .ok_or_else(|| anyhow!("Report {} does not exist", stored.report_id))?;
             let scan: ScanResult = store
                 .scan_payload(&report.scan_id)?
                 .ok_or_else(|| anyhow!("Snapshot {} is no longer retained", report.scan_id))?;
+            let affected_skill_ids = object
+                .get("affected_skill_ids")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
             let affected_placement_ids = object
                 .get("affected_placement_ids")
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
-            let placements = scan
+            let end = detail_offset.saturating_add(detail_limit);
+            let paged_skill_ids = affected_skill_ids
+                .iter()
+                .skip(detail_offset)
+                .take(detail_limit)
+                .cloned()
+                .collect::<Vec<_>>();
+            let paged_placement_ids = affected_placement_ids
+                .iter()
+                .skip(detail_offset)
+                .take(detail_limit)
+                .cloned()
+                .collect::<Vec<_>>();
+            let paged_evidence_ids = stored
+                .evidence_ids
+                .iter()
+                .skip(detail_offset)
+                .take(detail_limit)
+                .cloned()
+                .collect::<Vec<_>>();
+            let mut placements = scan
                 .placements
                 .iter()
                 .filter(|placement| {
-                    affected_placement_ids
+                    paged_placement_ids
                         .iter()
                         .any(|id| id.as_str() == Some(&placement.id))
                 })
@@ -1028,16 +1099,47 @@ fn report_command(store: &StateStore, finding: Option<&str>, summary_only: bool)
                     })
                 })
                 .collect::<Vec<_>>();
-            let evidence = stored
-                .evidence_ids
+            placements.sort_by(|left, right| left["id"].as_str().cmp(&right["id"].as_str()));
+            let evidence = paged_evidence_ids
                 .iter()
                 .map(|id| store.get_evidence(id))
                 .collect::<Result<Vec<_>, _>>()?
                 .into_iter()
                 .flatten()
                 .collect::<Vec<_>>();
+            let total = affected_skill_ids
+                .len()
+                .max(affected_placement_ids.len())
+                .max(stored.evidence_ids.len());
+            let next_offset = (end < total).then_some(end);
+            object.insert("affected_skill_ids".into(), json!(paged_skill_ids));
+            object.insert("affected_placement_ids".into(), json!(paged_placement_ids));
+            object.insert("evidence_ids".into(), json!(paged_evidence_ids));
+            object.insert(
+                "primary_evidence_id".into(),
+                json!(stored.evidence_ids.first()),
+            );
             object.insert("placements".into(), json!(placements));
             object.insert("evidence".into(), json!(evidence));
+            object.insert(
+                "page".into(),
+                json!({
+                    "offset": detail_offset,
+                    "limit": detail_limit,
+                    "next_offset": next_offset,
+                    "has_more": next_offset.is_some(),
+                    "totals": {
+                        "affected_skills": affected_skill_ids.len(),
+                        "affected_placements": affected_placement_ids.len(),
+                        "evidence": stored.evidence_ids.len()
+                    },
+                    "returned": {
+                        "affected_skills": object["affected_skill_ids"].as_array().map_or(0, Vec::len),
+                        "affected_placements": object["affected_placement_ids"].as_array().map_or(0, Vec::len),
+                        "evidence": object["evidence_ids"].as_array().map_or(0, Vec::len)
+                    }
+                }),
+            );
         }
         return Ok(details);
     }
@@ -1140,6 +1242,25 @@ fn report_command(store: &StateStore, finding: Option<&str>, summary_only: bool)
 
 fn compact_report(report: &Value) -> Value {
     let findings = report["findings"].as_array().cloned().unwrap_or_default();
+    let compact_findings = findings
+        .iter()
+        .take(3)
+        .map(|finding| {
+            json!({
+                "id": finding["id"],
+                "category": finding["category"],
+                "severity": finding["severity"],
+                "title": finding["title"],
+                "summary": finding["summary"],
+                "evidence_quality": finding["evidence_quality"],
+                "primary_evidence_id": finding["evidence_ids"].as_array().and_then(|ids| ids.first()),
+                "affected_skill_count": finding["affected_skill_count"],
+                "affected_placement_count": finding["affected_placement_count"],
+                "impact": finding["impact"],
+                "coverage": finding["coverage"]
+            })
+        })
+        .collect::<Vec<_>>();
     json!({
         "report_id": report["report_id"],
         "snapshot_id": report["snapshot_id"],
@@ -1150,7 +1271,7 @@ fn compact_report(report: &Value) -> Value {
         "coverage_reliable_agent_count": report["coverage_reliable_agent_count"],
         "primary_metrics": report["primary_metrics"],
         "finding_count": findings.len(),
-        "findings": findings.into_iter().take(3).collect::<Vec<_>>(),
+        "findings": compact_findings,
         "category_counts": report["category_counts"],
         "files_changed": false
     })
@@ -3128,6 +3249,35 @@ fn action(
 mod recovery_tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn scan_warnings_group_repeated_unsafe_links_for_agent_callers() {
+        let warnings = vec![
+            "did not read unsafe Skill link /one/SKILL.md".into(),
+            "did not read unsafe Skill link /two/SKILL.md".into(),
+            "did not read unsafe Skill link /three/SKILL.md".into(),
+            "session evidence was truncated".into(),
+        ];
+
+        let compact = compact_scan_warnings(warnings);
+
+        assert_eq!(compact.len(), 2);
+        assert_eq!(
+            compact[0],
+            "3 unsafe Skill links were not read; inspect the layout Finding for paths and link targets"
+        );
+        assert_eq!(compact[1], "session evidence was truncated");
+    }
+
+    #[test]
+    fn source_roots_must_be_absolute_and_are_deduplicated() {
+        assert!(parse_source_roots(&[PathBuf::from("relative")]).is_err());
+        let absolute = std::env::current_dir().unwrap().join("source");
+        assert_eq!(
+            parse_source_roots(&[absolute.clone(), absolute.clone()]).unwrap(),
+            vec![absolute]
+        );
+    }
 
     #[test]
     fn readable_skill_path_ignores_stale_alternatives_when_a_valid_copy_exists() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,10 @@ pub struct Cli {
     #[arg(long = "root", global = true, value_name = "AGENT=PATH")]
     pub roots: Vec<String>,
 
+    /// Add a non-exposed approved Skill source directory. Repeatable.
+    #[arg(long = "source-root", global = true, value_name = "PATH")]
+    pub source_roots: Vec<PathBuf>,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 }
@@ -77,6 +81,14 @@ pub struct ReportArgs {
     /// Return core metrics and the three highest-priority Findings.
     #[arg(long)]
     pub summary: bool,
+
+    /// Maximum Finding detail rows returned per collection.
+    #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u16).range(1..=100))]
+    pub limit: u16,
+
+    /// Zero-based offset for Finding detail pagination.
+    #[arg(long, default_value_t = 0)]
+    pub offset: u32,
 }
 
 #[derive(Debug, Args)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -98,12 +98,7 @@ pub fn build_report(scan: &ScanResult) -> Report {
     overlap_findings(scan, &mut findings);
     routing_findings(scan, &mut findings);
     lifecycle_findings(scan, &mut findings);
-    findings.sort_by(|left, right| {
-        right
-            .severity
-            .cmp(&left.severity)
-            .then_with(|| left.id.cmp(&right.id))
-    });
+    prioritize_report_findings(&mut findings, 3);
 
     let mut category_counts = BTreeMap::new();
     for finding in &findings {
@@ -116,6 +111,84 @@ pub fn build_report(scan: &ScanResult) -> Report {
         findings,
         category_counts,
         files_changed: false,
+    }
+}
+
+fn prioritize_report_findings(findings: &mut Vec<Finding>, first_view_limit: usize) {
+    findings.sort_by(|left, right| {
+        right
+            .severity
+            .cmp(&left.severity)
+            .then_with(|| {
+                evidence_priority(right.evidence_quality)
+                    .cmp(&evidence_priority(left.evidence_quality))
+            })
+            .then_with(|| {
+                right
+                    .affected_placement_ids
+                    .len()
+                    .cmp(&left.affected_placement_ids.len())
+            })
+            .then_with(|| {
+                right
+                    .affected_skill_ids
+                    .len()
+                    .cmp(&left.affected_skill_ids.len())
+            })
+            .then_with(|| left.title.cmp(&right.title))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    if first_view_limit == 0 || findings.is_empty() {
+        return;
+    }
+
+    let ranked = findings.clone();
+    let mut selected_ids = BTreeSet::new();
+    let mut selected_categories = BTreeSet::new();
+    for severity in [
+        Severity::High,
+        Severity::Medium,
+        Severity::Low,
+        Severity::Info,
+    ] {
+        for finding in ranked.iter().filter(|finding| finding.severity == severity) {
+            if selected_ids.len() == first_view_limit {
+                break;
+            }
+            let category = category_name(finding.category);
+            if selected_categories.insert(category) {
+                selected_ids.insert(finding.id.clone());
+            }
+        }
+        for finding in ranked.iter().filter(|finding| finding.severity == severity) {
+            if selected_ids.len() == first_view_limit {
+                break;
+            }
+            selected_ids.insert(finding.id.clone());
+        }
+        if selected_ids.len() == first_view_limit {
+            break;
+        }
+    }
+
+    let mut ordered = ranked
+        .iter()
+        .filter(|finding| selected_ids.contains(&finding.id))
+        .cloned()
+        .collect::<Vec<_>>();
+    ordered.extend(
+        ranked
+            .into_iter()
+            .filter(|finding| !selected_ids.contains(&finding.id)),
+    );
+    *findings = ordered;
+}
+
+fn evidence_priority(quality: EvidenceQuality) -> u8 {
+    match quality {
+        EvidenceQuality::Observed => 2,
+        EvidenceQuality::Inferred => 1,
+        EvidenceQuality::Unknown => 0,
     }
 }
 
@@ -300,35 +373,45 @@ fn exposure_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             exposed_by_agent.entry(agent).or_default().push(placement);
         }
     }
-    for (agent, placements) in exposed_by_agent {
-        // This is a review threshold, not a claim that any Skill is useless.
-        if placements.len() > 50 {
-            push_finding(
-                findings,
-                FindingCategory::Exposure,
-                Severity::Medium,
-                "Large default Roster needs review",
-                format!(
-                    "{} has {} default-exposed placements; no archive decision is implied.",
-                    agent.display_name(),
-                    placements.len()
-                ),
-                placements
-                    .iter()
-                    .map(|placement| placement.skill_id.clone())
-                    .collect(),
-                placements
-                    .iter()
-                    .map(|placement| placement.id.clone())
-                    .collect(),
-                placements
-                    .iter()
-                    .map(|placement| format!("path:{}", placement.entrypoint.display()))
-                    .collect(),
-                EvidenceQuality::Observed,
-            );
-        }
+    let oversized = exposed_by_agent
+        .into_iter()
+        .filter(|(_, placements)| placements.len() > 50)
+        .collect::<Vec<_>>();
+    if oversized.is_empty() {
+        return;
     }
+    let breakdown = oversized
+        .iter()
+        .map(|(agent, placements)| format!("{}={}", agent.display_name(), placements.len()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    // This is a review threshold, not a claim that any Skill is useless.
+    push_finding(
+        findings,
+        FindingCategory::Exposure,
+        Severity::Medium,
+        "Large default Rosters need review",
+        format!(
+            "{} Agents exceed 50 default-exposed placements: {breakdown}; no archive decision is implied.",
+            oversized.len()
+        ),
+        oversized
+            .iter()
+            .flat_map(|(_, placements)| placements.iter())
+            .map(|placement| placement.skill_id.clone())
+            .collect(),
+        oversized
+            .iter()
+            .flat_map(|(_, placements)| placements.iter())
+            .map(|placement| placement.id.clone())
+            .collect(),
+        oversized
+            .iter()
+            .flat_map(|(_, placements)| placements.iter())
+            .map(|placement| format!("path:{}", placement.entrypoint.display()))
+            .collect(),
+        EvidenceQuality::Observed,
+    );
 }
 
 fn usage_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
@@ -1339,6 +1422,116 @@ mod tests {
         let review_matches = find(&scan, "review a pull request", 2);
         assert_eq!(review_matches[0].name, "github-code-review");
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn report_first_view_prioritizes_systemic_and_category_diverse_findings() {
+        fn finding(
+            category: FindingCategory,
+            severity: Severity,
+            title: &str,
+            skill_count: usize,
+            placement_count: usize,
+        ) -> Finding {
+            Finding {
+                id: format!("finding_{title}"),
+                category,
+                severity,
+                title: title.into(),
+                summary: title.into(),
+                affected_skill_ids: (0..skill_count)
+                    .map(|index| format!("skill_{title}_{index}"))
+                    .collect(),
+                affected_placement_ids: (0..placement_count)
+                    .map(|index| format!("placement_{title}_{index}"))
+                    .collect(),
+                evidence: Vec::new(),
+                evidence_quality: EvidenceQuality::Observed,
+            }
+        }
+
+        let mut findings = vec![
+            finding(
+                FindingCategory::Overlap,
+                Severity::Medium,
+                "duplicate-a",
+                1,
+                6,
+            ),
+            finding(
+                FindingCategory::Overlap,
+                Severity::Medium,
+                "duplicate-b",
+                1,
+                5,
+            ),
+            finding(
+                FindingCategory::Layout,
+                Severity::High,
+                "unsafe-links",
+                16,
+                16,
+            ),
+            finding(
+                FindingCategory::Exposure,
+                Severity::Medium,
+                "large-roster",
+                128,
+                128,
+            ),
+            finding(
+                FindingCategory::Layout,
+                Severity::Medium,
+                "name-conflicts",
+                8,
+                8,
+            ),
+            finding(FindingCategory::Usage, Severity::Info, "coverage", 0, 0),
+        ];
+
+        prioritize_report_findings(&mut findings, 3);
+
+        assert_eq!(
+            findings
+                .iter()
+                .take(3)
+                .map(|finding| finding.title.as_str())
+                .collect::<Vec<_>>(),
+            vec!["unsafe-links", "large-roster", "duplicate-a"]
+        );
+    }
+
+    #[test]
+    fn exposure_is_one_systemic_finding_with_an_agent_breakdown() {
+        let mut scan = ScanResult::default();
+        for (agent, count) in [
+            (crate::harness::AgentKind::Codex, 52_usize),
+            (crate::harness::AgentKind::ClaudeCode, 51_usize),
+        ] {
+            scan.placements
+                .extend((0..count).map(|index| crate::scan::SkillPlacement {
+                    id: format!("placement_{}_{index}", agent.id()),
+                    skill_id: format!("skill_{}_{index}", agent.id()),
+                    agent: Some(agent),
+                    root: PathBuf::from(format!("/{}/skills", agent.id())),
+                    directory: PathBuf::from(format!("/{}/skills/{index}", agent.id())),
+                    entrypoint: PathBuf::from(format!("/{}/skills/{index}/SKILL.md", agent.id())),
+                    content_digest: format!("digest_{index}"),
+                    link_target: None,
+                    link_status: crate::scan::LinkStatus::NotLink,
+                    default_exposed: true,
+                    executable_files: Vec::new(),
+                    declared_name_matches_directory: Some(true),
+                }));
+        }
+        let mut findings = Vec::new();
+
+        exposure_findings(&scan, &mut findings);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].affected_placement_ids.len(), 103);
+        assert!(findings[0].summary.contains("Codex=52"));
+        assert!(findings[0].summary.contains("Claude Code=51"));
     }
 
     #[test]

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -21,6 +21,7 @@ const MAX_SESSION_LINES_PER_AGENT: usize = 20_000;
 pub struct ScanOptions {
     pub home: PathBuf,
     pub explicit_skill_roots: Vec<ExplicitSkillRoot>,
+    pub explicit_source_roots: Vec<PathBuf>,
     pub excluded_session_agents: BTreeSet<AgentKind>,
     pub include_session_evidence: bool,
     pub max_depth: usize,
@@ -37,6 +38,7 @@ impl ScanOptions {
         Self {
             home: home.into(),
             explicit_skill_roots: Vec::new(),
+            explicit_source_roots: Vec::new(),
             excluded_session_agents: BTreeSet::new(),
             include_session_evidence: true,
             max_depth: 5,
@@ -202,6 +204,7 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
                 .iter()
                 .map(|root| root.path.clone()),
         )
+        .chain(options.explicit_source_roots.iter().cloned())
         .collect::<Vec<_>>();
     let mut candidates = Vec::new();
 
@@ -223,6 +226,17 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
             None,
             root,
             false,
+            &approved_roots,
+            options.max_depth,
+            &mut result,
+            &mut candidates,
+        );
+    }
+    for root in &options.explicit_source_roots {
+        observe_skill_root(
+            None,
+            root,
+            true,
             &approved_roots,
             options.max_depth,
             &mut result,
@@ -1059,6 +1073,48 @@ mod tests {
         assert_eq!(result.skills.len(), 1);
         assert_eq!(result.placements.len(), 2);
         assert!(result.roots.iter().any(|seen| seen.explicit));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_source_root_approves_links_without_adding_agent_exposure() {
+        let root = temp_directory("source-root");
+        let home = root.join("home");
+        let source_root = root.join("sources");
+        let source_skill = source_root.join("external");
+        fs::create_dir_all(&source_skill).unwrap();
+        fs::write(
+            source_skill.join("SKILL.md"),
+            "---\nname: external\ndescription: External source Skill\n---\n",
+        )
+        .unwrap();
+        let codex_root = home.join(".codex/skills");
+        fs::create_dir_all(&codex_root).unwrap();
+        std::os::unix::fs::symlink(&source_skill, codex_root.join("external")).unwrap();
+
+        let mut options = ScanOptions::for_home(&home);
+        options.explicit_source_roots.push(source_root.clone());
+        options.include_session_evidence = false;
+        let result = scan(&options).unwrap();
+
+        assert!(result.warnings.is_empty());
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.placements.len(), 2);
+        assert_eq!(
+            result
+                .placements
+                .iter()
+                .filter(|placement| placement.default_exposed)
+                .count(),
+            1
+        );
+        assert!(
+            result
+                .roots
+                .iter()
+                .any(|seen| { seen.path == source_root && seen.explicit && seen.agent.is_none() })
+        );
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -52,6 +52,85 @@ fn assert_find_paths_are_readable(found: &Value) {
 }
 
 #[test]
+fn finding_drilldown_is_bounded_and_pageable() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for index in 0..51 {
+        let directory = skill_root.join(format!("skill-{index:02}"));
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(
+            directory.join("SKILL.md"),
+            format!(
+                "---\nname: skill-{index:02}\ndescription: Dedicated task number {index}\n---\n"
+            ),
+        )
+        .unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let report = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["category"] == "exposure")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+
+    let first_output = run(
+        &[&common[..], &["report", "--finding", finding_id]].concat(),
+        None,
+    );
+    assert!(first_output.stdout.len() < 40_000);
+    let first = json_output(&first_output);
+    assert_eq!(first["result"]["page"]["offset"], 0);
+    assert_eq!(first["result"]["page"]["limit"], 20);
+    assert_eq!(first["result"]["page"]["next_offset"], 20);
+    assert_eq!(first["result"]["placements"].as_array().unwrap().len(), 20);
+    assert_eq!(
+        first["result"]["affected_placement_ids"]
+            .as_array()
+            .unwrap()
+            .len(),
+        20
+    );
+
+    let second = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "report",
+                "--finding",
+                finding_id,
+                "--offset",
+                "20",
+                "--limit",
+                "20",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(second["result"]["page"]["offset"], 20);
+    assert_ne!(
+        first["result"]["affected_placement_ids"][0],
+        second["result"]["affected_placement_ids"][0]
+    );
+}
+
+#[test]
 fn public_cli_scans_reports_plans_applies_and_undoes() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
@@ -136,6 +215,14 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
             <= 3
     );
     assert!(summary_report_output_len < report_output_len);
+    for finding in summary_report["result"]["findings"].as_array().unwrap() {
+        assert!(finding.get("affected_skill_ids").is_none());
+        assert!(finding.get("affected_placement_ids").is_none());
+        assert!(finding.get("evidence_ids").is_none());
+        assert!(finding.get("primary_evidence_id").is_some());
+        assert!(finding["affected_skill_count"].is_number());
+        assert!(finding["affected_placement_count"].is_number());
+    }
     let finding_id = report["result"]["findings"]
         .as_array()
         .unwrap()


### PR DESCRIPTION
## Problem

A real Agent-driven scan of 180 local Skills found that the first diagnosis was technically correct but expensive to consume: duplicate Findings could dominate the first view, repeated unsafe-link warnings were noisy, systemic exposure was split by Agent, and one exposure drill-down produced 677 KB of JSON. Treating trusted canonical sources as Agent roots also inflated default exposure.

## Solution

- rank the first three Findings by severity, evidence quality, impact, and category diversity
- aggregate oversized Agent rosters into one systemic exposure Finding
- keep summary Findings compact and expose one primary Evidence reference
- page Finding details with bounded `--limit` and `--offset` controls
- group repeated unsafe-link scan warnings
- add repeatable `--source-root PATH` for trusted, non-exposed canonical sources
- document the Agent workflow for source trust and paged evidence

## Real-use evidence

- public v1.0.1 scan: 8 Agents, 180 Skills, 676 placements, 548 default exposure
- repeated unsafe-link warnings: 16 to 1 grouped warning
- compact first view: about 2.9 KB, with category-diverse top Findings
- exposure Findings: 4 per-Agent records to 1 systemic record
- systemic exposure drill-down: 677,507 bytes to 29,232 bytes at the default page size
- trusted source rescan: 0 unsafe-link warnings, 167 logical Skills, and default exposure remained 548
- a real Managed Library Plan was prepared against the duplicate source evidence; no Apply was run and no Agent files changed

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (89 tests)
- Bootstrap Skill validation (`Skill is valid!`)
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- `git diff --check`
