### PR TITLE
fix: recognize exact Codex skill usage evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "b814c9fa14966f6e36013a5cae9d95cb36ce10a3"
+      revision: "f298d521a7f135bb0733708590e730518adcee1f"
   version "1.5.1"
 
   depends_on "rust" => :build

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -3,7 +3,7 @@ class Skillroster < Formula
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "cb3922bd2362a0a61ad6646a57fc93936d0c35b6"
-  version "1.5.0"
+  version "1.5.1"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.5.0", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.5.1", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "cb3922bd2362a0a61ad6646a57fc93936d0c35b6"
+      revision: "a073747fe8c046fdc5e27c496827cf43669b3181"
   version "1.5.1"
 
   depends_on "rust" => :build

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "bff308ad5b5c3e059253ed0adb869d15098b8344"
+      revision: "b814c9fa14966f6e36013a5cae9d95cb36ce10a3"
   version "1.5.1"
 
   depends_on "rust" => :build

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "a073747fe8c046fdc5e27c496827cf43669b3181"
+      revision: "bff308ad5b5c3e059253ed0adb869d15098b8344"
   version "1.5.1"
 
   depends_on "rust" => :build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.5.0
+SKILLROSTER_VERSION=1.5.1
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.5.0 skillroster
+  --tag v1.5.1 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.5.0
+git checkout v1.5.1
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -2,7 +2,7 @@
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
 metadata:
-  bootstrap-version: "1.5.0"
+  bootstrap-version: "1.5.1"
 ---
 
 # SkillRoster

--- a/src/app.rs
+++ b/src/app.rs
@@ -3652,6 +3652,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.4.0",
         "2161ba4834fb350afee75fd6ab90ecff49741c971bb2d670b8d3c9f6588f9b70",
     ),
+    (
+        "1.5.0",
+        "0afb58572bf602024f78e0f8c7312cc3485abb184746898945d1f7501a5425b5",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -77,7 +77,7 @@ pub enum SessionSignal {
 pub fn classify_session_record(agent: AgentKind, line: &str) -> Option<SessionSignal> {
     let value: Value = serde_json::from_str(line).ok()?;
     let keys = adapter_event_keys(agent);
-    classify_value(&value, keys)
+    classify_value(agent, &value, keys)
 }
 
 fn adapter_event_keys(agent: AgentKind) -> &'static [&'static str] {
@@ -93,14 +93,34 @@ fn adapter_event_keys(agent: AgentKind) -> &'static [&'static str] {
     }
 }
 
-fn classify_value(value: &Value, event_keys: &[&str]) -> Option<SessionSignal> {
+fn classify_value(agent: AgentKind, value: &Value, event_keys: &[&str]) -> Option<SessionSignal> {
     let object = value.as_object()?;
-    let event = event_keys
-        .iter()
-        .filter_map(|key| object.get(*key).and_then(Value::as_str))
+    let record_type = object.get("type").and_then(Value::as_str);
+    let payload = object.get("payload").and_then(Value::as_object);
+    let active = if matches!(record_type, Some("response_item" | "event_msg")) {
+        payload.unwrap_or(object)
+    } else {
+        object
+    };
+    let mut event_parts = Vec::new();
+    for key in event_keys {
+        event_parts.extend([
+            object.get(*key).and_then(Value::as_str),
+            active.get(*key).and_then(Value::as_str),
+        ]);
+    }
+    event_parts.extend(
+        ["type", "name", "event", "tool", "tool_name", "subtype"]
+            .into_iter()
+            .map(|key| active.get(key).and_then(Value::as_str)),
+    );
+    let event = event_parts
+        .into_iter()
+        .flatten()
         .map(str::to_ascii_lowercase)
         .collect::<Vec<_>>()
         .join(" ");
+    let contains_field = |key: &str| object.contains_key(key) || active.contains_key(key);
     let explicit_skill_field = [
         "skill_id",
         "skill_name",
@@ -112,31 +132,53 @@ fn classify_value(value: &Value, event_keys: &[&str]) -> Option<SessionSignal> {
         "outcome_skill",
     ]
     .iter()
-    .any(|key| object.contains_key(*key));
-    let serialized = value.to_string().to_ascii_lowercase();
+    .any(|key| contains_field(key));
+    let serialized = Value::Object(active.clone())
+        .to_string()
+        .to_ascii_lowercase();
     let reads_skill_file = serialized.contains("skill.md")
         && ["read_file", "read", "load", "open"]
             .iter()
             .any(|marker| event.contains(marker));
+    let codex_shell_read = agent == AgentKind::Codex
+        && active.get("type").and_then(Value::as_str) == Some("custom_tool_call")
+        && active.get("name").and_then(Value::as_str) == Some("exec")
+        && active
+            .get("input")
+            .and_then(Value::as_str)
+            .is_some_and(|input| {
+                let input = input.to_ascii_lowercase();
+                input.contains("skill.md")
+                    && input.contains("exec_command")
+                    && ["sed ", "rg ", "head ", "tail ", "awk ", "grep ", "less "]
+                        .iter()
+                        .any(|marker| input.contains(marker))
+            });
+    let codex_user_skill_reference = agent == AgentKind::Codex
+        && record_type == Some("response_item")
+        && active.get("type").and_then(Value::as_str) == Some("message")
+        && active.get("role").and_then(Value::as_str) == Some("user")
+        && serialized.contains("skill.md");
 
-    if explicit_skill_field
-        && (object.contains_key("outcome_skill") || event.contains("skill_outcome"))
+    if explicit_skill_field && (contains_field("outcome_skill") || event.contains("skill_outcome"))
     {
         Some(SessionSignal::Outcome)
     } else if explicit_skill_field
-        && (object.contains_key("applied_skill")
-            || object.contains_key("invoked_skill")
+        && (contains_field("applied_skill")
+            || contains_field("invoked_skill")
             || event.contains("invoke_skill")
             || event.contains("apply_skill"))
     {
         Some(SessionSignal::Applied)
     } else if reads_skill_file
-        || object.contains_key("loaded_skill")
+        || codex_shell_read
+        || contains_field("loaded_skill")
         || (explicit_skill_field && event.contains("load_skill"))
     {
         Some(SessionSignal::Loaded)
-    } else if object.contains_key("selected_skill")
-        || object.contains_key("matched_skill")
+    } else if codex_user_skill_reference
+        || contains_field("selected_skill")
+        || contains_field("matched_skill")
         || (explicit_skill_field && event.contains("match_skill"))
     {
         Some(SessionSignal::Matched)
@@ -225,5 +267,51 @@ mod tests {
             ),
             Some(SessionSignal::Applied)
         );
+    }
+
+    #[test]
+    fn codex_nested_exec_read_is_loaded_evidence() {
+        let line = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "exec",
+                "input": "await tools.exec_command({cmd: \"sed -n '1,80p' /skills/research/SKILL.md\"})"
+            }
+        })
+        .to_string();
+        assert_eq!(
+            classify_session_record(AgentKind::Codex, &line),
+            Some(SessionSignal::Loaded)
+        );
+    }
+
+    #[test]
+    fn codex_user_skill_link_is_matched_but_catalog_metadata_is_not() {
+        let invoked = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": "[$research](/skills/research/SKILL.md)"
+                }]
+            }
+        })
+        .to_string();
+        assert_eq!(
+            classify_session_record(AgentKind::Codex, &invoked),
+            Some(SessionSignal::Matched)
+        );
+
+        let catalog = serde_json::json!({
+            "type": "session_meta",
+            "payload": {
+                "base_instructions": "research is stored at /skills/research/SKILL.md"
+            }
+        })
+        .to_string();
+        assert_eq!(classify_session_record(AgentKind::Codex, &catalog), None);
     }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -798,7 +798,7 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
         }
         for entrypoint in entrypoints {
             skill_ids_by_reference
-                .entry(entrypoint.to_string_lossy().to_ascii_lowercase())
+                .entry(normalize_reference_text(&entrypoint.to_string_lossy()))
                 .or_default()
                 .insert(placement.skill_id.clone());
         }
