### PR TITLE
fix: deduplicate Setup operations for shared Agent roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.2"
+version = "1.8.3"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -3,7 +3,7 @@ class Skillroster < Formula
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "8133f323acf7e08fc6a3b6e3254981ccb81d89a2"
-  version "1.8.2"
+  version "1.8.3"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.2", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.3", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "8133f323acf7e08fc6a3b6e3254981ccb81d89a2"
+      revision: "e0da84967995b5f83f9f4fdb20cd8c8b95c6f6d5"
   version "1.8.3"
 
   depends_on "rust" => :build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.2
+SKILLROSTER_VERSION=1.8.3
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.2 skillroster
+  --tag v1.8.3 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.2
+git checkout v1.8.3
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -3938,6 +3938,7 @@ fn setup_command(
             "modified_count": 0,
             "unsupported_count": 0,
             "replace_count": 0,
+            "physical_target_count": 0,
             "canonical_deletion_count": 0,
             "files_changed": false,
             "next": "skillroster scan --json"
@@ -3955,10 +3956,19 @@ fn setup_command(
     let mut modified_count = 0_usize;
     let mut unsupported_count = 0_usize;
     let mut replace_count = 0_usize;
+    let mut physical_targets = BTreeSet::new();
+    let mut planned_directories = BTreeSet::new();
+    let mut planned_entrypoints = BTreeSet::new();
     for roots in harness::known_agent_roots(home) {
         for root in roots.skill_roots.into_iter().filter(|path| path.is_dir()) {
             let directory = root.join("skillroster");
             let entrypoint = directory.join("SKILL.md");
+            let physical_root = std::fs::canonicalize(&root).with_context(|| {
+                format!("failed to resolve Agent Skill root {}", root.display())
+            })?;
+            let physical_directory = physical_root.join("skillroster");
+            let physical_entrypoint = physical_directory.join("SKILL.md");
+            physical_targets.insert(physical_entrypoint.clone());
             detected.push(json!({"agent": roots.agent.id(), "target": entrypoint}));
             let directory_is_unsupported = match std::fs::symlink_metadata(&directory) {
                 Ok(metadata) => metadata.file_type().is_symlink() || !metadata.file_type().is_dir(),
@@ -3983,12 +3993,14 @@ fn setup_command(
                             BootstrapContentStatus::OfficialOutdated(_) => {
                                 outdated_count += 1;
                                 replace_count += 1;
-                                operations.push(json!({
-                                    "kind": "replace_file",
-                                    "target": entrypoint,
-                                    "content": &current_content,
-                                    "expected_fingerprint": change::fingerprint(&entrypoint)?
-                                }));
+                                if planned_entrypoints.insert(physical_entrypoint.clone()) {
+                                    operations.push(json!({
+                                        "kind": "replace_file",
+                                        "target": entrypoint,
+                                        "content": &current_content,
+                                        "expected_fingerprint": change::fingerprint(&entrypoint)?
+                                    }));
+                                }
                             }
                             BootstrapContentStatus::Modified => {
                                 modified_count += 1;
@@ -3997,12 +4009,14 @@ fn setup_command(
                                     Some(ModifiedBootstrapChoice::AdoptCurrent)
                                 ) {
                                     replace_count += 1;
-                                    operations.push(json!({
-                                        "kind": "replace_file",
-                                        "target": entrypoint,
-                                        "content": &current_content,
-                                        "expected_fingerprint": change::fingerprint(&entrypoint)?
-                                    }));
+                                    if planned_entrypoints.insert(physical_entrypoint.clone()) {
+                                        operations.push(json!({
+                                            "kind": "replace_file",
+                                            "target": entrypoint,
+                                            "content": &current_content,
+                                            "expected_fingerprint": change::fingerprint(&entrypoint)?
+                                        }));
+                                    }
                                 }
                             }
                         }
@@ -4018,19 +4032,22 @@ fn setup_command(
                         && !directory_is_unsupported =>
                 {
                     missing_count += 1;
-                    if !directory.exists() {
+                    if !directory.exists() && planned_directories.insert(physical_directory.clone())
+                    {
                         operations.push(json!({
                             "kind": "create_directory",
                             "target": directory,
                             "expected_fingerprint": "missing"
                         }));
                     }
-                    operations.push(json!({
-                        "kind": "write_file",
-                        "target": entrypoint,
-                        "content": &current_content,
-                        "expected_fingerprint": "missing"
-                    }));
+                    if planned_entrypoints.insert(physical_entrypoint.clone()) {
+                        operations.push(json!({
+                            "kind": "write_file",
+                            "target": entrypoint,
+                            "content": &current_content,
+                            "expected_fingerprint": "missing"
+                        }));
+                    }
                     ("missing", None)
                 }
                 Err(_) => {
@@ -4041,6 +4058,7 @@ fn setup_command(
             targets.push(json!({
                 "agent": roots.agent.id(),
                 "target": entrypoint,
+                "physical_target": physical_entrypoint,
                 "status": status,
                 "installed_version": installed_version
             }));
@@ -4057,6 +4075,7 @@ fn setup_command(
         "modified_count": modified_count,
         "unsupported_count": unsupported_count,
         "replace_count": replace_count,
+        "physical_target_count": physical_targets.len(),
         "canonical_deletion_count": 0,
         "files_changed": false
     });

--- a/src/app.rs
+++ b/src/app.rs
@@ -3867,6 +3867,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.8.1",
         "996891144bca51a654fc51294cd6d63c41df4afb5796af7846480b168f69edc6",
     ),
+    (
+        "1.8.2",
+        "d79be31fe878267d00f21cf8e198443ebf8b95eb6631fc2395f132f12289e3e5",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/present.rs
+++ b/src/present.rs
@@ -840,6 +840,11 @@ fn setup(value: &Value, lines: &mut Vec<String>, width: usize) {
         "Detected Agents",
         array_len(value, "detected_agents"),
     );
+    fact(
+        lines,
+        "Physical targets",
+        text(value, "physical_target_count"),
+    );
     fact(lines, "Current", text(value, "current_count"));
     fact(lines, "Missing", text(value, "missing_count"));
     fact(lines, "Official outdated", text(value, "outdated_count"));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -990,6 +990,73 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let shared = home.join(".agents_skills");
+    let opencode = home.join(".config/opencode/skills");
+    let hermes = home.join(".hermes/skills");
+    for root in [&shared, &opencode, &hermes] {
+        fs::create_dir_all(root).unwrap();
+    }
+    for (parent, link) in [
+        (home.join(".codex"), home.join(".codex/skills")),
+        (home.join(".claude"), home.join(".claude/skills")),
+        (home.join(".pi/agent"), home.join(".pi/agent/skills")),
+    ] {
+        fs::create_dir_all(parent).unwrap();
+        symlink(&shared, link).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(setup["result"]["state"], "preview_ready");
+    assert_eq!(
+        setup["result"]["detected_agents"].as_array().unwrap().len(),
+        5
+    );
+    assert_eq!(setup["result"]["targets"].as_array().unwrap().len(), 5);
+    assert_eq!(setup["result"]["missing_count"], 5);
+    assert_eq!(setup["result"]["physical_target_count"], 3);
+    assert_eq!(setup["result"]["operation_count"], 6);
+
+    let plan_id = setup["result"]["plan_id"].as_str().unwrap();
+    let detail = json_output(&run(
+        &[&common[..], &["plan", "--show", plan_id]].concat(),
+        None,
+    ));
+    let operations = detail["result"]["operations"].as_array().unwrap();
+    assert_eq!(operations.len(), 6);
+    let unique_targets = operations
+        .iter()
+        .map(|operation| operation["target"].as_str().unwrap())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(unique_targets.len(), 6);
+
+    let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+    for root in [&shared, &opencode, &hermes] {
+        assert!(root.join("skillroster/SKILL.md").is_file());
+    }
+    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+    assert_eq!(undone["result"]["verification"], "passed");
+    for root in [&shared, &opencode, &hermes] {
+        assert!(!root.join("skillroster").exists());
+    }
+}
+
 #[test]
 fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     let temp = TempDir::new().unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -908,7 +908,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.2"
+        "1.8.3"
     );
 
     let undone = json_output(&run(
@@ -934,6 +934,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
         ("1.7.1", include_str!("fixtures/bootstrap-v1.7.1.md")),
         ("1.8.0", include_str!("fixtures/bootstrap-v1.8.0.md")),
         ("1.8.1", include_str!("fixtures/bootstrap-v1.8.1.md")),
+        ("1.8.2", include_str!("fixtures/bootstrap-v1.8.2.md")),
     ] {
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
@@ -1075,7 +1076,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.2");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.3");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],

--- a/tests/fixtures/bootstrap-v1.8.2.md
+++ b/tests/fixtures/bootstrap-v1.8.2.md
@@ -2,7 +2,7 @@
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
 metadata:
-  bootstrap-version: "1.8.3"
+  bootstrap-version: "1.8.2"
 ---
 
 # SkillRoster


### PR DESCRIPTION
## Problem

Setup treated several Agent Skill roots that symlink to one shared directory as independent write targets. The resulting operations normalized to the same path and were correctly rejected as `ambiguous_target`, blocking Bootstrap installation or upgrade.

## Solution

- preserve every logical Agent in Setup coverage and target reporting;
- resolve each existing Agent Skill root to a physical root for operation identity;
- deduplicate directory and file operations deterministically per physical target;
- expose `physical_target_count` and each target's `physical_target` in JSON, plus the count in human output;
- retain existing approved-root, fingerprint, unsupported-target, Plan, Apply, Receipt, and Undo checks;
- add a real symlink-topology integration regression covering Plan, Apply, and Undo;
- prepare v1.8.3 with exact v1.8.2 Bootstrap upgrade compatibility.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (153 passed)
- Release build reports `skillroster 1.8.3`
- Formula Ruby syntax and Homebrew style passed
- Bootstrap Skill validation passed
- real-machine preview: 5 logical Agents, 3 physical targets, 6 unique operations, `files_changed=false`
- independent Standards and Spec reviews passed

Closes #41
