### PR TITLE
Safely upgrade bootstrap Skills

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.sh text eol=lf
+skill/**/SKILL.md text eol=lf
+tests/fixtures/bootstrap-*.md text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "be6b29445377cfa6d37f410ac50feae094ff3511"
-  version "1.1.0"
+      revision: "cd71da7a6adb341fb29bacd201375047cd4b541b"
+  version "1.2.0"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.1.0", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.2.0", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "cd71da7a6adb341fb29bacd201375047cd4b541b"
+      revision: "0c139cc604d907250227ccea246ec8387a16b265"
   version "1.2.0"
 
   depends_on "rust" => :build

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Plan/Receipt history or deleting the local database.
 See [docs/installation.md](docs/installation.md) for verified Release, Cargo,
 and Homebrew installation paths.
 
+Run `setup` after the first Scan and after each CLI upgrade. Missing or exact
+official older bootstrap Skills become a recoverable Plan. A locally modified
+copy is never replaced implicitly: the Agent must show the affected targets and
+ask the user before retrying with `--modified-choice retain-local` or
+`--modified-choice adopt-current`. Links, non-files, and unreadable targets are
+preserved and reported as blocked.
+
 `--root AGENT=PATH` adds an Agent placement root and therefore contributes to
 that Agent's default exposure. `--source-root PATH` approves a non-exposed
 canonical source directory for the current Scan. Neither option crawls outside

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -48,6 +48,8 @@ The Agent selects one primary action from current state:
 | Applied | Show verification and Receipt | 完成 |
 | Undo available | Show reverse impact on request | 撤销上次应用 |
 | Recovery required | Stop unrelated writes | 处理恢复 |
+| Bootstrap modified | Show affected targets and ask retain/adopt | 保留本地 or 采用当前版 |
+| Bootstrap target unsupported | Explain the preserved link/non-file | 检查目标 |
 
 The Agent never manufactures a problem so that an Apply action exists.
 
@@ -162,6 +164,13 @@ The Agent discovers 100+ Skills, creates a Plan in the same read-only turn, make
 ### Healthy setup
 
 The Agent reports that no change is justified and does not create artificial archive or consolidation work.
+
+### Bootstrap upgrade
+
+After a CLI upgrade, the Agent runs `setup`. Exact official older bootstrap
+content produces a recoverable upgrade Plan. Locally modified content produces
+no Plan until the person explicitly chooses retain or adopt; unsupported
+targets remain untouched.
 
 ### Partial Evidence
 

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -121,7 +121,13 @@ Human TTY mode repeats the exact Plan or Receipt impact before confirmation. JSO
 
 ### `setup`
 
-Show detected Agents and exact bootstrap Skill targets. Installation remains a normal Plan followed by Apply.
+Show the bundled bootstrap version, detected Agents, exact targets, verified
+installed version when known, and counts for current, missing,
+official-outdated, locally modified, and unsupported states. Installation and
+official upgrades remain a normal Plan followed by Apply. A modified copy
+stops planning until the user chooses `retain-local` or `adopt-current`; the
+Agent must not choose. Unsupported targets remain unchanged and are shown as
+blocked.
 
 ## 7. Confirmation language
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.1.0
+SKILLROSTER_VERSION=1.2.0
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.1.0 skillroster
+  --tag v1.2.0 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.1.0
+git checkout v1.2.0
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```
@@ -68,3 +68,20 @@ The repository is public, so cloning the source and downloading Release
 archives do not require GitHub authentication. This is a checked-in Formula,
 not yet a published Homebrew tap. Never paste a GitHub token into the Formula
 or a command line.
+
+## Install or upgrade the Agent bootstrap Skill
+
+After installing a new CLI version, refresh the local Snapshot and inspect all
+detected bootstrap targets:
+
+```sh
+skillroster scan --json
+skillroster setup --json
+```
+
+`setup` changes no files. Apply its returned Plan only after review. Exact
+official older copies are upgraded through the same reversible Plan/Receipt
+path as first installation. If setup reports `modified_choice_required`, ask
+the user whether to retain the local copy or adopt the current bundled copy;
+never infer the choice. `unsupported_targets` means links, non-files, or
+unreadable paths were preserved for manual inspection.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -106,10 +106,16 @@ skillroster plan --show <plan-id> [--json]
 skillroster apply <plan-id> [--json]
 skillroster undo <receipt-id> [--json]
 skillroster status [--json]
-skillroster setup [--json]
+skillroster setup [--modified-choice retain-local|adopt-current] [--json]
 ```
 
