### PR TITLE
Compact Finding detail for Agent callers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "0c139cc604d907250227ccea246ec8387a16b265"
-  version "1.2.0"
+      revision: "d59aa9b273f75ccb479efd0046f5b4ed4ea76fa7"
+  version "1.3.0"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.2.0", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.3.0", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ skillroster scan --json
 skillroster --source-root /absolute/trusted/source scan --json
 skillroster report --summary --json
 skillroster report --finding <finding-id> --limit 20 --json
+skillroster report --finding <finding-id> --full --json
 skillroster find "database migration" --json
 skillroster find "诊断命令性能回归" --hint "diagnose command performance regression" --json
 skillroster plan --stdin --json
@@ -81,6 +82,13 @@ For an exact-duplicate Finding, the Agent submits only the choices it owns:
 
 SkillRoster resolves the current Snapshot, Evidence, Skill, and complete
 placement set from that immutable Finding and rejects stale or mismatched input.
+
+Finding drilldown is compact by default: each paged `item` carries one
+traceable Evidence ID, subject, path, and decision facts. Complete duplicate ID
+collections, placement records, and Evidence records stay behind explicit
+`report --finding ID --full --json`. Unsafe escaping links return a trust
+decision and observed targets instead of suggesting an automatic filesystem
+Plan.
 
 ## Status
 

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -110,10 +110,27 @@ authorization for the synthetic scope, then verified Apply, Receipt, Undo, and
 recovery-clear Status. The bootstrap Skill separately requires an explicit user
 confirmation before any real Apply or Undo and never asks per-file questions.
 
+## Agent-led Finding drilldown evidence
+
+Before the 1.3 release, the Agent reused one immutable read-only Snapshot from
+the reference macOS home: 180 independent Skills, 676 placements, 548 default
+exposures, and 189 Findings. It changed no Agent files. On that same Snapshot:
+
+- the unsafe-link Finding response fell from 24,817 to 10,410 bytes (58.1%) in
+  default compact mode while retaining all 16 paged Evidence items;
+- an exact-duplicate Finding fell from 11,814 to 6,807 bytes (42.4%) while
+  retaining seven traceable Evidence items and its planning action;
+- `--full` preserved the complete IDs, placements, and Evidence records on
+  explicit request;
+- unsafe links no longer suggest a generic Plan. They return a typed trust
+  decision, observed targets, and a repeatable `--source-root` rescan template;
+- plain 60-, 80-, and 120-column Finding views preserve the issue, counts,
+  Evidence paths, and next decision without exceeding the requested width.
+
 ## Evidence boundary
 
 These checks establish deterministic routing and safe local governance; they do
 not claim model quality, token or labor savings, production performance, or
 access to arbitrary future Agent log formats. Final support additionally
-requires the official `v1.0.0` tag workflow, published artifact checksums, and
+ requires the official release tag workflow, published artifact checksums, and
 the installation checks recorded in the Release notes.

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -146,7 +146,7 @@ Machine results should expose facts, not preformatted prose:
 
 - `primary_metrics` with value, unit, coverage, and comparison baseline;
 - Findings with stable ID, category, severity, Evidence quality, impact fields, and affected IDs;
-- a bounded `report --summary --json` first view with no more than three Findings and one primary Evidence reference, plus paged placement paths and Evidence facts from `report --finding ID --json`; exact-duplicate detail also exposes at most five ranked, owned canonical candidates without requiring pagination;
+- a bounded `report --summary --json` first view with no more than three Findings and one primary Evidence reference, plus compact paged Evidence items from `report --finding ID --json`; exact complete records require `--full`, and exact-duplicate detail exposes at most five ranked, owned canonical candidates without requiring pagination;
 - Find results that keep the original task, expose Agent-authored retrieval hints, and collapse same-name identities into one explicitly variant capability result;
 - bounded Plan `change_summary`, `operation_groups`, affected-scope counts and `impact` deltas for current and proposed state; source-update line details remain in the bounded `diff_summary`, while full operations are loaded only through `plan --show PLAN_ID` when needed;
 - affected Agents, Skills, placements, operation groups, exclusions, and deletion count;

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -94,14 +94,22 @@ contains those four metrics, total Finding count, category totals, and at most
 three complete Finding summaries. Full `report --json` is an explicit
 exhaustive view, not the bootstrap workflow default.
 
