### PR TITLE
fix: deduplicate confirmed source roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.4"
+version = "1.8.5"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.4"
+version = "1.8.5"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -3,7 +3,7 @@ class Skillroster < Formula
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "db2ee7f7b71d36fde86f35ad3690ccb6e54bf74b"
-  version "1.8.4"
+  version "1.8.5"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.4", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.5", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "db2ee7f7b71d36fde86f35ad3690ccb6e54bf74b"
+      revision: "afc981a5482b5431b4dc92808a0b02aa9c0ae5fc"
   version "1.8.5"
 
   depends_on "rust" => :build

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -226,6 +226,32 @@ Plan. Selected IDs still lead to compact Evidence drilldown. Automated tests
 cover pagination, filtering, action argv, invalid flag combinations, and plain
 60-, 80-, and 120-column rendering.
 
+## Agent-led confirmed-source normalization dogfood
+
+The 1.8.5 pre-release dogfood used a fresh isolated state directory against the
+real eight-Agent home. Before source confirmation, Scan reported 244
+independent Skills, 740 placements, 548 default exposures, and 16 escaping-link
+placements without reading those targets. The trust-resolution response listed
+four observed targets. Two were a symlink alias and physical path for the same
+source; following the response literally caused the pre-fix inventory to add
+four source placements instead of three.
+
+Confirmed source roots are now resolved only after the caller explicitly
+supplies `--source-root`. The scanner preserves each confirmed alias for trust
+containment but inventories its canonical physical directory once. The same
+real rescan completed in 10.51 seconds with 231 independent Skills, 743
+placements, unchanged default exposure at 548, no unsafe-link warning, and no
+escaping-link Finding. The lower Skill count reflects formerly unread aliases
+resolving to shared content rather than removal or archive activity.
+
+On that Snapshot, `setup` prepared but did not apply a six-operation Plan for
+five logical bootstrap targets across three physical roots. The Chinese
+cross-Agent Skill-management task returned `agent-skills-manager` at rank one.
+The exact-duplicate Finding retained six logical placements, three physical
+canonical candidates, and a bounded five-operation managed-Library Plan. No
+real Agent file was changed; Apply/Undo remained confined to automated
+temporary-home acceptance tests.
+
 ## Evidence boundary
 
 These checks establish deterministic routing and safe local governance; they do

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.4
+SKILLROSTER_VERSION=1.8.5
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -45,7 +45,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.4 skillroster
+  --tag v1.8.5 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +59,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.4
+git checkout v1.8.5
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -3963,6 +3963,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.8.3",
         "3eba54753cfe8cdf987a8a4fe1ab1337317aef9b72e55b9be49b3158117470b1",
     ),
