### PR TITLE
feat: plan duplicate governance from findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "c142d98941fd32122ab7db893a5122aad7f29878"
-  version "1.0.3"
+      revision: "32de61249238904c344409592a17202dcaf88077"
+  version "1.0.4"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.0.3", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.0.4", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ source update. Raw filesystem operations are rejected. Library consolidation
 keeps canonical content recoverable and replaces verified duplicate placements
 with links; every applied sequence is bounded by a Receipt and can be undone.
 
+For an exact-duplicate Finding, the Agent submits only the choices it owns:
+
+```json
+{"schema_version":1,"finding_library_changes":[{"finding_id":"finding_...","canonical_placement_id":"placement_...","requested_state":"managed"}]}
+```
+
+SkillRoster resolves the current Snapshot, Evidence, Skill, and complete
+placement set from that immutable Finding and rejects stale or mismatched input.
+
 ## Status
 
 SkillRoster 1.0 implements the complete local governance loop,

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -144,7 +144,7 @@ Machine results should expose facts, not preformatted prose:
 
 - `primary_metrics` with value, unit, coverage, and comparison baseline;
 - Findings with stable ID, category, severity, Evidence quality, impact fields, and affected IDs;
-- a bounded `report --summary --json` first view with no more than three Findings and one primary Evidence reference, plus paged placement paths and Evidence facts from `report --finding ID --json`;
+- a bounded `report --summary --json` first view with no more than three Findings and one primary Evidence reference, plus paged placement paths and Evidence facts from `report --finding ID --json`; exact-duplicate detail also exposes at most five ranked, owned canonical candidates without requiring pagination;
 - Find results that keep the original task, expose Agent-authored retrieval hints, and collapse same-name identities into one explicitly variant capability result;
 - Plan `change_summary` counts and `impact` deltas for current and proposed state; source-update line details remain in `diff_summary`;
 - affected Agents, Skills, placements, operation groups, exclusions, and deletion count;

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -98,7 +98,10 @@ exhaustive view, not the bootstrap workflow default.
 Evidence records per collection. Its `page.next_offset` is the only pagination
 cursor; callers request another page only when the decision still lacks
 relevant evidence. Counts and `primary_evidence_id` remain available in the
-compact first view.
+compact first view. An actionable exact-duplicate Finding also returns a
+bounded `planning` object with at most five owned canonical candidates and the
+semantic `finding_library_changes` request shape; the complete placement set
+remains CLI-owned rather than Agent-copied.
 
 ### `find`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.0.3
+SKILLROSTER_VERSION=1.0.4
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.0.0 skillroster
+  --tag v1.0.4 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.0.0
+git checkout v1.0.4
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -83,7 +83,7 @@ Each Agent Roster classifies Skills as Core, On-demand, Explicit-only, or Archiv
 
 ### 4.4 Planning, mutation, and recovery
 
-Read-only commands never mutate Agent configuration or Skill contents. Agent recommendations enter the CLI through `plan --stdin` as structured data referencing Scan IDs, Skill IDs, Evidence IDs, and requested target states.
+Read-only commands never mutate Agent configuration or Skill contents. Agent recommendations enter the CLI through `plan --stdin` as structured target states. Most requests cite current Scan, Skill, and Evidence IDs directly. Exact-duplicate consolidation instead cites the immutable Finding plus the Agent's two semantic choices; the CLI derives the bound Snapshot, Evidence, Skill, and complete placement set.
 
 The CLI validates targets, ownership, conflicts, and current fingerprints, then stores an immutable Plan. `apply <plan-id>` executes only the approved scope. Cross-filesystem operations use a journal and compensating steps; the CLI never claims atomicity it cannot provide.
 

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -11,14 +11,15 @@ Use the local `skillroster` binary as the deterministic source of facts. Invoke 
 
 1. Run `skillroster scan --json`, then `skillroster report --summary --json`. Use the compact result for the first user-facing diagnosis; do not request the full report unless exhaustive Finding enumeration is necessary.
 2. Distinguish observed, inferred, and unknown usage. Missing evidence does not mean unused.
