### PR TITLE
fix: pin Formula to reachable v1.8.9 source

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "b0343d2f950479aa2b83be045dd96a1d35f3f3bb"
+      revision: "150fa591cbbc09e07c7aa0aa78cdac6037c16625"
   version "1.8.9"
 
   depends_on "rust" => :build


### PR DESCRIPTION
## Summary
- pin the Homebrew Formula to the public v1.8.9 merge commit
- remove reliance on the deleted feature branch and retained PR ref

## Why
The previous revision was absent from a fresh anonymous shallow clone after squash merge. The new revision is reachable from `main` and `v1.8.9`, and its Cargo package version is 1.8.9.

## Verification
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- fresh anonymous `--depth 1` clone can resolve the pinned commit
- pinned `Cargo.toml` reports version 1.8.9
- `git diff --check`