### PR TITLE
fix: improve agent skill routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "2dcd14ebec60c9c2db4424e9665165bf6138a79e"
-  version "1.0.2"
+      revision: "e9ac96eea9cd8c5f53bf62a4aa52ce4873e2c630"
+  version "1.0.3"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.0.2", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.0.3", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "e9ac96eea9cd8c5f53bf62a4aa52ce4873e2c630"
+      revision: "c142d98941fd32122ab7db893a5122aad7f29878"
   version "1.0.3"
 
   depends_on "rust" => :build

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ skillroster --source-root /absolute/trusted/source scan --json
 skillroster report --summary --json
 skillroster report --finding <finding-id> --limit 20 --json
 skillroster find "database migration" --json
+skillroster find "诊断命令性能回归" --hint "diagnose command performance regression" --json
 skillroster plan --stdin --json
 skillroster apply <plan-id> --json
 skillroster undo <receipt-id> --json

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -14,7 +14,7 @@ The suite proves:
 
 - all eight direct adapters discover their independent filesystem fixture;
 - each adapter conservatively normalizes Exposed, Matched, Loaded, Applied, and Outcome evidence, while prose-only mentions create no observed stage;
-- the maintained 40-task routing set reaches at least 95% Top-3 recall;
+- the maintained 47-task routing set, including Agent-hinted Chinese tasks, reaches at least 95% Top-3 recall;
 - a public `plan`/`apply` moves non-Core Skills to On-demand, `find` still returns readable paths, and Receipt-bounded `undo` restores the original Agent tree;
 - small (5 Skills), large (120 Skills), and cross-Agent (12 Skills) duplicate scenarios preserve counts, traceable Finding evidence, and the four report metrics;
 - plain 60-, 80-, and 120-column reports retain their core fields, no-change statement, and no ANSI bytes.
@@ -26,7 +26,7 @@ Top-3 routing and task success are separate checks:
 
 The governed run uses the public `scan`, `report`, `plan`, `apply`, `find`, and `undo` commands. It marks seven of ten Skills On-demand, then repeats both checks against paths returned after the real Apply. This validates deterministic fixture capability, not whether an external model completed a natural-language task.
 
-Current local result (2026-08-22): **40/40 Top-3 hits before governance and 40/40 after governance**. Re-run the test above for release evidence; this recorded result is not a substitute for CI.
+Current local result (2026-08-22): **47/47 Top-3 hits before governance and 47/47 after governance**. Re-run the test above for release evidence; this recorded result is not a substitute for CI.
 
 ## Executed three-arm value comparison
 

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -145,6 +145,7 @@ Machine results should expose facts, not preformatted prose:
 - `primary_metrics` with value, unit, coverage, and comparison baseline;
 - Findings with stable ID, category, severity, Evidence quality, impact fields, and affected IDs;
 - a bounded `report --summary --json` first view with no more than three Findings and one primary Evidence reference, plus paged placement paths and Evidence facts from `report --finding ID --json`;
+- Find results that keep the original task, expose Agent-authored retrieval hints, and collapse same-name identities into one explicitly variant capability result;
 - Plan `change_summary` counts and `impact` deltas for current and proposed state; source-update line details remain in `diff_summary`;
 - affected Agents, Skills, placements, operation groups, exclusions, and deletion count;
 - risk, reversibility, drift, confirmation, and recovery state;

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -102,7 +102,11 @@ compact first view.
 
 ### `find`
 
-Show ranked matches with Skill name, current Roster state, source, and concise match reasons. Empty results are calm, successful output. Find never implies activation.
+Show ranked matches with Skill name, current Roster state, source, concise match
+reasons, and same-name variant count. Preserve the original task separately
+from repeatable `--hint` retrieval text. A CJK task without hints receives an
+actionable lexical-retrieval warning when English metadata may be missed.
+Empty results are calm, successful output. Find never implies activation.
 
 ### `plan`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.0.2
