### PR TITLE
Add paged Finding enumeration for Agent callers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "d59aa9b273f75ccb479efd0046f5b4ed4ea76fa7"
-  version "1.3.0"
+      revision: "5806c8f3c00cd77266cb7e839f2bd7bfbd26f274"
+  version "1.4.0"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.3.0", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.4.0", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The agent then calls the `skillroster` CLI and returns an evidence-backed plan f
 skillroster scan --json
 skillroster --source-root /absolute/trusted/source scan --json
 skillroster report --summary --json
+skillroster report --findings --limit 20 --json
+skillroster report --findings --category usage --json
 skillroster report --finding <finding-id> --limit 20 --json
 skillroster report --finding <finding-id> --full --json
 skillroster find "database migration" --json
@@ -89,6 +91,11 @@ collections, placement records, and Evidence records stay behind explicit
 `report --finding ID --full --json`. Unsafe escaping links return a trust
 decision and observed targets instead of suggesting an automatic filesystem
 Plan.
+
+The three-Finding summary leads to `report --findings`, a compact paged list
+that can be filtered by category or severity. This gives Agents a bounded path
+to every Finding without loading the exhaustive report. Only a selected
+Finding leads to Evidence inspection or planning.
 
 ## Status
 

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -127,10 +127,28 @@ exposures, and 189 Findings. It changed no Agent files. On that same Snapshot:
 - plain 60-, 80-, and 120-column Finding views preserve the issue, counts,
   Evidence paths, and next decision without exceeding the requested width.
 
+## Agent-led Finding enumeration evidence
+
+The 1.4 discovery run started with the public 1.3.0 macOS arm64 binary and a
+fresh isolated state directory. Its read-only Scan found the same 180 Skills,
+676 placements, 548 default exposures, and 189 Findings in 9.41 seconds, with
+no Agent-file changes. The Agent then measured a 3,179-byte three-Finding
+summary against a 645,511-byte exhaustive report and confirmed there was no
+bounded enumeration path.
+
+On the same immutable Snapshot, the new paged interface returned 20 complete
+Finding summaries in 15,590 bytes. A `usage` category filter selected exactly
+two Findings; combined `overlap` and `medium` filters selected 125. The summary
+now suggests `list_findings`, a partial page preserves its filters in
+`list_more_findings`, and the exhaustive diagnostic export suggests no generic
+Plan. Selected IDs still lead to compact Evidence drilldown. Automated tests
+cover pagination, filtering, action argv, invalid flag combinations, and plain
+60-, 80-, and 120-column rendering.
+
 ## Evidence boundary
 
 These checks establish deterministic routing and safe local governance; they do
 not claim model quality, token or labor savings, production performance, or
 access to arbitrary future Agent log formats. Final support additionally
- requires the official release tag workflow, published artifact checksums, and
+requires the official release tag workflow, published artifact checksums, and
 the installation checks recorded in the Release notes.

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -146,7 +146,7 @@ Machine results should expose facts, not preformatted prose:
 
 - `primary_metrics` with value, unit, coverage, and comparison baseline;
 - Findings with stable ID, category, severity, Evidence quality, impact fields, and affected IDs;
-- a bounded `report --summary --json` first view with no more than three Findings and one primary Evidence reference, plus compact paged Evidence items from `report --finding ID --json`; exact complete records require `--full`, and exact-duplicate detail exposes at most five ranked, owned canonical candidates without requiring pagination;
+- a bounded `report --summary --json` first view with no more than three Findings and one primary Evidence reference; a category/severity-filterable `report --findings --json` page for enumerating compact Finding summaries; and compact paged Evidence items from `report --finding ID --json`; exact complete records require `--full`, and exact-duplicate detail exposes at most five ranked, owned canonical candidates without requiring pagination;
 - Find results that keep the original task, expose Agent-authored retrieval hints, and collapse same-name identities into one explicitly variant capability result;
 - bounded Plan `change_summary`, `operation_groups`, affected-scope counts and `impact` deltas for current and proposed state; source-update line details remain in the bounded `diff_summary`, while full operations are loaded only through `plan --show PLAN_ID` when needed;
 - affected Agents, Skills, placements, operation groups, exclusions, and deletion count;

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -91,8 +91,12 @@ Lead with four counts: independent Skills, placements, default exposure, and obs
 
 Agent callers use `report --summary --json` by default. The compact payload
 contains those four metrics, total Finding count, category totals, and at most
-three complete Finding summaries. Full `report --json` is an explicit
-exhaustive view, not the bootstrap workflow default.
+three complete Finding summaries. When the Agent needs another category or an
+exhaustive selection surface, it uses `report --findings --json`, optionally
+filtered by one `--category` and one `--severity`. That mode returns compact
+Finding summaries plus `page.next_offset`; it never suggests planning before a
+Finding is selected. Full `report --json` remains an explicit diagnostic export,
+not the bootstrap workflow default.
 
 `report --finding ID --json` returns at most 20 compact Evidence items. Each
 item combines its stable Evidence ID, subject, path, quality, and decision facts
