### PR TITLE
perf: make first governance report responsive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "beb6cf553d0e872d028d775fec613d6468ebaaf8"
-  version "1.7.0"
+      revision: "ae80c4a4fd835c47a37b744a4de0f69e00e53a54"
+  version "1.7.1"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.7.0", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.7.1", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -14,7 +14,7 @@ The suite proves:
 
 - all eight direct adapters discover their independent filesystem fixture;
 - each adapter conservatively normalizes Exposed, Matched, Loaded, Applied, and Outcome evidence, while prose-only mentions create no observed stage;
-- the maintained 47-task routing set, including Agent-hinted Chinese tasks, reaches at least 95% Top-3 recall;
+- the maintained 59-task routing set, including Agent-hinted Chinese tasks, reaches 100% Top-3 recall;
 - a public `plan`/`apply` moves non-Core Skills to On-demand, `find` still returns readable paths, and Receipt-bounded `undo` restores the original Agent tree;
 - small (5 Skills), large (120 Skills), and cross-Agent (12 Skills) duplicate scenarios preserve counts, traceable Finding evidence, and the four report metrics;
 - plain 60-, 80-, and 120-column reports retain their core fields, no-change statement, and no ANSI bytes.
@@ -26,7 +26,7 @@ Top-3 routing and task success are separate checks:
 
 The governed run uses the public `scan`, `report`, `plan`, `apply`, `find`, and `undo` commands. It marks seven of ten Skills On-demand, then repeats both checks against paths returned after the real Apply. This validates deterministic fixture capability, not whether an external model completed a natural-language task.
 
-Current local result (2026-08-22): **47/47 Top-3 hits before governance and 47/47 after governance**. Re-run the test above for release evidence; this recorded result is not a substitute for CI.
+Current local result (2026-08-22): **59/59 Top-3 hits before governance and 59/59 after governance**. Re-run the test above for release evidence; this recorded result is not a substitute for CI.
 
 ## Executed three-arm value comparison
 
@@ -95,6 +95,23 @@ The maintained routing fixture now contains 59 English and cross-language
 cases. All 59 route within Top-3, all 12 surface-disambiguation cases require
 the dedicated capability at rank one, and the Apply/Undo governance loop must
 preserve those results.
+
+## Agent-led first-report performance evidence
+
+The 1.7.1 dogfood run used a fresh isolated state directory against the same
+reference home: eight Agents, 193 independent Skills, and 689 placements. The
+public 1.7.0 behavior took 34.26 seconds to produce the first 3,237-byte
+`report --summary --json`; the cached response took 0.04 seconds. Timing each
+Finding family showed semantic-overlap analysis consumed 34.59 seconds while
+all other report analysis completed in under 8 milliseconds.
+
+The analyzer now tokenizes each complete Skill search document once and reuses
+those vocabularies for pair comparison. On the unchanged real Snapshot the
+first report fell to 2.22 seconds with identical Finding counts, category
+counts, and first-view facts. A 193-Skill core regression that previously took
+75.32 seconds now completes in under one second and enforces a five-second
+upper bound in the unoptimized test profile. These measurements describe the
+recorded reference run, not a universal machine-performance guarantee.
 
 ## Release-candidate platform evidence
 

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -99,17 +99,21 @@ preserve those results.
 ## Agent-led first-report performance evidence
 
 The 1.7.1 dogfood run used a fresh isolated state directory against the same
-reference home: eight Agents, 193 independent Skills, and 689 placements. The
-public 1.7.0 behavior took 34.26 seconds to produce the first 3,237-byte
-`report --summary --json`; the cached response took 0.04 seconds. Timing each
-Finding family showed semantic-overlap analysis consumed 34.59 seconds while
-all other report analysis completed in under 8 milliseconds.
+reference home: eight Agents, 193 independent Skills, and 689 placements. An
+unoptimized 1.7.0 build took 34.26 seconds to produce the first 3,237-byte
+`report --summary --json`; the cached response took 0.04 seconds. The official
+optimized 1.7.0 binary produced the complete 626,759-byte report in 4.85
+seconds. Timing the unoptimized build showed semantic-overlap analysis consumed
+34.59 seconds while all other report analysis completed in under 8
+milliseconds.
 
 The analyzer now tokenizes each complete Skill search document once and reuses
 those vocabularies for pair comparison. On the unchanged real Snapshot the
-first report fell to 2.22 seconds with identical Finding counts, category
-counts, and first-view facts. A 193-Skill core regression that previously took
-75.32 seconds now completes in under one second and enforces a five-second
+unoptimized first report fell to 2.22 seconds and the optimized 1.7.1 build
+produced the complete report in 0.84 seconds. Normalized complete reports from
+the official 1.7.0 binary and the 1.7.1 build were byte-identical after removing
+random Run, Report, and Finding IDs. A 193-Skill core regression that previously
+took 75.32 seconds now completes in under one second and enforces a five-second
 upper bound in the unoptimized test profile. These measurements describe the
 recorded reference run, not a universal machine-performance guarantee.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.7.0
