### PR TITLE
fix: make Agent hints rank-sensitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.14"
+version = "1.8.15"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.14"
+version = "1.8.15"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "e9b63a22a5ac4c91499281fdfbea4245b8b8ed0a"
-  version "1.8.14"
+      revision: "d04dcda8336890e012d45971d65c09dcf565fcb2"
+  version "1.8.15"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.14", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.15", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -357,6 +357,19 @@ produced five unique preview keys. Compact and full JSON retained the same
 bounded overview with `files_changed=false`; no Apply was run and no Agent file
 changed.
 
+The v1.8.15 Agent-hint dogfood reused the official v1.8.14 real-home Snapshot:
+244 independent Skills and 740 placements. For the Chinese task `把产品想法压力
+测试成明确规格`, the positive English capability hint found `grilling` at
+augmented rank two, but the previous large reciprocal-rank offset still placed
+the unrelated `x-post-writer` first from weak task-rank-six and
+augmented-rank-fourteen overlap. The small-pool fusion now preserves rank
+discrimination: `plan`, `grilling`, and `product-business-analysis` form the
+Top-3 and the unrelated writer is removed from the bounded result. Three other
+real read-only probes ranked `code-review`, `computer-history`, and
+`analyze-data-quality` first; the maintained routing baseline and the strong
+native-task preservation regression remained green. Every Find response kept
+both channel ranks and `files_changed=false`.
+
 ## Evidence boundary
 
 These checks establish deterministic routing and safe local governance; they do

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -144,6 +144,8 @@ The single `skillroster` bootstrap Skill must instruct every supported Agent to:
   relevant metadata may be English or the native-language result is uncertain;
 - when hints are present, require task/hint rank fusion and retain the channel
   ranks so a hint cannot silently replace the user's original task evidence;
+  high-ranked hint evidence must outrank weak overlap that only appears in both
+  lexical channels;
 - treat `suggested_actions` as typed options, not authorization;
 - automatically prepare a read-only Plan when evidence is sufficient;
 - show the complete Plan impact before Apply;

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.14
+SKILLROSTER_VERSION=1.8.15
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -46,7 +46,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.14 skillroster
+  --tag v1.8.15 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -60,7 +60,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.14
+git checkout v1.8.15
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -124,7 +124,10 @@ index. Without hints, Find uses one lexical channel. With hints, it ranks the
 original task and the task-plus-hints expansion independently, then applies
 deterministic reciprocal-rank fusion over a bounded candidate pool. The JSON
 `ranking_strategy`, `task_channel_rank`, and `augmented_channel_rank` facts make
-that decision inspectable. A hint can therefore surface English metadata
+that decision inspectable. Rank position remains discriminating within these
+small candidate pools: a high-ranked Agent hint match outranks weak lexical
+overlap that merely appears in both channels, while a strong original-task
+match remains protected in the bounded result. A hint can therefore surface English metadata
 without letting its raw token count set one global cutoff that discards a
 strong native-task result. Each task or hint also remains a separate phrase for
 exact name, description, and declared-trigger evidence. The scanner reads

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -8,7 +8,7 @@ description: >
   distributing, synchronizing, or repairing shared Skill directories and
   symlinks.
 metadata:
-  bootstrap-version: "1.8.14"
+  bootstrap-version: "1.8.15"
   skillroster-routing-triggers: "scan analyze duplicate unused local Agent Skills; inventory installed Agent Skills; analyze duplicate Agent Skills; evaluate possible unused local Agent Skills from usage evidence; govern a Skill Roster; prepare a Skill governance Plan; apply approved Skill Plan; create Skill Receipt; undo Skill organization"
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4289,6 +4289,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.8.13",
         "3063f8913c22846640389f5a633697aea253ab0805e974bd19fa0f06f2b01682",
     ),
+    (
+        "1.8.14",
+        "ebf48e298ece30cd850146362b3fa73950b4fa26e35f3ce774a5700ae8b3e3cb",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -1695,7 +1695,10 @@ pub(crate) fn fuse_retrieval_channels(
     task: &RetrievalQuery,
     limit: usize,
 ) -> Vec<FindMatch> {
-    const RECIPROCAL_RANK_OFFSET: f64 = 60.0;
+    // Find fuses small, already-ranked candidate pools. A large web-search-style
+    // offset flattens rank positions enough for weak overlap to beat the Agent's
+    // high-ranked capability hint.
+    const RECIPROCAL_RANK_OFFSET: f64 = 1.0;
     const AUGMENTED_CHANNEL_WEIGHT: f64 = 3.0;
 
     if limit == 0 {
@@ -2641,6 +2644,54 @@ mod tests {
         assert!(native.rank <= 3);
         assert_eq!(fused.len(), 3);
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn hint_fusion_prefers_a_high_rank_hint_match_over_weak_channel_overlap() {
+        fn matched(name: &str, rank: usize, reasons: &[&str]) -> FindMatch {
+            FindMatch {
+                rank,
+                skill_id: format!("skill_{name}"),
+                name: name.into(),
+                score: 1.0,
+                paths: Vec::new(),
+                agents: Vec::new(),
+                roster_state: "unknown".into(),
+                source: None,
+                providers: Vec::new(),
+                governable: true,
+                match_reasons: reasons.iter().map(|reason| (*reason).into()).collect(),
+                task_channel_rank: None,
+                augmented_channel_rank: None,
+                evidence_quality: EvidenceQuality::Inferred,
+                variant_skill_ids: Vec::new(),
+                variants: Vec::new(),
+                variant_count: 1,
+                variants_truncated: false,
+            }
+        }
+
+        let task_matches = vec![
+            matched("native-task", 1, &["description_tokens:2"]),
+            matched("weak-overlap", 2, &["description_tokens:1"]),
+        ];
+        let augmented_matches = vec![
+            matched("direct-hint", 1, &["declared_trigger"]),
+            matched("weak-overlap", 3, &["all_text_tokens:5"]),
+        ];
+        let task_query = RetrievalQuery::from_parts(["原始任务"]);
+
+        let fused = fuse_retrieval_channels(task_matches, augmented_matches, &task_query, 3);
+        let rank = |name: &str| {
+            fused
+                .iter()
+                .find(|matched| matched.name == name)
+                .map(|matched| matched.rank)
+                .expect("expected bounded capability")
+        };
+
+        assert!(rank("direct-hint") < rank("weak-overlap"));
+        assert!(rank("native-task") <= 3);
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1183,7 +1183,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.14"
+        "1.8.15"
     );
 
     let undone = json_output(&run(
@@ -1353,7 +1353,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.14");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.15");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],


### PR DESCRIPTION
Closes #73.

## What changed

- tune reciprocal-rank fusion for the small bounded Find candidate pool
- make a high-ranked Agent hint capability beat weak overlap that appears in both channels
- preserve strong original-task matches in the bounded result
- add one focused core-logic regression
- bump release and Bootstrap surfaces to v1.8.15

## Verification

- 135 unit + 7 acceptance + 36 CLI = 178 tests PASS
- strict Clippy, fmt, diff check PASS
- maintained Top-3 routing and governance no-regression baseline PASS
- Bootstrap Skill validation and Homebrew Formula style PASS
- Standards review PASS; Spec review PASS; no P0/P1/P2

## Real read-only dogfood

Reused a 244-Skill/740-placement Snapshot. Four CJK tasks plus Agent-authored English hints ranked `code-review`, `computer-history`, and `analyze-data-quality` first; the plan stress-test task kept `grilling` in Top-2 and removed unrelated `x-post-writer` from the bounded result. Every response kept channel ranks and `files_changed=false`; no Apply was run.