+SKILLROSTER_VERSION=1.0.3
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -100,7 +100,7 @@ The first complete command surface is:
 ```bash
 skillroster scan [--json]
 skillroster report [--finding <id>] [--json]
-skillroster find <task> [--json]
+skillroster find <task> [--hint <text>]... [--json]
 skillroster plan --stdin [--json]
 skillroster apply <plan-id> [--json]
 skillroster undo <receipt-id> [--json]
@@ -109,6 +109,12 @@ skillroster setup [--json]
 ```
 
 `setup` detects supported Agents and returns a preview for installing the single bootstrap Skill. In JSON mode it never prompts or mutates; the installation is represented by a Plan and completed through the normal Apply path.
+
+`find` preserves the user's original task and accepts repeatable Agent-authored
+retrieval hints. Hints let the semantic caller supply a cross-language or
+capability paraphrase while the CLI remains a deterministic local lexical
+index. Same-name Skill identities occupy one ranked capability result and are
+reported as explicit variants rather than silently treated as equivalent.
 
 All JSON responses use a versioned envelope:
 

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -45,6 +45,6 @@ Use `skillroster status --json` for pending Plans, the last Receipt, retention, 
 
 ## Find an on-demand Skill
 
-Run `skillroster find "TASK" --json`. Explain the top matches and evidence, then read the selected `SKILL.md` directly from its returned path. If the lexical matches are clearly about another domain, retry once with concrete tool or operation terms already implied by the task (for example, `MySQL DDL` for a database migration); do not present an irrelevant top result as confidence. Finding a Skill does not activate or install it.
+Run `skillroster find "TASK" --json`, keeping the user's task verbatim. For a non-English or mixed-language task, include one concise English capability paraphrase through `--hint "TEXT"` on the first call; use tool and operation terms implied by the task, not a guessed Skill name. Retry once with a refined hint only when the result is empty or clearly about another domain. Explain the top matches and evidence. A `variant_count` above one is unresolved same-name content ambiguity: show the warning and inspect the corresponding layout Finding before choosing content. Otherwise read the selected `SKILL.md` directly from its returned path. Finding a Skill does not activate or install it.
 
 Never parse styled terminal output, invent a health score, infer token savings, or claim files changed without a successful Receipt.

--- a/src/app.rs
+++ b/src/app.rs
@@ -132,7 +132,13 @@ pub fn run(cli: Cli) -> Result<Output> {
         ),
         Some(Command::Find(args)) => (
             "find",
-            find_command(&store, &state_dir, &args.task, usize::from(args.limit))?,
+            find_command(
+                &store,
+                &state_dir,
+                &args.task,
+                &args.hints,
+                usize::from(args.limit),
+            )?,
             vec![],
             vec![],
         ),
@@ -1332,10 +1338,22 @@ fn finding_coverage(finding: &crate::query::Finding, scan: &ScanResult) -> Value
     })
 }
 
-fn find_command(store: &StateStore, state_dir: &Path, task: &str, limit: usize) -> Result<Value> {
+fn find_command(
+    store: &StateStore,
+    state_dir: &Path,
+    task: &str,
+    hints: &[String],
+    limit: usize,
+) -> Result<Value> {
     let (scan_id, scan) = latest_scan(store)?;
+    let retrieval_hints = normalize_retrieval_hints(hints);
+    let retrieval_query = std::iter::once(task.trim())
+        .chain(retrieval_hints.iter().map(String::as_str))
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
     let mut candidate_ids = store
-        .search_skill_ids(task, scan.skills.len())?
+        .search_skill_ids(&retrieval_query, scan.skills.len())?
         .into_iter()
         .map(|id| id.to_string())
         .collect::<std::collections::BTreeSet<_>>();
@@ -1346,10 +1364,11 @@ fn find_command(store: &StateStore, state_dir: &Path, task: &str, limit: usize) 
             candidate_ids.remove(&skill_id);
         }
     }
-    let mut matches = crate::query::find_matching(&scan, task, limit, Some(&candidate_ids));
+    let mut matches =
+        crate::query::find_matching(&scan, &retrieval_query, limit, Some(&candidate_ids));
     let mut warnings = Vec::new();
     let mut rescan_required = false;
