### PR TITLE
fix: ignore already-shared skills in overlap findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.1"
+version = "1.8.2"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -3,7 +3,7 @@ class Skillroster < Formula
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "49608057bf43d08bc34e98e2bdef2470a327f705"
-  version "1.8.1"
+  version "1.8.2"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.1", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.2", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "49608057bf43d08bc34e98e2bdef2470a327f705"
+      revision: "8133f323acf7e08fc6a3b6e3254981ccb81d89a2"
   version "1.8.2"
 
   depends_on "rust" => :build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.1
+SKILLROSTER_VERSION=1.8.2
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.1 skillroster
+  --tag v1.8.2 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.1
+git checkout v1.8.2
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -3863,6 +3863,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.8.0",
         "820b760c5f6cc8c2ad6695e211044882077af138014579236b8824039fd1f394",
     ),
+    (
+        "1.8.1",
+        "996891144bca51a654fc51294cd6d63c41df4afb5796af7846480b168f69edc6",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,6 +6,7 @@ use crate::scan::{
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -691,15 +692,23 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             if exact_placements.len() < 2 {
                 continue;
             }
+            let physical_sources = exact_placements
+                .iter()
+                .map(|placement| physical_source_identity(placement, &scan.placements))
+                .collect::<BTreeSet<_>>();
+            if physical_sources.len() < 2 {
+                continue;
+            }
             push_finding(
                 findings,
                 FindingCategory::Overlap,
                 Severity::Medium,
                 "Exact duplicate Skill placements",
                 format!(
-                    "{} has {} placements with the same normalized content digest.",
+                    "{} has {} placements across {} distinct physical sources with the same normalized content digest.",
                     skill.name,
-                    exact_placements.len()
+                    exact_placements.len(),
+                    physical_sources.len()
                 ),
                 vec![skill.id.clone()],
                 exact_placements
@@ -770,6 +779,41 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             ],
             EvidenceQuality::Inferred,
         );
+    }
+}
+
+fn physical_source_identity(
+    start: &crate::scan::SkillPlacement,
+    placements: &[crate::scan::SkillPlacement],
+) -> PathBuf {
+    let mut current = start;
+    let mut visited = BTreeSet::new();
+    loop {
+        if current.link_status != LinkStatus::Valid {
+            return current.directory.clone();
+        }
+        if !visited.insert(current.directory.clone()) {
+            return current.directory.clone();
+        }
+        let Some(target) = current.link_target.as_deref() else {
+            return current.directory.clone();
+        };
+        if let Some(next) = placements
+            .iter()
+            .find(|placement| placement.directory == target || placement.entrypoint == target)
+        {
+            current = next;
+            continue;
+        }
+        return skill_directory_for_link_target(target);
+    }
+}
+
+fn skill_directory_for_link_target(target: &Path) -> PathBuf {
+    if target.file_name().is_some_and(|name| name == "SKILL.md") {
+        target.parent().unwrap_or(target).to_path_buf()
+    } else {
+        target.to_path_buf()
     }
 }
 
