### PR TITLE
feat: bound agent plan responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.0.4"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "32de61249238904c344409592a17202dcaf88077"
-  version "1.0.4"
+      revision: "be6b29445377cfa6d37f410ac50feae094ff3511"
+  version "1.1.0"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.0.4", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.1.0", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ skillroster report --finding <finding-id> --limit 20 --json
 skillroster find "database migration" --json
 skillroster find "诊断命令性能回归" --hint "diagnose command performance regression" --json
 skillroster plan --stdin --json
+skillroster plan --show <plan-id> --json
 skillroster apply <plan-id> --json
 skillroster undo <receipt-id> --json
 skillroster setup --json
@@ -60,6 +61,10 @@ Evidence IDs, then request Roster states, managed/hosted Library placement, or a
 source update. Raw filesystem operations are rejected. Library consolidation
 keeps canonical content recoverable and replaces verified duplicate placements
 with links; every applied sequence is bounded by a Receipt and can be undone.
+The initial Plan response is a bounded decision summary. Exact operations and
+complete internal ID lists remain in the immutable local Plan and are available
+on demand through `plan --show`, so large governance scopes do not flood the
+Agent's context.
 
 For an exact-duplicate Finding, the Agent submits only the choices it owns:
 

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -146,7 +146,7 @@ Machine results should expose facts, not preformatted prose:
 - Findings with stable ID, category, severity, Evidence quality, impact fields, and affected IDs;
 - a bounded `report --summary --json` first view with no more than three Findings and one primary Evidence reference, plus paged placement paths and Evidence facts from `report --finding ID --json`; exact-duplicate detail also exposes at most five ranked, owned canonical candidates without requiring pagination;
 - Find results that keep the original task, expose Agent-authored retrieval hints, and collapse same-name identities into one explicitly variant capability result;
-- Plan `change_summary` counts and `impact` deltas for current and proposed state; source-update line details remain in `diff_summary`;
+- bounded Plan `change_summary`, `operation_groups`, affected-scope counts and `impact` deltas for current and proposed state; source-update line details remain in the bounded `diff_summary`, while full operations are loaded only through `plan --show PLAN_ID` when needed;
 - affected Agents, Skills, placements, operation groups, exclusions, and deletion count;
 - risk, reversibility, drift, confirmation, and recovery state;
 - typed `suggested_actions` containing argv, mutation status, confirmation requirement, and reason code.

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -113,7 +113,7 @@ Empty results are calm, successful output. Find never implies activation.
 
 ### `plan`
 
-Show before/after Roster counts, affected Agents and Skills, operation categories, risk, reversibility, exclusions, and blocked preconditions. A ready Plan ends with its immutable ID and digest; it performs no mutation.
+Show before/after Roster counts, affected Agents and Skills, operation categories, risk, reversibility, exclusions, and blocked preconditions. A ready Plan ends with its immutable ID and digest; it performs no mutation. Agent JSON defaults to the bounded summary even when the stored Plan contains hundreds of operations. `plan --show PLAN_ID --json` explicitly returns the complete stored operations, changes, and before-state collections for audits or exact-path questions.
 
 ### `apply` and `undo`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.0.4
+SKILLROSTER_VERSION=1.1.0
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.0.4 skillroster
+  --tag v1.1.0 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.0.4
+git checkout v1.1.0
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -102,6 +102,7 @@ skillroster scan [--json]
 skillroster report [--finding <id>] [--json]
 skillroster find <task> [--hint <text>]... [--json]
 skillroster plan --stdin [--json]
+skillroster plan --show <plan-id> [--json]
 skillroster apply <plan-id> [--json]
 skillroster undo <receipt-id> [--json]
 skillroster status [--json]