-    for found in &mut matches {
+    for (index, found) in matches.iter_mut().enumerate() {
         let skill_id = SkillId::parse(found.skill_id.clone())?;
         found.roster_state = current_roster_state(&store.roster_states_for_skill(&skill_id)?);
         let paths = current_readable_skill_paths(&scan, state_dir, &found.skill_id)?;
@@ -1361,17 +1380,57 @@ fn find_command(store: &StateStore, state_dir: &Path, task: &str, limit: usize) 
                 found.name
             ));
         }
+        if index < 3 && found.variant_count > 1 {
+            warnings.push(format!(
+                "{} represents {} same-name Skill variants; inspect the layout Finding before choosing content",
+                found.name, found.variant_count
+            ));
+        }
+    }
+    if retrieval_hints.is_empty() && contains_cjk(task) {
+        warnings.push(
+            "Find is lexical and the task contains CJK text; retry with one concise English capability paraphrase via --hint if relevant Skills use English metadata"
+                .into(),
+        );
+    }
+    if matches.is_empty() {
+        warnings.push(
+            "No lexical Skill match was found; retry once with concrete capability, tool, or operation terms via --hint"
+                .into(),
+        );
     }
     warnings.sort();
     warnings.dedup();
     Ok(json!({
         "snapshot_id": scan_id,
         "task": task,
+        "retrieval_hints": retrieval_hints,
         "matches": matches,
         "rescan_required": rescan_required,
         "warnings": warnings,
         "files_changed": false
     }))