-`report --finding ID --json` returns at most 20 affected IDs, placements, and
-Evidence records per collection. Its `page.next_offset` is the only pagination
-cursor; callers request another page only when the decision still lacks
-relevant evidence. Counts and `primary_evidence_id` remain available in the
-compact first view. An actionable exact-duplicate Finding also returns a
-bounded `planning` object with at most five owned canonical candidates and the
-semantic `finding_library_changes` request shape; the complete placement set
-remains CLI-owned rather than Agent-copied.
+`report --finding ID --json` returns at most 20 compact Evidence items. Each
+item combines its stable Evidence ID, subject, path, quality, and decision facts
+without repeating affected-ID, placement, and full Evidence collections.
+`report --finding ID --full --json` explicitly returns those complete paged
+records. `page.next_offset` is the only pagination cursor; callers request
+another page only when the decision still lacks relevant evidence. Counts and
+`primary_evidence_id` remain available in the compact first view. An actionable
+exact-duplicate Finding also returns a bounded `planning` object with at most
+five owned canonical candidates and the semantic `finding_library_changes`
+request shape; the complete placement set remains CLI-owned rather than
+Agent-copied. An escaping-link Finding returns observed targets and a required
+trust decision instead of a Plan suggestion.
+
+Human Finding output shows the issue, severity, affected counts, bounded paths,
+and any required trust decision. It must not render a Finding as an empty
+aggregate report.
 
 ### `find`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.2.0
+SKILLROSTER_VERSION=1.3.0
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.2.0 skillroster
+  --tag v1.3.0 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.2.0
+git checkout v1.3.0
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -99,7 +99,7 @@ The first complete command surface is:
 
 ```bash
 skillroster scan [--json]
-skillroster report [--finding <id>] [--json]
+skillroster report [--finding <id>] [--full] [--json]
 skillroster find <task> [--hint <text>]... [--json]
 skillroster plan --stdin [--json]
 skillroster plan --show <plan-id> [--json]
@@ -139,6 +139,13 @@ All JSON responses use a versioned envelope:
 ```
 
 IDs for Agents, Scans, reports, Skills, placements, Evidence, Findings, Plans, operations, and Receipts are opaque and stable within the local state store. Names and paths are never write-operation identities. Errors carry a stable code, human-readable message, retryability, and relevant IDs or paths. In JSON mode stdout contains exactly one JSON document and never an interactive prompt, progress bar, ANSI sequence, or log line. Terminal output is a polished human interface; Agents consume JSON rather than scraping styled text. The normative human-output, accessibility, progress, confirmation, and responsive-layout requirements live in [cli-ux-spec.md](cli-ux-spec.md).
+
+`report --finding ID --json` returns compact paged Evidence items by default.
+Each item contains the Evidence ID, subject, path, quality, and decision facts;
+it does not repeat complete affected-ID, placement, and Evidence collections.
+`--full` explicitly requests those complete paged records. For escaping links,
+the Finding returns a trust-confirmation resolution and observed link targets;
+it must not advertise an automatic Plan before the source is confirmed.
 
 `plan --stdin --json` returns a bounded decision-complete summary: total change counts, operation groups, affected-scope counts with at most ten Skill IDs, before/after impact, risk, reversibility, and the immutable Plan ID. It does not inline filesystem operations or complete large ID collections. `plan --show PLAN_ID --json` is the explicit full-detail path; it reads the stored Plan and never mutates files.
 

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -2,7 +2,7 @@
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
 metadata:
-  bootstrap-version: "1.2.0"
+  bootstrap-version: "1.3.0"
 ---
 
 # SkillRoster
@@ -13,7 +13,7 @@ Use the local `skillroster` binary as the deterministic source of facts. Invoke 
 
 1. Run `skillroster scan --json`, then `skillroster report --summary --json`. Use the compact result for the first user-facing diagnosis; do not request the full report unless exhaustive Finding enumeration is necessary.
 2. Distinguish observed, inferred, and unknown usage. Missing evidence does not mean unused.
