### PR TITLE
fix: improve CJK routing and variant decisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.10"
+version = "1.8.11"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.10"
+version = "1.8.11"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -3,7 +3,7 @@ class Skillroster < Formula
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "be9801f872047b82e8202aa4d38b30f53c06ff5c"
-  version "1.8.10"
+  version "1.8.11"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.10", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.11", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "be9801f872047b82e8202aa4d38b30f53c06ff5c"
+      revision: "f62403d1530f0ffdfb667e1f4588dc4fbb585291"
   version "1.8.11"
 
   depends_on "rust" => :build

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ skillroster report --findings --category usage --json
 skillroster report --finding <finding-id> --limit 20 --json
 skillroster report --finding <finding-id> --full --json
 skillroster find "database migration" --json
+skillroster find "把中文改自然一点" --json
 skillroster find "诊断命令性能回归" --hint "diagnose command performance regression" --json
 skillroster find "分析本地表格" --hint "analyze standalone spreadsheet file workbook data" --json
 skillroster plan --stdin --json

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -280,9 +280,30 @@ evidence, Core/On-demand Roster governance, and approved Apply/Undo requests;
 shared installation and symlink synchronization still ranked
 `agent-skills-manager` first. The exact original `duplicate unused` query and
 each inventory, duplicate, usage-evidence, Roster, Plan, Apply, Receipt, and
-Undo branch passed independently. The maintained 84-task English/CJK routing set
+Undo branch passed independently. The maintained 86-task English/CJK routing set
 passed before governance, after Apply, and after Undo. Inspection and routing
 changed no real Agent files.
+
+The v1.8.11 CJK routing dogfood reused a fresh isolated Snapshot of the real
+home with the bundled Bootstrap as a trusted non-exposed source: 232 independent
+Skills and 744 placements. Before the change, a near-verbatim Chinese
+description routed to `humanizer-zh`, while the natural paraphrases
+`把中文改自然一点` and `编辑中文让它更像人写的` returned no matches. CJK-aware
+local scoring then ranked `humanizer-zh` first for both, exposed the contributing
+description/body bigrams, and kept the previously sampled real task routes in
+Top-3. A bounded Chinese stop-unit list removed generic `帮我` / `看看` noise;
+the maintained 86-task set passed before governance, after Apply, and after
+Undo. All real-home Find operations were read-only.
+
+The same run followed the `humanizer-zh` variant warning into its Layout
+Finding. Before the fix, full detail contained two Skill IDs and two digests but
+zero placements or readable paths, while still suggesting a generic Plan. The
+new immutable Report identified five real placements: one shared-content
+variant across Codex, Claude Code, Pi, and the shared source, plus one divergent
+Hermes variant. Compact and full detail kept each digest, Agent set, root, and
+path together, returned `choose_same_name_variant`, and offered no Plan before
+the canonical-content decision. Human output preserved the same facts at 60,
+80, and 120 columns without displaying null paths or changing Agent files.
 
 ## Evidence boundary
 

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -132,7 +132,8 @@ The single `skillroster` bootstrap Skill must instruct every supported Agent to:
 - set `schema_version: 1` on every declarative Plan request;
 - never parse human terminal output or TUI frames;
 - preserve a non-English Find task verbatim and supply a positive English
-  target-surface, object, operation, and state paraphrase through `--hint`;
+  target-surface, object, operation, and state paraphrase through `--hint` when
+  relevant metadata may be English or the native-language result is uncertain;
 - treat `suggested_actions` as typed options, not authorization;
 - automatically prepare a read-only Plan when evidence is sufficient;
 - show the complete Plan impact before Apply;
@@ -149,7 +150,7 @@ Machine results should expose facts, not preformatted prose:
 - `primary_metrics` with value, unit, coverage, and comparison baseline;
 - Findings with stable ID, category, severity, Evidence quality, impact fields, and affected IDs;
 - a bounded `report --summary --json` first view with no more than three Findings, one primary Evidence reference per selected Finding, and complete `finding_rollups` grouped by category, severity, and title with deduplicated affected counts; a category/severity-filterable `report --findings --json` page for enumerating compact Finding summaries; and compact paged Evidence items from `report --finding ID --json`; exact complete records require `--full`, exact-duplicate detail exposes at most five ranked owned canonical candidates, and large-Roster detail exposes bounded per-Agent Core selection previews without requiring pagination;
