### PR TITLE
fix: emit canonical Agent IDs in scan JSON

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1285,6 +1285,24 @@ fn scan_command(
         .filter_map(|root| root.agent)
         .collect::<std::collections::BTreeSet<_>>()
         .len();
+    let roots = result
+        .roots
+        .iter()
+        .map(|root| {
+            let mut value = json!(root);
+            value["agent"] = json!(root.agent.map(AgentKind::id));
+            value
+        })
+        .collect::<Vec<_>>();
+    let coverage = result
+        .coverage
+        .iter()
+        .map(|coverage| {
+            let mut value = json!(coverage);
+            value["agent"] = json!(coverage.agent.id());
+            value
+        })
+        .collect::<Vec<_>>();
     let warnings = compact_scan_warnings(result.warnings);
     Ok((
         json!({
@@ -1292,8 +1310,8 @@ fn scan_command(
             "agents_checked": agents_checked,
             "skill_count": result.skills.len(),
             "placement_count": result.placements.len(),
-            "roots": result.roots,
-            "coverage": result.coverage,
+            "roots": roots,
+            "coverage": coverage,
             "files_changed": false
         }),
         warnings,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1688,14 +1688,14 @@ fn explicit_roots_preserve_all_eight_agent_identities() {
     let home = temp.path().join("empty-home");
     let state = temp.path().join("state");
     let agents = [
-        ("codex", "codex"),
-        ("claude-code", "claude_code"),
-        ("pi", "pi"),
-        ("opencode", "open_code"),
-        ("hermes", "hermes"),
-        ("cursor", "cursor"),
-        ("gemini-cli", "gemini_cli"),
-        ("github-copilot", "git_hub_copilot"),
+        "codex",
+        "claude-code",
+        "pi",
+        "opencode",
+        "hermes",
+        "cursor",
+        "gemini-cli",
+        "github-copilot",
     ];
     let shared_root = temp.path().join("shared-skills");
     let shared_skill = shared_root.join("shared-fixture");
@@ -1712,7 +1712,7 @@ fn explicit_roots_preserve_all_eight_agent_identities() {
         state.display().to_string(),
         "--json".to_owned(),
     ];
-    for (agent, _) in agents {
+    for agent in agents {
         args.push("--root".to_owned());
         args.push(format!("{agent}={}", shared_root.display()));
     }
@@ -1726,10 +1726,17 @@ fn explicit_roots_preserve_all_eight_agent_identities() {
         .filter(|root| root["explicit"] == true)
         .collect::<Vec<_>>();
     assert_eq!(explicit.len(), 8);
-    for (_, json_agent) in agents {
-        assert!(explicit.iter().any(|root| root["agent"] == json_agent));
+    for agent in agents {
+        assert!(explicit.iter().any(|root| root["agent"] == agent));
     }
     assert!(explicit.iter().all(|root| root["status"] == "included"));
+    let coverage_agents = scan["result"]["coverage"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|coverage| coverage["agent"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(coverage_agents, agents);
     assert_eq!(scan["result"]["placement_count"], 8);
     let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
     let assigned_agents: i64 = database


### PR DESCRIPTION
## Summary

- Normalize `scan --json` roots and coverage to the same eight canonical public Agent IDs used by report, find, and usage surfaces.
- Keep internal `AgentKind` serialization and persisted Scan payloads unchanged; normalization happens only at the public response boundary.
- Replace the integration test that encoded Rust enum spellings with an eight-Agent public-contract regression covering both roots and coverage.

Closes #85

## Dogfood evidence

A fresh isolated read-only real-home Scan reproduced `claude_code`, `open_code`, `gemini_cli`, and `git_hub_copilot` in Scan JSON while downstream facts used `claude-code`, `opencode`, `gemini-cli`, and `github-copilot`.

After the fix, a fresh isolated Scan returned exactly:

```text
codex, claude-code, pi, opencode, hermes, cursor, gemini-cli, github-copilot
```

The following compact Report reused the same Snapshot successfully. Both commands reported `files_changed: false`; no Agent or Skill files were modified.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
  - 142 unit
  - 7 acceptance
  - 37 CLI
- `git diff --check`
- focused real-home isolated-state Scan → Report replay

## Scope

No database migration, stored payload rewrite, Apply, Agent-file mutation, or release. Stop at a reviewable PR; do not merge.