### PR TITLE
fix: keep release license bytes canonical

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.sh text eol=lf
+LICENSE text eol=lf
 skill/**/SKILL.md text eol=lf
 tests/fixtures/bootstrap-*.md text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.7"
+version = "1.8.8"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.7"
+version = "1.8.8"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -3,7 +3,7 @@ class Skillroster < Formula
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "3bc4eb710dad10b5d66f8b527ef479c6f1b485d3"
-  version "1.8.7"
+  version "1.8.8"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.7", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.8", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "3bc4eb710dad10b5d66f8b527ef479c6f1b485d3"
+      revision: "97b6e03da5bf9f7e501b849f61e3af81e43c6161"
   version "1.8.8"
 
   depends_on "rust" => :build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.7
+SKILLROSTER_VERSION=1.8.8
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -46,7 +46,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.7 skillroster
+  --tag v1.8.8 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -60,7 +60,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.7
+git checkout v1.8.8
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -8,7 +8,7 @@ description: >
   distributing, synchronizing, or repairing shared Skill directories and
   symlinks.
 metadata:
-  bootstrap-version: "1.8.7"
+  bootstrap-version: "1.8.8"
   skillroster-routing-triggers: "scan analyze duplicate unused local Agent Skills; inventory installed Agent Skills; analyze duplicate Agent Skills; evaluate possible unused local Agent Skills from usage evidence; govern a Skill Roster; prepare a Skill governance Plan; apply approved Skill Plan; create Skill Receipt; undo Skill organization"
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3973,6 +3973,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.8.6",
         "4412ddc1fa4006492c28f8813462504a68cc71f4025398c3d60d5c225b2b904b",
     ),
+    (
+        "1.8.7",
+        "68007e9c80a942cf4afa581f90639bbd260b69a36cb72aebdbca63e92d787eed",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -908,7 +908,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.7"
+        "1.8.8"
     );
 
     let undone = json_output(&run(
@@ -1078,7 +1078,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.7");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.8");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],


### PR DESCRIPTION
## Summary

- force the repository `LICENSE` to LF on every checkout, including Windows
- make all four binary archives carry the same canonical Apache-2.0 bytes
- publish as v1.8.8 while keeping the unpublished v1.8.7 RC Bootstrap recognizable and reversible

## Why another patch

The v1.8.7 Windows RC included the complete license and passed same-checkout validation, but Git converted the file to CRLF. Its raw digest differed from the Git blob and Unix archives. Removing CR reproduced the canonical digest exactly. v1.8.7 remains an unpublished RC tag.

## Verification

- Windows-like checkout simulation with `core.autocrlf=true`: zero CR bytes
- simulated Windows checkout, Git blob, and Unix source all SHA-256 `c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4`
- 164 Rust tests, strict Clippy, formatting, Formula style, and Bootstrap validation pass

Closes #52