### PR TITLE
docs: define the Agent-first responsibility boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-`src/main.rs` contains the Rust CLI entry point. As behavior grows, move reusable logic into focused modules under `src/` and keep `main.rs` limited to argument parsing and orchestration. Place integration tests in `tests/`; keep small unit tests beside their modules with `#[cfg(test)]`. Canonical vocabulary lives in `CONTEXT.md`; normative requirements live in `docs/product-spec.md`. Cargo build artifacts under `target/` are generated and must remain untracked.
+`src/main.rs` contains the Rust CLI entry point. Move reusable logic into focused modules under `src/` and keep `main.rs` to parsing and orchestration. Place integration tests in `tests/`; keep small unit tests beside modules with `#[cfg(test)]`. Canonical vocabulary lives in `CONTEXT.md`; normative requirements live in `docs/product-spec.md`. Keep generated `target/` artifacts untracked.
 
 ## Build, Test, and Development Commands
 
@@ -28,4 +28,4 @@ Write short commit messages in the form `type: summary`, matching the existing `
 
 ## Architecture & Safety
 
-SkillRoster is local-first and agent-first. The first release is a Rust CLI plus one thin bootstrap Skill, not an MCP server. Preserve user-owned Skill contents, preview mutations as immutable plans, refuse ambiguous targets, and produce receipts for every applied change. Read `CONTEXT.md` and `docs/product-spec.md` before changing domain terms or safety boundaries.
+SkillRoster is a local-first engine for Agents. Keep semantic comparison, intent interpretation, prioritization, and explanation in the caller. The Rust CLI returns bounded deterministic facts, validates structured decisions, and executes reversible Plans; people need not compose command workflows. Preserve user-owned contents, refuse ambiguity, and produce a Receipt for every mutation. Read `CONTEXT.md` and `docs/product-spec.md` before changing this boundary, domain terms, or safety rules.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -42,7 +42,13 @@ Person
       <- concise diagnosis and confirmation request
 ```
 
-The CLI owns deterministic discovery, normalization, hashing, indexing, statistics, validation, mutation, and recovery. The calling Agent owns semantic comparison, explanation, prioritization, and natural-language presentation. The binary contains no model API, second Agent, or prompt framework.
+### 3.1 Agent-first responsibility boundary
+
+The person delegates intent in natural language and should not need to learn or compose a CLI workflow. The calling Agent owns intent interpretation, semantic comparison, prioritization, recommendation, and natural-language presentation. It translates the person's request into structured SkillRoster calls, asks only for genuine preference or authorization decisions, and explains the resulting Evidence and Plan.
+
+The CLI owns deterministic discovery, normalization, hashing, indexing, statistics, validation, mutation, and recovery. It returns bounded, decision-complete facts and typed options so the Agent does not need to rediscover filesystem state or scrape prose. It validates the Agent's structured choices but does not replace model reasoning with embedded intent classifiers, semantic policy trees, or a second prompt framework. Human-readable terminal output supports audit, diagnosis, and fallback use; versioned JSON is the primary Agent integration contract.
+
+Use this placement test for every capability: local truth, stable identity, reproducibility, safety, and reversible execution belong in the CLI; context-sensitive meaning and open-ended judgment belong in the Agent. The person retains preference and material-change authority. The binary contains no model API or second Agent.
 
 ## 4. Capability requirements
 


### PR DESCRIPTION
## Summary

- make the Agent/CLI/person responsibility split normative in the product spec
- state that models own semantic judgment while the CLI owns deterministic facts, validation, and reversible execution
- expose the same implementation gate concisely in `AGENTS.md` for future contributors

## Validation

- `git diff --check`
- `AGENTS.md` remains within the 200-400 word contributor-guide target

## Context

This boundary applies directly to the implementation approach for #80: the CLI should return bounded actionable evidence, while the calling Agent interprets intent and requests the user's trust decision.