+    (
+        "1.8.4",
+        "2758bed89792128c47d01f613a4df277dd32c9641cb036e7ed1f03c0c94e8381",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -5160,7 +5164,7 @@ mod recovery_tests {
     }
 
     #[test]
-    fn source_roots_must_be_absolute_and_are_deduplicated() {
+    fn source_roots_must_be_absolute_and_are_lexically_deduplicated() {
         assert!(parse_source_roots(&[PathBuf::from("relative")]).is_err());
         let absolute = std::env::current_dir().unwrap().join("source");
         assert_eq!(

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -595,6 +595,10 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
     let mut result = ScanResult::default();
     let known = known_agent_roots(&options.home);
     let plugin_roots = codex_plugin_skill_roots(&options.home, &mut result.warnings);
+    // These paths are already an explicit trust decision from the caller.
+    // Preserve the supplied aliases for link-containment checks, while
+    // inventorying each resolved physical source only once.
+    let confirmed_source_roots = normalized_confirmed_source_roots(&options.explicit_source_roots);
     let shared_roots = [
         options.home.join(".agents_skills"),
         options.home.join(".skillroster/library"),
@@ -611,6 +615,7 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
                 .map(|root| root.path.clone()),
         )
         .chain(options.explicit_source_roots.iter().cloned())
+        .chain(confirmed_source_roots.iter().cloned())
         .collect::<Vec<_>>();
     let mut candidates = Vec::new();
 
@@ -648,7 +653,7 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
             &mut candidates,
         );
     }
-    for root in &options.explicit_source_roots {
+    for root in &confirmed_source_roots {
         observe_skill_root(
             root,
             SkillRootPolicy {
@@ -726,6 +731,16 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
     result.skills.sort_by(|a, b| a.id.cmp(&b.id));
     result.placements.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(result)
+}
+
+fn normalized_confirmed_source_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut normalized = roots
+        .iter()
+        .map(|root| fs::canonicalize(root).unwrap_or_else(|_| root.clone()))
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized.dedup();
+    normalized
 }
 
 fn observe_excluded_session_roots(
@@ -2234,10 +2249,11 @@ enabled = true
 
     #[cfg(unix)]
     #[test]
-    fn explicit_source_root_approves_links_without_adding_agent_exposure() {
+    fn explicit_source_roots_deduplicate_physical_sources_and_preserve_confirmed_aliases() {
         let root = temp_directory("source-root");
         let home = root.join("home");
         let source_root = root.join("sources");
+        let source_alias = root.join("source-alias");
         let source_skill = source_root.join("external");
         fs::create_dir_all(&source_skill).unwrap();
         fs::write(
@@ -2245,31 +2261,40 @@ enabled = true
             "---\nname: external\ndescription: External source Skill\n---\n",
         )
         .unwrap();
+        std::os::unix::fs::symlink(&source_root, &source_alias).unwrap();
         let codex_root = home.join(".codex/skills");
+        let claude_root = home.join(".claude/skills");
         fs::create_dir_all(&codex_root).unwrap();
-        std::os::unix::fs::symlink(&source_skill, codex_root.join("external")).unwrap();
+        fs::create_dir_all(&claude_root).unwrap();
+        std::os::unix::fs::symlink(source_alias.join("external"), codex_root.join("external"))
+            .unwrap();
+        std::os::unix::fs::symlink(&source_skill, claude_root.join("external")).unwrap();
 
         let mut options = ScanOptions::for_home(&home);
-        options.explicit_source_roots.push(source_root.clone());
+        options.explicit_source_roots = vec![source_alias, source_root.clone()];
         options.include_session_evidence = false;
         let result = scan(&options).unwrap();
 
         assert!(result.warnings.is_empty());
         assert_eq!(result.skills.len(), 1);
-        assert_eq!(result.placements.len(), 2);
+        assert_eq!(result.placements.len(), 3);
         assert_eq!(
             result
                 .placements
                 .iter()
                 .filter(|placement| placement.default_exposed)
                 .count(),
-            1
+            2
         );
-        assert!(
-            result
-                .roots
-                .iter()
-                .any(|seen| { seen.path == source_root && seen.explicit && seen.agent.is_none() })
+        let source_observations = result
+            .roots
+            .iter()
+            .filter(|seen| seen.explicit && seen.agent.is_none())
+            .collect::<Vec<_>>();
+        assert_eq!(source_observations.len(), 1);
+        assert_eq!(
+            source_observations[0].path,
+            fs::canonicalize(source_root).unwrap()
         );
         fs::remove_dir_all(root).unwrap();
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -908,7 +908,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.4"
+        "1.8.5"
     );
 
     let undone = json_output(&run(
@@ -936,6 +936,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
         ("1.8.1", include_str!("fixtures/bootstrap-v1.8.1.md")),
         ("1.8.2", include_str!("fixtures/bootstrap-v1.8.2.md")),
         ("1.8.3", include_str!("fixtures/bootstrap-v1.8.3.md")),
+        ("1.8.4", include_str!("fixtures/bootstrap-v1.8.4.md")),
     ] {
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
@@ -1077,7 +1078,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.4");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.5");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],
@@ -2234,7 +2235,10 @@ fn exact_duplicate_finding_prepares_library_plan_from_semantic_choices() {
     assert_eq!(planning["canonical_candidates_truncated"], true);
     assert_eq!(
         candidates[0]["path"],
-        source_skill.join("SKILL.md").to_str().unwrap()
+        fs::canonicalize(source_skill.join("SKILL.md"))
+            .unwrap()
+            .to_str()
+            .unwrap()
     );
     assert_eq!(candidates[0]["reason"], "non_exposed_source");
     let canonical_placement_id = candidates[0]["placement_id"].as_str().unwrap();

--- a/tests/fixtures/bootstrap-v1.8.4.md
+++ b/tests/fixtures/bootstrap-v1.8.4.md
@@ -2,7 +2,7 @@
 name: skillroster
 description: Inspect, search, organize, apply, or undo governance for locally installed Agent Skills with the SkillRoster CLI. Use when the user asks which Skills are installed or used, wants duplicates or broken links analyzed, needs a smaller default Skill roster, wants an on-demand Skill found, or asks to apply or undo an approved Skill organization plan.
 metadata:
-  bootstrap-version: "1.8.5"
+  bootstrap-version: "1.8.4"
 ---
 
 # SkillRoster


### PR DESCRIPTION
## Problem

Real Agent dogfood followed the escaping-link trust workflow and supplied four confirmed `--source-root` values. Two were aliases of the same physical source, so the pre-fix inventory added four source placements instead of three.

Closes #48.

## Solution

- preserve explicitly confirmed aliases for link-containment checks;
- canonicalize and deduplicate only the source roots used for inventory;
- preserve missing roots for normal Scan observations;
- keep unconfirmed escaping targets unread;
- release as 1.8.5 with Apache-2.0 metadata and immediate 1.8.4 Bootstrap upgrade support.

## Real dogfood

A fresh read-only scan of the eight-Agent reference home completed with 231 independent Skills, 743 placements, 548 default exposures, no unsafe-link warning, and no Agent-file changes. The same inputs previously produced 744 placements. `setup` remained preview-only, and the cross-Agent Chinese Skill-management query returned `agent-skills-manager` at rank one.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (122 unit + 6 acceptance + 32 CLI)
- `cargo package --locked --allow-dirty`
- Bootstrap `quick_validate.py`: `Skill is valid!`
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- independent Standards review: PASS
- independent Spec review: PASS