@@ -1013,13 +1013,16 @@ fn observed_reference_skill_ids(
     let Some(matcher) = matcher else {
         return BTreeSet::new();
     };
-    let searchable = decoded_record_text(line)
-        .unwrap_or_else(|| line.to_owned())
-        .to_ascii_lowercase();
+    let decoded = decoded_record_text(line).unwrap_or_else(|| line.to_owned());
+    let searchable = normalize_reference_text(&decoded);
     matcher
         .find_iter(&searchable)
         .map(|matched| reference_lookup[matched.pattern().as_usize()].0.clone())
         .collect()
+}
+
+fn normalize_reference_text(value: &str) -> String {
+    value.replace('\\', "/").to_ascii_lowercase()
 }
 
 fn decoded_record_text(line: &str) -> Option<String> {
@@ -1433,9 +1436,10 @@ mod tests {
     #[test]
     fn json_escaped_windows_reference_binds_observed_usage() {
         let windows_path = r"C:\Users\tester\.codex\skills\research\SKILL.md";
+        let session_path = r"C:\Users\tester\.codex/skills/research\SKILL.md";
         let reference_lookup = vec![(
             "skill_windows".to_owned(),
-            windows_path.to_ascii_lowercase(),
+            normalize_reference_text(windows_path),
         )];
         let matcher = AhoCorasickBuilder::new()
             .ascii_case_insensitive(true)
@@ -1452,7 +1456,7 @@ mod tests {
                 "name": "exec",
                 "input": format!(
                     "await tools.exec_command({{cmd: \"rg -n name {}\"}})",
-                    windows_path
+                    session_path
                 )
             }
         })

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -760,11 +760,23 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
         first_seen_unix: None,
         last_seen_unix: None,
     };
-    let skill_lookup: Vec<(String, String)> = result
-        .skills
+    let mut skill_ids_by_name = BTreeMap::<String, BTreeSet<String>>::new();
+    for skill in &result.skills {
+        skill_ids_by_name
+            .entry(skill.name.to_ascii_lowercase())
+            .or_default()
+            .insert(skill.id.clone());
+    }
+    let skill_lookup = skill_ids_by_name
         .iter()