-3. Use stable Finding and Evidence IDs for follow-up questions. The summary exposes one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when the exact paths or Evidence affect the decision. Finding detail is paged. Continue with `--offset NEXT_OFFSET --limit 20` only until the requested decision has enough relevant evidence, and keep the same Snapshot rather than silently rescanning.
-4. Make semantic governance choices in the conversation, then submit declarative target states to `skillroster plan --stdin --json`. Set request `schema_version` to `1`, include the latest `scan_id` and one or more relevant `evidence_ids`, and submit only the supported governance fields.
+3. Use stable Finding and Evidence IDs for follow-up questions. The summary exposes one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Exact-duplicate detail includes a bounded `planning.canonical_candidates` list independently of pagination. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
+4. Make semantic governance choices in the conversation, then submit declarative target states to `skillroster plan --stdin --json`. For an exact-duplicate Finding, send `schema_version` plus `finding_library_changes`; SkillRoster derives the current Snapshot, Evidence, Skill, and complete placement set. For other request families, include the latest `scan_id` and relevant `evidence_ids`.
 5. Present the validated Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `impact` before/after facts, affected Agents, uncertainty, canonical deletion count, reversibility, and Plan ID. The source-oriented `diff_summary` may be empty for ordinary Roster or Library Plans; do not treat that as a missing Plan delta.
 
 Use only these Plan request families:
 
+- `finding_library_changes` (preferred for exact duplicates): `finding_id`, a `canonical_placement_id` chosen from `planning.canonical_candidates`, and `requested_state` (`managed` or `hosted`). Do not copy paged placement or Evidence IDs into this request.
 - `roster_changes`: `agent`, `skill_id`, and `state` (`core`, `on_demand`, `explicit_only`, or `archived`).