@@ -1495,7 +1539,6 @@ mod tests {
     use super::*;
     use crate::scan::{ScanOptions, scan};
     use std::fs;
-    use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn fixture() -> (PathBuf, ScanResult) {
@@ -1561,6 +1604,73 @@ mod tests {
                 && finding.evidence_quality == EvidenceQuality::Unknown
         }));
         assert!(!report.files_changed);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn exact_duplicate_ignores_one_physical_source_shared_by_valid_links() {
+        let (root, mut scan) = fixture();
+        let source = scan
+            .placements
+            .iter()
+            .find(|placement| placement.directory.ends_with("research-a"))
+            .unwrap()
+            .clone();
+        let mut direct_link = source.clone();
+        direct_link.id = "placement_direct_link".into();
+        direct_link.directory = root.join("linked-direct");
+        direct_link.entrypoint = direct_link.directory.join("SKILL.md");
+        direct_link.link_target = Some(source.directory.clone());
+        direct_link.link_status = LinkStatus::Valid;
+        let mut indirect_link = source.clone();
+        indirect_link.id = "placement_indirect_link".into();
+        indirect_link.directory = root.join("linked-indirect");
+        indirect_link.entrypoint = indirect_link.directory.join("SKILL.md");
+        indirect_link.link_target = Some(direct_link.directory.clone());
+        indirect_link.link_status = LinkStatus::Valid;
+        scan.placements
+            .retain(|placement| placement.skill_id != source.skill_id || placement.id == source.id);
+        scan.placements.push(direct_link);
+        scan.placements.push(indirect_link);
+
+        let report = build_report(&scan);
+
+        assert!(!report.findings.iter().any(|finding| {
+            finding.title == "Exact duplicate Skill placements"
+                && finding.affected_skill_ids.contains(&source.skill_id)
+        }));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn exact_duplicate_keeps_multiple_physical_sources_with_shared_links() {
+        let (root, mut scan) = fixture();
+        let source = scan
+            .placements
+            .iter()
+            .find(|placement| placement.directory.ends_with("research-a"))
+            .unwrap()
+            .clone();
+        let mut shared_link = source.clone();
+        shared_link.id = "placement_shared_link".into();
+        shared_link.directory = root.join("linked-copy");
+        shared_link.entrypoint = shared_link.directory.join("SKILL.md");
+        shared_link.link_target = Some(source.directory.clone());
+        shared_link.link_status = LinkStatus::Valid;
+        scan.placements.push(shared_link);
+
+        let report = build_report(&scan);
+        let finding = report
+            .findings
+            .iter()
+            .find(|finding| {
+                finding.title == "Exact duplicate Skill placements"
+                    && finding.affected_skill_ids.contains(&source.skill_id)
+            })
+            .unwrap();
+
+        assert_eq!(finding.affected_placement_ids.len(), 3);
+        assert!(finding.summary.contains("2 distinct physical sources"));
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -908,7 +908,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.1"
+        "1.8.2"
     );
 
     let undone = json_output(&run(
@@ -933,6 +933,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
         ("1.7.0", include_str!("fixtures/bootstrap-v1.7.0.md")),
         ("1.7.1", include_str!("fixtures/bootstrap-v1.7.1.md")),
         ("1.8.0", include_str!("fixtures/bootstrap-v1.8.0.md")),
+        ("1.8.1", include_str!("fixtures/bootstrap-v1.8.1.md")),
     ] {
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
@@ -1007,7 +1008,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.1");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.2");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],

--- a/tests/fixtures/bootstrap-v1.8.1.md
+++ b/tests/fixtures/bootstrap-v1.8.1.md
@@ -2,7 +2,7 @@
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
 metadata:
-  bootstrap-version: "1.8.2"
+  bootstrap-version: "1.8.1"
 ---
 
 # SkillRoster


### PR DESCRIPTION
## Problem

Already-shared Skills were still reported as exact duplicates. On the real reference machine, three Skills each had one physical source and otherwise valid direct or indirect symlinks, but SkillRoster offered unnecessary consolidation Plans.

## Solution

- resolve valid direct and indirect placement links to a stable physical-source identity;
- emit exact-duplicate Findings only when the same digest spans at least two physical sources;
- keep multi-source and mixed topologies actionable;
- include physical-source counts in the Finding summary;
- add direct-link, indirect-link, and multi-source regressions;
- prepare v1.8.2 and retain exact v1.8.1 Bootstrap upgrade/Apply/Undo compatibility.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (152 passed)
- `cargo build --release --locked`; `skillroster 1.8.2`
- Formula Ruby syntax and Homebrew style passed
- Bootstrap Skill validation passed
- real read-only dogfood: 180 Skills, 692 placements; overlap 153 -> 150; exact duplicates 128 -> 125; all three confirmed shared-link false positives removed; no Agent files changed
- independent Standards and Spec reviews passed

Closes #39