-        .map(|skill| (skill.id.clone(), skill.name.to_lowercase()))
-        .collect();
+        .filter(|(_, ids)| ids.len() == 1)
+        .map(|(name, ids)| {
+            (
+                ids.iter().next().expect("length checked").clone(),
+                name.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
     let patterns = skill_lookup
         .iter()
         .map(|(_, name)| name.as_str())
@@ -772,6 +784,38 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
     let matcher = AhoCorasickBuilder::new()
         .ascii_case_insensitive(true)
         .build(&patterns)
+        .ok();
+    let mut skill_ids_by_reference = BTreeMap::<String, BTreeSet<String>>::new();
+    for placement in &result.placements {
+        let mut entrypoints = vec![placement.entrypoint.clone()];
+        if let Some(target) = &placement.link_target {
+            entrypoints.push(target.join("SKILL.md"));
+        }
+        if placement.link_status != LinkStatus::EscapesRoot {
+            if let Ok(resolved) = fs::canonicalize(&placement.entrypoint) {
+                entrypoints.push(resolved);
+            }
+        }
+        for entrypoint in entrypoints {
+            skill_ids_by_reference
+                .entry(entrypoint.to_string_lossy().to_ascii_lowercase())
+                .or_default()
+                .insert(placement.skill_id.clone());
+        }
+    }
+    let reference_lookup = skill_ids_by_reference
+        .into_iter()
+        .filter_map(|(reference, ids)| {
+            (ids.len() == 1).then(|| (ids.into_iter().next().expect("length checked"), reference))
+        })
+        .collect::<Vec<_>>();
+    let reference_patterns = reference_lookup
+        .iter()
+        .map(|(_, reference)| reference.as_str())
+        .collect::<Vec<_>>();
+    let reference_matcher = AhoCorasickBuilder::new()
+        .ascii_case_insensitive(true)
+        .build(&reference_patterns)
         .ok();
     let mut events = BTreeMap::<(String, UsageStage, String), UsageEvidence>::new();
     let mut bytes_observed = 0_u64;
@@ -857,10 +901,45 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                 }
                 lines_observed += 1;
                 let lower = line.to_lowercase();
+                if let Some((stage, quality)) = classify_usage_line(agent, &line) {
+                    let mut observed_skill_ids = BTreeSet::new();
+                    if let Some(reference_matcher) = &reference_matcher {
+                        for matched in reference_matcher.find_iter(&lower) {
+                            observed_skill_ids
+                                .insert(reference_lookup[matched.pattern().as_usize()].0.clone());
+                        }
+                    }
+                    for reference in explicit_skill_field_values(&line) {
+                        if result.skills.iter().any(|skill| skill.id == reference) {
+                            observed_skill_ids.insert(reference.clone());
+                        }
+                        if let Some(ids) = skill_ids_by_name.get(&reference.to_ascii_lowercase()) {
+                            if ids.len() == 1 {
+                                observed_skill_ids.extend(ids.iter().cloned());
+                            }
+                        }
+                    }
+                    for skill_id in observed_skill_ids {
+                        let key = (skill_id.clone(), stage, source_path_digest.clone());
+                        let event = events.entry(key).or_insert_with(|| UsageEvidence {
+                            agent,
+                            skill_id,
+                            stage,
+                            quality,
+                            event_count: 0,
+                            first_seen_unix: timestamp,
+                            last_seen_unix: timestamp,
+                            source_path_digest: source_path_digest.clone(),
+                        });
+                        event.event_count += 1;
+                    }
+                    continue;
+                }
                 let Some(matcher) = &matcher else { continue };
                 for matched in matcher.find_iter(&lower) {
-                    let (skill_id, skill_name) = &skill_lookup[matched.pattern().as_usize()];
-                    let (stage, quality) = classify_usage_line(agent, &line, skill_name);
+                    let (skill_id, _) = &skill_lookup[matched.pattern().as_usize()];
+                    let stage = UsageStage::Exposed;
+                    let quality = EvidenceQuality::Inferred;
                     let key = (skill_id.clone(), stage, source_path_digest.clone());
                     let event = events.entry(key).or_insert_with(|| UsageEvidence {
                         agent,
@@ -918,33 +997,22 @@ fn collect_session_files(
     Ok(false)
 }
 
-fn classify_usage_line(
-    agent: AgentKind,
-    line: &str,
-    matched_skill_name: &str,
-) -> (UsageStage, EvidenceQuality) {
+fn classify_usage_line(agent: AgentKind, line: &str) -> Option<(UsageStage, EvidenceQuality)> {
     match classify_session_record(agent, line) {
-        Some(_)
-            if agent == AgentKind::Codex
-                && !codex_line_explicitly_references_skill(line, matched_skill_name)
-                && !line_has_explicit_skill_field(line, matched_skill_name) =>
-        {
-            (UsageStage::Exposed, EvidenceQuality::Inferred)
-        }
-        Some(SessionSignal::Outcome) => (UsageStage::Outcome, EvidenceQuality::Observed),
-        Some(SessionSignal::Applied) => (UsageStage::Applied, EvidenceQuality::Observed),
-        Some(SessionSignal::Loaded) => (UsageStage::Loaded, EvidenceQuality::Observed),
-        Some(SessionSignal::Matched) => (UsageStage::Matched, EvidenceQuality::Observed),
-        None => (UsageStage::Exposed, EvidenceQuality::Inferred),
+        Some(SessionSignal::Outcome) => Some((UsageStage::Outcome, EvidenceQuality::Observed)),
+        Some(SessionSignal::Applied) => Some((UsageStage::Applied, EvidenceQuality::Observed)),
+        Some(SessionSignal::Loaded) => Some((UsageStage::Loaded, EvidenceQuality::Observed)),
+        Some(SessionSignal::Matched) => Some((UsageStage::Matched, EvidenceQuality::Observed)),
+        None => None,
     }
 }
 
-fn line_has_explicit_skill_field(line: &str, skill_name: &str) -> bool {
+fn explicit_skill_field_values(line: &str) -> Vec<String> {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-        return false;
+        return Vec::new();
     };
     let Some(object) = value.as_object() else {
-        return false;
+        return Vec::new();
     };
     let payload = object.get("payload").and_then(serde_json::Value::as_object);
     [
@@ -958,28 +1026,16 @@ fn line_has_explicit_skill_field(line: &str, skill_name: &str) -> bool {
         "outcome_skill",
     ]
     .into_iter()
-    .any(|field| {
+    .flat_map(|field| {
         [
             object.get(field),
             payload.and_then(|payload| payload.get(field)),
         ]
-        .into_iter()
-        .flatten()
-        .filter_map(serde_json::Value::as_str)
-        .any(|value| value.eq_ignore_ascii_case(skill_name))
     })
-}
-
-fn codex_line_explicitly_references_skill(line: &str, skill_name: &str) -> bool {
-    let line = line.to_ascii_lowercase();
-    let skill_name = skill_name.to_ascii_lowercase();
-    [
-        format!("/{skill_name}/skill.md"),
-        format!("\\{skill_name}\\skill.md"),
-        format!("${skill_name}]("),
-    ]
-    .iter()
-    .any(|reference| line.contains(reference))
+    .flatten()
+    .filter_map(serde_json::Value::as_str)
+    .map(str::to_owned)
+    .collect()
 }
 
 fn update_window(first: &mut Option<u64>, last: &mut Option<u64>, timestamp: Option<u64>) {
@@ -1077,7 +1133,13 @@ pub fn placements_by_skill(scan: &ScanResult) -> BTreeMap<&str, Vec<&SkillPlacem
 }
 
 pub fn agents_with_usage(scan: &ScanResult) -> BTreeSet<AgentKind> {
-    scan.usage.iter().map(|usage| usage.agent).collect()
+    scan.usage
+        .iter()
+        .filter(|usage| {
+            usage.stage > UsageStage::Exposed && usage.quality == EvidenceQuality::Observed
+        })
+        .map(|usage| usage.agent)
+        .collect()
 }
 
 #[cfg(test)]
@@ -1228,15 +1290,16 @@ mod tests {
     #[test]
     fn codex_nested_records_produce_matched_and_loaded_usage() {
         let home = temp_directory("codex-nested-usage");
-        let skill = home.join(".codex/skills/research");
+        let skill = home.join(".codex/skills/research-directory");
         let sessions = home.join(".codex/sessions");
         fs::create_dir_all(&skill).unwrap();
         fs::create_dir_all(&sessions).unwrap();
         fs::write(
             skill.join("SKILL.md"),
-            "---\nname: research\ndescription: Primary-source research\n---\n",
+            "---\nname: primary-research\ndescription: Primary-source research\n---\n",
         )
         .unwrap();
+        let entrypoint = skill.join("SKILL.md");
         let generic = home.join(".codex/skills/plan");
         fs::create_dir_all(&generic).unwrap();
         fs::write(
@@ -1248,7 +1311,7 @@ mod tests {
             serde_json::json!({
                 "type": "session_meta",
                 "payload": {
-                    "base_instructions": "research: /skills/research/SKILL.md"
+                    "base_instructions": "primary-research is available in the local Skill catalog"
                 }
             }),
             serde_json::json!({
@@ -1258,7 +1321,10 @@ mod tests {
                     "role": "user",
                     "content": [{
                         "type": "input_text",
-                        "text": "Plan this with [$research](/skills/research/SKILL.md)"
+                        "text": format!(
+                            "Plan this with [$primary-research]({})",
+                            entrypoint.display()
+                        )
                     }]
                 }
             }),
@@ -1267,7 +1333,10 @@ mod tests {
                 "payload": {
                     "type": "custom_tool_call",
                     "name": "exec",
-                    "input": "await tools.exec_command({cmd: \"sed -n '1,80p' /skills/research/SKILL.md\"})"
+                    "input": format!(
+                        "await tools.exec_command({{cmd: \"sed -n '1,80p' {}\"}})",
+                        entrypoint.display()
+                    )
                 }
             }),
         ]
@@ -1281,7 +1350,7 @@ mod tests {
         let skill_id = &result
             .skills
             .iter()
-            .find(|skill| skill.name == "research")
+            .find(|skill| skill.name == "primary-research")
             .unwrap()
             .id;
         let generic_skill_id = &result
@@ -1308,6 +1377,70 @@ mod tests {
                 .all(|usage| usage.stage == UsageStage::Exposed)
         );
         fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn ambiguous_skill_name_does_not_receive_observed_usage() {
+        let home = temp_directory("ambiguous-usage-name");
+        for (directory, body) in [("one", "first"), ("two", "second")] {
+            let skill = home.join(".codex/skills").join(directory);
+            fs::create_dir_all(&skill).unwrap();
+            fs::write(
+                skill.join("SKILL.md"),
+                format!("---\nname: research\n---\n{body}\n"),
+            )
+            .unwrap();
+        }
+        let sessions = home.join(".codex/sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        fs::write(
+            sessions.join("session.jsonl"),
+            "{\"type\":\"match_skill\",\"matched_skill\":\"research\"}\n",
+        )
+        .unwrap();
+
+        let result = scan(&ScanOptions::for_home(&home)).unwrap();
+
+        assert_eq!(result.skills.len(), 2);
+        assert!(
+            result
+                .usage
+                .iter()
+                .all(|usage| usage.stage == UsageStage::Exposed)
+        );
+        assert!(agents_with_usage(&result).is_empty());
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn exposed_inference_is_not_counted_as_observed_agent_usage() {
+        let mut result = ScanResult::default();
+        result.usage.push(UsageEvidence {
+            agent: AgentKind::Codex,
+            skill_id: "skill_fixture".into(),
+            stage: UsageStage::Exposed,
+            quality: EvidenceQuality::Inferred,
+            event_count: 1,
+            first_seen_unix: None,
+            last_seen_unix: None,
+            source_path_digest: "sha256:fixture".into(),
+        });
+        assert!(agents_with_usage(&result).is_empty());
+
+        result.usage.push(UsageEvidence {
+            agent: AgentKind::Codex,
+            skill_id: "skill_fixture".into(),
+            stage: UsageStage::Matched,
+            quality: EvidenceQuality::Observed,
+            event_count: 1,
+            first_seen_unix: None,
+            last_seen_unix: None,
+            source_path_digest: "sha256:fixture".into(),
+        });
+        assert_eq!(
+            agents_with_usage(&result),
+            BTreeSet::from([AgentKind::Codex])
+        );
     }
 
     #[cfg(unix)]

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,5 +1,5 @@
 use crate::harness::{AgentKind, SessionSignal, classify_session_record, known_agent_roots};
-use aho_corasick::AhoCorasickBuilder;
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -902,13 +902,11 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                 lines_observed += 1;
                 let lower = line.to_lowercase();
                 if let Some((stage, quality)) = classify_usage_line(agent, &line) {
-                    let mut observed_skill_ids = BTreeSet::new();
-                    if let Some(reference_matcher) = &reference_matcher {
-                        for matched in reference_matcher.find_iter(&lower) {
-                            observed_skill_ids
-                                .insert(reference_lookup[matched.pattern().as_usize()].0.clone());
-                        }
-                    }
+                    let mut observed_skill_ids = observed_reference_skill_ids(
+                        &line,
+                        reference_matcher.as_ref(),
+                        &reference_lookup,
+                    );
                     for reference in explicit_skill_field_values(&line) {
                         if result.skills.iter().any(|skill| skill.id == reference) {
                             observed_skill_ids.insert(reference.clone());
@@ -1005,6 +1003,47 @@ fn classify_usage_line(agent: AgentKind, line: &str) -> Option<(UsageStage, Evid
         Some(SessionSignal::Matched) => Some((UsageStage::Matched, EvidenceQuality::Observed)),
         None => None,
     }
+}
+
+fn observed_reference_skill_ids(
+    line: &str,
+    matcher: Option<&AhoCorasick>,
+    reference_lookup: &[(String, String)],
+) -> BTreeSet<String> {
+    let Some(matcher) = matcher else {
+        return BTreeSet::new();
+    };
+    let searchable = decoded_record_text(line)
+        .unwrap_or_else(|| line.to_owned())
+        .to_ascii_lowercase();
+    matcher
+        .find_iter(&searchable)
+        .map(|matched| reference_lookup[matched.pattern().as_usize()].0.clone())
+        .collect()
+}
+
+fn decoded_record_text(line: &str) -> Option<String> {
+    fn collect_strings(value: &serde_json::Value, output: &mut Vec<String>) {
+        match value {
+            serde_json::Value::String(value) => output.push(value.clone()),
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    collect_strings(value, output);
+                }
+            }
+            serde_json::Value::Object(values) => {
+                for value in values.values() {
+                    collect_strings(value, output);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let value = serde_json::from_str(line).ok()?;
+    let mut strings = Vec::new();
+    collect_strings(&value, &mut strings);
+    Some(strings.join("\n"))
 }
 
 fn explicit_skill_field_values(line: &str) -> Vec<String> {
@@ -1377,6 +1416,45 @@ mod tests {
                 .all(|usage| usage.stage == UsageStage::Exposed)
         );
         fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn json_escaped_windows_reference_binds_observed_usage() {
+        let windows_path = r"C:\Users\tester\.codex\skills\research\SKILL.md";
+        let reference_lookup = vec![(
+            "skill_windows".to_owned(),
+            windows_path.to_ascii_lowercase(),
+        )];
+        let matcher = AhoCorasickBuilder::new()
+            .ascii_case_insensitive(true)
+            .build(
+                reference_lookup
+                    .iter()
+                    .map(|(_, reference)| reference.as_str()),
+            )
+            .unwrap();
+        let line = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "exec",
+                "input": format!(
+                    "await tools.exec_command({{cmd: \"rg -n name {}\"}})",
+                    windows_path
+                )
+            }
+        })
+        .to_string();
+
+        assert!(line.contains(r"C:\\Users\\tester"));
+        assert_eq!(
+            classify_usage_line(AgentKind::Codex, &line),
+            Some((UsageStage::Loaded, EvidenceQuality::Observed))
+        );
+        assert_eq!(
+            observed_reference_skill_ids(&line, Some(&matcher), &reference_lookup),
+            BTreeSet::from(["skill_windows".to_owned()])
+        );
     }
 
     #[test]

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -859,8 +859,8 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                 let lower = line.to_lowercase();
                 let Some(matcher) = &matcher else { continue };
                 for matched in matcher.find_iter(&lower) {
-                    let (skill_id, _) = &skill_lookup[matched.pattern().as_usize()];
-                    let (stage, quality) = classify_usage_line(agent, &line);
+                    let (skill_id, skill_name) = &skill_lookup[matched.pattern().as_usize()];
+                    let (stage, quality) = classify_usage_line(agent, &line, skill_name);
                     let key = (skill_id.clone(), stage, source_path_digest.clone());
                     let event = events.entry(key).or_insert_with(|| UsageEvidence {
                         agent,
@@ -918,14 +918,68 @@ fn collect_session_files(
     Ok(false)
 }
 
-fn classify_usage_line(agent: AgentKind, line: &str) -> (UsageStage, EvidenceQuality) {
+fn classify_usage_line(
+    agent: AgentKind,
+    line: &str,
+    matched_skill_name: &str,
+) -> (UsageStage, EvidenceQuality) {
     match classify_session_record(agent, line) {
+        Some(_)
+            if agent == AgentKind::Codex
+                && !codex_line_explicitly_references_skill(line, matched_skill_name)
+                && !line_has_explicit_skill_field(line, matched_skill_name) =>
+        {
+            (UsageStage::Exposed, EvidenceQuality::Inferred)
+        }
         Some(SessionSignal::Outcome) => (UsageStage::Outcome, EvidenceQuality::Observed),
         Some(SessionSignal::Applied) => (UsageStage::Applied, EvidenceQuality::Observed),
         Some(SessionSignal::Loaded) => (UsageStage::Loaded, EvidenceQuality::Observed),
         Some(SessionSignal::Matched) => (UsageStage::Matched, EvidenceQuality::Observed),
         None => (UsageStage::Exposed, EvidenceQuality::Inferred),
     }
+}
+
+fn line_has_explicit_skill_field(line: &str, skill_name: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+        return false;
+    };
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    let payload = object.get("payload").and_then(serde_json::Value::as_object);
+    [
+        "skill_id",
+        "skill_name",
+        "selected_skill",
+        "matched_skill",
+        "loaded_skill",
+        "applied_skill",
+        "invoked_skill",
+        "outcome_skill",
+    ]
+    .into_iter()
+    .any(|field| {
+        [
+            object.get(field),
+            payload.and_then(|payload| payload.get(field)),
+        ]
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .any(|value| value.eq_ignore_ascii_case(skill_name))
+    })
+}
+
+fn codex_line_explicitly_references_skill(line: &str, skill_name: &str) -> bool {
+    let line = line.to_ascii_lowercase();
+    let skill_name = skill_name.to_ascii_lowercase();
+    [
+        format!("/{skill_name}/skill.md"),
+        format!("\\{skill_name}\\skill.md"),
+        format!("${skill_name}]("),
+    ]
+    .iter()
+    .any(|reference| line.contains(reference))
 }
 
 fn update_window(first: &mut Option<u64>, last: &mut Option<u64>, timestamp: Option<u64>) {
@@ -1168,6 +1222,91 @@ mod tests {
             .collect::<BTreeSet<_>>();
         assert_eq!(discovered, AgentKind::ALL.into_iter().collect());
         assert_eq!(result.skills.len(), 8);
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn codex_nested_records_produce_matched_and_loaded_usage() {
+        let home = temp_directory("codex-nested-usage");
+        let skill = home.join(".codex/skills/research");
+        let sessions = home.join(".codex/sessions");
+        fs::create_dir_all(&skill).unwrap();
+        fs::create_dir_all(&sessions).unwrap();
+        fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: research\ndescription: Primary-source research\n---\n",
+        )
+        .unwrap();
+        let generic = home.join(".codex/skills/plan");
+        fs::create_dir_all(&generic).unwrap();
+        fs::write(
+            generic.join("SKILL.md"),
+            "---\nname: plan\ndescription: Planning workflow\n---\n",
+        )
+        .unwrap();
+        let records = [
+            serde_json::json!({
+                "type": "session_meta",
+                "payload": {
+                    "base_instructions": "research: /skills/research/SKILL.md"
+                }
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{
+                        "type": "input_text",
+                        "text": "Plan this with [$research](/skills/research/SKILL.md)"
+                    }]
+                }
+            }),
+            serde_json::json!({
+                "type": "response_item",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "exec",
+                    "input": "await tools.exec_command({cmd: \"sed -n '1,80p' /skills/research/SKILL.md\"})"
+                }
+            }),
+        ]
+        .into_iter()
+        .map(|record| record.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+        fs::write(sessions.join("session.jsonl"), records).unwrap();
+
+        let result = scan(&ScanOptions::for_home(&home)).unwrap();
+        let skill_id = &result
+            .skills
+            .iter()
+            .find(|skill| skill.name == "research")
+            .unwrap()
+            .id;
+        let generic_skill_id = &result
+            .skills
+            .iter()
+            .find(|skill| skill.name == "plan")
+            .unwrap()
+            .id;
+        let stages = result
+            .usage
+            .iter()
+            .filter(|usage| usage.skill_id == *skill_id && usage.agent == AgentKind::Codex)
+            .map(|usage| (usage.stage, usage.quality))
+            .collect::<Vec<_>>();
+
+        assert!(stages.contains(&(UsageStage::Exposed, EvidenceQuality::Inferred)));
+        assert!(stages.contains(&(UsageStage::Matched, EvidenceQuality::Observed)));
+        assert!(stages.contains(&(UsageStage::Loaded, EvidenceQuality::Observed)));
+        assert!(
+            result
+                .usage
+                .iter()
+                .filter(|usage| usage.skill_id == *generic_skill_id)
+                .all(|usage| usage.stage == UsageStage::Exposed)
+        );
         fs::remove_dir_all(home).unwrap();
     }
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1406,8 +1406,20 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(stages.contains(&(UsageStage::Exposed, EvidenceQuality::Inferred)));
-        assert!(stages.contains(&(UsageStage::Matched, EvidenceQuality::Observed)));
-        assert!(stages.contains(&(UsageStage::Loaded, EvidenceQuality::Observed)));
+        assert!(
+            stages.contains(&(UsageStage::Matched, EvidenceQuality::Observed)),
+            "entrypoint={} placements={:?} usage={:?}",
+            entrypoint.display(),
+            result.placements,
+            result.usage
+        );
+        assert!(
+            stages.contains(&(UsageStage::Loaded, EvidenceQuality::Observed)),
+            "entrypoint={} placements={:?} usage={:?}",
+            entrypoint.display(),
+            result.placements,
+            result.usage
+        );
         assert!(
             result
                 .usage

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -828,7 +828,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.5.0"
+        "1.5.1"
     );
 
     let undone = json_output(&run(
@@ -918,7 +918,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.5.0");
+    assert_eq!(output["result"]["bootstrap_version"], "1.5.1");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -845,59 +845,63 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
 
 #[test]
 fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
-    let temp = TempDir::new().unwrap();
-    let home = temp.path().join("home");
-    let state = temp.path().join("state");
-    let root = home.join(".codex/skills");
-    let ordinary = root.join("ordinary");
-    let bootstrap = root.join("skillroster/SKILL.md");
-    fs::create_dir_all(&ordinary).unwrap();
-    fs::write(
-        ordinary.join("SKILL.md"),
-        "---\nname: ordinary\ndescription: fixture\n---\n",
-    )
-    .unwrap();
-    fs::create_dir_all(bootstrap.parent().unwrap()).unwrap();
-    let legacy = include_str!("fixtures/bootstrap-v1.4.0.md");
-    fs::write(&bootstrap, legacy).unwrap();
-    let common = [
-        "--home",
-        home.to_str().unwrap(),
-        "--state-dir",
-        state.to_str().unwrap(),
-        "--json",
-    ];
-    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    for (legacy_version, legacy) in [
+        ("1.4.0", include_str!("fixtures/bootstrap-v1.4.0.md")),
+        ("1.5.0", include_str!("fixtures/bootstrap-v1.5.0.md")),
+    ] {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let state = temp.path().join("state");
+        let root = home.join(".codex/skills");
+        let ordinary = root.join("ordinary");
+        let bootstrap = root.join("skillroster/SKILL.md");
+        fs::create_dir_all(&ordinary).unwrap();
+        fs::write(
+            ordinary.join("SKILL.md"),
+            "---\nname: ordinary\ndescription: fixture\n---\n",
+        )
+        .unwrap();
+        fs::create_dir_all(bootstrap.parent().unwrap()).unwrap();
+        fs::write(&bootstrap, legacy).unwrap();
+        let common = [
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--json",
+        ];
+        json_output(&run(&[&common[..], &["scan"]].concat(), None));
 
-    let upgrade = json_output(&run(&[&common[..], &["setup"]].concat(), None));
-    assert_eq!(upgrade["result"]["state"], "preview_ready");
-    assert_eq!(upgrade["result"]["outdated_count"], 1);
-    assert_eq!(upgrade["result"]["modified_count"], 0);
-    assert_eq!(upgrade["result"]["replace_count"], 1);
-    assert_eq!(
-        upgrade["result"]["targets"][0]["status"],
-        "official_outdated"
-    );
-    assert_eq!(
-        upgrade["result"]["targets"][0]["installed_version"],
-        "1.4.0"
-    );
-    assert_eq!(fs::read_to_string(&bootstrap).unwrap(), legacy);
+        let upgrade = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+        assert_eq!(upgrade["result"]["state"], "preview_ready");
+        assert_eq!(upgrade["result"]["outdated_count"], 1);
+        assert_eq!(upgrade["result"]["modified_count"], 0);
+        assert_eq!(upgrade["result"]["replace_count"], 1);
+        assert_eq!(
+            upgrade["result"]["targets"][0]["status"],
+            "official_outdated"
+        );
+        assert_eq!(
+            upgrade["result"]["targets"][0]["installed_version"],
+            legacy_version
+        );
+        assert_eq!(fs::read_to_string(&bootstrap).unwrap(), legacy);
 
-    let plan_id = upgrade["result"]["plan_id"].as_str().unwrap();
-    let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
-    assert_eq!(applied["result"]["verification"], "passed");
-    assert_eq!(
-        fs::read_to_string(&bootstrap).unwrap(),
-        include_str!("../skill/skillroster/SKILL.md").replace("\r\n", "\n")
-    );
-    let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
-    assert_eq!(current["result"]["state"], "up_to_date");
+        let plan_id = upgrade["result"]["plan_id"].as_str().unwrap();
+        let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+        assert_eq!(applied["result"]["verification"], "passed");
+        assert_eq!(
+            fs::read_to_string(&bootstrap).unwrap(),
+            include_str!("../skill/skillroster/SKILL.md").replace("\r\n", "\n")
+        );
+        let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+        assert_eq!(current["result"]["state"], "up_to_date");
 
-    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
-    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
-    assert_eq!(undone["result"]["verification"], "passed");
-    assert_eq!(fs::read_to_string(&bootstrap).unwrap(), legacy);
+        let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+        let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+        assert_eq!(undone["result"]["verification"], "passed");
+        assert_eq!(fs::read_to_string(&bootstrap).unwrap(), legacy);
+    }
 }
 
 #[test]

--- a/tests/fixtures/bootstrap-v1.5.0.md
+++ b/tests/fixtures/bootstrap-v1.5.0.md
@@ -1,0 +1,59 @@
+---
+name: skillroster
+description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
+metadata:
+  bootstrap-version: "1.5.0"
+---
+
+# SkillRoster
+
+Use the local `skillroster` binary as the deterministic source of facts. Invoke every command with explicit `--json`; validate `schema_version` and `ok` before reading `result`. Treat typed `suggested_actions` as options, never authorization.
+
+## Inspect and propose
+
+1. Run `skillroster scan --json`, then `skillroster report --summary --json`. Use the compact result for the first user-facing diagnosis.
+2. Distinguish observed, inferred, and unknown usage. Missing evidence does not mean unused. When the three-item summary is insufficient, use `report --findings --limit 20 --json`; narrow it with one `--category` or `--severity` from the summary totals, and follow `page.next_offset` only while that category still affects the decision. This paged list is the enumeration path; keep the exhaustive report out of the Agent context.
+3. Use stable Finding and Evidence IDs for follow-up questions. The summary and paged list expose one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Its compact `items` combine the Evidence ID, subject, path, quality, and decision facts without repeating complete internal collections. Use `--full` only when an exact complete ID or record is needed. Exact-duplicate and large-Roster details include bounded `planning` choices independently of pagination. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
+4. Make semantic governance choices in the conversation, then submit them to `skillroster plan --stdin --json`. For exact duplicates or a large default Roster, send `schema_version` plus the corresponding Finding request below; SkillRoster derives the current Snapshot, Evidence, Skills, placements, and complete changes. Other request families include the latest `scan_id` and relevant `evidence_ids`.
+5. Present the validated summary Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `operation_groups`, bounded `affected` facts, `impact` before/after facts, uncertainty, canonical deletion count, reversibility, and Plan ID. The full immutable representation stays in local state; use `skillroster plan --show PLAN_ID --json` only when an exact operation, path, or complete ID list is needed to answer the user. Do not load it by default.
+
+Use only these Plan request families:
+
+- `finding_roster_changes` (preferred for `Large default Rosters need review`): `finding_id`, a per-Agent `core_budget` from 1 through 50, and optional `protected_skill_ids`. Review `planning.agents`, especially positive-signal and fallback counts, before choosing the budget. SkillRoster preserves requested, declared, and bootstrap Core Skills, ranks positive usage evidence, and uses stable ordering only as a fallback. Remaining affected Skills become On-demand; this request never implies Explicit-only or Archived. If `planning.supported` is false, follow its typed `decision`: confirm reported source roots or resolve dependent source links, then rescan. Do not submit a partial Plan.
+- `finding_library_changes` (preferred for exact duplicates): `finding_id`, a `canonical_placement_id` chosen from `planning.canonical_candidates`, and `requested_state` (`managed` or `hosted`). Do not copy paged placement or Evidence IDs into this request.
+- `roster_changes`: the advanced raw form with `agent`, `skill_id`, and `state` (`core`, `on_demand`, `explicit_only`, or `archived`). Use it for deliberate exceptions or when no supported Finding can bind the complete scope.
+- `library_changes`: the advanced raw form with `skill_id`, `canonical_placement_id`, the complete `placement_ids` set, and `requested_state`. Use it only when there is no exact-duplicate Finding to bind.
+- `source_updates`: the latest Skill/placement/source/revision/fingerprint facts plus upstream content and SHA-256 digest. If local content changed, include the user's explicit `choice`: `retain_local`, `adopt_upstream`, or `preserve_both`.
+
+Keep Roster, source-update, and Library changes in separate Plans. Semantic Finding requests derive their Evidence internally. For raw requests, cite Evidence returned by the relevant Finding page; a convenient but unrelated Evidence ID is not support for a governance change. Treat a rejected stale Snapshot, Evidence ID, fingerprint, incomplete scope, or source revision as a reason to rescan or ask the user—not as permission to weaken the request.
+
+State explicitly that inspection and planning changed no Agent files. When evidence cannot justify a change, recommend keeping the current state.
+
+For `Skill links escape an approved root`, load one compact Finding page and
+show `resolution.observed_link_targets`. Treat each target as unread until the
+user confirms that its canonical source directory is intentional and trusted.
+Do not follow a generic Plan action for this Finding. After confirmation,
+rescan with one repeatable `--source-root ABSOLUTE_PATH` per canonical source
+directory; this approves reading without adding Agent exposure. Then prefer a
+reviewed Hosted or Managed Library Plan so future Scans no longer depend on
+the temporary source-root arguments. Keep unconfirmed targets unread.
+
+## Apply or undo
+
+Run `skillroster setup --json` when installing the Bootstrap Skill or after upgrading the CLI. An exact official older copy produces a normal upgrade Plan. If `state` is `modified_choice_required`, show the affected Agent targets and ask whether to `retain-local` or `adopt-current`; do not choose for the user. Adopting still only prepares a recoverable Plan and requires the usual Apply confirmation. Treat `unsupported_targets` as blocked rather than replacing links or non-files.
+
+Show the complete immutable Plan before requesting one explicit confirmation. After the user confirms, run `skillroster apply PLAN_ID --json`; do not substitute direct filesystem commands or bypass drift checks. Report verification, changed-path count, Receipt ID, and canonical deletion count.
+
+“Complete” means the summary accounts for every affected Agent, Skill, placement, operation group, exclusion, risk, and before/after delta by count; it does not require copying every internal operation into the conversation. If the user asks for an exact path or operation, load the stored detail with `plan --show` before confirmation.
+
+For Undo, first explain the bounded Receipt impact and obtain one explicit confirmation, then run `skillroster undo RECEIPT_ID --json`.
+
+Stop mutating when the result reports ambiguity, drift, unsupported scope, or recovery required. Make recovery the only mutating next action until cleared.
+
+Use `skillroster status --json` for pending Plans, the last Receipt, retention, and recovery state. Use `skillroster lifecycle recovery --json` to inspect an unresolved Receipt. Export or purge local lifecycle data only when the user asks; purge changes controlled SQLite history, not Agent files.
+
+## Find an on-demand Skill
+
+Run `skillroster find "TASK" --json`, keeping the user's task verbatim. For a non-English or mixed-language task, include one concise English capability paraphrase through `--hint "TEXT"` on the first call; use tool and operation terms implied by the task, not a guessed Skill name. Retry once with a refined hint only when the result is empty or clearly about another domain. Explain the top matches and evidence. A `variant_count` above one is unresolved same-name content ambiguity: show the warning and inspect the corresponding layout Finding before choosing content. Otherwise read the selected `SKILL.md` directly from its returned path. Finding a Skill does not activate or install it.
+
+Never parse styled terminal output, invent a health score, infer token savings, or claim files changed without a successful Receipt.


### PR DESCRIPTION
## Problem

Real dogfood on the public v1.5.0 artifact found that Codex session evidence was present but the scanner only saw top-level records. All 995 initial usage rows were therefore Exposed/Inferred, so large-Roster recommendations could not use actual Skill activity.

## Solution

- recognize nested Codex user Skill links and Skill file reads
- bind observed usage only to unique exact Skill identity or exact placement paths
- decode JSON string values before matching Windows paths
- exclude Exposed/Inferred rows from observed-use Agent metrics
- support safe bootstrap upgrades from official v1.5.0
- bump the CLI and bootstrap Skill to v1.5.1

## Real dogfood evidence

A fresh read-only local scan found 180 independent Skills, 676 placements, and 548 default exposures. Codex now contributes five positive usage signals to its Core recommendation; other Agents remain conservative where no recognized evidence format exists. No Agent or Skill file changed.

## Verification

- cargo fmt --check
- cargo test --locked --all-targets --all-features: 118 passed
- cargo clippy --locked --all-targets --all-features -- -D warnings
- git diff --check
- ruby -c Formula/skillroster.rb
- brew style Formula/skillroster.rb
- independent Standards review: PASS, no P0/P1/P2
- independent Spec review: PASS, no P0/P1/P2