-`setup` detects supported Agents and returns a preview for installing the single bootstrap Skill. In JSON mode it never prompts or mutates; the installation is represented by a Plan and completed through the normal Apply path.
+`setup` detects supported Agents and returns a preview for installing or
+upgrading the single bootstrap Skill. Exact official older copies are eligible
+for automatic planning. Unknown content is treated as a local modification and
+requires an explicit retain/adopt choice before any Plan is created. Links,
+non-files, and unreadable targets are blocked. In JSON mode setup never prompts
+or mutates; every write remains a normal Plan completed through Apply and
+recoverable through Undo.
 
 `find` preserves the user's original task and accepts repeatable Agent-authored
 retrieval hints. Hints let the semantic caller supply a cross-language or

--- a/src/app.rs
+++ b/src/app.rs
@@ -3008,6 +3008,17 @@ fn bootstrap_content_status(digest: &str, current_digest: &str) -> BootstrapCont
     }
 }
 
+fn normalized_bootstrap_content(content: &str) -> String {
+    content.replace("\r\n", "\n")
+}
+
+fn bootstrap_content_digest(content: &[u8]) -> String {
+    match std::str::from_utf8(content) {
+        Ok(content) => content_digest(normalized_bootstrap_content(content).as_bytes()),
+        Err(_) => content_digest(content),
+    }
+}
+
 fn setup_command(
     store: &StateStore,
     home: &Path,
@@ -3033,7 +3044,8 @@ fn setup_command(
             "next": "skillroster scan --json"
         }));
     };
-    let current_content = include_str!("../skill/skillroster/SKILL.md");
+    let current_content =
+        normalized_bootstrap_content(include_str!("../skill/skillroster/SKILL.md"));
     let current_digest = content_digest(current_content.as_bytes());
     let mut detected = Vec::new();
     let mut targets = Vec::new();