-- Find results that keep the original task, expose Agent-authored retrieval hints, and collapse same-name identities into one explicitly variant capability result;
+- Find results that keep the original task, expose Agent-authored retrieval hints, and collapse same-name identities into one explicitly variant capability result; the linked divergent-content Finding groups readable paths, digests, Agents, providers, and governance facts by variant and requires a canonical-content choice before Plan;
 - bounded Plan `change_summary`, `operation_groups`, affected-scope counts and `impact` deltas for current and proposed state; `diff_summary` contains at most three semantic Roster, Library, and filesystem items, or bounded line details for a source update; the same persisted summary appears in initial JSON, full detail, and confirmation preview, while full operations are loaded only through `plan --show PLAN_ID` when needed;
 - affected Agents, Skills, placements, operation groups, exclusions, and deletion count;
 - risk, reversibility, drift, confirmation, and recovery state;

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.10
+SKILLROSTER_VERSION=1.8.11
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -46,7 +46,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.10 skillroster
+  --tag v1.8.11 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -60,7 +60,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.10
+git checkout v1.8.11
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -127,12 +127,21 @@ top-level `triggers` and the semicolon-separated string
 `metadata.skillroster-routing-triggers` as the same declared retrieval
 evidence. The latter must be explicitly quoted and remains valid under the
 Agent Skills metadata string-value contract; non-string and nested forms are
-ignored. Ranking
-normalizes conservative ASCII plurals, treats explicit use and do-not-use
-description clauses as positive and exclusion evidence, and removes the
+ignored. Ranking normalizes conservative ASCII plurals and segments contiguous
+Han text into overlapping two-character lexical units after removing a bounded
+set of common Chinese stop-units. A query containing Han text expands scoring
+only to the already-scanned, locally routable Skill set so natural CJK
+paraphrases can reach CJK metadata even when SQLite FTS has no whole-token
+candidate; Archived Skills remain excluded. Match reasons expose CJK
+description and full-text bigram counts. Ranking also treats explicit use and
+do-not-use description clauses as positive and exclusion evidence, and removes the
 low-confidence tail relative to the strongest result. Same-name Skill
 identities occupy one ranked capability result and are
 reported as explicit variants rather than silently treated as equivalent.
+The corresponding divergent-content Finding carries the affected placements
+and a bounded `choose_same_name_variant` resolution that keeps each digest,
+path, Agent, provider, root, and governability fact together. It offers no Plan
+until the caller has compared the variants and chosen canonical content.
 Variant details keep provider, governance, and path facts bound to one identity;
 the response preserves the total count and marks bounded detail truncation.
 Provider-managed results include their plugin identity and a non-governable

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -8,7 +8,7 @@ description: >
   distributing, synchronizing, or repairing shared Skill directories and
   symlinks.
 metadata:
-  bootstrap-version: "1.8.10"
+  bootstrap-version: "1.8.11"
   skillroster-routing-triggers: "scan analyze duplicate unused local Agent Skills; inventory installed Agent Skills; analyze duplicate Agent Skills; evaluate possible unused local Agent Skills from usage evidence; govern a Skill Roster; prepare a Skill governance Plan; apply approved Skill Plan; create Skill Receipt; undo Skill organization"
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1133,6 +1133,7 @@ fn report_command(store: &StateStore, request: ReportRequest<'_>) -> Result<Valu
             {
                 object.insert("planning".into(), planning);
             }
+            add_same_name_resolution(object, &scan);
             let affected_skill_ids = object
                 .get("affected_skill_ids")
                 .and_then(Value::as_array)
@@ -1387,6 +1388,87 @@ fn add_finding_resolution(object: &mut serde_json::Map<String, Value>) {
     );
 }
 