-3. Use stable Finding and Evidence IDs for follow-up questions. The summary exposes one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Exact-duplicate detail includes a bounded `planning.canonical_candidates` list independently of pagination. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
+3. Use stable Finding and Evidence IDs for follow-up questions. The summary exposes one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Its compact `items` combine the Evidence ID, subject, path, and decision facts without repeating complete internal collections. Use `--full` only when an exact complete ID or record is needed. Exact-duplicate detail includes a bounded `planning.canonical_candidates` list independently of pagination. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
 4. Make semantic governance choices in the conversation, then submit declarative target states to `skillroster plan --stdin --json`. For an exact-duplicate Finding, send `schema_version` plus `finding_library_changes`; SkillRoster derives the current Snapshot, Evidence, Skill, and complete placement set. For other request families, include the latest `scan_id` and relevant `evidence_ids`.
 5. Present the validated summary Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `operation_groups`, bounded `affected` facts, `impact` before/after facts, uncertainty, canonical deletion count, reversibility, and Plan ID. The full immutable representation stays in local state; use `skillroster plan --show PLAN_ID --json` only when an exact operation, path, or complete ID list is needed to answer the user. Do not load it by default.
 
@@ -28,13 +28,14 @@ Keep source updates and Library changes in separate Plans. Cite Evidence returne
 
 State explicitly that inspection and planning changed no Agent files. When evidence cannot justify a change, recommend keeping the current state.
 
-For `Skill links escape an approved root`, load one Finding page and show the
-link targets. Treat each target as unread until the user confirms that its
-source directory is intentional and trusted. After confirmation, rescan with
-one repeatable `--source-root ABSOLUTE_PATH` per canonical source directory;
-this approves reading without adding Agent exposure. Then prefer a reviewed
-Hosted or Managed Library Plan so future Scans no longer depend on the
-temporary source-root arguments. Keep unconfirmed targets unread.
+For `Skill links escape an approved root`, load one compact Finding page and
+show `resolution.observed_link_targets`. Treat each target as unread until the
+user confirms that its canonical source directory is intentional and trusted.
+Do not follow a generic Plan action for this Finding. After confirmation,
+rescan with one repeatable `--source-root ABSOLUTE_PATH` per canonical source
+directory; this approves reading without adding Agent exposure. Then prefer a
+reviewed Hosted or Managed Library Plan so future Scans no longer depend on
+the temporary source-root arguments. Keep unconfirmed targets unread.
 
 ## Apply or undo
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::io::Read;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -112,24 +113,19 @@ pub fn run(cli: Cli) -> Result<Output> {
                 )],
             )
         }
-        Some(Command::Report(args)) => (
-            "report",
-            report_command(
+        Some(Command::Report(args)) => {
+            let finding_id = args.finding.as_deref();
+            let result = report_command(
                 &store,
-                args.finding.as_deref(),
+                finding_id,
                 args.summary,
+                args.full,
                 usize::from(args.limit),
                 usize::try_from(args.offset)?,
-            )?,
-            vec![],
-            vec![action(
-                "plan",
-                &["plan", "--stdin", "--json"],
-                false,
-                false,
-                "findings_available",
-            )],
-        ),
+            )?;
+            let actions = report_actions(&result, finding_id, args.full, args.limit, args.offset);
+            ("report", result, vec![], actions)
+        }
         Some(Command::Find(args)) => (
             "find",
             find_command(
@@ -1065,6 +1061,7 @@ fn report_command(
     store: &StateStore,
     finding: Option<&str>,
     summary_only: bool,
+    full_detail: bool,
     detail_limit: usize,
     detail_offset: usize,
 ) -> Result<Value> {
@@ -1184,8 +1181,20 @@ fn report_command(
                     }
                 }),
             );
+            add_finding_resolution(object);
+            object.insert(
+                "detail".into(),
+                json!({
+                    "mode": if full_detail { "full" } else { "compact" },
+                    "full_available": !full_detail
+                }),
+            );
         }