-- `library_changes`: `skill_id`, `canonical_placement_id`, the complete `placement_ids` set returned by the Snapshot, and `requested_state` (`managed` or `hosted`).
+- `library_changes`: the advanced raw form with `skill_id`, `canonical_placement_id`, the complete `placement_ids` set, and `requested_state`. Use it only when there is no exact-duplicate Finding to bind.
 - `source_updates`: the latest Skill/placement/source/revision/fingerprint facts plus upstream content and SHA-256 digest. If local content changed, include the user's explicit `choice`: `retain_local`, `adopt_upstream`, or `preserve_both`.
 
 Keep source updates and Library changes in separate Plans. Cite Evidence returned by the relevant Finding page; a convenient but unrelated Evidence ID is not support for a governance change. Treat a rejected stale Snapshot, Evidence ID, fingerprint, incomplete placement set, or source revision as a reason to rescan or ask the user—not as permission to weaken the request.

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::Utc;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
@@ -1044,7 +1044,7 @@ fn report_command(
         let stored = store
             .get_finding(&id)?
             .ok_or_else(|| anyhow!("Finding {id} does not exist"))?;
-        let mut details = stored.details;
+        let mut details = stored.details.clone();
         if let Some(object) = details.as_object_mut() {
             object.insert("report_id".into(), json!(stored.report_id));
             let report = store
@@ -1053,6 +1053,15 @@ fn report_command(
             let scan: ScanResult = store
                 .scan_payload(&report.scan_id)?
                 .ok_or_else(|| anyhow!("Snapshot {} is no longer retained", report.scan_id))?;
+            let latest_scan_id = store
+                .latest_completed_scan()?
+                .ok_or_else(|| anyhow!("no completed Snapshot exists"))?
+                .id;
+            if let Some(planning) =
+                finding_library_planning(&stored, &report.scan_id, &latest_scan_id, &scan)
+            {
+                object.insert("planning".into(), planning);
+            }
             let affected_skill_ids = object
                 .get("affected_skill_ids")
                 .and_then(Value::as_array)
@@ -1244,6 +1253,82 @@ fn report_command(
     } else {
         value
     })
+}
+
+fn finding_library_planning(
+    finding: &FindingRecord,
+    scan_id: &ScanId,
+    latest_scan_id: &ScanId,
+    scan: &ScanResult,
+) -> Option<Value> {
+    let (_, placement_ids) = exact_duplicate_finding_scope(finding, scan).ok()?;
+    if scan_id != latest_scan_id {
+        return Some(json!({
+            "supported": false,
+            "reason": "stale_finding",
+            "snapshot_id": scan_id,
+            "latest_snapshot_id": latest_scan_id
+        }));
+    }
+    let affected = placement_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut candidates = scan
+        .placements
+        .iter()
+        .filter(|placement| {
+            affected.contains(placement.id.as_str()) && placement.link_target.is_none()
+        })
+        .map(|placement| {
+            let (rank, reason) = if placement.agent.is_none() && !placement.default_exposed {
+                (0_u8, "non_exposed_source")
+            } else if !placement.default_exposed {
+                (1_u8, "non_exposed_owned_placement")
+            } else {
+                (2_u8, "agent_owned_placement")
+            };
+            (
+                rank,
+                placement.entrypoint.display().to_string(),
+                json!({
+                    "placement_id": placement.id,
+                    "path": placement.entrypoint,
+                    "agent": placement.agent.map(AgentKind::id),
+                    "default_exposed": placement.default_exposed,
+                    "reason": reason
+                }),
+            )
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| (left.0, &left.1).cmp(&(right.0, &right.1)));
+    let candidate_count = candidates.len();
+    let candidates = candidates
+        .into_iter()
+        .take(5)
+        .map(|(_, _, value)| value)
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return None;
+    }
+    Some(json!({
+        "supported": true,
+        "decision": "consolidate_exact_duplicates",
+        "snapshot_id": scan_id,
+        "request_field": "finding_library_changes",
+        "allowed_requested_states": ["managed", "hosted"],
+        "canonical_candidate_count": candidate_count,
+        "canonical_candidates_truncated": candidate_count > 5,
+        "canonical_candidates": candidates,
+        "plan_request_template": {
+            "schema_version": 1,
+            "finding_library_changes": [{
+                "finding_id": finding.id,
+                "canonical_placement_id": "<choose a canonical_candidates placement_id>",
+                "requested_state": "<managed|hosted>"
+            }]
+        }
+    }))
 }
 
 fn compact_report(report: &Value) -> Value {
@@ -1572,20 +1657,182 @@ struct SourceUpdateRequest {
     choice: Option<SourceUpdateChoice>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 enum RequestedGovernanceState {
     Managed,
     Hosted,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct LibraryChangeRequest {
     skill_id: String,
     canonical_placement_id: String,
     placement_ids: Vec<String>,
     requested_state: RequestedGovernanceState,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FindingLibraryChangeRequest {
+    finding_id: String,
+    canonical_placement_id: String,
+    requested_state: RequestedGovernanceState,
+}
+
+struct FindingPlanProvenance {
+    report_id: ReportId,
+    finding_ids: Vec<FindingId>,
+}
+
+fn exact_duplicate_finding_scope(
+    finding: &FindingRecord,
+    scan: &ScanResult,
+) -> Result<(String, Vec<String>)> {
+    if finding.category != FindingCategory::Overlap {
+        bail!("Finding {} is not an exact-duplicate Finding", finding.id);
+    }
+    let object = finding
+        .details
+        .as_object()
+        .ok_or_else(|| anyhow!("Finding {} has invalid stored details", finding.id))?;
+    let ids = |key: &str| -> Result<Vec<String>> {
+        object
+            .get(key)
+            .and_then(Value::as_array)
+            .ok_or_else(|| anyhow!("Finding {} has no {key}", finding.id))?
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .map(str::to_owned)
+                    .ok_or_else(|| anyhow!("Finding {} has an invalid {key}", finding.id))
+            })
+            .collect()
+    };
+    let skill_ids = ids("affected_skill_ids")?;
+    let placement_ids = ids("affected_placement_ids")?;
+    if skill_ids.len() != 1 || placement_ids.len() < 2 {
+        bail!("Finding {} is not an exact-duplicate Finding", finding.id);
+    }
+    let unique_ids = placement_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    if unique_ids.len() != placement_ids.len() {
+        bail!(
+            "Finding {} contains duplicate placement references",
+            finding.id
+        );
+    }
+    let skill_id = &skill_ids[0];
+    let all_placements = scan
+        .placements
+        .iter()
+        .filter(|placement| placement.skill_id == *skill_id)
+        .collect::<Vec<_>>();
+    let all_ids = all_placements
+        .iter()
+        .map(|placement| placement.id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    if unique_ids != all_ids {
+        bail!(
+            "Finding {} does not cover every placement of Skill {}",
+            finding.id,
+            skill_id
+        );
+    }
+    let digests = all_placements
+        .iter()
+        .map(|placement| placement.content_digest.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    if digests.len() != 1 {
+        bail!("Finding {} does not contain exact duplicates", finding.id);
+    }
+    Ok((skill_id.clone(), placement_ids))
+}
+
+fn expand_finding_library_changes(
+    store: &StateStore,
+    mut input: Value,
+    latest_scan_id: &ScanId,
+    scan: &ScanResult,
+) -> Result<(Value, Option<FindingPlanProvenance>)> {
+    let object = input
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("Plan input must be a JSON object"))?;
+    let raw = object
+        .remove("finding_library_changes")
+        .unwrap_or_else(|| json!([]));
+    let requests: Vec<FindingLibraryChangeRequest> = serde_json::from_value(raw)?;
+    if requests.is_empty() {
+        return Ok((input, None));
+    }
+    if [
+        "scan_id",
+        "evidence_ids",
+        "roster_changes",
+        "source_updates",
+        "library_changes",
+    ]
+    .iter()
+    .any(|key| object.contains_key(*key))
+    {
+        bail!(
+            "finding_library_changes cannot be mixed with CLI-derived IDs or other governance changes"
+        );
+    }
+
+    let mut evidence_ids = std::collections::BTreeSet::new();
+    let mut library_changes = Vec::with_capacity(requests.len());
+    let mut report_id = None;
+    let mut finding_ids = Vec::with_capacity(requests.len());
+    for request in requests {
+        let finding_id = FindingId::parse(request.finding_id)?;
+        let finding = store
+            .get_finding(&finding_id)?
+            .ok_or_else(|| anyhow!("Finding {finding_id} does not exist"))?;
+        let report = store
+            .get_report(&finding.report_id)?
+            .ok_or_else(|| anyhow!("Report {} does not exist", finding.report_id))?;
+        if report.scan_id != *latest_scan_id {
+            bail!("Finding {finding_id} does not belong to the latest Snapshot {latest_scan_id}");
+        }
+        if report_id
+            .as_ref()
+            .is_some_and(|existing| existing != &finding.report_id)
+        {
+            bail!("finding_library_changes must come from one Report");
+        }
+        report_id.get_or_insert_with(|| finding.report_id.clone());
+        let (skill_id, placement_ids) = exact_duplicate_finding_scope(&finding, scan)?;
+        if !placement_ids.contains(&request.canonical_placement_id) {
+            bail!("canonical placement is not part of Finding {finding_id}");
+        }
+        let evidence_id = finding
+            .evidence_ids
+            .first()
+            .ok_or_else(|| anyhow!("Finding {finding_id} has no Evidence"))?;
+        evidence_ids.insert(evidence_id.as_str().to_owned());
+        library_changes.push(LibraryChangeRequest {
+            skill_id,
+            canonical_placement_id: request.canonical_placement_id,
+            placement_ids,
+            requested_state: request.requested_state,
+        });
+        finding_ids.push(finding_id);
+    }
+    input["scan_id"] = json!(latest_scan_id);
+    input["evidence_ids"] = json!(evidence_ids);
+    input["library_changes"] = serde_json::to_value(library_changes)?;
+    Ok((
+        input,
+        Some(FindingPlanProvenance {
+            report_id: report_id.expect("non-empty Finding requests have a Report"),
+            finding_ids,
+        }),
+    ))
 }
 
 fn normalize_agent_plan(
@@ -2111,6 +2358,11 @@ fn prepare_plan(
         bail!("recovery is required before another Plan can be prepared");
     }
     let (scan_id, scan) = latest_scan(store)?;
+    let (input, finding_provenance) = if matches!(origin, PlanOrigin::Agent) {
+        expand_finding_library_changes(store, input, &scan_id, &scan)?
+    } else {
+        (input, None)
+    };
     let canonical_state_dir = std::fs::canonicalize(state_dir)?;
     let requested_scan_id = input["scan_id"]
         .as_str()
@@ -2217,6 +2469,9 @@ fn prepare_plan(
         input,
         roster_before.clone(),
         library_before.clone(),
+        finding_provenance
+            .as_ref()
+            .map(|provenance| provenance.report_id.clone()),
     )?)?;
     Ok(json!({
         "plan_id": prepared.id,
@@ -2226,6 +2481,10 @@ fn prepare_plan(
         "operations": prepared.operations,
         "roster_changes": prepared.roster_changes,
         "evidence_ids": prepared.evidence_ids,
+        "finding_ids": finding_provenance
+            .as_ref()
+            .map(|provenance| provenance.finding_ids.clone())
+            .unwrap_or_default(),
         "source_updates": prepared.source_updates,
         "library_changes": prepared.library_changes,
         "change_summary": change_summary,
@@ -3057,6 +3316,7 @@ fn plan_record(
     raw: Value,
     roster_before: Vec<Value>,
     library_before: Vec<Value>,
+    report_id: Option<ReportId>,
 ) -> Result<PlanRecord> {
     let operations = prepared
         .operations
@@ -3096,7 +3356,7 @@ fn plan_record(
     Ok(PlanRecord {
         id: PlanId::parse(prepared.id.clone())?,
         scan_id: ScanId::parse(prepared.scan_id.clone())?,
-        report_id: None,
+        report_id,
         created_at: Utc::now().timestamp(),
         status: PlanStatus::Ready,
         input: json!({

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1378,6 +1378,177 @@ fn library_governance_managed_and_hosted_round_trip_and_refuse_drift() {
 }
 
 #[test]
+fn exact_duplicate_finding_prepares_library_plan_from_semantic_choices() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let source_root = temp.path().join("sources");
+    let source_skill = source_root.join("shared");
+    let codex_skill = home.join(".codex/skills/shared");
+    let claude_skill = home.join(".claude/skills/shared");
+    let content = "---\nname: shared\ndescription: shared fixture\n---\nbody\n";
+    for directory in [&source_skill, &codex_skill, &claude_skill] {
+        fs::create_dir_all(directory).unwrap();
+        fs::write(directory.join("SKILL.md"), content).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--source-root",
+        source_root.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let report = json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Exact duplicate Skill placements")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let detail = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id]].concat(),
+        None,
+    ));
+    let planning = &detail["result"]["planning"];
+    assert_eq!(planning["supported"], true);
+    assert_eq!(planning["snapshot_id"], report["result"]["snapshot_id"]);
+    assert_eq!(planning["request_field"], "finding_library_changes");
+    let candidates = planning["canonical_candidates"].as_array().unwrap();
+    assert_eq!(planning["canonical_candidate_count"], 3);
+    assert_eq!(planning["canonical_candidates_truncated"], false);
+    assert_eq!(
+        candidates[0]["path"],
+        source_skill.join("SKILL.md").to_str().unwrap()
+    );
+    assert_eq!(candidates[0]["reason"], "non_exposed_source");
+    let canonical_placement_id = candidates[0]["placement_id"].as_str().unwrap();
+
+    let request = json!({
+        "schema_version": 1,
+        "finding_library_changes": [{
+            "finding_id": finding_id,
+            "canonical_placement_id": canonical_placement_id,
+            "requested_state": "managed"
+        }]
+    });
+    let plan = json_output(&run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&request.to_string()),
+    ));
+    assert_eq!(plan["result"]["risk"], "library_governance");
+    assert_eq!(plan["result"]["finding_ids"], json!([finding_id]));
+    assert_eq!(
+        plan["result"]["library_changes"][0]["placement_ids"]
+            .as_array()
+            .unwrap()
+            .len(),
+        3
+    );
+    assert_eq!(plan["result"]["evidence_ids"].as_array().unwrap().len(), 1);
+    assert_eq!(plan["result"]["files_changed"], false);
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let stored_report_id: String = database
+        .query_row(
+            "SELECT report_id FROM plans WHERE id = ?1",
+            [plan["result"]["plan_id"].as_str().unwrap()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stored_report_id, report["result"]["report_id"]);
+    assert!(
+        !fs::symlink_metadata(&codex_skill)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        !fs::symlink_metadata(&claude_skill)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+
+    let invalid_canonical = json!({
+        "schema_version": 1,
+        "finding_library_changes": [{
+            "finding_id": finding_id,
+            "canonical_placement_id": "placement_not_in_finding",
+            "requested_state": "managed"
+        }]
+    });
+    let rejected = run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&invalid_canonical.to_string()),
+    );
+    assert!(!rejected.status.success());
+    let rejected: Value = serde_json::from_slice(&rejected.stdout).unwrap();
+    assert!(
+        rejected["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("canonical placement is not part of Finding")
+    );
+
+    let non_overlap_finding = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["category"] != "overlap")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let wrong_finding_type = json!({
+        "schema_version": 1,
+        "finding_library_changes": [{
+            "finding_id": non_overlap_finding,
+            "canonical_placement_id": canonical_placement_id,
+            "requested_state": "managed"
+        }]
+    });
+    let rejected = run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&wrong_finding_type.to_string()),
+    );
+    assert!(!rejected.status.success());
+    let rejected: Value = serde_json::from_slice(&rejected.stdout).unwrap();
+    assert!(
+        rejected["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("is not an exact-duplicate Finding")
+    );
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let stale = run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&request.to_string()),
+    );
+    assert!(!stale.status.success());
+    let stale: Value = serde_json::from_slice(&stale.stdout).unwrap();
+    assert!(
+        stale["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("does not belong to the latest Snapshot")
+    );
+    let stale_detail = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id]].concat(),
+        None,
+    ));
+    assert_eq!(stale_detail["result"]["planning"]["supported"], false);
+    assert_eq!(
+        stale_detail["result"]["planning"]["reason"],
+        "stale_finding"
+    );
+}
+
+#[test]
 fn large_roster_apply_reduces_exposure_and_undo_restores_every_skill() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## Problem

Exact-duplicate governance forced Agent callers to page through every placement and copy Snapshot, Evidence, Skill, and placement IDs that SkillRoster already owns. A 51-placement case required about 72 KB of Finding detail and a 4.3 KB Plan request containing 55 opaque IDs.

## Solution

- add a Finding-bound `finding_library_changes` Plan request with only the Finding, canonical placement, and requested state
- derive and validate the latest Snapshot, Evidence, Skill, and complete placement set inside the CLI
- expose a bounded, ranked canonical-candidate list on exact-duplicate Finding detail
- retain Report/Finding provenance on the immutable Plan
- reject stale Findings, unrelated canonical placements, mixed raw input, and non-exact Findings
- update the bootstrap Skill and Agent-facing contracts

## Evidence

- real 7-placement replay: 956 bytes / 11 IDs -> 236 bytes / 2 IDs
- controlled 51-placement replay: 4,344 bytes / 55 IDs -> 236 bytes / 2 IDs
- no Agent files changed during Scan, Report, or Plan

## Checks

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (92 passed)
- bootstrap Skill validation
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- `git diff --check`