+}
+
+fn normalize_retrieval_hints(hints: &[String]) -> Vec<String> {
+    let mut normalized = hints
+        .iter()
+        .map(|hint| hint.trim())
+        .filter(|hint| !hint.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized.dedup();
+    normalized
+}
+
+fn contains_cjk(text: &str) -> bool {
+    text.chars().any(|character| {
+        matches!(
+            character as u32,
+            0x3400..=0x4dbf | 0x4e00..=0x9fff | 0x20000..=0x2fa1f
+        )
+    })
 }
 
 fn current_roster_state(states: &[RosterState]) -> String {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,6 +95,10 @@ pub struct ReportArgs {
 pub struct FindArgs {
     pub task: String,
 
+    /// Add an Agent-authored lexical retrieval hint while preserving TASK. Repeatable.
+    #[arg(long = "hint", value_name = "TEXT")]
+    pub hints: Vec<String>,
+
     #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(1..=100))]
     pub limit: u16,
 }

--- a/src/present.rs
+++ b/src/present.rs
@@ -327,13 +327,13 @@ fn find(value: &Value, lines: &mut Vec<String>, width: usize) {
             lines.push("  No matching Skills found.".into());
         }
     }
-    if let Some(warnings) = value.get("warnings").and_then(Value::as_array)
-        && !warnings.is_empty()
-    {
-        lines.push(String::new());
-        lines.push("  Retrieval notes".into());
-        for warning in warnings.iter().filter_map(Value::as_str).take(3) {
-            lines.push(format!("  - {warning}"));
+    if let Some(warnings) = value.get("warnings").and_then(Value::as_array) {
+        if !warnings.is_empty() {
+            lines.push(String::new());
+            lines.push("  Retrieval notes".into());
+            for warning in warnings.iter().filter_map(Value::as_str).take(3) {
+                lines.push(format!("  - {warning}"));
+            }
         }
     }
     lines.extend(summary(

--- a/src/present.rs
+++ b/src/present.rs
@@ -307,6 +307,16 @@ fn find(value: &Value, lines: &mut Vec<String>, width: usize) {
                 .unwrap_or_else(|| "not provided".into());
             lines.push(format!("  {}. {}", index + 1, text(item, "name")));
             lines.push(format!("     roster {roster} · source {source}"));
+            if item
+                .get("variant_count")
+                .and_then(Value::as_u64)
+                .is_some_and(|count| count > 1)
+            {
+                lines.push(format!(
+                    "     variants {} · inspect layout Finding",
+                    text(item, "variant_count")
+                ));
+            }
             lines.push(format!("     reasons {reasons}"));
             lines.push(format!(
                 "     {}",
@@ -315,6 +325,15 @@ fn find(value: &Value, lines: &mut Vec<String>, width: usize) {
         }
         if items.is_empty() {
             lines.push("  No matching Skills found.".into());
+        }
+    }
+    if let Some(warnings) = value.get("warnings").and_then(Value::as_array)
+        && !warnings.is_empty()
+    {
+        lines.push(String::new());
+        lines.push("  Retrieval notes".into());
+        for warning in warnings.iter().filter_map(Value::as_str).take(3) {
+            lines.push(format!("  - {warning}"));
         }
     }
     lines.extend(summary(
@@ -857,16 +876,19 @@ mod tests {
                 "name": "research",
                 "roster_state": "core",
                 "source": "github:owner/repo",
+                "variant_count": 2,
                 "match_reasons": ["declared_trigger", "token_overlap:2"],
                 "paths": ["/skills/research/SKILL.md"]
-            }]}),
+            }], "warnings": ["research has two content variants"]}),
             RenderOptions {
                 width: 80,
                 styled: false,
             },
         );
         assert!(found.contains("roster core · source github:owner/repo"));
+        assert!(found.contains("variants 2 · inspect layout Finding"));
         assert!(found.contains("declared_trigger"));
+        assert!(found.contains("Retrieval notes"));
 
         let planned = render(
             "plan",

--- a/src/query.rs
+++ b/src/query.rs
@@ -72,6 +72,10 @@ pub struct FindMatch {
     pub source: Option<String>,
     pub match_reasons: Vec<String>,
     pub evidence_quality: EvidenceQuality,
+    /// Same declared name with distinct Skill identities is one ambiguous capability result.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub variant_skill_ids: Vec<String>,
+    pub variant_count: usize,
 }
 
 pub fn build_report(scan: &ScanResult) -> Report {
@@ -1028,6 +1032,17 @@ pub(crate) fn find_matching(
     }
     let query_tokens = tokens(&query);
     let placement_groups = placements_by_skill(scan);
+    let mut variants_by_name = BTreeMap::<String, Vec<String>>::new();
+    for skill in &scan.skills {
+        variants_by_name
+            .entry(skill.name.trim().to_lowercase())
+            .or_default()
+            .push(skill.id.clone());
+    }
+    for variants in variants_by_name.values_mut() {
+        variants.sort();
+        variants.dedup();
+    }
     let mut matches = scan
         .skills
         .iter()
@@ -1088,6 +1103,14 @@ pub(crate) fn find_matching(
             if score <= 0.0 {
                 return None;
             }
+            let mut variant_skill_ids = variants_by_name
+                .get(&name.trim().to_lowercase())
+                .cloned()
+                .unwrap_or_else(|| vec![skill.id.clone()]);
+            let variant_count = variant_skill_ids.len();
+            if variant_count == 1 {
+                variant_skill_ids.clear();
+            }
             let placements = placement_groups
                 .get(skill.id.as_str())
                 .cloned()
@@ -1120,6 +1143,8 @@ pub(crate) fn find_matching(
                 } else {
                     EvidenceQuality::Inferred
                 },
+                variant_skill_ids,
+                variant_count,
             })
         })
         .collect::<Vec<_>>();
@@ -1131,11 +1156,33 @@ pub(crate) fn find_matching(
             .then_with(|| left.name.cmp(&right.name))
             .then_with(|| left.skill_id.cmp(&right.skill_id))
     });