+fn add_same_name_resolution(object: &mut serde_json::Map<String, Value>, scan: &ScanResult) {
+    if object.get("title").and_then(Value::as_str)
+        != Some("Same-name Skills have different content")
+    {
+        return;
+    }
+    let mut affected_skill_ids = object
+        .get("affected_skill_ids")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    affected_skill_ids.sort();
+    affected_skill_ids.dedup();
+    let variant_count = affected_skill_ids.len();
+    let variants = affected_skill_ids
+        .iter()
+        .take(10)
+        .filter_map(|skill_id| {
+            let skill = scan.skills.iter().find(|skill| skill.id == *skill_id)?;
+            let placements = scan
+                .placements
+                .iter()
+                .filter(|placement| placement.skill_id == *skill_id)
+                .collect::<Vec<_>>();
+            let content_digests = std::iter::once(skill.content_digest.clone())
+                .chain(
+                    placements
+                        .iter()
+                        .map(|placement| placement.content_digest.clone()),
+                )
+                .collect::<BTreeSet<_>>();
+            let paths = placements
+                .iter()
+                .map(|placement| placement.entrypoint.display().to_string())
+                .collect::<BTreeSet<_>>();
+            let path_count = paths.len();
+            let paths = paths.into_iter().take(10).collect::<Vec<_>>();
+            let paths_truncated = paths.len() < path_count;
+            let agents = placements
+                .iter()
+                .filter_map(|placement| placement.agent.map(AgentKind::id))
+                .collect::<BTreeSet<_>>();
+            let providers = placements
+                .iter()
+                .filter_map(|placement| placement.provider.clone())
+                .collect::<BTreeSet<_>>();
+            let roots = placements
+                .iter()
+                .map(|placement| placement.root.display().to_string())
+                .collect::<BTreeSet<_>>();
+            let governable = placements.iter().any(|placement| placement.governable);
+            Some(json!({
+                "skill_id": skill_id,
+                "content_digests": content_digests,
+                "paths": paths,
+                "path_count": path_count,
+                "paths_truncated": paths_truncated,
+                "agents": agents,
+                "providers": providers,
+                "roots": roots,
+                "source": skill.metadata.source.clone(),
+                "governable": governable
+            }))
+        })
+        .collect::<Vec<_>>();
+    object.insert(
+        "resolution".into(),
+        json!({
+            "decision": "choose_same_name_variant",
+            "automatic_change_supported": false,
+            "variant_count": variant_count,
+            "variants_truncated": variants.len() < variant_count,
+            "variants": variants,
+            "next_step": "compare_variant_content_and_choose_canonical"
+        }),
+    );
+}
+
 fn compact_finding_detail(mut details: Value) -> Value {
     let Some(object) = details.as_object_mut() else {
         return details;
@@ -1494,9 +1576,11 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
         } => {
             let requires_trust_decision =
                 result["resolution"]["decision"].as_str() == Some("confirm_trusted_source_roots");
+            let requires_variant_decision =
+                result["resolution"]["decision"].as_str() == Some("choose_same_name_variant");
             let planning_blocked = result["planning"]["supported"].as_bool() == Some(false);
             let mut actions = Vec::new();
-            if !requires_trust_decision && !planning_blocked {
+            if !requires_trust_decision && !requires_variant_decision && !planning_blocked {
                 actions.push(action(
                     "plan",
                     &["plan", "--stdin", "--json"],
@@ -2141,6 +2225,9 @@ fn find_command(
             routable_ids.remove(&skill_id);
         }
     }
+    if crate::query::contains_cjk(retrieval_query.text()) {
+        candidate_ids.extend(routable_ids.iter().cloned());
+    }
     candidate_ids.retain(|skill_id| routable_ids.contains(skill_id));
     let mut matches = crate::query::find_matching(
         &scan,
@@ -2199,7 +2286,7 @@ fn find_command(
             ));
         }
     }
-    let cjk_hint_required = retrieval_hints.is_empty() && contains_cjk(task);
+    let cjk_hint_required = retrieval_hints.is_empty() && crate::query::contains_cjk(task);
     if cjk_hint_required {
         warnings.push(
             "Find is lexical and the task contains CJK text; retry with one concise English capability paraphrase via --hint if relevant Skills use English metadata"
@@ -2235,15 +2322,6 @@ fn normalize_retrieval_hints(hints: &[String]) -> Vec<String> {
     normalized.sort();
     normalized.dedup();
     normalized
-}
-
-fn contains_cjk(text: &str) -> bool {
-    text.chars().any(|character| {
-        matches!(
-            character as u32,
-            0x3400..=0x4dbf | 0x4e00..=0x9fff | 0x20000..=0x2fa1f
-        )
-    })
 }
 
 fn current_roster_state(states: &[RosterState]) -> String {
@@ -4164,6 +4242,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
     (
         "1.8.9",
         "1087110d8f8f9bb2c1839b1eda11b4417ca7b57af4449113a6fb5b1394e3309d",
+    ),
+    (
+        "1.8.10",
+        "dbc604dbfc45db5bf766609b28513eacb1ba87a96fc0cba7bb11337561bddd01",
     ),
 ];
 

--- a/src/present.rs
+++ b/src/present.rs
@@ -496,9 +496,20 @@ fn finding_report(value: &Value, lines: &mut Vec<String>, width: usize) {
         .and_then(Value::as_array)
         .or_else(|| value.get("placements").and_then(Value::as_array));
     if let Some(rows) = evidence_rows.filter(|rows| !rows.is_empty()) {
-        lines.push(String::new());
-        lines.push("  Evidence paths".into());
-        for row in rows.iter().take(10) {
+        let path_count = rows
+            .iter()
+            .filter(|row| row.get("path").and_then(Value::as_str).is_some())
+            .count();
+        let rows_with_paths = rows
+            .iter()
+            .filter(|row| row.get("path").and_then(Value::as_str).is_some())
+            .take(10)
+            .collect::<Vec<_>>();
+        if !rows_with_paths.is_empty() {
+            lines.push(String::new());
+            lines.push("  Evidence paths".into());
+        }
+        for row in rows_with_paths {
             let agent = row
                 .get("facts")
                 .and_then(|facts| facts.get("agent"))
@@ -512,8 +523,8 @@ fn finding_report(value: &Value, lines: &mut Vec<String>, width: usize) {
             );
             lines.push(format!("{prefix}{path}"));
         }
-        if rows.len() > 10 {
-            lines.push(format!("  + {} more on this page", rows.len() - 10));
+        if path_count > 10 {
+            lines.push(format!("  + {} more on this page", path_count - 10));
         }
     }
 
@@ -537,6 +548,55 @@ fn finding_report(value: &Value, lines: &mut Vec<String>, width: usize) {
         lines.extend(summary(
             "Blocked · no automatic change is supported",
             "Confirm trusted source directories before rescanning",
+        ));
+    } else if value["resolution"]["decision"].as_str() == Some("choose_same_name_variant") {
+        lines.push(String::new());
+        lines.push("  Variants requiring a choice".into());
+        if let Some(variants) = value["resolution"]["variants"].as_array() {
+            for variant in variants.iter().take(5) {
+                let digest = variant["content_digests"]
+                    .as_array()
+                    .and_then(|digests| digests.first())
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown");
+                let agents = variant["agents"]
+                    .as_array()
+                    .map(|agents| {
+                        agents
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    })
+                    .filter(|agents| !agents.is_empty())
+                    .unwrap_or_else(|| "source-only".into());
+                let label = format!("  {} · {agents}", take_width(digest, 12, false));
+                lines.push(middle_truncate(&label, width));
+                if let Some(path) = variant["paths"]
+                    .as_array()
+                    .and_then(|paths| paths.first())
+                    .and_then(Value::as_str)
+                {
+                    lines.push(format!(
+                        "    {}",
+                        middle_truncate(path, width.saturating_sub(4))
+                    ));
+                }
+                if let Some(additional) = variant["paths"]
+                    .as_array()
+                    .map(|paths| paths.len().saturating_sub(1))
+                    .filter(|count| *count > 0)
+                {
+                    lines.push(format!("    + {additional} additional placements"));
+                }
+            }
+        }
+        if value["resolution"]["variants_truncated"].as_bool() == Some(true) {
+            lines.push("  Additional variants require --full pagination".into());
+        }
+        lines.extend(summary(
+            "Blocked · choose one canonical variant first",
+            "Compare the reported paths before authoring a Plan",
         ));
     } else if value["planning"]["decision"].as_str() == Some("resolve_source_dependency") {
         lines.push(String::new());
@@ -1495,6 +1555,56 @@ mod tests {
             assert!(output.contains("Observed link targets"));
             assert!(output.contains("no automatic change is supported"));
             assert!(!output.contains("Independent Skills     none"));
+            assert!(
+                output.lines().all(|line| display_width(line) <= width),
+                "line exceeded {width} columns:\n{output}"
+            );
+        }
+    }
+
+    #[test]
+    fn finding_report_shows_same_name_variant_choice_without_empty_paths() {
+        let value = json!({
+            "id": "finding_00000000000000000000000000000000",
+            "title": "Same-name Skills have different content",
+            "summary": "humanizer-zh resolves to 2 distinct content digests.",
+            "severity": "medium",
+            "category": "layout",
+            "evidence_quality": "observed",
+            "impact": {"affected_skill_count": 2, "affected_placement_count": 5},
+            "detail": {"mode": "compact"},
+            "items": [{"path": null}, {"path": null}],
+            "resolution": {
+                "decision": "choose_same_name_variant",
+                "variants_truncated": false,
+                "variants": [
+                    {
+                        "content_digests": ["13ccd64485a12613e9e10c96b5289290"],
+                        "agents": ["claude-code", "codex", "pi"],
+                        "paths": ["/Users/example/.agents_skills/humanizer-zh/SKILL.md"]
+                    },
+                    {
+                        "content_digests": ["b3685e6c0ee6f527e9462db3d36b2a1b"],
+                        "agents": ["hermes"],
+                        "paths": ["/Users/example/.hermes/skills/humanizer-zh/SKILL.md"]
+                    }
+                ]
+            }
+        });
+        for width in [60, 80, 120] {
+            let output = render(
+                "report",
+                &value,
+                RenderOptions {
+                    width,
+                    styled: false,
+                },
+            );
+            assert!(output.contains("Variants requiring a choice"));
+            assert!(output.contains("13ccd64485a1"));
+            assert!(output.contains("hermes"));
+            assert!(output.contains("choose one canonical variant first"));
+            assert!(!output.contains("source       none"));
             assert!(
                 output.lines().all(|line| display_width(line) <= width),
                 "line exceeded {width} columns:\n{output}"

--- a/src/query.rs
+++ b/src/query.rs
@@ -361,6 +361,16 @@ fn layout_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             .map(|skill| skill.content_digest.as_str())
             .collect::<BTreeSet<_>>();
         if skills.len() > 1 && digests.len() > 1 {
+            let affected_skill_ids = skills
+                .iter()
+                .map(|skill| skill.id.clone())
+                .collect::<Vec<_>>();
+            let affected_placement_ids = scan
+                .placements
+                .iter()
+                .filter(|placement| affected_skill_ids.contains(&placement.skill_id))
+                .map(|placement| placement.id.clone())
+                .collect::<Vec<_>>();
             push_finding(
                 findings,
                 FindingCategory::Layout,
@@ -370,8 +380,8 @@ fn layout_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
                     "{name} resolves to {} distinct content digests.",
                     digests.len()
                 ),
-                skills.iter().map(|skill| skill.id.clone()).collect(),
-                Vec::new(),
+                affected_skill_ids,
+                affected_placement_ids,
                 skills
                     .iter()
                     .map(|skill| format!("digest:{}", skill.content_digest))
@@ -1251,20 +1261,31 @@ pub(crate) fn find_matching(
                 description_routing_sections(&description);
             let triggers = skill.metadata.triggers.join(" ").to_lowercase();
             let all_text = skill_search_text(skill).to_lowercase();
-            let name_overlap = query_tokens.intersection(&tokens(&name)).count();
-            let trigger_overlap = query_tokens.intersection(&tokens(&triggers)).count();
-            let description_overlap = query_tokens
-                .intersection(&tokens(&positive_description))
-                .count();
+            let name_tokens = tokens(&name);
+            let trigger_tokens = tokens(&triggers);
+            let description_tokens = tokens(&positive_description);
+            let excluded_description_tokens = tokens(&excluded_description);
+            let all_text_tokens = tokens(&all_text);
+            let name_overlap = query_tokens.intersection(&name_tokens).count();
+            let trigger_overlap = query_tokens.intersection(&trigger_tokens).count();
+            let description_overlap = query_tokens.intersection(&description_tokens).count();
             let excluded_description_overlap = query_tokens
-                .intersection(&tokens(&excluded_description))
+                .intersection(&excluded_description_tokens)
                 .count();
             let exclusion_penalty_tokens = if excluded_description_overlap >= 2 {
                 excluded_description_overlap
             } else {
                 0
             };
-            let overlap = query_tokens.intersection(&tokens(&all_text)).count();
+            let overlap = query_tokens.intersection(&all_text_tokens).count();
+            let cjk_description_overlap = query_tokens
+                .intersection(&description_tokens)
+                .filter(|token| contains_cjk(token))
+                .count();
+            let cjk_all_text_overlap = query_tokens
+                .intersection(&all_text_tokens)
+                .filter(|token| contains_cjk(token))
+                .count();
             let mut score = name_overlap as f64 * 24.0
                 + trigger_overlap as f64 * 18.0
                 + description_overlap as f64 * 12.0
@@ -1300,6 +1321,9 @@ pub(crate) fn find_matching(
             if description_overlap > 0 {
                 reasons.push(format!("description_tokens:{description_overlap}"));
             }
+            if cjk_description_overlap > 0 {
+                reasons.push(format!("cjk_description_bigrams:{cjk_description_overlap}"));
+            }
             if exclusion_penalty_tokens > 0 {
                 reasons.push(format!(
                     "excluded_description_tokens:{exclusion_penalty_tokens}"
@@ -1307,6 +1331,9 @@ pub(crate) fn find_matching(
             }
             if overlap > 0 {
                 reasons.push(format!("all_text_tokens:{overlap}"));
+            }
+            if cjk_all_text_overlap > 0 {
+                reasons.push(format!("cjk_all_text_bigrams:{cjk_all_text_overlap}"));
             }
             let observed_usage = scan.usage.iter().any(|usage| {
                 usage.skill_id == skill.id && usage.quality == EvidenceQuality::Observed
@@ -1464,12 +1491,55 @@ pub(crate) fn find_matching(
 }
 
 fn tokens(text: &str) -> BTreeSet<String> {
-    text.split(|character: char| !character.is_alphanumeric())
-        .map(str::trim)
-        .filter(|token| token.len() >= 2)
-        .map(normalize_token)
-        .filter(|token| !is_search_stopword(token))
-        .collect()
+    let mut output = BTreeSet::new();
+    let mut word = String::new();
+    let mut cjk_run = Vec::new();
+    for character in text.chars() {
+        if is_cjk(character) {
+            insert_word_token(&mut output, &mut word);
+            cjk_run.push(character);
+        } else if character.is_alphanumeric() {
+            insert_cjk_bigrams(&mut output, &mut cjk_run);
+            word.push(character);
+        } else {
+            insert_word_token(&mut output, &mut word);
+            insert_cjk_bigrams(&mut output, &mut cjk_run);
+        }
+    }
+    insert_word_token(&mut output, &mut word);
+    insert_cjk_bigrams(&mut output, &mut cjk_run);
+    output
+}
+
+fn insert_word_token(output: &mut BTreeSet<String>, word: &mut String) {
+    if word.chars().count() >= 2 {
+        let normalized = normalize_token(word.trim());
+        if !is_search_stopword(&normalized) {
+            output.insert(normalized);
+        }
+    }
+    word.clear();
+}
+
+fn insert_cjk_bigrams(output: &mut BTreeSet<String>, run: &mut Vec<char>) {
+    for pair in run.windows(2) {
+        let token = pair.iter().collect::<String>();
+        if !is_search_stopword(&token) {
+            output.insert(token);
+        }
+    }
+    run.clear();
+}
+
+pub(crate) fn contains_cjk(text: &str) -> bool {
+    text.chars().any(is_cjk)
+}
+
+fn is_cjk(character: char) -> bool {
+    matches!(
+        character as u32,
+        0x3400..=0x4dbf | 0x4e00..=0x9fff | 0x20000..=0x2fa1f
+    )
 }
 
 fn is_search_stopword(token: &str) -> bool {
@@ -1498,6 +1568,23 @@ fn is_search_stopword(token: &str) -> bool {
             | "use"
             | "using"
             | "with"
+            | "一个"
+            | "一份"
+            | "一下"
+            | "一点"
+            | "什么"
+            | "使用"
+            | "创建"
+            | "可以"
+            | "已经"
+            | "当前"
+            | "帮我"
+            | "怎么"
+            | "需要"
+            | "看看"
+            | "这个"
+            | "那个"
+            | "进行"
     )
 }
 
@@ -2099,6 +2186,17 @@ mod tests {
             ])
         );
         assert_eq!(candidate_search_text("publish blogs"), "publish blogs blog");
+    }
+
+    #[test]
+    fn token_matching_segments_cjk_runs_into_overlapping_bigrams() {
+        let segmented = tokens("把中文改自然一点 AI");
+
+        for expected in ["把中", "中文", "文改", "改自", "自然", "然一", "ai"] {
+            assert!(segmented.contains(expected), "missing token {expected:?}");
+        }
+        assert!(!segmented.contains("一点"));
+        assert!(!segmented.contains("把中文改自然一点"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -111,6 +111,55 @@ fn public_find_keeps_the_user_task_and_uses_agent_retrieval_hints() {
 }
 
 #[test]
+fn public_find_routes_natural_cjk_paraphrases_against_cjk_metadata() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    let humanizer = skill_root.join("humanizer-zh");
+    let unrelated = skill_root.join("generic-writer");
+    fs::create_dir_all(&humanizer).unwrap();
+    fs::create_dir_all(&unrelated).unwrap();
+    fs::write(
+        humanizer.join("SKILL.md"),
+        "---\nname: humanizer-zh\ndescription: 去除文本中的 AI 生成痕迹，让中文表达更自然、更像人类书写。\n---\n编辑中文并保留原意。\n",
+    )
+    .unwrap();
+    fs::write(
+        unrelated.join("SKILL.md"),
+        "---\nname: generic-writer\ndescription: Generic English writing helper\n---\n",
+    )
+    .unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[&common[..], &["find", "把中文改自然一点", "--limit", "3"]].concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["task"], "把中文改自然一点");
+    assert_eq!(found["result"]["matches"][0]["name"], "humanizer-zh");
+    assert!(
+        found["result"]["matches"][0]["match_reasons"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reason| reason
+                .as_str()
+                .unwrap()
+                .starts_with("cjk_description_bigrams:"))
+    );
+    assert_find_paths_are_readable(&found);
+}
+
+#[test]
 fn public_find_expands_plural_candidates_and_bounds_incidental_single_token_matches() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
@@ -394,6 +443,88 @@ fn finding_list_is_paged_filterable_and_leads_to_evidence() {
         let output: Value = serde_json::from_slice(&output.stdout).unwrap();
         assert_eq!(output["error"]["code"], "invalid_cli_arguments");
     }
+}
+
+#[test]
+fn same_name_divergent_finding_keeps_variant_paths_and_requires_a_choice() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let codex = home.join(".codex/skills/shared-capability");
+    let claude = home.join(".claude/skills/shared-capability");
+    fs::create_dir_all(&codex).unwrap();
+    fs::create_dir_all(&claude).unwrap();
+    fs::write(
+        codex.join("SKILL.md"),
+        "---\nname: shared-capability\ndescription: First implementation\n---\nalpha\n",
+    )
+    .unwrap();
+    fs::write(
+        claude.join("SKILL.md"),
+        "---\nname: shared-capability\ndescription: Second implementation\n---\nbeta\n",
+    )
+    .unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let report = json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let finding = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| {
+            finding["title"] == "Same-name Skills have different content"
+                && finding["summary"]
+                    .as_str()
+                    .unwrap()
+                    .contains("shared-capability")
+        })
+        .unwrap();
+    assert_eq!(finding["affected_skill_count"], 2);
+    assert_eq!(finding["affected_placement_count"], 2);
+    let finding_id = finding["id"].as_str().unwrap();
+
+    let compact = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id]].concat(),
+        None,
+    ));
+    assert_eq!(
+        compact["result"]["resolution"]["decision"],
+        "choose_same_name_variant"
+    );
+    assert_eq!(
+        compact["result"]["resolution"]["automatic_change_supported"],
+        false
+    );
+    let variants = compact["result"]["resolution"]["variants"]
+        .as_array()
+        .unwrap();
+    assert_eq!(variants.len(), 2);
+    for variant in variants {
+        assert!(variant["skill_id"].as_str().unwrap().starts_with("skill_"));
+        assert_eq!(variant["content_digests"].as_array().unwrap().len(), 1);
+        assert_eq!(variant["paths"].as_array().unwrap().len(), 1);
+        assert!(Path::new(variant["paths"][0].as_str().unwrap()).is_file());
+        assert_eq!(variant["agents"].as_array().unwrap().len(), 1);
+    }
+    assert!(
+        compact["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|action| action["action"] != "plan")
+    );
+
+    let full = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id, "--full"]].concat(),
+        None,
+    ));
+    assert_eq!(full["result"]["placements"].as_array().unwrap().len(), 2);
 }
 
 #[test]
@@ -921,7 +1052,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.10"
+        "1.8.11"
     );
 
     let undone = json_output(&run(
@@ -1091,7 +1222,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.10");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.11");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],

--- a/tests/fixtures/routing-eval.json
+++ b/tests/fixtures/routing-eval.json
@@ -82,5 +82,7 @@
   {"task":"应用已经批准的 Skill 计划","hints":["apply approved Skill Plan"],"skill":"skillroster","rank_first":true},
   {"task":"为这次 Skill 变更创建回执","hints":["create Skill Receipt"],"skill":"skillroster","rank_first":true},
   {"task":"撤销上次 Skill 整理","hints":["undo Skill organization"],"skill":"skillroster","rank_first":true},
-  {"task":"统一管理各个 Agent 安装的 Skill","hints":["manage Skills across coding Agents with shared library symlinks"],"skill":"agent-skills-manager","rank_first":true,"max_matches":3}
+  {"task":"统一管理各个 Agent 安装的 Skill","hints":["manage Skills across coding Agents with shared library symlinks"],"skill":"agent-skills-manager","rank_first":true,"max_matches":3},
+  {"task":"把中文改自然一点","skill":"humanizer-zh","rank_first":true,"max_matches":3},
+  {"task":"编辑中文让它更像人写的","skill":"humanizer-zh","rank_first":true,"max_matches":3}
 ]

--- a/tests/fixtures/routing-skills/humanizer-zh/SKILL.md
+++ b/tests/fixtures/routing-skills/humanizer-zh/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: humanizer-zh
+description: 去除文本中的 AI 生成痕迹，让中文表达更自然、更像人类书写。
+---
+编辑中文并保留原意。
+
+CAPABILITY: humanizer-zh


### PR DESCRIPTION
## Summary

- route natural Han-language tasks against CJK Skill metadata with bounded bigram scoring
- keep archived Skills excluded and expose CJK match evidence
- make same-name divergent-content Findings carry readable variant paths and require a canonical choice before planning
- bump the Bootstrap and package to v1.8.11

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `git diff --check`
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- isolated Bootstrap v1.8.10 -> v1.8.11 Apply/Undo with exact digest restoration
- real-home read-only dogfood: 232 Skills, 744 placements; natural CJK routes fixed; divergent `humanizer-zh` variant paths made actionable

## Merge requirement

Use a regular merge commit. Do not squash or rebase: the Homebrew Formula pins `f62403d1530f0ffdfb667e1f4588dc4fbb585291`, which must remain reachable.

Closes #63
Closes #64