+SKILLROSTER_VERSION=1.7.1
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.7.0 skillroster
+  --tag v1.7.1 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.7.0
+git checkout v1.7.1
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -3737,6 +3737,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.6.0",
         "c5f05692527bb2b8c45012ba6a464268b6a91a683a429a11dbe67022bbcc2aa5",
     ),
+    (
+        "1.7.0",
+        "8b503801efa6a5dd13c8767647654bb9fcd4dcfaf10cdbbb61429dfe29995129",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -638,16 +638,21 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
 
     // Semantic similarity is deliberately candidate evidence only. It never
     // authorizes consolidation, deletion, or an automatic Plan.
+    let vocabularies = scan
+        .skills
+        .iter()
+        .map(|skill| tokens(&skill_search_text(skill)))
+        .collect::<Vec<_>>();
     let mut candidates = Vec::new();
     for (index, left) in scan.skills.iter().enumerate() {
-        for right in scan.skills.iter().skip(index + 1) {
+        let left_tokens = &vocabularies[index];
+        for (right_index, right) in scan.skills.iter().enumerate().skip(index + 1) {
             if left.content_digest == right.content_digest {
                 continue;
             }
-            let left_tokens = tokens(&skill_search_text(left));
-            let right_tokens = tokens(&skill_search_text(right));
-            let intersection = left_tokens.intersection(&right_tokens).count();
-            let union = left_tokens.union(&right_tokens).count();
+            let right_tokens = &vocabularies[right_index];
+            let intersection = left_tokens.intersection(right_tokens).count();
+            let union = left_tokens.union(right_tokens).count();
             if intersection < 3 || union == 0 {
                 continue;
             }
@@ -1502,6 +1507,47 @@ mod tests {
         assert!(finding.summary.contains("review-only candidate evidence"));
         assert!(finding.summary.contains("not a confirmed duplicate"));
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn semantic_overlap_analysis_stays_bounded_for_a_realistic_inventory() {
+        let (_, mut scan) = fixture();
+        let representative = scan.skills[0].clone();
+        let shared_body = std::iter::repeat_n(
+            "shared architecture workflow browser database agent skill governance local evidence",
+            500,
+        )
+        .collect::<Vec<_>>()
+        .join(" ");
+        scan.skills = (0..193)
+            .map(|index| {
+                let mut skill = representative.clone();
+                skill.id = format!("realistic-{index:03}");
+                skill.name = format!("realistic-{index:03}");
+                skill.content_digest = format!("digest-{index:03}");
+                skill.normalized_text = format!("{shared_body} unique-{index:03}");
+                skill
+            })
+            .collect();
+        scan.placements.clear();
+        scan.usage.clear();
+
+        let started = std::time::Instant::now();
+        let report = build_report(&scan);
+
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "semantic overlap analysis took {:?} for 193 Skills",
+            started.elapsed()
+        );
+        assert_eq!(
+            report
+                .findings
+                .iter()
+                .filter(|finding| finding.title == "Semantic overlap candidate")
+                .count(),
+            25
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -875,7 +875,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.7.0"
+        "1.7.1"
     );
 
     let undone = json_output(&run(
@@ -897,6 +897,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
         ("1.5.0", include_str!("fixtures/bootstrap-v1.5.0.md")),
         ("1.5.1", include_str!("fixtures/bootstrap-v1.5.1.md")),
         ("1.6.0", include_str!("fixtures/bootstrap-v1.6.0.md")),
+        ("1.7.0", include_str!("fixtures/bootstrap-v1.7.0.md")),
     ] {
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
@@ -971,7 +972,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.7.0");
+    assert_eq!(output["result"]["bootstrap_version"], "1.7.1");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],

--- a/tests/fixtures/bootstrap-v1.7.0.md
+++ b/tests/fixtures/bootstrap-v1.7.0.md
@@ -2,7 +2,7 @@
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
 metadata:
-  bootstrap-version: "1.7.1"
+  bootstrap-version: "1.7.0"
 ---
 
 # SkillRoster


### PR DESCRIPTION
Closes #33.

## Problem

Real Agent dogfood found that first-report semantic-overlap analysis tokenized both complete Skill documents again for every pair. The cached report was fast, but the first governance diagnosis did avoidable repeated work.

## Change

- tokenize each Skill search document once per report and reuse the vocabulary for every pair comparison
- preserve the existing Jaccard threshold, deterministic ordering, 25-candidate cap, severity, and review-only safety boundary
- add a 193-Skill core regression with a five-second unoptimized upper bound
- distinguish debug and optimized-release timings in acceptance evidence
- bump the CLI and Bootstrap Skill to 1.7.1 with exact v1.7.0 upgrade/Undo coverage

## Evidence

- official optimized v1.7.0 complete report: 4.85s
- optimized v1.7.1 build complete report: 0.84s (~5.8x faster)
- unoptimized real first summary: 34.26s -> 2.22s (~15.4x faster)
- synthetic 193-Skill regression: 75.32s -> <1s
- old/new complete reports: 626,759 bytes each and byte-identical after removing random Run/Report/Finding IDs
- real inventory: 8 Agents, 193 Skills, 689 placements, no Agent files changed

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` — 100 unit + 6 acceptance + 27 CLI = 133 passed
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- independent Standards and Spec reviews: PASS, no P0/P1/P2
