### PR TITLE
feat: improve Agent Skill retrieval precision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "3c36cc5aa3b0bf3c22b880a1c3855f570ba7cf0f"
-  version "1.6.0"
+      revision: "d291a83999d3ea08e632ca5a8e2f311d9c2d82ba"
+  version "1.7.0"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.6.0", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.7.0", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "d291a83999d3ea08e632ca5a8e2f311d9c2d82ba"
+      revision: "beb6cf553d0e872d028d775fec613d6468ebaaf8"
   version "1.7.0"
 
   depends_on "rust" => :build

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ skillroster report --finding <finding-id> --limit 20 --json
 skillroster report --finding <finding-id> --full --json
 skillroster find "database migration" --json
 skillroster find "诊断命令性能回归" --hint "diagnose command performance regression" --json
+skillroster find "分析本地表格" --hint "analyze standalone spreadsheet file workbook data" --json
 skillroster plan --stdin --json
 skillroster plan --show <plan-id> --json
 skillroster apply <plan-id> --json

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -73,6 +73,29 @@ the terminal and JSON results identified each plugin provider and its read-only
 governance boundary. Disabled plugins stayed absent, ambiguous cache versions
 failed closed, and exact-duplicate planning refused provider-managed placements.
 
+## Agent-led retrieval precision evidence
+
+The 1.7 pre-release dogfood started from the public 1.6 behavior reported in
+[Issue #31](https://github.com/tt-a1i/skillroster/issues/31), then rescanned the
+same reference macOS home into fresh isolated state. It again found 193 Skills,
+689 placements, and eight Agents with `files_changed=false`. The source build:
+
+- ranked the dedicated browser, presentation, standalone-spreadsheet,
+  live-Excel, session-mining, and cross-Agent Skill-management capabilities
+  first for seven English tasks and five Chinese tasks with Agent-authored
+  English hints;
+- returned no more than three results for each of those 12 decisions instead
+  of filling a ten-result response with incidental body-token matches;
+- read folded YAML descriptions such as the real `agent-skills-manager`
+  metadata, which moved that capability from rank four to rank one;
+- reduced an unhinted CJK miss to one actionable warning while preserving the
+  original task and requiring no cloud model or embedded translation table.
+
+The maintained routing fixture now contains 59 English and cross-language
+cases. All 59 route within Top-3, all 12 surface-disambiguation cases require
+the dedicated capability at rank one, and the Apply/Undo governance loop must
+preserve those results.
+
 ## Release-candidate platform evidence
 
 The 2026-08-22 release gates use actual hosted operating systems and the packaged

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -131,6 +131,8 @@ The single `skillroster` bootstrap Skill must instruct every supported Agent to:
 - validate `schema_version` and `ok` before reading `result`;
 - set `schema_version: 1` on every declarative Plan request;
 - never parse human terminal output or TUI frames;
+- preserve a non-English Find task verbatim and supply a positive English
+  target-surface, object, operation, and state paraphrase through `--hint`;
 - treat `suggested_actions` as typed options, not authorization;
 - automatically prepare a read-only Plan when evidence is sufficient;
 - show the complete Plan impact before Apply;

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -127,7 +127,10 @@ Show ranked matches with Skill name, current Roster state, source, concise match
 reasons, and same-name variant count. Preserve the original task separately
 from repeatable `--hint` retrieval text. A CJK task without hints receives an
 actionable lexical-retrieval warning when English metadata may be missed.
-Empty results are calm, successful output. Find never implies activation.
+Hints describe the desired surface, object, operation, and state. Results below
+the deterministic confidence floor are omitted instead of filling the first
+view with incidental body-token matches. Empty results are calm, successful
+output. Find never implies activation.
 
 ### `plan`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.6.0
+SKILLROSTER_VERSION=1.7.0
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.6.0 skillroster
+  --tag v1.7.0 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.6.0
+git checkout v1.7.0
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -120,7 +120,11 @@ recoverable through Undo.
 `find` preserves the user's original task and accepts repeatable Agent-authored
 retrieval hints. Hints let the semantic caller supply a cross-language or
 capability paraphrase while the CLI remains a deterministic local lexical
-index. Same-name Skill identities occupy one ranked capability result and are
+index. The scanner reads ordinary and folded YAML description scalars. Ranking
+normalizes conservative ASCII plurals, treats explicit use and do-not-use
+description clauses as positive and exclusion evidence, and removes the
+low-confidence tail relative to the strongest result. Same-name Skill
+identities occupy one ranked capability result and are
 reported as explicit variants rather than silently treated as equivalent.
 Variant details keep provider, governance, and path facts bound to one identity;
 the response preserves the total count and marks bounded detail truncation.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2047,13 +2047,14 @@ fn find_command(
             ));
         }
     }