@@ -110,6 +114,10 @@ trust decision instead of a Plan suggestion.
 Human Finding output shows the issue, severity, affected counts, bounded paths,
 and any required trust decision. It must not render a Finding as an empty
 aggregate report.
+
+Human `report --findings` output shows the matching range, active filters,
+stable IDs, impact counts, and next offset. Every line remains bounded at 60,
+80, and 120 columns.
 
 ### `find`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.3.0
+SKILLROSTER_VERSION=1.4.0
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.3.0 skillroster
+  --tag v1.4.0 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.3.0
+git checkout v1.4.0
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -99,7 +99,7 @@ The first complete command surface is:
 
 ```bash
 skillroster scan [--json]
-skillroster report [--finding <id>] [--full] [--json]
+skillroster report [--summary | --findings [--category <category>] [--severity <severity>] | --finding <id> [--full]] [--limit <n>] [--offset <n>] [--json]
 skillroster find <task> [--hint <text>]... [--json]
 skillroster plan --stdin [--json]
 skillroster plan --show <plan-id> [--json]

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -2,7 +2,7 @@
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
 metadata:
-  bootstrap-version: "1.3.0"
+  bootstrap-version: "1.4.0"
 ---
 
 # SkillRoster
@@ -11,9 +11,9 @@ Use the local `skillroster` binary as the deterministic source of facts. Invoke 
 
 ## Inspect and propose
 
-1. Run `skillroster scan --json`, then `skillroster report --summary --json`. Use the compact result for the first user-facing diagnosis; do not request the full report unless exhaustive Finding enumeration is necessary.
-2. Distinguish observed, inferred, and unknown usage. Missing evidence does not mean unused.
-3. Use stable Finding and Evidence IDs for follow-up questions. The summary exposes one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Its compact `items` combine the Evidence ID, subject, path, and decision facts without repeating complete internal collections. Use `--full` only when an exact complete ID or record is needed. Exact-duplicate detail includes a bounded `planning.canonical_candidates` list independently of pagination. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
+1. Run `skillroster scan --json`, then `skillroster report --summary --json`. Use the compact result for the first user-facing diagnosis.
+2. Distinguish observed, inferred, and unknown usage. Missing evidence does not mean unused. When the three-item summary is insufficient, use `report --findings --limit 20 --json`; narrow it with one `--category` or `--severity` from the summary totals, and follow `page.next_offset` only while that category still affects the decision. This paged list is the enumeration path; keep the exhaustive report out of the Agent context.
+3. Use stable Finding and Evidence IDs for follow-up questions. The summary and paged list expose one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Its compact `items` combine the Evidence ID, subject, path, and decision facts without repeating complete internal collections. Use `--full` only when an exact complete ID or record is needed. Exact-duplicate detail includes a bounded `planning.canonical_candidates` list independently of pagination. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
 4. Make semantic governance choices in the conversation, then submit declarative target states to `skillroster plan --stdin --json`. For an exact-duplicate Finding, send `schema_version` plus `finding_library_changes`; SkillRoster derives the current Snapshot, Evidence, Skill, and complete placement set. For other request families, include the latest `scan_id` and relevant `evidence_ids`.
 5. Present the validated summary Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `operation_groups`, bounded `affected` facts, `impact` before/after facts, uncertainty, canonical deletion count, reversibility, and Plan ID. The full immutable representation stays in local state; use `skillroster plan --show PLAN_ID --json` only when an exact operation, path, or complete ID list is needed to answer the user. Do not load it by default.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,9 @@ use sha2::{Digest, Sha256};
 use crate::change::{
     self, ChangeReceipt, Operation, OperationPolicy, PrepareContext, PreparedPlan,
 };
-use crate::cli::{Cli, Command, LifecycleCommand, ModifiedBootstrapChoice};
+use crate::cli::{
+    Cli, Command, LifecycleCommand, ModifiedBootstrapChoice, ReportCategory, ReportSeverity,
+};
 use crate::harness::{self, AgentKind};
 use crate::model::{
     AgentId, AgentRecord, ApiError, EvidenceId, EvidenceKind, EvidenceQuality, EvidenceRecord,
@@ -114,16 +116,27 @@ pub fn run(cli: Cli) -> Result<Output> {
             )
         }
         Some(Command::Report(args)) => {
-            let finding_id = args.finding.as_deref();
-            let result = report_command(
-                &store,
-                finding_id,
-                args.summary,
-                args.full,
-                usize::from(args.limit),
-                usize::try_from(args.offset)?,
-            )?;
-            let actions = report_actions(&result, finding_id, args.full, args.limit, args.offset);
+            let request = if let Some(id) = args.finding.as_deref() {
+                ReportRequest::Finding {
+                    id,
+                    full: args.full,
+                    limit: usize::from(args.limit),
+                    offset: usize::try_from(args.offset)?,
+                }
+            } else if args.summary {
+                ReportRequest::Summary
+            } else if args.findings {
+                ReportRequest::Findings {
+                    category: args.category,
+                    severity: args.severity,
+                    limit: usize::from(args.limit),
+                    offset: usize::try_from(args.offset)?,
+                }
+            } else {
+                ReportRequest::Exhaustive
+            };
+            let result = report_command(&store, request)?;
+            let actions = report_actions(&result, request);
             ("report", result, vec![], actions)
         }
         Some(Command::Find(args)) => (
@@ -1057,15 +1070,32 @@ fn compact_scan_warnings(warnings: Vec<String>) -> Vec<String> {
     remaining
 }
 
-fn report_command(
-    store: &StateStore,
-    finding: Option<&str>,
-    summary_only: bool,
-    full_detail: bool,
-    detail_limit: usize,
-    detail_offset: usize,
-) -> Result<Value> {
-    if let Some(id) = finding {
+#[derive(Clone, Copy)]
+enum ReportRequest<'a> {
+    Summary,
+    Findings {
+        category: Option<ReportCategory>,
+        severity: Option<ReportSeverity>,
+        limit: usize,
+        offset: usize,
+    },
+    Finding {
+        id: &'a str,
+        full: bool,
+        limit: usize,
+        offset: usize,
+    },
+    Exhaustive,
+}
+
+fn report_command(store: &StateStore, request: ReportRequest<'_>) -> Result<Value> {
+    if let ReportRequest::Finding {
+        id,
+        full,
+        limit,
+        offset,
+    } = request
+    {
         let id = FindingId::parse(id.to_string())?;
         let stored = store
             .get_finding(&id)?
@@ -1098,24 +1128,24 @@ fn report_command(
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
-            let end = detail_offset.saturating_add(detail_limit);
+            let end = offset.saturating_add(limit);
             let paged_skill_ids = affected_skill_ids
                 .iter()
-                .skip(detail_offset)
-                .take(detail_limit)
+                .skip(offset)
+                .take(limit)
                 .cloned()
                 .collect::<Vec<_>>();
             let paged_placement_ids = affected_placement_ids
                 .iter()
-                .skip(detail_offset)
-                .take(detail_limit)
+                .skip(offset)
+                .take(limit)
                 .cloned()
                 .collect::<Vec<_>>();
             let paged_evidence_ids = stored
                 .evidence_ids
                 .iter()
-                .skip(detail_offset)
-                .take(detail_limit)
+                .skip(offset)
+                .take(limit)
                 .cloned()
                 .collect::<Vec<_>>();
             let mut placements = scan
@@ -1165,8 +1195,8 @@ fn report_command(
             object.insert(
                 "page".into(),
                 json!({
-                    "offset": detail_offset,
-                    "limit": detail_limit,
+                    "offset": offset,
+                    "limit": limit,
                     "next_offset": next_offset,
                     "has_more": next_offset.is_some(),
                     "totals": {
@@ -1185,12 +1215,12 @@ fn report_command(
             object.insert(
                 "detail".into(),
                 json!({
-                    "mode": if full_detail { "full" } else { "compact" },
-                    "full_available": !full_detail
+                    "mode": if full { "full" } else { "compact" },
+                    "full_available": !full
                 }),
             );
         }
-        return Ok(if full_detail {
+        return Ok(if full {
             details
         } else {
             compact_finding_detail(details)
@@ -1199,11 +1229,7 @@ fn report_command(
     let (scan_id, scan): (ScanId, ScanResult) = latest_scan(store)?;
     if let Some(existing) = store.latest_report()? {
         if existing.scan_id == scan_id {
-            return Ok(if summary_only {
-                compact_report(&existing.summary)
-            } else {
-                existing.summary
-            });
+            return Ok(select_report_view(&existing.summary, request));
         }
     }
     let report = crate::query::build_report(&scan);
@@ -1286,11 +1312,7 @@ fn report_command(
         },
         &findings,
     )?;
-    Ok(if summary_only {
-        compact_report(&value)
-    } else {
-        value
-    })
+    Ok(select_report_view(&value, request))
 }
 
 fn add_finding_resolution(object: &mut serde_json::Map<String, Value>) {
@@ -1367,56 +1389,107 @@ fn compact_finding_detail(mut details: Value) -> Value {
     details
 }
 
-fn report_actions(
-    result: &Value,
-    finding_id: Option<&str>,
-    full_detail: bool,
-    limit: u16,
-    offset: u32,
-) -> Vec<SuggestedAction> {
-    let Some(finding_id) = finding_id else {
-        return vec![action(
-            "plan",
-            &["plan", "--stdin", "--json"],
-            false,
-            false,
-            "findings_available",
-        )];
-    };
-    let requires_trust_decision =
-        result["resolution"]["decision"].as_str() == Some("confirm_trusted_source_roots");
-    let mut actions = Vec::new();
-    if !requires_trust_decision {
-        actions.push(action(
-            "plan",
-            &["plan", "--stdin", "--json"],
-            false,
-            false,
-            "finding_action_available",
-        ));
+fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAction> {
+    match request {
+        ReportRequest::Summary => {
+            let total = result["finding_count"].as_u64().unwrap_or_default();
+            let returned = result["findings"]
+                .as_array()
+                .map_or(0, |findings| findings.len() as u64);
+            if total <= returned {
+                return Vec::new();
+            }
+            vec![action(
+                "list_findings",
+                &[
+                    "report",
+                    "--findings",
+                    "--limit",
+                    "20",
+                    "--offset",
+                    "0",
+                    "--json",
+                ],
+                false,
+                false,
+                "more_findings_available",
+            )]
+        }
+        ReportRequest::Findings {
+            category,
+            severity,
+            limit,
+            ..
+        } => {
+            let Some(next_offset) = result["page"]["next_offset"].as_u64() else {
+                return Vec::new();
+            };
+            let mut argv = vec!["report".to_owned(), "--findings".to_owned()];
+            if let Some(category) = category {
+                argv.extend(["--category".to_owned(), category.id().to_owned()]);
+            }
+            if let Some(severity) = severity {
+                argv.extend(["--severity".to_owned(), severity.id().to_owned()]);
+            }
+            argv.extend([
+                "--limit".to_owned(),
+                limit.to_string(),
+                "--offset".to_owned(),
+                next_offset.to_string(),
+                "--json".to_owned(),
+            ]);
+            let argv = argv.iter().map(String::as_str).collect::<Vec<_>>();
+            vec![action(
+                "list_more_findings",
+                &argv,
+                false,
+                false,
+                "more_filtered_findings_available",
+            )]
+        }
+        ReportRequest::Finding {
+            id,
+            full,
+            limit,
+            offset,
+        } => {
+            let requires_trust_decision =
+                result["resolution"]["decision"].as_str() == Some("confirm_trusted_source_roots");
+            let mut actions = Vec::new();
+            if !requires_trust_decision {
+                actions.push(action(
+                    "plan",
+                    &["plan", "--stdin", "--json"],
+                    false,
+                    false,
+                    "finding_action_available",
+                ));
+            }
+            if !full {
+                let limit = limit.to_string();
+                let offset = offset.to_string();
+                actions.push(action(
+                    "show_full_finding",
+                    &[
+                        "report",
+                        "--finding",
+                        id,
+                        "--full",
+                        "--limit",
+                        &limit,
+                        "--offset",
+                        &offset,
+                        "--json",
+                    ],
+                    false,
+                    false,
+                    "finding_full_detail_available",
+                ));
+            }
+            actions
+        }
+        ReportRequest::Exhaustive => Vec::new(),
     }
-    if !full_detail {
-        let limit = limit.to_string();
-        let offset = offset.to_string();
-        actions.push(action(
-            "show_full_finding",
-            &[
-                "report",
-                "--finding",
-                finding_id,
-                "--full",
-                "--limit",
-                &limit,
-                "--offset",
-                &offset,
-                "--json",
-            ],
-            false,
-            false,
-            "finding_full_detail_available",
-        ));
-    }
-    actions
 }
 
 fn finding_library_planning(
@@ -1495,26 +1568,101 @@ fn finding_library_planning(
     }))
 }
 
+fn select_report_view(report: &Value, request: ReportRequest<'_>) -> Value {
+    match request {
+        ReportRequest::Summary => compact_report(report),
+        ReportRequest::Findings {
+            category,
+            severity,
+            limit,
+            offset,
+        } => paged_finding_report(report, category, severity, limit, offset),
+        ReportRequest::Exhaustive | ReportRequest::Finding { .. } => report.clone(),
+    }
+}
+
+fn compact_finding_summary(finding: &Value) -> Value {
+    json!({
+        "id": finding["id"],
+        "category": finding["category"],
+        "severity": finding["severity"],
+        "title": finding["title"],
+        "summary": finding["summary"],
+        "evidence_quality": finding["evidence_quality"],
+        "primary_evidence_id": finding["evidence_ids"].as_array().and_then(|ids| ids.first()),
+        "affected_skill_count": finding["affected_skill_count"],
+        "affected_placement_count": finding["affected_placement_count"],
+        "impact": finding["impact"],
+        "coverage": finding["coverage"]
+    })
+}
+
+fn paged_finding_report(
+    report: &Value,
+    category: Option<ReportCategory>,
+    severity: Option<ReportSeverity>,
+    limit: usize,
+    offset: usize,
+) -> Value {
+    let findings = report["findings"]
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let matching = findings
+        .iter()
+        .filter(|finding| {
+            category.is_none_or(|value| finding["category"].as_str() == Some(value.id()))
+                && severity.is_none_or(|value| finding["severity"].as_str() == Some(value.id()))
+        })
+        .collect::<Vec<_>>();
+    let total = matching.len();
+    let items = matching
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(compact_finding_summary)
+        .collect::<Vec<_>>();
+    let end = offset.saturating_add(items.len());
+    let next_offset = (end < total).then_some(end);
+    json!({
+        "view": "findings",
+        "report_id": report["report_id"],
+        "snapshot_id": report["snapshot_id"],
+        "skill_count": report["skill_count"],
+        "placement_count": report["placement_count"],
+        "default_exposure": report["default_exposure"],
+        "observed_use_agent_count": report["observed_use_agent_count"],
+        "coverage_reliable_agent_count": report["coverage_reliable_agent_count"],
+        "primary_metrics": report["primary_metrics"],
+        "finding_count": findings.len(),
+        "matched_finding_count": total,
+        "category_counts": report["category_counts"],
+        "filters": {
+            "category": category.map(ReportCategory::id),
+            "severity": severity.map(ReportSeverity::id)
+        },
+        "page": {
+            "offset": offset,
+            "limit": limit,
+            "returned": items.len(),
+            "total": total,
+            "next_offset": next_offset,
+            "has_more": next_offset.is_some()
+        },
+        "items": items,
+        "files_changed": false
+    })
+}
+
 fn compact_report(report: &Value) -> Value {
-    let findings = report["findings"].as_array().cloned().unwrap_or_default();
+    let findings = report["findings"]
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or_default();
     let compact_findings = findings
         .iter()
         .take(3)
-        .map(|finding| {
-            json!({
-                "id": finding["id"],
-                "category": finding["category"],
-                "severity": finding["severity"],
-                "title": finding["title"],
-                "summary": finding["summary"],
-                "evidence_quality": finding["evidence_quality"],
-                "primary_evidence_id": finding["evidence_ids"].as_array().and_then(|ids| ids.first()),
-                "affected_skill_count": finding["affected_skill_count"],
-                "affected_placement_count": finding["affected_placement_count"],
-                "impact": finding["impact"],
-                "coverage": finding["coverage"]
-            })
-        })
+        .map(compact_finding_summary)
         .collect::<Vec<_>>();
     json!({
         "report_id": report["report_id"],
@@ -3107,6 +3255,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.2.0",
         "a12e3bbf45e4a3d51b8075dd2b56a410f113fb27cd803676fb614bd88f278f9c",
     ),
+    (
+        "1.3.0",
+        "0fe2e7b8aed1f6db1c57a3d5b6efc247b795e1af01d5422b9168e707bc8c7b47",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -4192,13 +4344,13 @@ mod recovery_tests {
             BootstrapContentStatus::Modified
         );
         let windows_legacy =
-            include_str!("../tests/fixtures/bootstrap-v1.2.0.md").replace('\n', "\r\n");
+            include_str!("../tests/fixtures/bootstrap-v1.3.0.md").replace('\n', "\r\n");
         assert_eq!(
             bootstrap_content_status(
                 &bootstrap_content_digest(windows_legacy.as_bytes()),
                 &current
             ),
-            BootstrapContentStatus::OfficialOutdated("1.2.0")
+            BootstrapContentStatus::OfficialOutdated("1.3.0")
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,24 +75,80 @@ pub enum Command {
 
 #[derive(Debug, Args)]
 pub struct ReportArgs {
-    #[arg(long)]
+    #[arg(long, conflicts_with_all = ["findings", "summary"])]
     pub finding: Option<String>,
+
+    /// List compact Finding summaries with pagination and optional filters.
+    #[arg(long, conflicts_with_all = ["finding", "summary", "full"])]
+    pub findings: bool,
 
     /// Show complete IDs, placement records, and Evidence records for one Finding.
     #[arg(long, requires = "finding")]
     pub full: bool,
 
     /// Return core metrics and the three highest-priority Findings.
-    #[arg(long)]
+    #[arg(long, conflicts_with_all = ["finding", "findings", "full"])]
     pub summary: bool,
 
-    /// Maximum Finding detail rows returned per collection.
+    /// Filter a paged Finding list to one category.
+    #[arg(long, value_enum, requires = "findings")]
+    pub category: Option<ReportCategory>,
+
+    /// Filter a paged Finding list to one severity.
+    #[arg(long, value_enum, requires = "findings")]
+    pub severity: Option<ReportSeverity>,
+
+    /// Maximum Finding summaries or detail rows returned.
     #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u16).range(1..=100))]
     pub limit: u16,
 
-    /// Zero-based offset for Finding detail pagination.
+    /// Zero-based offset for Finding list or detail pagination.
     #[arg(long, default_value_t = 0)]
     pub offset: u32,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum ReportCategory {
+    Inventory,
+    Layout,
+    Exposure,
+    Usage,
+    Overlap,
+    Routing,
+    Lifecycle,
+}
+
+impl ReportCategory {
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::Inventory => "inventory",
+            Self::Layout => "layout",
+            Self::Exposure => "exposure",
+            Self::Usage => "usage",
+            Self::Overlap => "overlap",
+            Self::Routing => "routing",
+            Self::Lifecycle => "lifecycle",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum ReportSeverity {
+    Info,
+    Low,
+    Medium,
+    High,
+}
+
+impl ReportSeverity {
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
 }
 
 #[derive(Debug, Args)]

--- a/src/present.rs
+++ b/src/present.rs
@@ -247,6 +247,10 @@ fn report(value: &Value, lines: &mut Vec<String>, width: usize) {
         finding_report(value, lines, width);
         return;
     }
+    if value.get("view").and_then(Value::as_str) == Some("findings") {
+        finding_list(value, lines, width);
+        return;
+    }
     fact(lines, "Independent Skills", text(value, "skill_count"));
     fact(lines, "Placements", text(value, "placement_count"));
     fact(lines, "Default exposure", text(value, "default_exposure"));
@@ -285,6 +289,69 @@ fn report(value: &Value, lines: &mut Vec<String>, width: usize) {
         "Read-only · no Agent files changed",
         "Review evidence before planning changes",
     ));
+}
+
+fn finding_list(value: &Value, lines: &mut Vec<String>, width: usize) {
+    let offset = value["page"]["offset"].as_u64().unwrap_or_default();
+    let returned = value["page"]["returned"].as_u64().unwrap_or_default();
+    let total = value["page"]["total"].as_u64().unwrap_or_default();
+    let range = if returned == 0 {
+        format!("0 of {total} matching")
+    } else {
+        format!("{}–{} of {total} matching", offset + 1, offset + returned)
+    };
+    fact(lines, "Finding page", range);
+    fact(lines, "All Findings", text(value, "finding_count"));
+    let category = value["filters"]["category"].as_str();
+    let severity = value["filters"]["severity"].as_str();
+    if category.is_some() || severity.is_some() {
+        fact(
+            lines,
+            "Filters",
+            format!(
+                "category {} · severity {}",
+                category.unwrap_or("any"),
+                severity.unwrap_or("any")
+            ),
+        );
+    }
+    lines.push(String::new());
+    if let Some(items) = value.get("items").and_then(Value::as_array) {
+        for (index, finding) in items.iter().enumerate() {
+            let prefix = format!(
+                "  {:>3}. {:<6} {:<10} ",
+                offset as usize + index + 1,
+                text(finding, "severity"),
+                text(finding, "category")
+            );
+            lines.push(format!(
+                "{prefix}{}",
+                middle_truncate(
+                    &text(finding, "title"),
+                    width.saturating_sub(display_width(&prefix))
+                )
+            ));
+            let detail_prefix = "       ";
+            let detail = format!(
+                "{} · {} Skills · {} placements",
+                text(finding, "id"),
+                text(finding, "affected_skill_count"),
+                text(finding, "affected_placement_count")
+            );
+            lines.push(format!(
+                "{detail_prefix}{}",
+                middle_truncate(&detail, width.saturating_sub(display_width(detail_prefix)))
+            ));
+        }
+        if items.is_empty() {
+            lines.push("  none".into());
+        }
+    }
+    let next = value["page"]["next_offset"].as_u64().map_or_else(
+        || "End of matching Findings".into(),
+        |next| format!("Continue with --offset {next}"),
+    );
+    lines.extend(summary("Read-only · no Agent files changed", &next));
 }
 
 fn finding_report(value: &Value, lines: &mut Vec<String>, width: usize) {
@@ -983,7 +1050,7 @@ mod tests {
             "setup",
             &json!({
                 "state": "modified_choice_required",
-                "bootstrap_version": "1.3.0",
+                "bootstrap_version": "1.4.0",
                 "detected_agents": [{"agent": "codex"}],
                 "current_count": 0,
                 "missing_count": 0,
@@ -1005,7 +1072,7 @@ mod tests {
             "setup",
             &json!({
                 "state": "unsupported_targets",
-                "bootstrap_version": "1.3.0",
+                "bootstrap_version": "1.4.0",
                 "detected_agents": [{"agent": "codex"}],
                 "current_count": 0,
                 "missing_count": 0,
@@ -1144,6 +1211,52 @@ mod tests {
             assert!(output.contains("Observed link targets"));
             assert!(output.contains("no automatic change is supported"));
             assert!(!output.contains("Independent Skills     none"));
+            assert!(
+                output.lines().all(|line| display_width(line) <= width),
+                "line exceeded {width} columns:\n{output}"
+            );
+        }
+    }
+
+    #[test]
+    fn finding_list_keeps_page_filters_ids_and_width_visible() {
+        let value = json!({
+            "view": "findings",
+            "finding_count": 189,
+            "filters": {"category": "overlap", "severity": "medium"},
+            "page": {"offset": 20, "returned": 2, "total": 150, "next_offset": 22},
+            "items": [
+                {
+                    "id": "finding_00000000000000000000000000000001",
+                    "title": "Exact duplicate Skill placements with an intentionally long title",
+                    "severity": "medium",
+                    "category": "overlap",
+                    "affected_skill_count": 1,
+                    "affected_placement_count": 6
+                },
+                {
+                    "id": "finding_00000000000000000000000000000002",
+                    "title": "Semantic overlap candidate",
+                    "severity": "medium",
+                    "category": "overlap",
+                    "affected_skill_count": 2,
+                    "affected_placement_count": 8
+                }
+            ]
+        });
+        for width in [60, 80, 120] {
+            let output = render(
+                "report",
+                &value,
+                RenderOptions {
+                    width,
+                    styled: false,
+                },
+            );
+            assert!(output.contains("21–22 of 150 matching"));
+            assert!(output.contains("category overlap · severity medium"));
+            assert!(output.contains("Exact dupl"));
+            assert!(output.contains("Continue with --offset 22"));
             assert!(
                 output.lines().all(|line| display_width(line) <= width),
                 "line exceeded {width} columns:\n{output}"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -201,6 +201,142 @@ fn finding_drilldown_is_bounded_and_pageable() {
 }
 
 #[test]
+fn finding_list_is_paged_filterable_and_leads_to_evidence() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    for index in 0..30 {
+        let content = format!(
+            "---\nname: duplicate-{index:02}\ndescription: Dedicated duplicate task {index}\n---\n"
+        );
+        for root in [".codex/skills", ".claude/skills"] {
+            let directory = home.join(root).join(format!("duplicate-{index:02}"));
+            fs::create_dir_all(&directory).unwrap();
+            fs::write(directory.join("SKILL.md"), &content).unwrap();
+        }
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let summary = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    assert_eq!(summary["suggested_actions"][0]["action"], "list_findings");
+    assert_eq!(
+        summary["suggested_actions"][0]["argv"],
+        json!([
+            "skillroster",
+            "report",
+            "--findings",
+            "--limit",
+            "20",
+            "--offset",
+            "0",
+            "--json"
+        ])
+    );
+
+    let first_output = run(
+        &[
+            &common[..],
+            &[
+                "report",
+                "--findings",
+                "--category",
+                "overlap",
+                "--severity",
+                "medium",
+                "--limit",
+                "10",
+            ],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(first_output.stdout.len() < 20_000);
+    let first = json_output(&first_output);
+    assert_eq!(first["result"]["view"], "findings");
+    assert_eq!(first["result"]["matched_finding_count"], 30);
+    assert_eq!(first["result"]["page"]["returned"], 10);
+    assert_eq!(first["result"]["page"]["next_offset"], 10);
+    assert_eq!(first["result"]["items"].as_array().unwrap().len(), 10);
+    assert!(
+        first["result"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|finding| finding["category"] == "overlap"
+                && finding["severity"] == "medium"
+                && finding.get("evidence_ids").is_none())
+    );
+    assert_eq!(
+        first["suggested_actions"][0]["argv"],
+        json!([
+            "skillroster",
+            "report",
+            "--findings",
+            "--category",
+            "overlap",
+            "--severity",
+            "medium",
+            "--limit",
+            "10",
+            "--offset",
+            "10",
+            "--json"
+        ])
+    );
+
+    let second = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "report",
+                "--findings",
+                "--category",
+                "overlap",
+                "--severity",
+                "medium",
+                "--limit",
+                "10",
+                "--offset",
+                "10",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_ne!(
+        first["result"]["items"][0]["id"],
+        second["result"]["items"][0]["id"]
+    );
+
+    let finding_id = first["result"]["items"][0]["id"].as_str().unwrap();
+    let detail = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id]].concat(),
+        None,
+    ));
+    assert!(!detail["result"]["items"].as_array().unwrap().is_empty());
+
+    for invalid in [
+        vec!["report", "--category", "overlap"],
+        vec!["report", "--summary", "--findings"],
+    ] {
+        let output = run(&[&common[..], &invalid].concat(), None);
+        assert!(!output.status.success());
+        let output: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(output["error"]["code"], "invalid_cli_arguments");
+    }
+}
+
+#[test]
 fn public_cli_scans_reports_plans_applies_and_undoes() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
@@ -692,7 +828,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.3.0"
+        "1.4.0"
     );
 
     let undone = json_output(&run(
@@ -722,7 +858,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
     )
     .unwrap();
     fs::create_dir_all(bootstrap.parent().unwrap()).unwrap();
-    let legacy = include_str!("fixtures/bootstrap-v1.2.0.md");
+    let legacy = include_str!("fixtures/bootstrap-v1.3.0.md");
     fs::write(&bootstrap, legacy).unwrap();
     let common = [
         "--home",
@@ -744,7 +880,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
     );
     assert_eq!(
         upgrade["result"]["targets"][0]["installed_version"],
-        "1.2.0"
+        "1.3.0"
     );
     assert_eq!(fs::read_to_string(&bootstrap).unwrap(), legacy);
 
@@ -782,7 +918,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.3.0");
+    assert_eq!(output["result"]["bootstrap_version"], "1.4.0");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],

--- a/tests/fixtures/bootstrap-v1.3.0.md
+++ b/tests/fixtures/bootstrap-v1.3.0.md
@@ -2,7 +2,7 @@
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
 metadata:
-  bootstrap-version: "1.2.0"
+  bootstrap-version: "1.3.0"
 ---
 
 # SkillRoster
@@ -13,7 +13,7 @@ Use the local `skillroster` binary as the deterministic source of facts. Invoke 
 
 1. Run `skillroster scan --json`, then `skillroster report --summary --json`. Use the compact result for the first user-facing diagnosis; do not request the full report unless exhaustive Finding enumeration is necessary.
 2. Distinguish observed, inferred, and unknown usage. Missing evidence does not mean unused.
-3. Use stable Finding and Evidence IDs for follow-up questions. The summary exposes one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Exact-duplicate detail includes a bounded `planning.canonical_candidates` list independently of pagination. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
+3. Use stable Finding and Evidence IDs for follow-up questions. The summary exposes one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Its compact `items` combine the Evidence ID, subject, path, and decision facts without repeating complete internal collections. Use `--full` only when an exact complete ID or record is needed. Exact-duplicate detail includes a bounded `planning.canonical_candidates` list independently of pagination. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
 4. Make semantic governance choices in the conversation, then submit declarative target states to `skillroster plan --stdin --json`. For an exact-duplicate Finding, send `schema_version` plus `finding_library_changes`; SkillRoster derives the current Snapshot, Evidence, Skill, and complete placement set. For other request families, include the latest `scan_id` and relevant `evidence_ids`.
 5. Present the validated summary Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `operation_groups`, bounded `affected` facts, `impact` before/after facts, uncertainty, canonical deletion count, reversibility, and Plan ID. The full immutable representation stays in local state; use `skillroster plan --show PLAN_ID --json` only when an exact operation, path, or complete ID list is needed to answer the user. Do not load it by default.
 
@@ -28,13 +28,14 @@ Keep source updates and Library changes in separate Plans. Cite Evidence returne
 
 State explicitly that inspection and planning changed no Agent files. When evidence cannot justify a change, recommend keeping the current state.
 
-For `Skill links escape an approved root`, load one Finding page and show the
-link targets. Treat each target as unread until the user confirms that its
-source directory is intentional and trusted. After confirmation, rescan with
-one repeatable `--source-root ABSOLUTE_PATH` per canonical source directory;
-this approves reading without adding Agent exposure. Then prefer a reviewed
-Hosted or Managed Library Plan so future Scans no longer depend on the
-temporary source-root arguments. Keep unconfirmed targets unread.
+For `Skill links escape an approved root`, load one compact Finding page and
+show `resolution.observed_link_targets`. Treat each target as unread until the
+user confirms that its canonical source directory is intentional and trusted.
+Do not follow a generic Plan action for this Finding. After confirmation,
+rescan with one repeatable `--source-root ABSOLUTE_PATH` per canonical source
+directory; this approves reading without adding Agent exposure. Then prefer a
+reviewed Hosted or Managed Library Plan so future Scans no longer depend on
+the temporary source-root arguments. Keep unconfirmed targets unread.
 
 ## Apply or undo
 


### PR DESCRIPTION
## Summary
- bridge the 3-item summary and exhaustive report with paged compact Finding summaries
- support category and severity filters while preserving next-page argv
- stop suggesting a generic Plan before the Agent selects a Finding
- add bounded human list rendering and upgrade the Bootstrap Skill to 1.4.0

## Real Agent replay
- public 1.3.0 scan: 180 Skills, 676 placements, 548 default exposure, 189 Findings
- old choice: 3,179-byte summary or 645,511-byte exhaustive report
- new page: 20 Findings in 15,590 bytes
- `--category usage`: 2 Findings; `--category overlap --severity medium`: 125 Findings
- no Agent files changed

## Verification
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (102 passed)
- Bootstrap Skill validation
- real v1.3.0 Bootstrap Apply/Undo with byte-exact restore