### PR TITLE
fix: bundle Apache-2.0 license with release archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.6"
+version = "1.8.7"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.6"
+version = "1.8.7"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -3,7 +3,7 @@ class Skillroster < Formula
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "a8460a3939fa813b453e76b55fc64447fae8115c"
-  version "1.8.6"
+  version "1.8.7"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.6", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.7", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "a8460a3939fa813b453e76b55fc64447fae8115c"
+      revision: "3bc4eb710dad10b5d66f8b527ef479c6f1b485d3"
   version "1.8.7"
 
   depends_on "rust" => :build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.6
+SKILLROSTER_VERSION=1.8.7
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -37,7 +37,8 @@ skillroster --version
 
 On Windows, compare `Get-FileHash .\skillroster-*.zip -Algorithm SHA256` with
 the checksum file. Extract the archive, open its versioned directory, then
-place `skillroster.exe` in a directory on `PATH`.
+place `skillroster.exe` in a directory on `PATH`. Every release archive also
+contains the complete Apache-2.0 `LICENSE` distributed with the binary.
 
 ## Build or install from source
 
@@ -45,7 +46,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.6 skillroster
+  --tag v1.8.7 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -59,7 +60,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.6
+git checkout v1.8.7
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/scripts/release/package-unix.sh
+++ b/scripts/release/package-unix.sh
@@ -36,8 +36,14 @@ fi
 mkdir -p "$stage"
 install -m 0755 "target/${target}/release/skillroster" "$stage/skillroster"
 cp README.md "$stage/README.md"
+cp LICENSE "$stage/LICENSE"
 tar -C "$dist_root" -czf "$archive" "$name"
 rm -rf "$stage"
+
+if ! tar -xOf "$archive" "$name/LICENSE" | cmp - LICENSE; then
+  echo "release archive does not contain the repository LICENSE" >&2
+  exit 1
+fi
 
 if command -v sha256sum >/dev/null 2>&1; then
   (cd "$dist_root" && sha256sum "${name}.tar.gz" > "${name}.tar.gz.sha256")

--- a/scripts/release/package-windows.ps1
+++ b/scripts/release/package-windows.ps1
@@ -16,6 +16,7 @@ $DistRoot = [System.IO.Path]::GetFullPath((Join-Path (Get-Location) "dist"))
 $Stage = [System.IO.Path]::GetFullPath((Join-Path $DistRoot $Name))
 $Archive = [System.IO.Path]::GetFullPath((Join-Path $DistRoot "$Name.zip"))
 $Checksum = "$Archive.sha256"
+$VerifyRoot = [System.IO.Path]::GetFullPath((Join-Path $DistRoot "$Name-license-check"))
 $Prefix = $DistRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
 if (-not $Stage.StartsWith($Prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
     throw "Staging path escapes dist"
@@ -26,14 +27,33 @@ $DistItem = Get-Item -LiteralPath $DistRoot -Force
 if (($DistItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
     throw "dist must not be a reparse point"
 }
-if ((Test-Path -LiteralPath $Stage) -or (Test-Path -LiteralPath $Archive) -or (Test-Path -LiteralPath $Checksum)) {
+if ((Test-Path -LiteralPath $Stage) -or (Test-Path -LiteralPath $Archive) -or (Test-Path -LiteralPath $Checksum) -or (Test-Path -LiteralPath $VerifyRoot)) {
     throw "Refusing to overwrite an existing staging path or artifact"
 }
 New-Item -ItemType Directory -Force -Path $Stage | Out-Null
 Copy-Item "target/$Target/release/skillroster.exe" (Join-Path $Stage "skillroster.exe")
 Copy-Item "README.md" (Join-Path $Stage "README.md")
+Copy-Item "LICENSE" (Join-Path $Stage "LICENSE")
 Compress-Archive -Path $Stage -DestinationPath $Archive -Force
 Remove-Item $Stage -Recurse -Force
+
+try {
+    Expand-Archive -LiteralPath $Archive -DestinationPath $VerifyRoot
+    $BundledLicense = Join-Path (Join-Path $VerifyRoot $Name) "LICENSE"
+    if (-not (Test-Path -LiteralPath $BundledLicense -PathType Leaf)) {
+        throw "Release archive does not contain LICENSE"
+    }
+    $ExpectedLicenseHash = (Get-FileHash -Algorithm SHA256 "LICENSE").Hash
+    $BundledLicenseHash = (Get-FileHash -Algorithm SHA256 $BundledLicense).Hash
+    if ($ExpectedLicenseHash -ne $BundledLicenseHash) {
+        throw "Release archive LICENSE differs from the repository LICENSE"
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $VerifyRoot) {
+        Remove-Item $VerifyRoot -Recurse -Force
+    }
+}
 
 $Hash = (Get-FileHash -Algorithm SHA256 $Archive).Hash.ToLowerInvariant()
 $ChecksumLine = "$Hash  $Name.zip`n"

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -8,7 +8,7 @@ description: >
   distributing, synchronizing, or repairing shared Skill directories and
   symlinks.
 metadata:
-  bootstrap-version: "1.8.6"
+  bootstrap-version: "1.8.7"
   skillroster-routing-triggers: "scan analyze duplicate unused local Agent Skills; inventory installed Agent Skills; analyze duplicate Agent Skills; evaluate possible unused local Agent Skills from usage evidence; govern a Skill Roster; prepare a Skill governance Plan; apply approved Skill Plan; create Skill Receipt; undo Skill organization"
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3969,6 +3969,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.8.5",
         "9f25609e002ad63e750214c54d7138f6e877849e46626aef441e00eaca8738d1",
     ),
+    (
+        "1.8.6",
+        "4412ddc1fa4006492c28f8813462504a68cc71f4025398c3d60d5c225b2b904b",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -908,7 +908,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.6"
+        "1.8.7"
     );
 
     let undone = json_output(&run(
@@ -1078,7 +1078,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.6");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.7");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],


### PR DESCRIPTION
## Summary

- include a byte-identical Apache-2.0 `LICENSE` in Unix and Windows release archives
- fail packaging when the bundled license is missing or differs from the repository copy
- publish the correction as v1.8.7 and preserve v1.8.6 as a recognized official Bootstrap upgrade source
- document that every binary archive carries its license

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (164 passed)
- local macOS ARM package contains byte-identical `LICENSE`; checksum passes
- `cargo package --locked --allow-dirty` includes `LICENSE`
- Formula Ruby syntax and `brew style` pass
- Bootstrap quick validation passes

Closes #52