@@ -3065,7 +3077,7 @@ fn setup_command(
                 }
                 Ok(_) => match std::fs::read(&entrypoint) {
                     Ok(content) => {
-                        let digest = content_digest(&content);
+                        let digest = bootstrap_content_digest(&content);
                         let content_status = bootstrap_content_status(&digest, &current_digest);
                         match content_status {
                             BootstrapContentStatus::Current => current_count += 1,
@@ -3075,7 +3087,7 @@ fn setup_command(
                                 operations.push(json!({
                                     "kind": "replace_file",
                                     "target": entrypoint,
-                                    "content": current_content,
+                                    "content": &current_content,
                                     "expected_fingerprint": change::fingerprint(&entrypoint)?
                                 }));
                             }
@@ -3089,7 +3101,7 @@ fn setup_command(
                                     operations.push(json!({
                                         "kind": "replace_file",
                                         "target": entrypoint,
-                                        "content": current_content,
+                                        "content": &current_content,
                                         "expected_fingerprint": change::fingerprint(&entrypoint)?
                                     }));
                                 }
@@ -3117,7 +3129,7 @@ fn setup_command(
                     operations.push(json!({
                         "kind": "write_file",
                         "target": entrypoint,
-                        "content": current_content,
+                        "content": &current_content,
                         "expected_fingerprint": "missing"
                     }));
                     ("missing", None)
@@ -4020,7 +4032,7 @@ mod recovery_tests {
 
     #[test]
     fn bootstrap_digest_classification_distinguishes_release_content_from_local_edits() {
-        let current = content_digest(include_bytes!("../skill/skillroster/SKILL.md"));
+        let current = bootstrap_content_digest(include_bytes!("../skill/skillroster/SKILL.md"));
         assert_eq!(
             bootstrap_content_status(&current, &current),
             BootstrapContentStatus::Current
@@ -4039,6 +4051,15 @@ mod recovery_tests {
         assert_eq!(
             bootstrap_content_status("sha256:local-edit", &current),
             BootstrapContentStatus::Modified
+        );
+        let windows_legacy =
+            include_str!("../tests/fixtures/bootstrap-v1.1.0.md").replace('\n', "\r\n");
+        assert_eq!(
+            bootstrap_content_status(
+                &bootstrap_content_digest(windows_legacy.as_bytes()),
+                &current
+            ),
+            BootstrapContentStatus::OfficialOutdated("1.1.0")
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use sha2::{Digest, Sha256};
 use crate::change::{
     self, ChangeReceipt, Operation, OperationPolicy, PrepareContext, PreparedPlan,
 };
-use crate::cli::{Cli, Command, LifecycleCommand};
+use crate::cli::{Cli, Command, LifecycleCommand, ModifiedBootstrapChoice};
 use crate::harness::{self, AgentKind};
 use crate::model::{
     AgentId, AgentRecord, ApiError, EvidenceId, EvidenceKind, EvidenceQuality, EvidenceRecord,
@@ -273,12 +273,44 @@ pub fn run(cli: Cli) -> Result<Output> {
             ),
             LifecycleCommand::Delete(_) => unreachable!("handled before opening SQLite"),
         },
-        Some(Command::Setup) => (
-            "setup",
-            setup_command(&store, &home, &state_dir)?,
-            vec![],
-            vec![],
-        ),
+        Some(Command::Setup(args)) => {
+            let result = setup_command(&store, &home, &state_dir, args.modified_choice)?;
+            let mut actions = Vec::new();
+            if result["state"].as_str() == Some("scan_required") {
+                actions.push(action(
+                    "scan",
+                    &["scan", "--json"],
+                    false,
+                    false,
+                    "setup_requires_snapshot",
+                ));
+            } else if result["state"].as_str() == Some("modified_choice_required") {
+                actions.push(action(
+                    "retain_modified_bootstrap",
+                    &["setup", "--modified-choice", "retain-local", "--json"],
+                    false,
+                    false,
+                    "bootstrap_modified_choice_required",
+                ));
+                actions.push(action(
+                    "adopt_current_bootstrap",
+                    &["setup", "--modified-choice", "adopt-current", "--json"],
+                    false,
+                    false,
+                    "bootstrap_modified_choice_required",
+                ));
+            }
+            if let Some(plan_id) = result["plan_id"].as_str() {
+                actions.push(action(
+                    "apply",
+                    &["apply", plan_id, "--json"],
+                    true,
+                    true,
+                    "setup_plan_ready",
+                ));
+            }
+            ("setup", result, vec![], actions)
+        }
     };
 
     let mut envelope = JsonEnvelope::success(command, result.clone());
@@ -2911,51 +2943,240 @@ fn undo_command(store: &StateStore, id: &str) -> Result<Value> {
     Ok(mutation_result(&outcome, &receipt, Some(id)))
 }
 
-fn setup_command(store: &StateStore, home: &Path, state_dir: &Path) -> Result<Value> {
+const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
+    (
+        "1.0.0",
+        "08440a4a3e10489eae2484d0a5bf8f4b0451d22c43edaa90c75fcd0b66fd4a74",
+    ),
+    (
+        "1.0.1",
+        "2e18b702cbe61660aafff0b4c01538b51561cd0ce979cc4cce914f539b8c755e",
+    ),
+    (
+        "1.0.2",
+        "4a6c9de673948dbccfe719973395b7712fe09706ae22b2119e4a8ed8c5446a73",
+    ),
+    (
+        "1.0.3",
+        "1c0ffe7e1ef65d88e5c42a8978d92de81353c69072d8e610dce0c33d3938290c",
+    ),
+    (
+        "1.0.4",
+        "629d2d959c5b4277398e48f7b10c29c6c2adb0c0415723938ad7bbe4f8fec1c8",
+    ),
+    (
+        "1.1.0",
+        "d463d28295055fde8012e5c2424a754bf93e8c84c9fd6b48b7194bbaff0b27c2",
+    ),
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BootstrapContentStatus {
+    Current,
+    OfficialOutdated(&'static str),
+    Modified,
+}
+
+impl BootstrapContentStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::OfficialOutdated(_) => "official_outdated",
+            Self::Modified => "modified",
+        }
+    }
+
+    fn installed_version(self) -> Option<&'static str> {
+        match self {
+            Self::Current => Some(env!("CARGO_PKG_VERSION")),
+            Self::OfficialOutdated(version) => Some(version),
+            Self::Modified => None,
+        }
+    }
+}
+
+fn bootstrap_content_status(digest: &str, current_digest: &str) -> BootstrapContentStatus {
+    if digest == current_digest {
+        BootstrapContentStatus::Current
+    } else if let Some((version, _)) = LEGACY_BOOTSTRAPS
+        .iter()
+        .find(|(_, official_digest)| *official_digest == digest)
+    {
+        BootstrapContentStatus::OfficialOutdated(version)
+    } else {
+        BootstrapContentStatus::Modified
+    }
+}
+
+fn setup_command(
+    store: &StateStore,
+    home: &Path,
+    state_dir: &Path,
+    modified_choice: Option<ModifiedBootstrapChoice>,
+) -> Result<Value> {
     let Some(snapshot) = store.latest_completed_scan()? else {
         return Ok(json!({
             "detected_agents": [],
+            "targets": [],
             "plan_id": Value::Null,
             "state": "scan_required",
             "bootstrap_skill": "skillroster",
+            "bootstrap_version": env!("CARGO_PKG_VERSION"),
+            "missing_count": 0,
+            "current_count": 0,
+            "outdated_count": 0,
+            "modified_count": 0,
+            "unsupported_count": 0,
+            "replace_count": 0,
+            "canonical_deletion_count": 0,
             "files_changed": false,
             "next": "skillroster scan --json"
         }));
     };
+    let current_content = include_str!("../skill/skillroster/SKILL.md");
+    let current_digest = content_digest(current_content.as_bytes());
     let mut detected = Vec::new();
+    let mut targets = Vec::new();
     let mut operations = Vec::new();
+    let mut missing_count = 0_usize;
+    let mut current_count = 0_usize;
+    let mut outdated_count = 0_usize;
+    let mut modified_count = 0_usize;
+    let mut unsupported_count = 0_usize;
+    let mut replace_count = 0_usize;
     for roots in harness::known_agent_roots(home) {
         for root in roots.skill_roots.into_iter().filter(|path| path.is_dir()) {
             let directory = root.join("skillroster");
             let entrypoint = directory.join("SKILL.md");
             detected.push(json!({"agent": roots.agent.id(), "target": entrypoint}));
-            if entrypoint.exists() {
-                continue;
-            }
-            if !directory.exists() {
-                operations.push(json!({
-                    "kind": "create_directory",
-                    "target": directory,
-                    "expected_fingerprint": "missing"
-                }));
-            }
-            operations.push(json!({
-                "kind": "write_file",
+            let directory_is_unsupported = match std::fs::symlink_metadata(&directory) {
+                Ok(metadata) => metadata.file_type().is_symlink() || !metadata.file_type().is_dir(),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+                Err(_) => true,
+            };
+            let (status, installed_version) = match std::fs::symlink_metadata(&entrypoint) {
+                Ok(metadata)
+                    if directory_is_unsupported
+                        || metadata.file_type().is_symlink()
+                        || !metadata.file_type().is_file() =>
+                {
+                    unsupported_count += 1;
+                    ("unsupported", None)
+                }
+                Ok(_) => match std::fs::read(&entrypoint) {
+                    Ok(content) => {
+                        let digest = content_digest(&content);
+                        let content_status = bootstrap_content_status(&digest, &current_digest);
+                        match content_status {
+                            BootstrapContentStatus::Current => current_count += 1,
+                            BootstrapContentStatus::OfficialOutdated(_) => {
+                                outdated_count += 1;
+                                replace_count += 1;
+                                operations.push(json!({
+                                    "kind": "replace_file",
+                                    "target": entrypoint,
+                                    "content": current_content,
+                                    "expected_fingerprint": change::fingerprint(&entrypoint)?
+                                }));
+                            }
+                            BootstrapContentStatus::Modified => {
+                                modified_count += 1;
+                                if matches!(
+                                    modified_choice,
+                                    Some(ModifiedBootstrapChoice::AdoptCurrent)
+                                ) {
+                                    replace_count += 1;
+                                    operations.push(json!({
+                                        "kind": "replace_file",
+                                        "target": entrypoint,
+                                        "content": current_content,
+                                        "expected_fingerprint": change::fingerprint(&entrypoint)?
+                                    }));
+                                }
+                            }
+                        }
+                        (content_status.as_str(), content_status.installed_version())
+                    }
+                    Err(_) => {
+                        unsupported_count += 1;
+                        ("unsupported", None)
+                    }
+                },
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::NotFound
+                        && !directory_is_unsupported =>
+                {
+                    missing_count += 1;
+                    if !directory.exists() {
+                        operations.push(json!({
+                            "kind": "create_directory",
+                            "target": directory,
+                            "expected_fingerprint": "missing"
+                        }));
+                    }
+                    operations.push(json!({
+                        "kind": "write_file",
+                        "target": entrypoint,
+                        "content": current_content,
+                        "expected_fingerprint": "missing"
+                    }));
+                    ("missing", None)
+                }
+                Err(_) => {
+                    unsupported_count += 1;
+                    ("unsupported", None)
+                }
+            };
+            targets.push(json!({
+                "agent": roots.agent.id(),
                 "target": entrypoint,
-                "content": include_str!("../skill/skillroster/SKILL.md"),
-                "expected_fingerprint": "missing"
+                "status": status,
+                "installed_version": installed_version
             }));
         }
     }
+    let base = json!({
+        "detected_agents": detected,
+        "targets": targets,
+        "bootstrap_skill": "skillroster",
+        "bootstrap_version": env!("CARGO_PKG_VERSION"),
+        "missing_count": missing_count,
+        "current_count": current_count,
+        "outdated_count": outdated_count,
+        "modified_count": modified_count,
+        "unsupported_count": unsupported_count,
+        "replace_count": replace_count,
+        "canonical_deletion_count": 0,
+        "files_changed": false
+    });
+    if unsupported_count > 0 {
+        let mut result = base;
+        result["plan_id"] = Value::Null;
+        result["state"] = json!("unsupported_targets");
+        return Ok(result);
+    }
+    if modified_count > 0 && modified_choice.is_none() {
+        let mut result = base;
+        result["plan_id"] = Value::Null;
+        result["state"] = json!("modified_choice_required");
+        result["allowed_modified_choices"] = json!(["retain-local", "adopt-current"]);
+        return Ok(result);
+    }
+    if matches!(modified_choice, Some(ModifiedBootstrapChoice::RetainLocal)) {
+        replace_count = outdated_count;
+    }
     if operations.is_empty() {
-        return Ok(json!({
-            "detected_agents": detected,
-            "plan_id": Value::Null,
-            "state": "already_installed_or_no_supported_agent",
-            "bootstrap_skill": "skillroster",
-            "canonical_deletion_count": 0,
-            "files_changed": false
-        }));
+        let mut result = base;
+        result["replace_count"] = json!(replace_count);
+        result["plan_id"] = Value::Null;
+        result["state"] = json!(if modified_count > 0 {
+            "local_modifications_retained"
+        } else if current_count > 0 {
+            "up_to_date"
+        } else {
+            "no_supported_agent"
+        });
+        return Ok(result);
     }
     let plan = prepare_plan(
         store,
@@ -2966,16 +3187,13 @@ fn setup_command(store: &StateStore, home: &Path, state_dir: &Path) -> Result<Va
     let operation_count = plan["change_summary"]["operation_count"]
         .as_u64()
         .unwrap_or_default();
-    Ok(json!({
-        "detected_agents": detected,
-        "plan_id": plan["plan_id"],
-        "state": "preview_ready",
-        "bootstrap_skill": "skillroster",
-        "operation_count": operation_count,
-        "canonical_deletion_count": 0,
-        "confirmation_required": true,
-        "files_changed": false
-    }))
+    let mut result = base;
+    result["replace_count"] = json!(replace_count);
+    result["plan_id"] = plan["plan_id"].clone();
+    result["state"] = json!("preview_ready");
+    result["operation_count"] = json!(operation_count);
+    result["confirmation_required"] = json!(true);
+    Ok(result)
 }
 
 fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Result<()> {
@@ -3799,6 +4017,30 @@ fn action(
 mod recovery_tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn bootstrap_digest_classification_distinguishes_release_content_from_local_edits() {
+        let current = content_digest(include_bytes!("../skill/skillroster/SKILL.md"));
+        assert_eq!(
+            bootstrap_content_status(&current, &current),
+            BootstrapContentStatus::Current
+        );
+        assert!(
+            !LEGACY_BOOTSTRAPS
+                .iter()
+                .any(|(_, digest)| *digest == current)
+        );
+        for (version, digest) in LEGACY_BOOTSTRAPS {
+            assert_eq!(
+                bootstrap_content_status(digest, &current),
+                BootstrapContentStatus::OfficialOutdated(version)
+            );
+        }
+        assert_eq!(
+            bootstrap_content_status("sha256:local-edit", &current),
+            BootstrapContentStatus::Modified
+        );
+    }
 
     #[test]
     fn scan_warnings_group_repeated_unsafe_links_for_agent_callers() {

--- a/src/change.rs
+++ b/src/change.rs
@@ -351,13 +351,15 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
             if input.operations.iter().any(|operation| {
                 !matches!(
                     operation,
-                    OperationInput::CreateDirectory { .. } | OperationInput::WriteFile { .. }
+                    OperationInput::CreateDirectory { .. }
+                        | OperationInput::WriteFile { .. }
+                        | OperationInput::ReplaceFile { .. }
                 )
             }) =>
         {
             return Err(ChangeError::new(
                 "invalid_setup_operation",
-                "bootstrap setup may only create its package directory and SKILL.md",
+                "bootstrap setup may only create or replace its package directory and SKILL.md",
             ));
         }
         OperationPolicy::SourceUpdate

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 /// Local Skill governance for AI Agents.
 #[derive(Debug, Parser)]
@@ -45,7 +45,7 @@ impl Cli {
             Some(Command::Undo(_)) => "undo",
             Some(Command::Status) => "status",
             Some(Command::Lifecycle(_)) => "lifecycle",
-            Some(Command::Setup) => "setup",
+            Some(Command::Setup(_)) => "setup",
             None => "home",
         }
     }
@@ -69,8 +69,8 @@ pub enum Command {
     Status,
     /// Inspect, export, or prune retained local lifecycle data.
     Lifecycle(LifecycleArgs),
-    /// Preview bootstrap Skill installation for detected Agents.
-    Setup,
+    /// Preview bootstrap Skill installation or upgrade for detected Agents.
+    Setup(SetupArgs),
 }
 
 #[derive(Debug, Args)]
@@ -116,6 +116,19 @@ pub struct PlanArgs {
 #[derive(Debug, Args)]
 pub struct IdArgs {
     pub id: String,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum ModifiedBootstrapChoice {
+    RetainLocal,
+    AdoptCurrent,
+}
+
+#[derive(Debug, Args)]
+pub struct SetupArgs {
+    /// Decide how setup handles locally modified bootstrap Skill files.
+    #[arg(long, value_enum)]
+    pub modified_choice: Option<ModifiedBootstrapChoice>,
 }
 
 #[derive(Debug, Args)]

--- a/src/present.rs
+++ b/src/present.rs
@@ -167,7 +167,7 @@ fn render(command: &str, result: &Value, options: RenderOptions) -> String {
         "plan" => plan(result, &mut lines),
         "apply" | "undo" => mutation(result, &mut lines),
         "lifecycle" => lifecycle(result, &mut lines),
-        "setup" => setup(result, &mut lines),
+        "setup" => setup(result, &mut lines, options.width),
         _ => home(result, &mut lines),
     }
     if styled {
@@ -537,17 +537,79 @@ fn mutation(value: &Value, lines: &mut Vec<String>) {
     }
 }
 
-fn setup(value: &Value, lines: &mut Vec<String>) {
+fn setup(value: &Value, lines: &mut Vec<String>, width: usize) {
+    fact(lines, "State", text(value, "state"));
+    fact(lines, "Bootstrap version", text(value, "bootstrap_version"));
     fact(
         lines,
         "Detected Agents",
         array_len(value, "detected_agents"),
     );
+    fact(lines, "Current", text(value, "current_count"));
+    fact(lines, "Missing", text(value, "missing_count"));
+    fact(lines, "Official outdated", text(value, "outdated_count"));
+    fact(lines, "Locally modified", text(value, "modified_count"));
+    fact(lines, "Unsupported", text(value, "unsupported_count"));
     fact(lines, "Plan", text(value, "plan_id"));
-    lines.extend(summary(
-        "Preview only · no files changed",
-        "Apply the Plan after review",
-    ));
+    let attention = value
+        .get("targets")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|target| target.get("status").and_then(Value::as_str) != Some("current"))
+        .collect::<Vec<_>>();
+    if !attention.is_empty() {
+        lines.push(String::new());
+        lines.push("Targets needing attention".into());
+        for target in attention {
+            let status = text(target, "status");
+            let agent = text(target, "agent");
+            let prefix = format!("  {status:<18} {agent:<10} ");
+            let path = middle_truncate(
+                &text(target, "target"),
+                width.saturating_sub(display_width(&prefix)),
+            );
+            lines.push(format!("{prefix}{path}"));
+        }
+    }
+    match value
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+    {
+        "preview_ready" => lines.extend(summary(
+            "Preview only · no files changed",
+            "Review the recoverable Plan before Apply",
+        )),
+        "modified_choice_required" => lines.extend(summary(
+            "Blocked · local bootstrap changes need a decision",
+            "Choose retain-local or adopt-current; setup will not decide",
+        )),
+        "unsupported_targets" => lines.extend(summary(
+            "Blocked · unsupported bootstrap targets were preserved",
+            "Inspect links, non-files, or unreadable targets before retrying",
+        )),
+        "local_modifications_retained" => lines.extend(summary(
+            "No change · local bootstrap modifications retained",
+            "Use adopt-current only after the user approves replacement",
+        )),
+        "up_to_date" => lines.extend(summary(
+            "Healthy · bootstrap Skill is current",
+            "No setup action is needed",
+        )),
+        "no_supported_agent" => lines.extend(summary(
+            "No change · no supported Agent target found",
+            "Run Scan after configuring a supported Agent Skill root",
+        )),
+        "scan_required" => lines.extend(summary(
+            "Blocked · no completed Scan is available",
+            "Run skillroster scan before setup",
+        )),
+        _ => lines.extend(summary(
+            "Preview only · no files changed",
+            "Follow the reported setup state",
+        )),
+    }
 }
 
 fn lifecycle(value: &Value, lines: &mut Vec<String>) {
@@ -814,6 +876,52 @@ mod tests {
         );
         assert!(output.contains("Verified · no files changed"));
         assert!(!output.contains("Changed · bounded"));
+    }
+
+    #[test]
+    fn setup_output_makes_modified_and_unsupported_targets_actionable() {
+        let modified = render(
+            "setup",
+            &json!({
+                "state": "modified_choice_required",
+                "bootstrap_version": "1.2.0",
+                "detected_agents": [{"agent": "codex"}],
+                "current_count": 0,
+                "missing_count": 0,
+                "outdated_count": 0,
+                "modified_count": 1,
+                "unsupported_count": 0,
+                "plan_id": null
+            }),
+            RenderOptions {
+                width: 80,
+                styled: false,
+            },
+        );
+        assert!(modified.contains("local bootstrap changes need a decision"));
+        assert!(modified.contains("retain-local or adopt-current"));
+        assert!(modified.contains("Locally modified       1"));
+
+        let unsupported = render(
+            "setup",
+            &json!({
+                "state": "unsupported_targets",
+                "bootstrap_version": "1.2.0",
+                "detected_agents": [{"agent": "codex"}],
+                "current_count": 0,
+                "missing_count": 0,
+                "outdated_count": 0,
+                "modified_count": 0,
+                "unsupported_count": 1,
+                "plan_id": null
+            }),
+            RenderOptions {
+                width: 80,
+                styled: false,
+            },
+        );
+        assert!(unsupported.contains("unsupported bootstrap targets were preserved"));
+        assert!(unsupported.contains("Unsupported            1"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -577,6 +577,249 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
 }
 
 #[test]
+fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    let ordinary = root.join("ordinary");
+    let bootstrap = root.join("skillroster/SKILL.md");
+    fs::create_dir_all(&ordinary).unwrap();
+    fs::write(
+        ordinary.join("SKILL.md"),
+        "---\nname: ordinary\ndescription: fixture\n---\n",
+    )
+    .unwrap();
+    fs::create_dir_all(bootstrap.parent().unwrap()).unwrap();
+    let modified =
+        "---\nname: skillroster\ndescription: locally customized\n---\ncustom instructions\n";
+    fs::write(&bootstrap, modified).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let blocked = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(blocked["result"]["state"], "modified_choice_required");
+    assert_eq!(blocked["result"]["modified_count"], 1);
+    assert!(blocked["result"]["plan_id"].is_null());
+    assert_eq!(blocked["result"]["targets"][0]["status"], "modified");
+    assert!(blocked["result"]["targets"][0]["installed_version"].is_null());
+    assert_eq!(blocked["suggested_actions"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        blocked["suggested_actions"][0]["argv"],
+        serde_json::json!([
+            "skillroster",
+            "setup",
+            "--modified-choice",
+            "retain-local",
+            "--json"
+        ])
+    );
+    assert_eq!(blocked["suggested_actions"][0]["mutates"], false);
+    assert_eq!(
+        blocked["suggested_actions"][0]["requires_confirmation"],
+        false
+    );
+    assert_eq!(
+        blocked["suggested_actions"][1]["argv"],
+        serde_json::json!([
+            "skillroster",
+            "setup",
+            "--modified-choice",
+            "adopt-current",
+            "--json"
+        ])
+    );
+    assert_eq!(fs::read_to_string(&bootstrap).unwrap(), modified);
+
+    let retained = json_output(&run(
+        &[&common[..], &["setup", "--modified-choice", "retain-local"]].concat(),
+        None,
+    ));
+    assert_eq!(retained["result"]["state"], "local_modifications_retained");
+    assert!(retained["result"]["plan_id"].is_null());
+    assert_eq!(fs::read_to_string(&bootstrap).unwrap(), modified);
+
+    let upgrade = json_output(&run(
+        &[
+            &common[..],
+            &["setup", "--modified-choice", "adopt-current"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(upgrade["result"]["state"], "preview_ready");
+    assert_eq!(upgrade["result"]["replace_count"], 1);
+    assert_eq!(upgrade["result"]["modified_count"], 1);
+    assert_eq!(upgrade["suggested_actions"].as_array().unwrap().len(), 1);
+    assert_eq!(upgrade["suggested_actions"][0]["action"], "apply");
+    assert_eq!(upgrade["suggested_actions"][0]["mutates"], true);
+    assert_eq!(
+        upgrade["suggested_actions"][0]["requires_confirmation"],
+        true
+    );
+    assert_eq!(fs::read_to_string(&bootstrap).unwrap(), modified);
+    let plan_id = upgrade["result"]["plan_id"].as_str().unwrap();
+    let detail = json_output(&run(
+        &[&common[..], &["plan", "--show", plan_id]].concat(),
+        None,
+    ));
+    assert_eq!(detail["result"]["operations"][0]["kind"], "replace_file");
+
+    let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+    assert_eq!(
+        fs::read_to_string(&bootstrap).unwrap(),
+        include_str!("../skill/skillroster/SKILL.md")
+    );
+    let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(current["result"]["state"], "up_to_date");
+    assert!(current["result"]["plan_id"].is_null());
+    assert_eq!(
+        current["result"]["targets"][0]["installed_version"],
+        "1.2.0"
+    );
+
+    let undone = json_output(&run(
+        &[
+            &common[..],
+            &["undo", applied["result"]["receipt_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert_eq!(fs::read_to_string(&bootstrap).unwrap(), modified);
+}
+
+#[test]
+fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    let ordinary = root.join("ordinary");
+    let bootstrap = root.join("skillroster/SKILL.md");
+    fs::create_dir_all(&ordinary).unwrap();
+    fs::write(
+        ordinary.join("SKILL.md"),
+        "---\nname: ordinary\ndescription: fixture\n---\n",
+    )
+    .unwrap();
+    fs::create_dir_all(bootstrap.parent().unwrap()).unwrap();
+    let legacy = include_str!("fixtures/bootstrap-v1.1.0.md");
+    fs::write(&bootstrap, legacy).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let upgrade = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(upgrade["result"]["state"], "preview_ready");
+    assert_eq!(upgrade["result"]["outdated_count"], 1);
+    assert_eq!(upgrade["result"]["modified_count"], 0);
+    assert_eq!(upgrade["result"]["replace_count"], 1);
+    assert_eq!(
+        upgrade["result"]["targets"][0]["status"],
+        "official_outdated"
+    );
+    assert_eq!(
+        upgrade["result"]["targets"][0]["installed_version"],
+        "1.1.0"
+    );
+    assert_eq!(fs::read_to_string(&bootstrap).unwrap(), legacy);
+
+    let plan_id = upgrade["result"]["plan_id"].as_str().unwrap();
+    let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+    assert_eq!(applied["result"]["verification"], "passed");
+    assert_eq!(
+        fs::read_to_string(&bootstrap).unwrap(),
+        include_str!("../skill/skillroster/SKILL.md")
+    );
+    let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(current["result"]["state"], "up_to_date");
+
+    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert_eq!(fs::read_to_string(&bootstrap).unwrap(), legacy);
+}
+
+#[test]
+fn setup_without_a_snapshot_returns_a_typed_scan_action() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let output = json_output(&run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--json",
+            "setup",
+        ],
+        None,
+    ));
+
+    assert_eq!(output["result"]["state"], "scan_required");
+    assert_eq!(output["result"]["bootstrap_version"], "1.2.0");
+    assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        output["suggested_actions"][0]["argv"],
+        serde_json::json!(["skillroster", "scan", "--json"])
+    );
+}
+
+#[test]
+fn setup_preserves_unsupported_bootstrap_targets_without_creating_a_plan() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    let ordinary = root.join("ordinary");
+    fs::create_dir_all(&ordinary).unwrap();
+    fs::write(
+        ordinary.join("SKILL.md"),
+        "---\nname: ordinary\ndescription: fixture\n---\n",
+    )
+    .unwrap();
+    let blocked_parent = root.join("skillroster");
+    fs::write(&blocked_parent, "user-owned non-directory target\n").unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    for setup_args in [
+        vec!["setup"],
+        vec!["setup", "--modified-choice", "adopt-current"],
+    ] {
+        let output = json_output(&run(&[&common[..], &setup_args].concat(), None));
+        assert_eq!(output["result"]["state"], "unsupported_targets");
+        assert_eq!(output["result"]["unsupported_count"], 1);
+        assert!(output["result"]["plan_id"].is_null());
+        assert_eq!(output["result"]["targets"][0]["status"], "unsupported");
+        assert_eq!(
+            fs::read_to_string(&blocked_parent).unwrap(),
+            "user-owned non-directory target\n"
+        );
+    }
+}
+
+#[test]
 fn agent_plan_refuses_arbitrary_skill_root_write_file() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -674,7 +674,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
     assert_eq!(
         fs::read_to_string(&bootstrap).unwrap(),
-        include_str!("../skill/skillroster/SKILL.md")
+        include_str!("../skill/skillroster/SKILL.md").replace("\r\n", "\n")
     );
     let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_eq!(current["result"]["state"], "up_to_date");
@@ -742,7 +742,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
     assert_eq!(applied["result"]["verification"], "passed");
     assert_eq!(
         fs::read_to_string(&bootstrap).unwrap(),
-        include_str!("../skill/skillroster/SKILL.md")
+        include_str!("../skill/skillroster/SKILL.md").replace("\r\n", "\n")
     );
     let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_eq!(current["result"]["state"], "up_to_date");

--- a/tests/fixtures/bootstrap-v1.1.0.md
+++ b/tests/fixtures/bootstrap-v1.1.0.md
@@ -1,8 +1,6 @@
 ---
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
-metadata:
-  bootstrap-version: "1.2.0"
 ---
 
 # SkillRoster
@@ -37,8 +35,6 @@ Hosted or Managed Library Plan so future Scans no longer depend on the
 temporary source-root arguments. Keep unconfirmed targets unread.
 
 ## Apply or undo
-
-Run `skillroster setup --json` when installing the Bootstrap Skill or after upgrading the CLI. An exact official older copy produces a normal upgrade Plan. If `state` is `modified_choice_required`, show the affected Agent targets and ask whether to `retain-local` or `adopt-current`; do not choose for the user. Adopting still only prepares a recoverable Plan and requires the usual Apply confirmation. Treat `unsupported_targets` as blocked rather than replacing links or non-files.
 
 Show the complete immutable Plan before requesting one explicit confirmation. After the user confirms, run `skillroster apply PLAN_ID --json`; do not substitute direct filesystem commands or bypass drift checks. Report verification, changed-path count, Receipt ID, and canonical deletion count.
 


### PR DESCRIPTION
## Summary

- detect current, exact official legacy, locally modified, and unsupported bootstrap targets
- keep setup read-only and route installs/upgrades through Plan, Apply, Receipt, and Undo
- require an explicit retain-local or adopt-current choice for modified content
- return verified installed versions and actionable Agent JSON/human output

## Verification

- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features (98 passed)
- bootstrap Skill validation
- isolated v1.1.0 -> v1.2.0 Apply/Undo replay
- Ruby syntax and Homebrew style