@@ -132,6 +133,8 @@ All JSON responses use a versioned envelope:
 ```
 
 IDs for Agents, Scans, reports, Skills, placements, Evidence, Findings, Plans, operations, and Receipts are opaque and stable within the local state store. Names and paths are never write-operation identities. Errors carry a stable code, human-readable message, retryability, and relevant IDs or paths. In JSON mode stdout contains exactly one JSON document and never an interactive prompt, progress bar, ANSI sequence, or log line. Terminal output is a polished human interface; Agents consume JSON rather than scraping styled text. The normative human-output, accessibility, progress, confirmation, and responsive-layout requirements live in [cli-ux-spec.md](cli-ux-spec.md).
+
+`plan --stdin --json` returns a bounded decision-complete summary: total change counts, operation groups, affected-scope counts with at most ten Skill IDs, before/after impact, risk, reversibility, and the immutable Plan ID. It does not inline filesystem operations or complete large ID collections. `plan --show PLAN_ID --json` is the explicit full-detail path; it reads the stored Plan and never mutates files.
 
 ## 6. Agent presentation contract
 

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -13,7 +13,7 @@ Use the local `skillroster` binary as the deterministic source of facts. Invoke 
 2. Distinguish observed, inferred, and unknown usage. Missing evidence does not mean unused.
 3. Use stable Finding and Evidence IDs for follow-up questions. The summary exposes one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Exact-duplicate detail includes a bounded `planning.canonical_candidates` list independently of pagination. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
 4. Make semantic governance choices in the conversation, then submit declarative target states to `skillroster plan --stdin --json`. For an exact-duplicate Finding, send `schema_version` plus `finding_library_changes`; SkillRoster derives the current Snapshot, Evidence, Skill, and complete placement set. For other request families, include the latest `scan_id` and relevant `evidence_ids`.
-5. Present the validated Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `impact` before/after facts, affected Agents, uncertainty, canonical deletion count, reversibility, and Plan ID. The source-oriented `diff_summary` may be empty for ordinary Roster or Library Plans; do not treat that as a missing Plan delta.
+5. Present the validated summary Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `operation_groups`, bounded `affected` facts, `impact` before/after facts, uncertainty, canonical deletion count, reversibility, and Plan ID. The full immutable representation stays in local state; use `skillroster plan --show PLAN_ID --json` only when an exact operation, path, or complete ID list is needed to answer the user. Do not load it by default.
 
 Use only these Plan request families:
 
@@ -37,6 +37,8 @@ temporary source-root arguments. Keep unconfirmed targets unread.
 ## Apply or undo
 
 Show the complete immutable Plan before requesting one explicit confirmation. After the user confirms, run `skillroster apply PLAN_ID --json`; do not substitute direct filesystem commands or bypass drift checks. Report verification, changed-path count, Receipt ID, and canonical deletion count.
+
+“Complete” means the summary accounts for every affected Agent, Skill, placement, operation group, exclusion, risk, and before/after delta by count; it does not require copying every internal operation into the conversation. If the user asks for an exact path or operation, load the stored detail with `plan --show` before confirmation.
 
 For Undo, first explain the bounded Receipt impact and obtain one explicit confirmation, then run `skillroster undo RECEIPT_ID --json`.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -142,21 +142,33 @@ pub fn run(cli: Cli) -> Result<Output> {
             vec![],
             vec![],
         ),
-        Some(Command::Plan(_)) => {
-            let result = plan_command(&store, &state_dir)?;
+        Some(Command::Plan(args)) => {
+            let showing_detail = args.show.is_some();
+            let result = match args.show.as_deref() {
+                Some(id) => plan_detail_command(&store, id)?,
+                None => plan_command(&store, &state_dir)?,
+            };
             let id = result["plan_id"].as_str().unwrap_or_default().to_string();
-            (
-                "plan",
-                result,
-                vec![],
-                vec![action(
+            let mut actions = Vec::new();
+            if !showing_detail {
+                actions.push(action(
+                    "show_plan_detail",
+                    &["plan", "--show", &id, "--json"],
+                    false,
+                    false,
+                    "plan_detail_available",
+                ));
+            }
+            if result["state"].as_str() == Some("ready") {
+                actions.push(action(
                     "apply",
                     &["apply", &id, "--json"],
                     true,
                     true,
                     "plan_ready",
-                )],
-            )
+                ));
+            }
+            ("plan", result, vec![], actions)
         }
         Some(Command::Apply(args)) => {
             if !cli.json {
@@ -436,22 +448,7 @@ fn human_plan_preview(store: &StateStore, id: &str) -> Result<String> {
         .get_plan(&id)?
         .ok_or_else(|| anyhow!("Plan {id} does not exist"))?;
     let prepared: PreparedPlan = serde_json::from_value(record.input["prepared"].clone())?;
-    let raw = &record.input["raw"];
-    let risk = if raw["source_updates"]
-        .as_array()
-        .is_some_and(|v| !v.is_empty())
-    {
-        "source_update"
-    } else if raw["library_changes"]
-        .as_array()
-        .is_some_and(|v| !v.is_empty())
-    {
-        "library_governance"
-    } else if prepared.operations.is_empty() {
-        "roster_change"
-    } else {
-        "filesystem_change"
-    };
+    let risk = plan_risk(&record.input["raw"], &prepared);
     Ok(crate::present::human(
         "plan",
         &json!({
@@ -1625,6 +1622,207 @@ fn plan_command(store: &StateStore, state_dir: &Path) -> Result<Value> {
     )
 }
 
+fn plan_detail_command(store: &StateStore, id: &str) -> Result<Value> {
+    let id = PlanId::parse(id.to_owned())?;
+    let record = store
+        .get_plan(&id)?
+        .ok_or_else(|| anyhow!("Plan {id} does not exist"))?;
+    let prepared: PreparedPlan = serde_json::from_value(record.input["prepared"].clone())?;
+    Ok(json!({
+        "detail_level": "full",
+        "plan_id": prepared.id,
+        "snapshot_id": prepared.scan_id,
+        "report_id": record.report_id,
+        "digest": prepared.digest,
+        "state": record.status,
+        "operations": prepared.operations,
+        "roster_changes": prepared.roster_changes,
+        "evidence_ids": prepared.evidence_ids,
+        "finding_ids": record
+            .input
+            .get("finding_ids")
+            .cloned()
+            .unwrap_or_else(|| json!([])),
+        "source_updates": prepared.source_updates,
+        "library_changes": prepared.library_changes,
+        "roster_before": record.input["roster_before"].clone(),
+        "library_before": record.input["library_before"].clone(),
+        "risk": plan_risk(&record.input["raw"], &prepared),
+        "reversible": true,
+        "canonical_deletion_count": 0,
+        "confirmation_required": true,
+        "files_changed": false
+    }))
+}
+
+fn plan_risk(raw: &Value, prepared: &PreparedPlan) -> &'static str {
+    if raw["source_updates"]
+        .as_array()
+        .is_some_and(|values| !values.is_empty())
+    {
+        "source_update"
+    } else if raw["library_changes"]
+        .as_array()
+        .is_some_and(|values| !values.is_empty())
+    {
+        "library_governance"
+    } else if prepared.operations.is_empty() {
+        "roster_change"
+    } else {
+        "filesystem_change"
+    }
+}
+
+fn operation_groups(operations: &[Operation]) -> Value {
+    let mut groups = std::collections::BTreeMap::<&str, usize>::new();
+    for operation in operations {
+        let kind = match operation {
+            Operation::CreateDirectory { .. } => "create_directory",
+            Operation::CreateSymlink { .. } => "create_symlink",
+            Operation::WriteFile { .. } => "write_file",
+            Operation::ReplaceFile { .. } => "replace_file",
+            Operation::RemoveSymlink { .. } => "remove_symlink",
+            Operation::Copy { .. } => "copy",
+            Operation::MoveRecoverable { .. } => "move_recoverable",
+        };
+        *groups.entry(kind).or_default() += 1;
+    }
+    json!(groups)
+}
+
+fn affected_summary(prepared: &PreparedPlan, scan: &ScanResult) -> Value {
+    let mut agents = prepared
+        .roster_changes
+        .iter()
+        .map(|change| change.agent.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    let skills = prepared
+        .roster_changes
+        .iter()
+        .map(|change| change.skill_id.clone())
+        .chain(
+            prepared
+                .library_changes
+                .iter()
+                .map(|change| change.skill_id.clone()),
+        )
+        .chain(
+            prepared
+                .source_updates
+                .iter()
+                .map(|change| change.skill_id.clone()),
+        )
+        .collect::<std::collections::BTreeSet<_>>();
+    let placements = prepared
+        .library_changes
+        .iter()
+        .flat_map(|change| change.placement_ids.iter().cloned())
+        .chain(
+            prepared
+                .source_updates
+                .iter()
+                .map(|change| change.placement_id.clone()),
+        )
+        .collect::<std::collections::BTreeSet<_>>();
+    for placement in &scan.placements {
+        if placements.contains(&placement.id) {
+            if let Some(agent) = placement.agent {
+                agents.insert(agent.id().to_owned());
+            }
+        }
+    }
+    let skill_count = skills.len();
+    let skill_ids = skills.iter().take(10).cloned().collect::<Vec<_>>();
+    json!({
+        "agent_count": agents.len(),
+        "agents": agents,
+        "skill_count": skill_count,
+        "skill_ids": skill_ids,
+        "skill_ids_truncated": skill_count > 10,
+        "placement_count": placements.len()
+    })
+}
+
+fn bounded_ids(ids: Vec<String>) -> Value {
+    json!({
+        "count": ids.len(),
+        "ids": ids.iter().take(10).collect::<Vec<_>>(),
+        "ids_truncated": ids.len() > 10
+    })
+}
+
+fn state_counts(values: &[Value], key: &str) -> Value {
+    let mut counts = std::collections::BTreeMap::<String, usize>::new();
+    for value in values {
+        let state = value
+            .get(key)
+            .and_then(Value::as_str)
+            .unwrap_or("unassigned");
+        *counts.entry(state.to_owned()).or_default() += 1;
+    }
+    json!(counts)
+}
+
+fn bound_transition(value: &mut Value, after_state_key: &str) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    let before = object
+        .remove("before")
+        .and_then(|value| value.as_array().cloned())
+        .unwrap_or_default();
+    let after = object
+        .remove("after")
+        .and_then(|value| value.as_array().cloned())
+        .unwrap_or_default();
+    object.insert("change_count".into(), json!(after.len()));
+    object.insert("before_state_counts".into(), state_counts(&before, "state"));
+    object.insert(
+        "after_state_counts".into(),
+        state_counts(&after, after_state_key),
+    );
+}
+
+fn bounded_plan_impact(mut impact: Value) -> Value {
+    let Some(object) = impact.as_object_mut() else {
+        let items = impact.as_array().cloned().unwrap_or_default();
+        return json!({
+            "item_count": items.len(),
+            "items": items.iter().take(10).collect::<Vec<_>>(),
+            "items_truncated": items.len() > 10
+        });
+    };
+    for (ids_key, count_key) in [
+        ("affected_skill_ids", "affected_skill_count"),
+        ("affected_placement_ids", "affected_placement_count"),
+    ] {
+        if let Some(ids) = object
+            .remove(ids_key)
+            .and_then(|value| value.as_array().cloned())
+        {
+            object.insert(count_key.into(), json!(ids.len()));
+        }
+    }
+    if let Some(exclusions) = object
+        .remove("exclusions")
+        .and_then(|value| value.as_array().cloned())
+    {
+        object.insert("exclusion_count".into(), json!(exclusions.len()));
+        object.insert(
+            "exclusions".into(),
+            json!(exclusions.iter().take(5).collect::<Vec<_>>()),
+        );
+        object.insert("exclusions_truncated".into(), json!(exclusions.len() > 5));
+    }
+    if let Some(roster) = object.get_mut("roster") {
+        bound_transition(roster, "state");
+    }
+    if let Some(library) = object.get_mut("library") {
+        bound_transition(library, "requested_state");
+    }
+    impact
+}
+
 #[derive(Clone, Copy)]
 enum PlanOrigin {
     Agent,
@@ -2464,43 +2662,72 @@ fn prepare_plan(
         );
         object.insert("operation_count".into(), json!(prepared.operations.len()));
     }
+    let finding_ids = finding_provenance
+        .as_ref()
+        .map(|provenance| provenance.finding_ids.clone())
+        .unwrap_or_default();
+    let report_id = finding_provenance
+        .as_ref()
+        .map(|provenance| provenance.report_id.clone());
+    let risk = match effective_origin {
+        PlanOrigin::Agent => "roster_change",
+        PlanOrigin::RosterGovernance => "roster_change",
+        PlanOrigin::BootstrapSetup => "filesystem_change",
+        PlanOrigin::SourceUpdate => "source_update",
+        PlanOrigin::LibraryGovernance => "library_governance",
+    };
+    let operations_by_kind = operation_groups(&prepared.operations);
+    let affected = affected_summary(&prepared, &scan);
+    let impact = bounded_plan_impact(impact);
+    let diff_items = if matches!(effective_origin, PlanOrigin::SourceUpdate) {
+        source_update_diffs.iter().take(10).collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
     store.save_plan(&plan_record(
         &prepared,
         input,
         roster_before.clone(),
         library_before.clone(),
-        finding_provenance
-            .as_ref()
-            .map(|provenance| provenance.report_id.clone()),
+        report_id,
+        finding_ids.clone(),
     )?)?;
     Ok(json!({
+        "detail_level": "summary",
         "plan_id": prepared.id,
         "snapshot_id": prepared.scan_id,
         "digest": prepared.digest,
         "state": "ready",
-        "operations": prepared.operations,
-        "roster_changes": prepared.roster_changes,
-        "evidence_ids": prepared.evidence_ids,
-        "finding_ids": finding_provenance
-            .as_ref()
-            .map(|provenance| provenance.finding_ids.clone())
-            .unwrap_or_default(),
-        "source_updates": prepared.source_updates,
-        "library_changes": prepared.library_changes,
+        "evidence": bounded_ids(prepared.evidence_ids.clone()),
+        "findings": bounded_ids(
+            finding_ids.iter().map(ToString::to_string).collect::<Vec<_>>()
+        ),
         "change_summary": change_summary,
-        "diff_summary": if matches!(effective_origin, PlanOrigin::SourceUpdate) {
-            json!(source_update_diffs)
-        } else {
-            json!([])
+        "operation_groups": operations_by_kind,
+        "affected": affected,
+        "diff_summary": {
+            "item_count": if matches!(effective_origin, PlanOrigin::SourceUpdate) {
+                source_update_diffs.len()
+            } else {
+                0
+            },
+            "items": diff_items,
+            "items_truncated": matches!(effective_origin, PlanOrigin::SourceUpdate)
+                && source_update_diffs.len() > 10
         },
         "impact": impact,
-        "risk": match effective_origin {
-            PlanOrigin::Agent => "roster_change",
-            PlanOrigin::RosterGovernance => "roster_change",
-            PlanOrigin::BootstrapSetup => "filesystem_change",
-            PlanOrigin::SourceUpdate => "source_update",
-            PlanOrigin::LibraryGovernance => "library_governance",
+        "detail": {
+            "available": true,
+            "command": ["plan", "--show", prepared.id, "--json"],
+            "contains": [
+                "operations",
+                "roster_changes",
+                "source_updates",
+                "library_changes",
+                "before_state"
+            ]
         },
+        "risk": risk,
         "reversible": true,
         "canonical_deletion_count": 0,
         "confirmation_required": true,
@@ -2736,7 +2963,9 @@ fn setup_command(store: &StateStore, home: &Path, state_dir: &Path) -> Result<Va
         json!({"schema_version": 1, "scan_id": snapshot.id, "operations": operations}),
         PlanOrigin::BootstrapSetup,
     )?;
-    let operation_count = plan["operations"].as_array().map_or(0, Vec::len);
+    let operation_count = plan["change_summary"]["operation_count"]
+        .as_u64()
+        .unwrap_or_default();
     Ok(json!({
         "detected_agents": detected,
         "plan_id": plan["plan_id"],
@@ -3317,6 +3546,7 @@ fn plan_record(
     roster_before: Vec<Value>,
     library_before: Vec<Value>,
     report_id: Option<ReportId>,
+    finding_ids: Vec<FindingId>,
 ) -> Result<PlanRecord> {
     let operations = prepared
         .operations
@@ -3362,6 +3592,7 @@ fn plan_record(
         input: json!({
             "raw": raw,
             "prepared": prepared,
+            "finding_ids": finding_ids,
             "roster_before": roster_before,
             "library_before": library_before
         }),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,6 +107,10 @@ pub struct FindArgs {
 pub struct PlanArgs {
     #[arg(long, default_value_t = true)]
     pub stdin: bool,
+
+    /// Show the complete stored representation of an immutable Plan.
+    #[arg(long, value_name = "PLAN_ID")]
+    pub show: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/src/present.rs
+++ b/src/present.rs
@@ -344,25 +344,39 @@ fn find(value: &Value, lines: &mut Vec<String>, width: usize) {
 
 fn plan(value: &Value, lines: &mut Vec<String>) {
     fact(lines, "Plan", text(value, "plan_id"));
-    fact(lines, "Operations", array_len(value, "operations"));
+    let operation_count = value
+        .pointer("/change_summary/operation_count")
+        .and_then(Value::as_u64)
+        .and_then(|count| usize::try_from(count).ok())
+        .unwrap_or_else(|| array_len(value, "operations"));
+    fact(lines, "Operations", operation_count);
     let operation_categories = value
-        .get("operations")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|item| item.get("kind").and_then(Value::as_str))
-        .fold(
-            std::collections::BTreeMap::<&str, usize>::new(),
-            |mut counts, kind| {
-                *counts.entry(kind).or_default() += 1;
-                counts
-            },
-        );
-    fact(
-        lines,
-        "Operation categories",
-        map_counts(&operation_categories),
-    );
+        .get("operation_groups")
+        .and_then(Value::as_object)
+        .map(|groups| {
+            groups
+                .iter()
+                .map(|(kind, count)| format!("{kind} {}", count.as_u64().unwrap_or_default()))
+                .collect::<Vec<_>>()
+                .join(" · ")
+        })
+        .unwrap_or_else(|| {
+            let counts = value
+                .get("operations")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|item| item.get("kind").and_then(Value::as_str))
+                .fold(
+                    std::collections::BTreeMap::<&str, usize>::new(),
+                    |mut counts, kind| {
+                        *counts.entry(kind).or_default() += 1;
+                        counts
+                    },
+                );
+            map_counts(&counts)
+        });
+    fact(lines, "Operation categories", operation_categories);
     let roster_changes = value
         .get("roster_changes")
         .and_then(Value::as_array)
@@ -386,26 +400,89 @@ fn plan(value: &Value, lines: &mut Vec<String>) {
                 counts
             },
         );
-    let roster_transition = match (
-        value
-            .pointer("/impact/before_default_exposure")
-            .and_then(Value::as_u64),
-        value
-            .pointer("/impact/after_default_exposure")
-            .and_then(Value::as_u64),
-    ) {
-        (Some(before), Some(after)) => {
-            format!("default exposure {before} → {after}")
-        }
-        _ => format!("current stored states → {}", map_counts(&after)),
+    let risk = text(value, "risk");
+    let (transition_label, transition) = if risk == "library_governance" {
+        let items = value
+            .pointer("/impact/items")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let relinked = items
+            .iter()
+            .filter_map(|item| item.pointer("/after/relinked_placement_count"))
+            .filter_map(Value::as_u64)
+            .sum::<u64>();
+        let before = items
+            .first()
+            .and_then(|item| item.pointer("/before/governance_state"))
+            .and_then(Value::as_str)
+            .unwrap_or("current");
+        let after = items
+            .first()
+            .and_then(|item| item.pointer("/after/governance_state"))
+            .and_then(Value::as_str)
+            .unwrap_or("planned");
+        (
+            "Library before → after",
+            format!("{before} → {after} · {relinked} placements relinked"),
+        )
+    } else if risk == "source_update" {
+        (
+            "Source updates",
+            format!(
+                "{} reviewed changes",
+                value
+                    .pointer("/diff_summary/item_count")
+                    .and_then(Value::as_u64)
+                    .unwrap_or_default()
+            ),
+        )
+    } else if risk == "filesystem_change" {
+        ("Filesystem change", format!("{operation_count} operations"))
+    } else {
+        let transition = match (
+            value
+                .pointer("/impact/before_default_exposure")
+                .and_then(Value::as_u64),
+            value
+                .pointer("/impact/after_default_exposure")
+                .and_then(Value::as_u64),
+        ) {
+            (Some(before), Some(after)) => format!("default exposure {before} → {after}"),
+            _ => value
+                .pointer("/impact/roster/after_state_counts")
+                .and_then(Value::as_object)
+                .map(|counts| {
+                    counts
+                        .iter()
+                        .map(|(state, count)| {
+                            format!("{state} {}", count.as_u64().unwrap_or_default())
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" · ")
+                })
+                .map(|after| format!("current stored states → {after}"))
+                .unwrap_or_else(|| format!("current stored states → {}", map_counts(&after))),
+        };
+        ("Roster before → after", transition)
     };
-    fact(lines, "Roster before → after", roster_transition);
+    fact(lines, transition_label, transition);
     fact(
         lines,
         "Affected",
-        format!("{} Agents · {} Skills", agents.len(), skills.len()),
+        format!(
+            "{} Agents · {} Skills",
+            value
+                .pointer("/affected/agent_count")
+                .and_then(Value::as_u64)
+                .unwrap_or(agents.len() as u64),
+            value
+                .pointer("/affected/skill_count")
+                .and_then(Value::as_u64)
+                .unwrap_or(skills.len() as u64)
+        ),
     );
-    fact(lines, "Risk", text(value, "risk"));
+    fact(lines, "Risk", risk);
     fact(lines, "Reversible", text(value, "reversible"));
     fact(
         lines,
@@ -912,6 +989,38 @@ mod tests {
         assert!(planned.contains("current stored states → core 1 · on_demand 1"));
         assert!(planned.contains("2 Agents · 1 Skills"));
         assert!(planned.contains("Reversible"));
+
+        let library = render(
+            "plan",
+            &json!({
+                "plan_id": "plan_2",
+                "change_summary": {"operation_count": 101},
+                "operation_groups": {
+                    "create_directory": 1,
+                    "create_symlink": 50,
+                    "move_recoverable": 50
+                },
+                "affected": {"agent_count": 1, "skill_count": 1},
+                "impact": {"items": [{
+                    "before": {"governance_state": "observed"},
+                    "after": {
+                        "governance_state": "managed",
+                        "relinked_placement_count": 50
+                    }
+                }]},
+                "risk": "library_governance",
+                "reversible": true,
+                "canonical_deletion_count": 0,
+                "state": "ready"
+            }),
+            RenderOptions {
+                width: 80,
+                styled: false,
+            },
+        );
+        assert!(library.contains("Library before → after"));
+        assert!(library.contains("observed → managed · 50 placements relinked"));
+        assert!(!library.contains("no Roster changes"));
     }
 
     fn strip_ansi(value: &str) -> String {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -368,11 +368,11 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
         Some(&plan_input),
     ));
     assert_eq!(plan["result"]["files_changed"], false);
-    assert_eq!(plan["result"]["evidence_ids"][0], evidence_id);
+    assert_eq!(plan["result"]["evidence"]["ids"][0], evidence_id);
     assert_eq!(plan["result"]["change_summary"]["roster_change_count"], 1);
     assert_eq!(
-        plan["result"]["impact"]["roster"]["after"][0]["state"],
-        "on_demand"
+        plan["result"]["impact"]["roster"]["after_state_counts"]["on_demand"],
+        1
     );
     let plan_id = plan["result"]["plan_id"].as_str().unwrap();
 
@@ -935,11 +935,11 @@ fn source_update_requires_conflict_choice_and_round_trips_adoption() {
     ));
     assert_eq!(plan["result"]["risk"], "source_update");
     assert_eq!(
-        plan["result"]["diff_summary"][0]["choice_reason"],
+        plan["result"]["diff_summary"]["items"][0]["choice_reason"],
         "first_observed_baseline_untrusted"
     );
     assert_eq!(
-        plan["result"]["diff_summary"][0]["choice"],
+        plan["result"]["diff_summary"]["items"][0]["choice"],
         "adopt_upstream"
     );
     let applied = json_output(&run(
@@ -998,7 +998,7 @@ fn source_update_requires_conflict_choice_and_round_trips_adoption() {
         Some(&trusted_request.to_string()),
     ));
     assert_eq!(
-        trusted_plan["result"]["diff_summary"][0]["choice_reason"],
+        trusted_plan["result"]["diff_summary"]["items"][0]["choice_reason"],
         "trusted_baseline_clean"
     );
     let undone = json_output(&run(&[&common[..], &["undo", receipt]].concat(), None));
@@ -1391,6 +1391,11 @@ fn exact_duplicate_finding_prepares_library_plan_from_semantic_choices() {
         fs::create_dir_all(directory).unwrap();
         fs::write(directory.join("SKILL.md"), content).unwrap();
     }
+    for index in 0..48 {
+        let directory = home.join(format!(".codex/skills/shared-copy-{index:02}"));
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(directory.join("SKILL.md"), content).unwrap();
+    }
     let common = [
         "--home",
         home.to_str().unwrap(),
@@ -1420,8 +1425,8 @@ fn exact_duplicate_finding_prepares_library_plan_from_semantic_choices() {
     assert_eq!(planning["snapshot_id"], report["result"]["snapshot_id"]);
     assert_eq!(planning["request_field"], "finding_library_changes");
     let candidates = planning["canonical_candidates"].as_array().unwrap();
-    assert_eq!(planning["canonical_candidate_count"], 3);
-    assert_eq!(planning["canonical_candidates_truncated"], false);
+    assert_eq!(planning["canonical_candidate_count"], 51);
+    assert_eq!(planning["canonical_candidates_truncated"], true);
     assert_eq!(
         candidates[0]["path"],
         source_skill.join("SKILL.md").to_str().unwrap()
@@ -1437,26 +1442,54 @@ fn exact_duplicate_finding_prepares_library_plan_from_semantic_choices() {
             "requested_state": "managed"
         }]
     });
-    let plan = json_output(&run(
+    let plan_output = run(
         &[&common[..], &["plan", "--stdin"]].concat(),
         Some(&request.to_string()),
-    ));
+    );
+    assert!(
+        plan_output.stdout.len() < 8_000,
+        "summary response was {} bytes",
+        plan_output.stdout.len()
+    );
+    let plan = json_output(&plan_output);
     assert_eq!(plan["result"]["risk"], "library_governance");
-    assert_eq!(plan["result"]["finding_ids"], json!([finding_id]));
+    assert_eq!(plan["result"]["findings"]["ids"], json!([finding_id]));
+    assert_eq!(plan["result"]["detail_level"], "summary");
+    assert!(plan["result"].get("operations").is_none());
+    assert!(plan["result"].get("library_changes").is_none());
+    assert_eq!(plan["result"]["change_summary"]["operation_count"], 101);
+    assert_eq!(plan["result"]["affected"]["placement_count"], 51);
+    assert_eq!(plan["result"]["affected"]["agent_count"], 2);
     assert_eq!(
-        plan["result"]["library_changes"][0]["placement_ids"]
+        plan["result"]["affected"]["agents"],
+        json!(["claude-code", "codex"])
+    );
+    assert_eq!(plan["result"]["evidence"]["count"], 1);
+    assert_eq!(plan["result"]["files_changed"], false);
+    let plan_id = plan["result"]["plan_id"].as_str().unwrap();
+    assert_eq!(
+        plan["result"]["detail"]["command"],
+        json!(["plan", "--show", plan_id, "--json"])
+    );
+    let full_output = run(&[&common[..], &["plan", "--show", plan_id]].concat(), None);
+    assert!(full_output.stdout.len() > plan_output.stdout.len());
+    let full = json_output(&full_output);
+    assert_eq!(full["result"]["detail_level"], "full");
+    assert_eq!(full["result"]["operations"].as_array().unwrap().len(), 101);
+    assert_eq!(
+        full["result"]["library_changes"][0]["placement_ids"]
             .as_array()
             .unwrap()
             .len(),
-        3
+        51
     );
-    assert_eq!(plan["result"]["evidence_ids"].as_array().unwrap().len(), 1);
-    assert_eq!(plan["result"]["files_changed"], false);
+    assert_eq!(full["result"]["finding_ids"], json!([finding_id]));
+    assert_eq!(full["result"]["files_changed"], false);
     let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
     let stored_report_id: String = database
         .query_row(
             "SELECT report_id FROM plans WHERE id = ?1",
-            [plan["result"]["plan_id"].as_str().unwrap()],
+            [plan_id],
             |row| row.get(0),
         )
         .unwrap();
@@ -1607,10 +1640,28 @@ fn large_roster_apply_reduces_exposure_and_undo_restores_every_skill() {
         "evidence_ids": [evidence_id],
         "roster_changes": roster_changes
     });
-    let plan = json_output(&run(
+    let plan_output = run(
         &[&common[..], &["plan", "--stdin"]].concat(),
         Some(&proposal.to_string()),
-    ));
+    );
+    assert!(
+        plan_output.stdout.len() < 12_000,
+        "large Roster summary was {} bytes",
+        plan_output.stdout.len()
+    );
+    let plan = json_output(&plan_output);
+    assert_eq!(plan["result"]["detail_level"], "summary");
+    assert!(plan["result"].get("operations").is_none());
+    assert!(plan["result"].get("roster_changes").is_none());
+    assert_eq!(plan["result"]["affected"]["skill_count"], 101);
+    assert!(
+        plan["result"]["affected"]["skill_ids"]
+            .as_array()
+            .unwrap()
+            .len()
+            <= 10
+    );
+    assert_eq!(plan["result"]["affected"]["skill_ids_truncated"], true);
     assert_eq!(plan["result"]["impact"]["before_default_exposure"], 101);
     assert!(
         plan["result"]["impact"]["after_default_exposure"]


### PR DESCRIPTION
## Problem

SkillRoster 1.0.4 reduced a 51-placement Plan request to 236 bytes, but the resulting Agent JSON still exposed the complete internal execution representation: 43 KB and 101 filesystem operations. A 101-Skill Roster Plan reached 208 KB. Mechanical detail had moved from request construction into the Agent's response context.

## Solution

- make `plan --stdin --json` return a bounded, decision-complete summary
- summarize operation groups, affected Agents/Skills/placements, state transitions, Evidence/Finding references, exclusions, and source diffs with explicit counts and truncation facts
- add read-only `plan --show PLAN_ID --json` for the complete immutable operations and before-state collections
- keep Apply bound to the full Plan stored in SQLite, independent of the summary representation
- preserve Finding/Report provenance in stored Plans
- render Library, Roster, source-update, and filesystem transitions with type-correct terminal labels
- update the bootstrap Skill to load full detail only for exact path or operation questions

## Real Agent replay

- 51 placements / 101 operations: default response 43,106 -> 2,162 bytes (about 95% smaller)
- full detail remains 43,106 bytes through explicit `plan --show`
- summary correctly reports 1 affected Agent, 1 Skill, 51 placements, and all operation-group counts
- Apply changed 101 paths and created 50 links; Undo restored all placements and removed all links
- planning and detail inspection changed no files

## Checks

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (92 passed)
- bootstrap Skill validation
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- `git diff --check`