-        return Ok(details);
+        return Ok(if full_detail {
+            details
+        } else {
+            compact_finding_detail(details)
+        });
     }
     let (scan_id, scan): (ScanId, ScanResult) = latest_scan(store)?;
     if let Some(existing) = store.latest_report()? {
@@ -1282,6 +1291,132 @@ fn report_command(
     } else {
         value
     })
+}
+
+fn add_finding_resolution(object: &mut serde_json::Map<String, Value>) {
+    if object.get("title").and_then(Value::as_str) != Some("Skill links escape an approved root") {
+        return;
+    }
+    let observed_link_targets = object
+        .get("placements")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|placement| placement.get("link_target").and_then(Value::as_str))
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    object.insert(
+        "resolution".into(),
+        json!({
+            "decision": "confirm_trusted_source_roots",
+            "automatic_change_supported": false,
+            "observed_link_targets": observed_link_targets,
+            "after_confirmation": {
+                "repeatable_option": "--source-root",
+                "value": "absolute canonical source directory",
+                "argv_template": [
+                    "skillroster",
+                    "--source-root",
+                    "<confirmed-canonical-source-directory>",
+                    "scan",
+                    "--json"
+                ]
+            }
+        }),
+    );
+}
+
+fn compact_finding_detail(mut details: Value) -> Value {
+    let Some(object) = details.as_object_mut() else {
+        return details;
+    };
+    let items = object
+        .remove("evidence")
+        .and_then(|value| value.as_array().cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|evidence| {
+            let mut facts = evidence
+                .get("details")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            if let Some(facts) = facts.as_object_mut() {
+                facts.remove("root_id");
+            }
+            json!({
+                "evidence_id": evidence["id"],
+                "kind": evidence["kind"],
+                "quality": evidence["quality"],
+                "subject_type": evidence["subject_type"],
+                "subject_id": evidence["subject_id"],
+                "path": evidence["path"],
+                "facts": facts
+            })
+        })
+        .collect::<Vec<_>>();
+    object.remove("affected_skill_ids");
+    object.remove("affected_placement_ids");
+    object.remove("evidence_ids");
+    object.remove("placements");
+    if let Some(page) = object.get_mut("page").and_then(Value::as_object_mut) {
+        if let Some(returned) = page.get_mut("returned").and_then(Value::as_object_mut) {
+            returned.insert("items".into(), json!(items.len()));
+        }
+    }
+    object.insert("items".into(), json!(items));
+    details
+}
+
+fn report_actions(
+    result: &Value,
+    finding_id: Option<&str>,
+    full_detail: bool,
+    limit: u16,
+    offset: u32,
+) -> Vec<SuggestedAction> {
+    let Some(finding_id) = finding_id else {
+        return vec![action(
+            "plan",
+            &["plan", "--stdin", "--json"],
+            false,
+            false,
+            "findings_available",
+        )];
+    };
+    let requires_trust_decision =
+        result["resolution"]["decision"].as_str() == Some("confirm_trusted_source_roots");
+    let mut actions = Vec::new();
+    if !requires_trust_decision {
+        actions.push(action(
+            "plan",
+            &["plan", "--stdin", "--json"],
+            false,
+            false,
+            "finding_action_available",
+        ));
+    }
+    if !full_detail {
+        let limit = limit.to_string();
+        let offset = offset.to_string();
+        actions.push(action(
+            "show_full_finding",
+            &[
+                "report",
+                "--finding",
+                finding_id,
+                "--full",
+                "--limit",
+                &limit,
+                "--offset",
+                &offset,
+                "--json",
+            ],
+            false,
+            false,
+            "finding_full_detail_available",
+        ));
+    }
+    actions
 }
 
 fn finding_library_planning(
@@ -2968,6 +3103,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.1.0",
         "d463d28295055fde8012e5c2424a754bf93e8c84c9fd6b48b7194bbaff0b27c2",
     ),