-    matches.truncate(limit);
-    for (index, matched) in matches.iter_mut().enumerate() {
+    let mut capability_indexes: BTreeMap<String, usize> = BTreeMap::new();
+    let mut capabilities: Vec<FindMatch> = Vec::new();
+    for matched in matches {
+        let capability = matched.name.trim().to_lowercase();
+        if let Some(index) = capability_indexes.get(&capability).copied() {
+            let existing = &mut capabilities[index];
+            existing.variant_skill_ids.push(matched.skill_id);
+            existing.variant_skill_ids.sort();
+            existing.variant_skill_ids.dedup();
+            existing.variant_count = existing.variant_skill_ids.len();
+            continue;
+        }
+        capability_indexes.insert(capability, capabilities.len());
+        capabilities.push(matched);
+    }
+    for matched in &mut capabilities {
+        if matched.variant_count > 1 {
+            matched
+                .match_reasons
+                .push(format!("name_variants:{}", matched.variant_count));
+        }
+    }
+    capabilities.truncate(limit);
+    for (index, matched) in capabilities.iter_mut().enumerate() {
         matched.rank = index + 1;
     }
-    matches
+    capabilities
 }
 
 fn tokens(text: &str) -> BTreeSet<String> {
@@ -1425,6 +1472,62 @@ mod tests {
     }
 
     #[test]
+    fn find_returns_one_ranked_capability_for_same_name_variants() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("skillroster-routing-variants-{nonce}"));
+        for (directory, description, body) in [
+            (
+                "essay-a",
+                "Write a technical essay",
+                "Draft technical essays with diagrams.",
+            ),
+            (
+                "essay-b",
+                "Manage financial spreadsheets",
+                "Build deterministic workbook formulas.",
+            ),
+        ] {
+            let path = root.join(directory);
+            fs::create_dir_all(&path).unwrap();
+            fs::write(
+                path.join("SKILL.md"),
+                format!("---\nname: tech-essay-writer\ndescription: {description}\n---\n{body}"),
+            )
+            .unwrap();
+        }
+        let mut options = ScanOptions::for_home(root.join("home"));
+        options
+            .explicit_skill_roots
+            .push(crate::scan::ExplicitSkillRoot {
+                agent: crate::harness::AgentKind::Codex,
+                path: root.clone(),
+            });
+        options.include_session_evidence = false;
+        let scan = scan(&options).unwrap();
+
+        let matches = find(&scan, "diagrams", 10);
+
+        assert_eq!(
+            matches
+                .iter()
+                .filter(|matched| matched.name == "tech-essay-writer")
+                .count(),
+            1
+        );
+        let matched = matches
+            .iter()
+            .find(|matched| matched.name == "tech-essay-writer")
+            .unwrap();
+        assert_eq!(matched.variant_count, 2);
+        assert_eq!(matched.variant_skill_ids.len(), 2);
+        assert!(matched.match_reasons.contains(&"name_variants:2".into()));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn report_first_view_prioritizes_systemic_and_category_diverse_findings() {
         fn finding(
             category: FindingCategory,
@@ -1540,6 +1643,8 @@ mod tests {
         struct Case {
             task: String,
             skill: String,
+            #[serde(default)]
+            hints: Vec<String>,
         }
 
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/routing-skills");
@@ -1557,7 +1662,11 @@ mod tests {
         let hits = cases
             .iter()
             .filter(|case| {
-                find(&scan, &case.task, 3)
+                let retrieval_query = std::iter::once(case.task.as_str())
+                    .chain(case.hints.iter().map(String::as_str))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                find(&scan, &retrieval_query, 3)
                     .iter()
                     .any(|item| item.name == case.skill)
             })

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -17,6 +17,8 @@ const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 struct RouteCase {
     task: String,
     skill: String,
+    #[serde(default)]
+    hints: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -113,7 +115,12 @@ fn evaluate_capabilities(home: &Path, state: &Path, routes: &[RouteCase]) -> (us
     let mut routed = 0;
     let mut succeeded = 0;
     for case in routes {
-        let found = cli_json(home, state, &["find", &case.task, "--limit", "3"], None);
+        let mut arguments = vec!["find", case.task.as_str()];
+        for hint in &case.hints {
+            arguments.extend(["--hint", hint.as_str()]);
+        }
+        arguments.extend(["--limit", "3"]);
+        let found = cli_json(home, state, &arguments, None);
         let Some(matched) = found["result"]["matches"]
             .as_array()
             .unwrap()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -52,6 +52,64 @@ fn assert_find_paths_are_readable(found: &Value) {
 }
 
 #[test]
+fn public_find_keeps_the_user_task_and_uses_agent_retrieval_hints() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill = home.join(".codex/skills/archify");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: archify\ndescription: Create interactive architecture workflow diagrams\n---\n",
+    )
+    .unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let unhinted = json_output(&run(
+        &[&common[..], &["find", "把架构流程画成可交互图"]].concat(),
+        None,
+    ));
+    assert!(unhinted["result"]["matches"].as_array().unwrap().is_empty());
+    assert!(
+        unhinted["result"]["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|warning| warning.as_str().unwrap().contains("--hint"))
+    );
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "把架构流程画成可交互图",
+                "--hint",
+                "interactive architecture workflow diagram",
+                "--hint",
+                "  interactive architecture workflow diagram  ",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["task"], "把架构流程画成可交互图");
+    assert_eq!(
+        found["result"]["retrieval_hints"],
+        json!(["interactive architecture workflow diagram"])
+    );
+    assert_eq!(found["result"]["matches"][0]["name"], "archify");
+}
+
+#[test]
 fn finding_drilldown_is_bounded_and_pageable() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");

--- a/tests/fixtures/routing-eval.json
+++ b/tests/fixtures/routing-eval.json
@@ -38,5 +38,12 @@
   {"task":"clarify ambiguous domain concepts","skill":"domain-modeling"},
   {"task":"review a GitHub pull request inline","skill":"github-code-review"},
   {"task":"publish PR review comments","skill":"github-code-review"},
-  {"task":"inspect GitHub PR diffs","skill":"github-code-review"}
+  {"task":"inspect GitHub PR diffs","skill":"github-code-review"},
+  {"task":"调查官方 API 文档","hints":["research official API documentation"],"skill":"research"},
+  {"task":"审查一个拉取请求","hints":["review pull request code changes"],"skill":"code-review"},
+  {"task":"诊断命令的性能回归","hints":["diagnose command performance regression"],"skill":"diagnose"},
+  {"task":"画出系统请求生命周期","hints":["visualize system request lifecycle diagram"],"skill":"archify"},
+  {"task":"修改并收紧技术文章","hints":["edit tighten technical article"],"skill":"edit-article"},
+  {"task":"从 GitHub 安装一个 Skill","hints":["install skill from GitHub"],"skill":"skill-installer"},
+  {"task":"定义项目的统一领域术语","hints":["define domain terminology ubiquitous language"],"skill":"domain-modeling"}
 ]


### PR DESCRIPTION
## Problem

Real Agent use against 167 local Skills showed that `find` was reliable for English fixture tasks but not for the user's Chinese tasks. Two representative tasks returned no results, a Rust CLI regression routed to generic CLI Skills, and same-name content variants repeatedly consumed Top-N positions.

## Solution

- add repeatable `find --hint TEXT` so the Agent can preserve the user's task while supplying a concise cross-language capability paraphrase
- keep retrieval deterministic and local; no model, translation service, or network dependency was added
- collapse same-name Skill identities into one ranked capability result
- expose `variant_count` and all distinct variant IDs only when content ambiguity exists
- warn CJK callers when lexical retrieval may need an English metadata hint
- teach the Bootstrap Skill to provide the hint on the first non-English call and stop before choosing ambiguous content
- extend maintained routing acceptance from 40 to 47 tasks with Agent-hinted Chinese cases

## Real-use evidence

- public v1.0.2 real index: 167 logical Skills, 679 placements, 548 default exposure
- before: architecture-diagram and technical-essay Chinese tasks returned no matches; diagnosis and GitHub release tasks ranked generic lexical matches first
- after: all 7 real Chinese scenarios reached the intended capability in Top-3; 6 ranked first and `archify` ranked second
- every real Top-5 contained five unique capability names
- `tech-essay-writer` changed from occupying ranks 1-3 to one result with three explicit variant IDs
- maintained acceptance: 47/47 Top-3 before governance and 47/47 after governance
- no Agent files were changed

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (91 tests)
- Bootstrap Skill validation (`Skill is valid!`)
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- `git diff --check`