-    if retrieval_hints.is_empty() && contains_cjk(task) {
+    let cjk_hint_required = retrieval_hints.is_empty() && contains_cjk(task);
+    if cjk_hint_required {
         warnings.push(
             "Find is lexical and the task contains CJK text; retry with one concise English capability paraphrase via --hint if relevant Skills use English metadata"
                 .into(),
         );
     }
-    if matches.is_empty() {
+    if matches.is_empty() && !cjk_hint_required {
         warnings.push(
             "No lexical Skill match was found; retry once with concrete capability, tool, or operation terms via --hint"
                 .into(),
@@ -3730,6 +3731,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
     (
         "1.5.1",
         "abb33e147e1b092ff70a2b02c5a8f89fc70d0c73eed2d8ec5ea88bba1ae58221",
+    ),
+    (
+        "1.6.0",
+        "c5f05692527bb2b8c45012ba6a464268b6a91a683a429a11dbe67022bbcc2aa5",
     ),
 ];
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1972,8 +1972,9 @@ fn find_command(
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>()
         .join(" ");
+    let candidate_search_text = crate::query::candidate_search_text(&retrieval_query);
     let mut candidate_ids = store
-        .search_skill_ids(&retrieval_query, scan.skills.len())?
+        .search_skill_ids(&candidate_search_text, scan.skills.len())?
         .into_iter()
         .map(|id| id.to_string())
         .collect::<std::collections::BTreeSet<_>>();

--- a/src/query.rs
+++ b/src/query.rs
@@ -1300,6 +1300,26 @@ fn tokens(text: &str) -> BTreeSet<String> {
         .collect()
 }
 
+pub(crate) fn candidate_search_text(text: &str) -> String {
+    let mut seen = BTreeSet::new();
+    let mut terms = Vec::new();
+    for term in text
+        .split(|character: char| !character.is_alphanumeric())
+        .map(str::trim)
+        .filter(|term| !term.is_empty())
+    {
+        let original = term.to_lowercase();
+        if seen.insert(original.clone()) {
+            terms.push(original.clone());
+        }
+        let normalized = normalize_token(&original);
+        if seen.insert(normalized.clone()) {
+            terms.push(normalized);
+        }
+    }
+    terms.join(" ")
+}
+
 fn normalize_token(token: &str) -> String {
     let mut normalized = token.to_lowercase();
     if normalized.is_ascii()
@@ -1349,11 +1369,29 @@ fn description_routing_sections(description: &str) -> (String, String) {
 }
 
 fn trim_low_confidence_tail(matches: &mut Vec<FindMatch>, query_token_count: usize) {
-    if matches.is_empty() || query_token_count < 2 {
+    if matches.is_empty() {
         return;
     }
     let cutoff = (matches[0].score * 0.5).max(3.0);
     matches.retain(|matched| matched.score >= cutoff);
+    if query_token_count == 1
+        && matches
+            .first()
+            .is_some_and(|matched| !has_strong_lexical_evidence(matched))
+    {
+        matches.truncate(3);
+    }
+}
+
+fn has_strong_lexical_evidence(matched: &FindMatch) -> bool {
+    matched.match_reasons.iter().any(|reason| {
+        matches!(
+            reason.as_str(),
+            "exact_name" | "name_phrase" | "declared_trigger" | "description_phrase"
+        ) || reason.starts_with("name_tokens:")
+            || reason.starts_with("trigger_tokens:")
+            || reason.starts_with("description_tokens:")
+    })
 }
 
 fn fnv1a64(bytes: &[u8]) -> String {
@@ -1721,6 +1759,43 @@ mod tests {
                 "slide".to_owned(),
                 "spreadsheet".to_owned(),
             ])
+        );
+        assert_eq!(candidate_search_text("publish blogs"), "publish blogs blog");
+    }
+
+    #[test]
+    fn single_token_body_only_matches_have_a_bounded_low_confidence_tail() {
+        let (_, mut scan) = fixture();
+        let representative = scan.skills[0].clone();
+        scan.skills = (0..8)
+            .map(|index| {
+                let mut skill = representative.clone();
+                skill.id = format!("incidental-{index}");
+                skill.name = format!("incidental-{index}");
+                skill.metadata.description = Some("generic helper".into());
+                skill.normalized_text = "mentions archive incidentally".into();
+                skill
+            })
+            .collect();
+        scan.usage.push(crate::scan::UsageEvidence {
+            agent: AgentKind::Codex,
+            skill_id: "incidental-0".into(),
+            stage: UsageStage::Loaded,
+            quality: EvidenceQuality::Observed,
+            event_count: 1,
+            first_seen_unix: Some(1),
+            last_seen_unix: Some(1),
+            source_path_digest: "fixture".into(),
+        });
+
+        let matches = find(&scan, "archive", 100);
+
+        assert_eq!(matches.len(), 3);
+        assert_eq!(matches[0].score, 5.0);
+        assert!(
+            matches[0]
+                .match_reasons
+                .contains(&"observed_local_usage".into())
         );
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1081,16 +1081,29 @@ pub(crate) fn find_matching(
                 .as_deref()
                 .unwrap_or_default()
                 .to_lowercase();
+            let (positive_description, excluded_description) =
+                description_routing_sections(&description);
             let triggers = skill.metadata.triggers.join(" ").to_lowercase();
             let all_text = skill_search_text(skill).to_lowercase();
             let name_overlap = query_tokens.intersection(&tokens(&name)).count();
             let trigger_overlap = query_tokens.intersection(&tokens(&triggers)).count();
-            let description_overlap = query_tokens.intersection(&tokens(&description)).count();
+            let description_overlap = query_tokens
+                .intersection(&tokens(&positive_description))
+                .count();
+            let excluded_description_overlap = query_tokens
+                .intersection(&tokens(&excluded_description))
+                .count();
+            let exclusion_penalty_tokens = if excluded_description_overlap >= 2 {
+                excluded_description_overlap
+            } else {
+                0
+            };
             let overlap = query_tokens.intersection(&tokens(&all_text)).count();
             let mut score = name_overlap as f64 * 24.0
                 + trigger_overlap as f64 * 18.0
                 + description_overlap as f64 * 12.0
-                + overlap as f64 * 3.0;
+                + overlap as f64 * 3.0
+                - exclusion_penalty_tokens as f64 * 18.0;
             let mut reasons = Vec::new();
             if name == query {
                 score += 100.0;
@@ -1103,7 +1116,7 @@ pub(crate) fn find_matching(
                 score += 35.0;
                 reasons.push("declared_trigger".into());
             }
-            if !description.is_empty() && description.contains(&query) {
+            if !positive_description.is_empty() && positive_description.contains(&query) {
                 score += 25.0;
                 reasons.push("description_phrase".into());
             }
@@ -1115,6 +1128,11 @@ pub(crate) fn find_matching(
             }
             if description_overlap > 0 {
                 reasons.push(format!("description_tokens:{description_overlap}"));
+            }
+            if exclusion_penalty_tokens > 0 {
+                reasons.push(format!(
+                    "excluded_description_tokens:{exclusion_penalty_tokens}"
+                ));
             }
             if overlap > 0 {
                 reasons.push(format!("all_text_tokens:{overlap}"));
@@ -1266,6 +1284,7 @@ pub(crate) fn find_matching(
                 .push(format!("name_variants:{}", matched.variant_count));
         }
     }
+    trim_low_confidence_tail(&mut capabilities, query_tokens.len());
     capabilities.truncate(limit);
     for (index, matched) in capabilities.iter_mut().enumerate() {
         matched.rank = index + 1;
@@ -1277,8 +1296,64 @@ fn tokens(text: &str) -> BTreeSet<String> {
     text.split(|character: char| !character.is_alphanumeric())
         .map(str::trim)
         .filter(|token| token.len() >= 2)
-        .map(str::to_lowercase)
+        .map(normalize_token)
         .collect()
+}
+
+fn normalize_token(token: &str) -> String {
+    let mut normalized = token.to_lowercase();
+    if normalized.is_ascii()
+        && normalized.len() > 3
+        && normalized.ends_with('s')
+        && !normalized.ends_with("ss")
+        && !normalized.ends_with("us")
+        && !normalized.ends_with("is")
+    {
+        normalized.pop();
+    }
+    normalized
+}
+
+fn description_routing_sections(description: &str) -> (String, String) {
+    const EXCLUSION_MARKERS: &[&str] = &[
+        "do not use",
+        "don't use",
+        "never use",
+        "must not use",
+        "should not use",
+        "not for",
+    ];
+    let description = description.to_lowercase();
+    let mut positive = Vec::new();
+    let mut excluded = Vec::new();
+    for section in description.split(['.', '!', '?', ';', '\n']) {
+        let section = section.trim();
+        if section.is_empty() {
+            continue;
+        }
+        if let Some(boundary) = EXCLUSION_MARKERS
+            .iter()
+            .filter_map(|marker| section.find(marker))
+            .min()
+        {
+            let desired = section[..boundary].trim().trim_end_matches(',').trim();
+            if !desired.is_empty() {
+                positive.push(desired);
+            }
+            excluded.push(section[boundary..].trim());
+        } else {
+            positive.push(section);
+        }
+    }
+    (positive.join(" "), excluded.join(" "))
+}
+
+fn trim_low_confidence_tail(matches: &mut Vec<FindMatch>, query_token_count: usize) {
+    if matches.is_empty() || query_token_count < 2 {
+        return;
+    }
+    let cutoff = (matches[0].score * 0.5).max(3.0);
+    matches.retain(|matched| matched.score >= cutoff);
 }
 
 fn fnv1a64(bytes: &[u8]) -> String {
@@ -1560,6 +1635,106 @@ mod tests {
     }
 
     #[test]
+    fn find_prefers_dedicated_surfaces_and_removes_a_low_confidence_tail() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("skillroster-routing-quality-{nonce}"));
+        for (directory, contents) in [
+            (
+                "presentations",
+                "---\nname: Presentations\ndescription: Read, create, or edit PowerPoint and Google Slides decks. Use for presentation and slide requests.\n---\nDedicated deck workflow.",
+            ),
+            (
+                "template-creator",
+                "---\nname: template-creator\ndescription: Create a reusable template from a reference presentation or spreadsheet. Do not use for one-off creation.\n---\nGeneric artifact template workflow.",
+            ),
+            (
+                "spreadsheets",
+                "---\nname: Spreadsheets\ndescription: Create, edit, and analyze standalone spreadsheet files and workbooks. Do not use for a live Microsoft Excel session.\n---\nDedicated file workflow.",
+            ),
+            (
+                "excel-live-control",
+                "---\nname: excel-live-control\ndescription: Control an open Microsoft Excel workbook in a connected live session. Do not use for standalone spreadsheet files.\n---\nDedicated live application workflow.",
+            ),
+            (
+                "control-browser",
+                "---\nname: control-browser\ndescription: Control browser automation in an existing logged-in session.\n---\nInspect and operate web pages.",
+            ),
+            (
+                "agent-session-miner",
+                "---\nname: agent-session-miner\ndescription: Mine local agent session history.\n---\nA browser can appear incidentally in session logs.",
+            ),
+        ] {
+            let path = root.join(directory);
+            fs::create_dir_all(&path).unwrap();
+            fs::write(path.join("SKILL.md"), contents).unwrap();
+        }
+        let mut options = ScanOptions::for_home(root.join("home"));
+        options
+            .explicit_skill_roots
+            .push(crate::scan::ExplicitSkillRoot {
+                agent: crate::harness::AgentKind::Codex,
+                path: root.clone(),
+            });
+        options.include_session_evidence = false;
+        let scan = scan(&options).unwrap();
+
+        let presentation = find(&scan, "create product release presentation slides", 10);
+        assert_eq!(presentation[0].name, "Presentations");
+
+        let spreadsheet = find(
+            &scan,
+            "analyze a standalone spreadsheet file and workbook",
+            10,
+        );
+        assert_eq!(spreadsheet[0].name, "Spreadsheets");
+        assert!(
+            spreadsheet
+                .iter()
+                .all(|matched| matched.name != "excel-live-control")
+        );
+
+        let browser = find(
+            &scan,
+            "control browser automation in a logged-in session",
+            10,
+        );
+        assert_eq!(browser[0].name, "control-browser");
+        assert!(
+            browser
+                .iter()
+                .all(|matched| matched.name != "agent-session-miner")
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn token_matching_normalizes_common_ascii_plurals() {
+        assert_eq!(
+            tokens("presentations slides spreadsheets skills agents"),
+            BTreeSet::from([
+                "agent".to_owned(),
+                "presentation".to_owned(),
+                "skill".to_owned(),
+                "slide".to_owned(),
+                "spreadsheet".to_owned(),
+            ])
+        );
+    }
+
+    #[test]
+    fn description_boundaries_keep_the_desired_clause_and_separate_the_exclusion() {
+        let (desired, excluded) = description_routing_sections(
+            "Use for standalone spreadsheet files, not for a live Excel session.",
+        );
+
+        assert_eq!(desired, "use for standalone spreadsheet files");
+        assert_eq!(excluded, "not for a live excel session");
+    }
+
+    #[test]
     fn find_returns_one_ranked_capability_for_same_name_variants() {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1804,7 +1979,7 @@ mod tests {
     }
 
     #[test]
-    fn maintained_routing_set_has_at_least_ninety_five_percent_top_three_recall() {
+    fn maintained_routing_set_has_complete_top_three_recall() {
         #[derive(serde::Deserialize)]
         struct Case {
             task: String,
@@ -1837,10 +2012,6 @@ mod tests {
                     .any(|item| item.name == case.skill)
             })
             .count();
-        assert!(
-            hits * 100 >= cases.len() * 95,
-            "Top-3 recall was {hits}/{}",
-            cases.len()
-        );
+        assert_eq!(hits, cases.len(), "Top-3 recall was {hits}/{}", cases.len());
     }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -833,13 +833,23 @@ fn materialize_candidates(candidates: Vec<EntryCandidate>, result: &mut ScanResu
 
 pub fn parse_skill_markdown(markdown: &str) -> SkillMetadata {
     let mut metadata = SkillMetadata::default();
-    let Some(frontmatter) = markdown.strip_prefix("---\n") else {
+    let mut markdown_lines = markdown.lines();
+    if markdown_lines.next() != Some("---") {
         return metadata;
-    };
-    let Some((frontmatter, _)) = frontmatter.split_once("\n---") else {
+    }
+    let mut frontmatter = Vec::new();
+    let mut closed = false;
+    for line in markdown_lines.by_ref() {
+        if line == "---" {
+            closed = true;
+            break;
+        }
+        frontmatter.push(line);
+    }
+    if !closed {
         return metadata;
-    };
-    let lines = frontmatter.lines().collect::<Vec<_>>();
+    }
+    let lines = frontmatter;
     let mut list_key: Option<String> = None;
     let mut index = 0;
     while index < lines.len() {
@@ -929,16 +939,25 @@ fn unquote(value: &str) -> String {
 }
 
 fn summarize_markdown(markdown: &str, limit: usize) -> String {
-    let body = if let Some(frontmatter) = markdown.strip_prefix("---\n") {
-        frontmatter
-            .split_once("\n---")
-            .map(|(_, body)| body)
-            .unwrap_or(markdown)
+    let mut lines = markdown.lines();
+    let body = if lines.next() == Some("---") {
+        let mut closed = false;
+        for line in lines.by_ref() {
+            if line == "---" {
+                closed = true;
+                break;
+            }
+        }
+        if closed {
+            lines.collect::<Vec<_>>()
+        } else {
+            markdown.lines().collect::<Vec<_>>()
+        }
     } else {
-        markdown
+        markdown.lines().collect::<Vec<_>>()
     };
     let summary = body
-        .lines()
+        .into_iter()
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .collect::<Vec<_>>()
@@ -1665,19 +1684,21 @@ enabled = true
 
     #[test]
     fn parses_folded_skill_descriptions_without_treating_nested_metadata_as_top_level() {
-        let metadata = parse_skill_markdown(
-            "---\nname: agent-skills-manager\ndescription: >\n  Manage skills across AI coding agents with one shared library.\n  Use for migration, distribution, and symlink repair.\nmetadata:\n  version: nested-value-must-not-win\ntriggers:\n- migrate skills\n- repair symlinks\nversion: 1.7.0\n---\nBody",
-        );
+        let markdown = "---\nname: agent-skills-manager\ndescription: >\n  Manage skills across AI coding agents with one shared library.\n  Use for migration, distribution, and symlink repair.\nmetadata:\n  version: nested-value-must-not-win\ntriggers:\n- migrate skills\n- repair symlinks\nversion: 1.7.0\n---\nBody";
+        for markdown in [markdown.to_owned(), markdown.replace('\n', "\r\n")] {
+            let metadata = parse_skill_markdown(&markdown);
 
-        assert_eq!(metadata.name.as_deref(), Some("agent-skills-manager"));
-        assert_eq!(
-            metadata.description.as_deref(),
-            Some(
-                "Manage skills across AI coding agents with one shared library. Use for migration, distribution, and symlink repair."
-            )
-        );
-        assert_eq!(metadata.triggers, ["migrate skills", "repair symlinks"]);
-        assert_eq!(metadata.version.as_deref(), Some("1.7.0"));
+            assert_eq!(metadata.name.as_deref(), Some("agent-skills-manager"));
+            assert_eq!(
+                metadata.description.as_deref(),
+                Some(
+                    "Manage skills across AI coding agents with one shared library. Use for migration, distribution, and symlink repair."
+                )
+            );
+            assert_eq!(metadata.triggers, ["migrate skills", "repair symlinks"]);
+            assert_eq!(metadata.version.as_deref(), Some("1.7.0"));
+            assert_eq!(summarize_markdown(&markdown, 320), "Body");
+        }
     }
 
     #[test]

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -839,30 +839,54 @@ pub fn parse_skill_markdown(markdown: &str) -> SkillMetadata {
     let Some((frontmatter, _)) = frontmatter.split_once("\n---") else {
         return metadata;
     };
-    let mut list_key: Option<&str> = None;
-    for line in frontmatter.lines() {
+    let lines = frontmatter.lines().collect::<Vec<_>>();
+    let mut list_key: Option<String> = None;
+    let mut index = 0;
+    while index < lines.len() {
+        let line = lines[index];
+        let indentation = leading_whitespace(line);
         let trimmed = line.trim();
         if let Some(value) = trimmed.strip_prefix("- ") {
-            if list_key == Some("triggers") {
+            if list_key.as_deref() == Some("triggers") {
                 metadata.triggers.push(unquote(value));
             }
+            index += 1;
+            continue;
+        }
+        if indentation > 0 {
+            index += 1;
             continue;
         }
         let Some((key, value)) = trimmed.split_once(':') else {
+            index += 1;
             continue;
         };
         let key = key.trim();
         let value = value.trim();
-        list_key = Some(key);
+        list_key = Some(key.to_owned());
         if value.is_empty() {
+            index += 1;
+            continue;
+        }
+        if value.starts_with(['>', '|']) {
+            let mut block = Vec::new();
+            index += 1;
+            while index < lines.len() {
+                let continuation = lines[index];
+                if !continuation.trim().is_empty()
+                    && leading_whitespace(continuation) <= indentation
+                {
+                    break;
+                }
+                if !continuation.trim().is_empty() {
+                    block.push(continuation.trim());
+                }
+                index += 1;
+            }
+            set_metadata_scalar(&mut metadata, key, block.join(" "));
             continue;
         }
         match key {
-            "name" => metadata.name = Some(unquote(value)),
-            "description" => metadata.description = Some(unquote(value)),
-            "source" | "repository" => metadata.source = Some(unquote(value)),
-            "version" => metadata.version = Some(unquote(value)),
-            "revision" | "rev" | "commit" => metadata.revision = Some(unquote(value)),
             "triggers" => {
                 metadata.triggers.extend(
                     value
@@ -872,10 +896,32 @@ pub fn parse_skill_markdown(markdown: &str) -> SkillMetadata {
                         .filter(|value| !value.is_empty()),
                 );
             }
-            _ => {}
+            _ => set_metadata_scalar(&mut metadata, key, unquote(value)),
         }
+        index += 1;
     }
     metadata
+}
+
+fn leading_whitespace(value: &str) -> usize {
+    value
+        .chars()
+        .take_while(|character| character.is_whitespace())
+        .count()
+}
+
+fn set_metadata_scalar(metadata: &mut SkillMetadata, key: &str, value: String) {
+    if value.is_empty() {
+        return;
+    }
+    match key {
+        "name" => metadata.name = Some(value),
+        "description" => metadata.description = Some(value),
+        "source" | "repository" => metadata.source = Some(value),
+        "version" => metadata.version = Some(value),
+        "revision" | "rev" | "commit" => metadata.revision = Some(value),
+        _ => {}
+    }
 }
 
 fn unquote(value: &str) -> String {
@@ -1615,6 +1661,23 @@ enabled = true
         assert_eq!(metadata.name.as_deref(), Some("research"));
         assert_eq!(metadata.revision.as_deref(), Some("abc"));
         assert_eq!(metadata.triggers, ["search", "verify"]);
+    }
+
+    #[test]
+    fn parses_folded_skill_descriptions_without_treating_nested_metadata_as_top_level() {
+        let metadata = parse_skill_markdown(
+            "---\nname: agent-skills-manager\ndescription: >\n  Manage skills across AI coding agents with one shared library.\n  Use for migration, distribution, and symlink repair.\nmetadata:\n  version: nested-value-must-not-win\ntriggers:\n- migrate skills\n- repair symlinks\nversion: 1.7.0\n---\nBody",
+        );
+
+        assert_eq!(metadata.name.as_deref(), Some("agent-skills-manager"));
+        assert_eq!(
+            metadata.description.as_deref(),
+            Some(
+                "Manage skills across AI coding agents with one shared library. Use for migration, distribution, and symlink repair."
+            )
+        );
+        assert_eq!(metadata.triggers, ["migrate skills", "repair symlinks"]);
+        assert_eq!(metadata.version.as_deref(), Some("1.7.0"));
     }
 
     #[test]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -19,6 +19,10 @@ struct RouteCase {
     skill: String,
     #[serde(default)]
     hints: Vec<String>,
+    #[serde(default)]
+    rank_first: bool,
+    #[serde(default)]
+    max_matches: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -119,14 +123,33 @@ fn evaluate_capabilities(home: &Path, state: &Path, routes: &[RouteCase]) -> (us
         for hint in &case.hints {
             arguments.extend(["--hint", hint.as_str()]);
         }
-        arguments.extend(["--limit", "3"]);
+        arguments.extend([
+            "--limit",
+            if case.max_matches.is_some() {
+                "10"
+            } else {
+                "3"
+            },
+        ]);
         let found = cli_json(home, state, &arguments, None);
-        let Some(matched) = found["result"]["matches"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .find(|matched| matched["name"] == case.skill)
-        else {
+        let matches = found["result"]["matches"].as_array().unwrap();
+        if case.rank_first {
+            assert_eq!(
+                matches.first().and_then(|matched| matched["name"].as_str()),
+                Some(case.skill.as_str()),
+                "dedicated capability must rank first for {:?}",
+                case.task
+            );
+        }
+        if let Some(max_matches) = case.max_matches {
+            assert!(
+                matches.len() <= max_matches,
+                "low-confidence tail for {:?} had {} matches",
+                case.task,
+                matches.len()
+            );
+        }
+        let Some(matched) = matches.iter().find(|matched| matched["name"] == case.skill) else {
             continue;
         };
         routed += 1;
@@ -320,8 +343,9 @@ fn maintained_routing_set_meets_top_three_and_governance_does_not_regress_succes
     let scan_result = cli_json(&home, &state, &["scan"], None);
     let scan_id = scan_result["result"]["snapshot_id"].as_str().unwrap();
     let (before_routed, before_succeeded) = evaluate_capabilities(&home, &state, &routes);
-    assert!(
-        before_routed * 100 >= routes.len() * 95,
+    assert_eq!(
+        before_routed,
+        routes.len(),
         "Top-3 recall was {before_routed}/{}",
         routes.len()
     );

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -77,6 +77,7 @@ fn public_find_keeps_the_user_task_and_uses_agent_retrieval_hints() {
         None,
     ));
     assert!(unhinted["result"]["matches"].as_array().unwrap().is_empty());
+    assert_eq!(unhinted["result"]["warnings"].as_array().unwrap().len(), 1);
     assert!(
         unhinted["result"]["warnings"]
             .as_array()
@@ -828,7 +829,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.6.0"
+        "1.7.0"
     );
 
     let undone = json_output(&run(
@@ -849,6 +850,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
         ("1.4.0", include_str!("fixtures/bootstrap-v1.4.0.md")),
         ("1.5.0", include_str!("fixtures/bootstrap-v1.5.0.md")),
         ("1.5.1", include_str!("fixtures/bootstrap-v1.5.1.md")),
+        ("1.6.0", include_str!("fixtures/bootstrap-v1.6.0.md")),
     ] {
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
@@ -923,7 +925,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.6.0");
+    assert_eq!(output["result"]["bootstrap_version"], "1.7.0");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -111,6 +111,52 @@ fn public_find_keeps_the_user_task_and_uses_agent_retrieval_hints() {
 }
 
 #[test]
+fn public_find_expands_plural_candidates_and_bounds_incidental_single_token_matches() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    let blog = skill_root.join("blog");
+    fs::create_dir_all(&blog).unwrap();
+    fs::write(
+        blog.join("SKILL.md"),
+        "---\nname: blog\ndescription: Publish a technical article\n---\n",
+    )
+    .unwrap();
+    for index in 0..8 {
+        let skill = skill_root.join(format!("incidental-{index}"));
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(
+            skill.join("SKILL.md"),
+            format!(
+                "---\nname: incidental-{index}\ndescription: Generic helper\n---\nMentions archive incidentally.\n"
+            ),
+        )
+        .unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let plural = json_output(&run(
+        &[&common[..], &["find", "blogs", "--limit", "10"]].concat(),
+        None,
+    ));
+    assert_eq!(plural["result"]["matches"][0]["name"], "blog");
+
+    let incidental = json_output(&run(
+        &[&common[..], &["find", "archive", "--limit", "100"]].concat(),
+        None,
+    ));
+    assert_eq!(incidental["result"]["matches"].as_array().unwrap().len(), 3);
+}
+
+#[test]
 fn finding_drilldown_is_bounded_and_pageable() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");

--- a/tests/fixtures/bootstrap-v1.6.0.md
+++ b/tests/fixtures/bootstrap-v1.6.0.md
@@ -2,7 +2,7 @@
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
 metadata:
-  bootstrap-version: "1.7.0"
+  bootstrap-version: "1.6.0"
 ---
 
 # SkillRoster
@@ -54,7 +54,7 @@ Use `skillroster status --json` for pending Plans, the last Receipt, retention, 
 
 ## Find an on-demand Skill
 
-Run `skillroster find "TASK" --json`, keeping the user's task verbatim. For a non-English or mixed-language task, include one concise English capability paraphrase through `--hint "TEXT"` on the first call. Build the hint entirely from the desired target surface, object, operation, and state—for example, `control existing logged-in Chrome tabs` or `analyze standalone spreadsheet file workbook data`. Use terms implied by the task rather than a guessed Skill name. Retry once with a refined target description only when the result is empty or clearly about another domain. Explain the top matches and evidence. A `variant_count` above one is unresolved same-name content ambiguity: keep each returned variant's path and provider facts together, respect `variants_truncated`, show the warning, and inspect the corresponding layout Finding before choosing content. Otherwise read the selected `SKILL.md` directly from its returned path. Finding a Skill does not activate or install it.
+Run `skillroster find "TASK" --json`, keeping the user's task verbatim. For a non-English or mixed-language task, include one concise English capability paraphrase through `--hint "TEXT"` on the first call; use tool and operation terms implied by the task, not a guessed Skill name. Retry once with a refined hint only when the result is empty or clearly about another domain. Explain the top matches and evidence. A `variant_count` above one is unresolved same-name content ambiguity: keep each returned variant's path and provider facts together, respect `variants_truncated`, show the warning, and inspect the corresponding layout Finding before choosing content. Otherwise read the selected `SKILL.md` directly from its returned path. Finding a Skill does not activate or install it.
 
 Treat `providers` with `governable: false` as enabled provider-managed Skills: they are valid read-only search results, but must not be moved, updated, consolidated, or added to a governance Plan.
 

--- a/tests/fixtures/routing-eval.json
+++ b/tests/fixtures/routing-eval.json
@@ -45,5 +45,17 @@
   {"task":"画出系统请求生命周期","hints":["visualize system request lifecycle diagram"],"skill":"archify"},
   {"task":"修改并收紧技术文章","hints":["edit tighten technical article"],"skill":"edit-article"},
   {"task":"从 GitHub 安装一个 Skill","hints":["install skill from GitHub"],"skill":"skill-installer"},
-  {"task":"定义项目的统一领域术语","hints":["define domain terminology ubiquitous language"],"skill":"domain-modeling"}
+  {"task":"定义项目的统一领域术语","hints":["define domain terminology ubiquitous language"],"skill":"domain-modeling"},
+  {"task":"control existing logged-in Chrome tabs","skill":"control-chrome","rank_first":true,"max_matches":3},
+  {"task":"inspect and click a page in the in-app browser","skill":"control-in-app-browser","rank_first":true,"max_matches":3},
+  {"task":"create product release presentation slides","skill":"Presentations","rank_first":true,"max_matches":3},
+  {"task":"analyze a standalone spreadsheet file","skill":"Spreadsheets","rank_first":true,"max_matches":3},
+  {"task":"control the open workbook in a live Microsoft Excel session","skill":"excel-live-control","rank_first":true,"max_matches":3},
+  {"task":"mine local coding Agent session history","skill":"agent-session-miner","rank_first":true,"max_matches":3},
+  {"task":"manage Skills across coding Agents with shared symlinks","skill":"agent-skills-manager","rank_first":true,"max_matches":3},
+  {"task":"在已经登录的 Chrome 页面里检查并操作","hints":["control existing logged-in Chrome browser tabs"],"skill":"control-chrome","rank_first":true,"max_matches":3},
+  {"task":"制作一份产品发布演示文稿","hints":["create product release presentation slide deck PowerPoint"],"skill":"Presentations","rank_first":true,"max_matches":3},
+  {"task":"分析本地 Excel 表格并生成结论","hints":["analyze standalone spreadsheet file workbook data"],"skill":"Spreadsheets","rank_first":true,"max_matches":3},
+  {"task":"挖掘本地 Agent 会话历史","hints":["mine local coding Agent session history"],"skill":"agent-session-miner","rank_first":true,"max_matches":3},
+  {"task":"统一管理各个 Agent 安装的 Skill","hints":["manage Skills across coding Agents with shared library symlinks"],"skill":"agent-skills-manager","rank_first":true,"max_matches":3}
 ]

--- a/tests/fixtures/routing-skills/Presentations/SKILL.md
+++ b/tests/fixtures/routing-skills/Presentations/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: Presentations
+description: Read, create, or edit PowerPoint and Google Slides decks. Use for presentation, slide deck, PowerPoint, PPT, and PPTX requests.
+---
+Create and verify a dedicated presentation deliverable.
+
+CAPABILITY: Presentations

--- a/tests/fixtures/routing-skills/Spreadsheets/SKILL.md
+++ b/tests/fixtures/routing-skills/Spreadsheets/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: Spreadsheets
+description: Create, edit, analyze, and verify standalone spreadsheet files and workbooks. Do not use for a live Microsoft Excel session.
+---
+Create and verify a dedicated spreadsheet deliverable.
+
+CAPABILITY: Spreadsheets

--- a/tests/fixtures/routing-skills/agent-session-miner/SKILL.md
+++ b/tests/fixtures/routing-skills/agent-session-miner/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: agent-session-miner
+description: Mine local AI coding agent session history into redacted reusable content and product insights.
+---
+Extract safe reusable evidence from local Agent sessions.
+
+CAPABILITY: agent-session-miner

--- a/tests/fixtures/routing-skills/agent-skills-manager/SKILL.md
+++ b/tests/fixtures/routing-skills/agent-skills-manager/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: agent-skills-manager
+description: >
+  Manage Skills across AI coding Agents with one shared library and unified symlinks.
+  Use for migration, distribution, synchronization, and symlink repair.
+---
+Govern a shared local Skill installation.
+
+CAPABILITY: agent-skills-manager

--- a/tests/fixtures/routing-skills/control-chrome/SKILL.md
+++ b/tests/fixtures/routing-skills/control-chrome/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: control-chrome
+description: Control Chrome for tasks that depend on existing browser state, logged-in sessions, tabs, or extensions.
+---
+Inspect and operate the user's existing Chrome session.
+
+CAPABILITY: control-chrome

--- a/tests/fixtures/routing-skills/control-in-app-browser/SKILL.md
+++ b/tests/fixtures/routing-skills/control-in-app-browser/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: control-in-app-browser
+description: Control the in-app browser for page inspection, navigation, clicking, typing, screenshots, and local web testing.
+---
+Inspect and operate the in-app browser.
+
+CAPABILITY: control-in-app-browser

--- a/tests/fixtures/routing-skills/excel-live-control/SKILL.md
+++ b/tests/fixtures/routing-skills/excel-live-control/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: excel-live-control
+description: Control an open Microsoft Excel workbook in a connected live session. Do not use for standalone spreadsheet files.
+---
+Operate the selected live Excel workbook.
+
+CAPABILITY: excel-live-control

--- a/tests/fixtures/routing-skills/template-creator/SKILL.md
+++ b/tests/fixtures/routing-skills/template-creator/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: template-creator
+description: Create or update a reusable artifact template from a reference presentation or spreadsheet. Do not use for one-off creation.
+---
+Manage reusable reference-backed templates.
+
+CAPABILITY: template-creator


### PR DESCRIPTION
Closes #31.

## What changed

- parse folded and literal YAML frontmatter descriptions without treating nested metadata as top-level fields
- normalize conservative ASCII plurals before the SQLite FTS candidate gate and during deterministic ranking
- separate positive routing clauses from explicit do-not-use evidence
- omit low-confidence tails, including bounded single-token body-only matches with observed usage
- teach the Bootstrap Skill to preserve the original task while supplying positive English `--hint` text for non-English or mixed-language requests
- expand routing fixtures and acceptance documentation for dedicated application/file/session/management surfaces

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` — 99 unit + 6 acceptance + 27 CLI = 132 passed
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- maintained routing set: 59/59 expected Skills in Top 3
- precision subset: 12/12 expected Skills at rank 1 with no more than 3 results
- real local read-only dogfood: 8 Agents, 193 Skills, 689 placements, `files_changed=false`
- independent Standards and Spec reviews: no P0/P1/P2 findings