+    (
+        "1.2.0",
+        "a12e3bbf45e4a3d51b8075dd2b56a410f113fb27cd803676fb614bd88f278f9c",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -4053,13 +4192,13 @@ mod recovery_tests {
             BootstrapContentStatus::Modified
         );
         let windows_legacy =
-            include_str!("../tests/fixtures/bootstrap-v1.1.0.md").replace('\n', "\r\n");
+            include_str!("../tests/fixtures/bootstrap-v1.2.0.md").replace('\n', "\r\n");
         assert_eq!(
             bootstrap_content_status(
                 &bootstrap_content_digest(windows_legacy.as_bytes()),
                 &current
             ),
-            BootstrapContentStatus::OfficialOutdated("1.1.0")
+            BootstrapContentStatus::OfficialOutdated("1.2.0")
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,6 +78,10 @@ pub struct ReportArgs {
     #[arg(long)]
     pub finding: Option<String>,
 
+    /// Show complete IDs, placement records, and Evidence records for one Finding.
+    #[arg(long, requires = "finding")]
+    pub full: bool,
+
     /// Return core metrics and the three highest-priority Findings.
     #[arg(long)]
     pub summary: bool,

--- a/src/present.rs
+++ b/src/present.rs
@@ -162,7 +162,7 @@ fn render(command: &str, result: &Value, options: RenderOptions) -> String {
     match command {
         "status" => status(result, &mut lines),
         "scan" => scan(result, &mut lines),
-        "report" => report(result, &mut lines),
+        "report" => report(result, &mut lines, options.width),
         "find" => find(result, &mut lines, options.width),
         "plan" => plan(result, &mut lines),
         "apply" | "undo" => mutation(result, &mut lines),
@@ -240,7 +240,13 @@ fn scan(value: &Value, lines: &mut Vec<String>) {
     ));
 }
 
-fn report(value: &Value, lines: &mut Vec<String>) {
+fn report(value: &Value, lines: &mut Vec<String>, width: usize) {
+    if value.get("id").and_then(Value::as_str).is_some()
+        && value.get("title").and_then(Value::as_str).is_some()
+    {
+        finding_report(value, lines, width);
+        return;
+    }
     fact(lines, "Independent Skills", text(value, "skill_count"));
     fact(lines, "Placements", text(value, "placement_count"));
     fact(lines, "Default exposure", text(value, "default_exposure"));
@@ -279,6 +285,99 @@ fn report(value: &Value, lines: &mut Vec<String>) {
         "Read-only · no Agent files changed",
         "Review evidence before planning changes",
     ));
+}
+
+fn finding_report(value: &Value, lines: &mut Vec<String>, width: usize) {
+    fact(
+        lines,
+        "Finding",
+        middle_truncate(&text(value, "id"), width.saturating_sub(25)),
+    );
+    fact(
+        lines,
+        "Issue",
+        middle_truncate(&text(value, "title"), width.saturating_sub(25)),
+    );
+    fact(
+        lines,
+        "Severity",
+        format!("{} · {}", text(value, "severity"), text(value, "category")),
+    );
+    fact(lines, "Evidence quality", text(value, "evidence_quality"));
+    fact(
+        lines,
+        "Affected",
+        format!(
+            "{} Skills · {} placements",
+            value
+                .pointer("/impact/affected_skill_count")
+                .map_or_else(|| "none".into(), Value::to_string),
+            value
+                .pointer("/impact/affected_placement_count")
+                .map_or_else(|| "none".into(), Value::to_string)
+        ),
+    );
+    fact(
+        lines,
+        "Detail",
+        value
+            .pointer("/detail/mode")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown"),
+    );
+    lines.push(String::new());
+    lines.push(format!(
+        "  {}",
+        middle_truncate(&text(value, "summary"), width.saturating_sub(2))
+    ));
+
+    let evidence_rows = value
+        .get("items")
+        .and_then(Value::as_array)
+        .or_else(|| value.get("placements").and_then(Value::as_array));
+    if let Some(rows) = evidence_rows.filter(|rows| !rows.is_empty()) {
+        lines.push(String::new());
+        lines.push("  Evidence paths".into());
+        for row in rows.iter().take(10) {
+            let agent = row
+                .get("facts")
+                .and_then(|facts| facts.get("agent"))
+                .and_then(Value::as_str)
+                .or_else(|| row.get("agent").and_then(Value::as_str))
+                .unwrap_or("source");
+            let prefix = format!("  {agent:<12} ");
+            let path = middle_truncate(
+                &text(row, "path"),
+                width.saturating_sub(display_width(&prefix)),
+            );
+            lines.push(format!("{prefix}{path}"));
+        }
+        if rows.len() > 10 {
+            lines.push(format!("  + {} more on this page", rows.len() - 10));
+        }
+    }
+
+    if value["resolution"]["decision"].as_str() == Some("confirm_trusted_source_roots") {
+        lines.push(String::new());
+        lines.push("  Observed link targets".into());
+        if let Some(targets) = value["resolution"]["observed_link_targets"].as_array() {
+            for target in targets.iter().filter_map(Value::as_str).take(5) {
+                lines.push(format!(
+                    "  {}",
+                    middle_truncate(target, width.saturating_sub(2))
+                ));
+            }
+        }
+        lines.extend(summary(
+            "Blocked · no automatic change is supported",
+            "Confirm trusted source directories before rescanning",
+        ));
+    } else {
+        lines.extend(summary(
+            "Read-only · no Agent files changed",
+            "Use --full only when exact complete records are needed",
+        ));
+    }
 }
 
 fn find(value: &Value, lines: &mut Vec<String>, width: usize) {
@@ -884,7 +983,7 @@ mod tests {
             "setup",
             &json!({
                 "state": "modified_choice_required",
-                "bootstrap_version": "1.2.0",
+                "bootstrap_version": "1.3.0",
                 "detected_agents": [{"agent": "codex"}],
                 "current_count": 0,
                 "missing_count": 0,
@@ -906,7 +1005,7 @@ mod tests {
             "setup",
             &json!({
                 "state": "unsupported_targets",
-                "bootstrap_version": "1.2.0",
+                "bootstrap_version": "1.3.0",
                 "detected_agents": [{"agent": "codex"}],
                 "current_count": 0,
                 "missing_count": 0,
@@ -1008,6 +1107,47 @@ mod tests {
                 assert!(output.contains(expected), "{expected} missing at {width}");
             }
             assert!(!output.contains("Coverage\n"));
+        }
+    }
+
+    #[test]
+    fn finding_report_shows_evidence_and_trust_decision_instead_of_empty_metrics() {
+        let value = json!({
+            "id": "finding_00000000000000000000000000000000",
+            "title": "Skill links escape an approved root",
+            "summary": "One placement points outside its approved Agent root.",
+            "severity": "high",
+            "category": "layout",
+            "evidence_quality": "observed",
+            "impact": {"affected_skill_count": 1, "affected_placement_count": 1},
+            "detail": {"mode": "compact"},
+            "items": [{
+                "path": "/Users/example/.codex/skills/example/SKILL.md",
+                "facts": {"agent": "codex"}
+            }],
+            "resolution": {
+                "decision": "confirm_trusted_source_roots",
+                "observed_link_targets": ["/Users/example/source/example"]
+            }
+        });
+        for width in [60, 80, 120] {
+            let output = render(
+                "report",
+                &value,
+                RenderOptions {
+                    width,
+                    styled: false,
+                },
+            );
+            assert!(output.contains("Skill links escape an approved root"));
+            assert!(output.contains("Evidence paths"));
+            assert!(output.contains("Observed link targets"));
+            assert!(output.contains("no automatic change is supported"));
+            assert!(!output.contains("Independent Skills     none"));
+            assert!(
+                output.lines().all(|line| display_width(line) <= width),
+                "line exceeded {width} columns:\n{output}"
+            );
         }
     }
 

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -88,10 +88,10 @@ fn plan_evidence_id(home: &Path, state: &Path) -> String {
         .and_then(|finding| finding["id"].as_str())
         .expect("fixture report must expose a traceable Finding");
     let detail = cli_json(home, state, &["report", "--finding", finding], None);
-    detail["result"]["evidence_ids"]
+    detail["result"]["items"]
         .as_array()
-        .and_then(|ids| ids.first())
-        .and_then(Value::as_str)
+        .and_then(|items| items.first())
+        .and_then(|item| item["evidence_id"].as_str())
         .expect("Finding must expose Evidence through the public CLI")
         .to_string()
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -133,6 +133,10 @@ fn finding_drilldown_is_bounded_and_pageable() {
         state.to_str().unwrap(),
         "--json",
     ];
+    let invalid_full = run(&[&common[..], &["report", "--full"]].concat(), None);
+    assert!(!invalid_full.status.success());
+    let invalid_full: Value = serde_json::from_slice(&invalid_full.stdout).unwrap();
+    assert_eq!(invalid_full["error"]["code"], "invalid_cli_arguments");
     json_output(&run(&[&common[..], &["scan"]].concat(), None));
     let report = json_output(&run(
         &[&common[..], &["report", "--summary"]].concat(),
@@ -151,19 +155,16 @@ fn finding_drilldown_is_bounded_and_pageable() {
         &[&common[..], &["report", "--finding", finding_id]].concat(),
         None,
     );
-    assert!(first_output.stdout.len() < 40_000);
+    assert!(first_output.stdout.len() < 20_000);
     let first = json_output(&first_output);
     assert_eq!(first["result"]["page"]["offset"], 0);
     assert_eq!(first["result"]["page"]["limit"], 20);
     assert_eq!(first["result"]["page"]["next_offset"], 20);
-    assert_eq!(first["result"]["placements"].as_array().unwrap().len(), 20);
-    assert_eq!(
-        first["result"]["affected_placement_ids"]
-            .as_array()
-            .unwrap()
-            .len(),
-        20
-    );
+    assert_eq!(first["result"]["items"].as_array().unwrap().len(), 20);
+    assert_eq!(first["result"]["detail"]["mode"], "compact");
+    assert!(first["result"].get("placements").is_none());
+    assert!(first["result"].get("affected_placement_ids").is_none());
+    assert!(first["result"].get("evidence_ids").is_none());
 
     let second = json_output(&run(
         &[
@@ -183,9 +184,20 @@ fn finding_drilldown_is_bounded_and_pageable() {
     ));
     assert_eq!(second["result"]["page"]["offset"], 20);
     assert_ne!(
-        first["result"]["affected_placement_ids"][0],
-        second["result"]["affected_placement_ids"][0]
+        first["result"]["items"][0]["evidence_id"],
+        second["result"]["items"][0]["evidence_id"]
     );
+
+    let full_output = run(
+        &[&common[..], &["report", "--finding", finding_id, "--full"]].concat(),
+        None,
+    );
+    let full = json_output(&full_output);
+    assert_eq!(full["result"]["detail"]["mode"], "full");
+    assert!(full["result"]["placements"].is_array());
+    assert!(full["result"]["evidence"].is_array());
+    assert!(full["result"]["affected_placement_ids"].is_array());
+    assert!(full_output.stdout.len() > first_output.stdout.len());
 }
 
 #[test]
@@ -299,24 +311,23 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
         None,
     ));
     assert_eq!(finding["result"]["id"], finding_id);
-    assert!(finding["result"]["affected_skill_ids"].is_array());
-    assert!(finding["result"]["affected_placement_ids"].is_array());
+    assert!(finding["result"].get("affected_skill_ids").is_none());
+    assert!(finding["result"].get("affected_placement_ids").is_none());
     assert!(finding["result"]["impact"].is_object());
     assert!(finding["result"]["coverage"].is_object());
     assert!(
-        finding["result"]["placements"]
+        finding["result"]["items"]
             .as_array()
             .unwrap()
             .iter()
-            .any(|placement| placement["path"].as_str()
-                == Some(skill.join("SKILL.md").to_str().unwrap()))
+            .any(|item| item["path"].as_str() == Some(skill.join("SKILL.md").to_str().unwrap()))
     );
-    assert!(!finding["result"]["evidence"].as_array().unwrap().is_empty());
-    for evidence_id in finding["result"]["evidence_ids"].as_array().unwrap() {
+    assert!(!finding["result"]["items"].as_array().unwrap().is_empty());
+    for item in finding["result"]["items"].as_array().unwrap() {
         let exists: i64 = database
             .query_row(
                 "SELECT COUNT(*) FROM evidence WHERE id = ?1",
-                [evidence_id.as_str().unwrap()],
+                [item["evidence_id"].as_str().unwrap()],
                 |row| row.get(0),
             )
             .unwrap();
@@ -681,7 +692,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.2.0"
+        "1.3.0"
     );
 
     let undone = json_output(&run(
@@ -711,7 +722,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
     )
     .unwrap();
     fs::create_dir_all(bootstrap.parent().unwrap()).unwrap();
-    let legacy = include_str!("fixtures/bootstrap-v1.1.0.md");
+    let legacy = include_str!("fixtures/bootstrap-v1.2.0.md");
     fs::write(&bootstrap, legacy).unwrap();
     let common = [
         "--home",
@@ -733,7 +744,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
     );
     assert_eq!(
         upgrade["result"]["targets"][0]["installed_version"],
-        "1.1.0"
+        "1.2.0"
     );
     assert_eq!(fs::read_to_string(&bootstrap).unwrap(), legacy);
 
@@ -771,7 +782,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.2.0");
+    assert_eq!(output["result"]["bootstrap_version"], "1.3.0");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],
@@ -2292,4 +2303,71 @@ fn find_rejects_a_skill_symlink_that_now_escapes_approved_roots() {
     ));
     assert_eq!(found["result"]["matches"][0]["paths"], json!([]));
     assert_eq!(found["result"]["rescan_required"], true);
+}
+
+#[cfg(unix)]
+#[test]
+fn escaping_link_finding_requests_trust_confirmation_instead_of_a_plan() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    let source = temp.path().join("trusted-source");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(&source).unwrap();
+    fs::write(
+        source.join("SKILL.md"),
+        "---\nname: external\ndescription: fixture\n---\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&source, root.join("external")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let report = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Skill links escape an approved root")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+
+    let detail = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id]].concat(),
+        None,
+    ));
+    assert_eq!(
+        detail["result"]["resolution"]["decision"],
+        "confirm_trusted_source_roots"
+    );
+    assert_eq!(
+        detail["result"]["resolution"]["observed_link_targets"],
+        json!([source])
+    );
+    assert_eq!(
+        detail["result"]["resolution"]["automatic_change_supported"],
+        false
+    );
+    assert_eq!(detail["suggested_actions"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        detail["suggested_actions"][0]["action"],
+        "show_full_finding"
+    );
+    assert!(
+        detail["result"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["facts"]["link_target"] == json!(source))
+    );
 }

--- a/tests/fixtures/bootstrap-v1.2.0.md
+++ b/tests/fixtures/bootstrap-v1.2.0.md
@@ -1,6 +1,8 @@
 ---
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
+metadata:
+  bootstrap-version: "1.2.0"
 ---
 
 # SkillRoster
@@ -35,6 +37,8 @@ Hosted or Managed Library Plan so future Scans no longer depend on the
 temporary source-root arguments. Keep unconfirmed targets unread.
 
 ## Apply or undo
+
+Run `skillroster setup --json` when installing the Bootstrap Skill or after upgrading the CLI. An exact official older copy produces a normal upgrade Plan. If `state` is `modified_choice_required`, show the affected Agent targets and ask whether to `retain-local` or `adopt-current`; do not choose for the user. Adopting still only prepares a recoverable Plan and requires the usual Apply confirmation. Treat `unsupported_targets` as blocked rather than replacing links or non-files.
 
 Show the complete immutable Plan before requesting one explicit confirmation. After the user confirms, run `skillroster apply PLAN_ID --json`; do not substitute direct filesystem commands or bypass drift checks. Report verification, changed-path count, Receipt ID, and canonical deletion count.
 


### PR DESCRIPTION
## Summary
- make single-Finding JSON compact by default, with explicit `--full` detail
- replace unsafe-link planning with a typed trusted-source decision
- render human Finding drilldowns with bounded evidence paths and actionable next steps
- upgrade the Bootstrap Skill and Homebrew formula to 1.3.0

## Verification
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (100 passed)
- Bootstrap Skill validation
- real v1.2.0 Bootstrap Apply/Undo with byte-exact restore
- real read-only Snapshot replay: unsafe-link response -58.1%, duplicate response -42.4%