### PR TITLE
fix: stabilize hinted find ranking across limits

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -132,10 +132,13 @@ deterministic reciprocal-rank fusion over a bounded candidate pool. The JSON
 `ranking_strategy`, `task_channel_rank`, and `augmented_channel_rank` facts make
 that decision inspectable. Rank position remains discriminating within these
 small candidate pools: a high-ranked Agent hint match outranks weak lexical
-overlap that merely appears in both channels, while a strong original-task
-match remains protected in the bounded result. For the same Snapshot, task,
-and hints, changing `--limit` only bounds the returned matches: each smaller
-result is a prefix of a larger result. A hint can therefore surface English
+overlap that merely appears in both channels, while the strongest original-task
+match remains within the default top three when it has protectable evidence.
+Smaller limits intentionally return only the corresponding stable prefix.
+Hinted retrieval uses a fixed internal pool of up to 100 capabilities, matching
+the public maximum limit. For the same Snapshot, task, and hints, changing
+`--limit` only bounds the returned matches: each smaller result is a prefix of
+a larger result. A hint can therefore surface English
 metadata without letting its raw token count set one global cutoff that
 discards a strong native-task result. Each task or hint also remains a separate phrase for
 exact name, description, and declared-trigger evidence. The scanner reads

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -133,9 +133,11 @@ deterministic reciprocal-rank fusion over a bounded candidate pool. The JSON
 that decision inspectable. Rank position remains discriminating within these
 small candidate pools: a high-ranked Agent hint match outranks weak lexical
 overlap that merely appears in both channels, while a strong original-task
-match remains protected in the bounded result. A hint can therefore surface English metadata
-without letting its raw token count set one global cutoff that discards a
-strong native-task result. Each task or hint also remains a separate phrase for
+match remains protected in the bounded result. For the same Snapshot, task,
+and hints, changing `--limit` only bounds the returned matches: each smaller
+result is a prefix of a larger result. A hint can therefore surface English
+metadata without letting its raw token count set one global cutoff that
+discards a strong native-task result. Each task or hint also remains a separate phrase for
 exact name, description, and declared-trigger evidence. The scanner reads
 ordinary and folded YAML description scalars. Ranking uses
 top-level `triggers` and the semicolon-separated string

--- a/src/app.rs
+++ b/src/app.rs
@@ -2475,6 +2475,8 @@ fn find_command(
     hints: &[String],
     limit: usize,
 ) -> Result<Value> {
+    const HINTED_RETRIEVAL_POOL_LIMIT: usize = 100;
+
     let (scan_id, scan) = latest_scan(store)?;
     let retrieval_hints = normalize_retrieval_hints(hints);
     let retrieval_query = crate::query::RetrievalQuery::from_parts(
@@ -2505,7 +2507,7 @@ fn find_command(
     let pool_limit = if retrieval_hints.is_empty() {
         limit
     } else {
-        limit.saturating_mul(4).clamp(20, 100)
+        HINTED_RETRIEVAL_POOL_LIMIT
     };
     let augmented_matches = crate::query::find_matching(
         &scan,

--- a/src/app.rs
+++ b/src/app.rs
@@ -2475,8 +2475,6 @@ fn find_command(
     hints: &[String],
     limit: usize,
 ) -> Result<Value> {
-    const HINTED_RETRIEVAL_POOL_LIMIT: usize = 100;
-
     let (scan_id, scan) = latest_scan(store)?;
     let retrieval_hints = normalize_retrieval_hints(hints);
     let retrieval_query = crate::query::RetrievalQuery::from_parts(
@@ -2507,7 +2505,7 @@ fn find_command(
     let pool_limit = if retrieval_hints.is_empty() {
         limit
     } else {
-        HINTED_RETRIEVAL_POOL_LIMIT
+        usize::from(crate::cli::MAX_FIND_RESULTS)
     };
     let augmented_matches = crate::query::find_matching(
         &scan,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,9 +159,11 @@ pub struct FindArgs {
     #[arg(long = "hint", value_name = "TEXT")]
     pub hints: Vec<String>,
 
-    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(1..=100))]
+    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(1..=i64::from(MAX_FIND_RESULTS)))]
     pub limit: u16,
 }
+
+pub const MAX_FIND_RESULTS: u16 = 100;
 
 #[derive(Debug, Args)]
 pub struct PlanArgs {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1700,6 +1700,7 @@ pub(crate) fn fuse_retrieval_channels(
     // high-ranked capability hint.
     const RECIPROCAL_RANK_OFFSET: f64 = 1.0;
     const AUGMENTED_CHANNEL_WEIGHT: f64 = 3.0;
+    const PROTECTED_TASK_MAX_RANK: usize = 3;
 
     if limit == 0 {
         return Vec::new();
@@ -1785,8 +1786,7 @@ pub(crate) fn fuse_retrieval_channels(
     let protected_task_capabilities = fused
         .iter()
         .filter(|matched| {
-            matched.task_channel_rank.is_some_and(|rank| rank <= limit)
-                && has_protectable_task_evidence(matched)
+            matched.task_channel_rank == Some(1) && has_protectable_task_evidence(matched)
         })
         .map(|matched| matched.name.trim().to_lowercase())
         .collect::<BTreeSet<_>>();
@@ -1804,19 +1804,19 @@ pub(crate) fn fuse_retrieval_channels(
             fused.push(matched);
         }
     }
-    while fused.len() > limit {
-        let removable = fused.iter().rposition(|matched| {
-            !protected_task_capabilities.contains(&matched.name.trim().to_lowercase())
-        });
-        match removable {
-            Some(index) => {
-                fused.remove(index);
-            }
-            None => {
-                fused.truncate(limit);
-            }
+    for protected in &protected_task_capabilities {
+        let Some(index) = fused
+            .iter()
+            .position(|matched| matched.name.trim().eq_ignore_ascii_case(protected))
+        else {
+            continue;
+        };
+        if index >= PROTECTED_TASK_MAX_RANK {
+            let matched = fused.remove(index);
+            fused.insert(PROTECTED_TASK_MAX_RANK - 1, matched);
         }
     }
+    fused.truncate(limit);
     for (index, matched) in fused.iter_mut().enumerate() {
         matched.rank = index + 1;
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1795,6 +1795,8 @@ pub(crate) fn fuse_retrieval_channels(
         .filter(|matched| protected_task_capabilities.contains(&matched.name.trim().to_lowercase()))
         .cloned()
         .collect::<Vec<_>>();
+    // This order defines the stable ranking: trim the fixed pool, restore and
+    // promote the strongest task match, then take the requested prefix.
     trim_low_confidence_tail(&mut fused, tokens(task.text()).len());
     for matched in protected_task_matches {
         if !fused

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -270,17 +270,28 @@ fn public_find_hinted_ranking_is_prefix_stable_across_limits() {
             "---\nname: Spreadsheets\ndescription: Create, edit, analyze, and verify standalone spreadsheet files and workbooks, including Excel files.\n---\n",
         ),
         (
-            "cowork-publish",
-            "---\nname: cowork-publish\ndescription: 创建本地表格数据管理工具和数据质量可视化系统。\n---\n",
+            "local-data-quality",
+            "---\nname: local-data-quality\ndescription: 分析本地表格数据和数据质量。\n---\n",
         ),
         (
-            "hi-pan",
-            "---\nname: hi-pan\ndescription: 管理本地表格数据和数据质量报告文件。\n---\n",
+            "local-report-storage",
+            "---\nname: local-report-storage\ndescription: 管理本地表格数据和数据质量报告文件。\n---\n",
         ),
     ] {
         let path = skill_root.join(directory);
         fs::create_dir_all(&path).unwrap();
         fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    for index in 0..24 {
+        let path = skill_root.join(format!("spreadsheet-helper-{index:02}"));
+        fs::create_dir_all(&path).unwrap();
+        fs::write(
+            path.join("SKILL.md"),
+            format!(
+                "---\nname: spreadsheet-helper-{index:02}\ndescription: Generic spreadsheet helper number {index}.\n---\n"
+            ),
+        )
+        .unwrap();
     }
     let common = [
         "--home",
@@ -319,8 +330,20 @@ fn public_find_hinted_ranking_is_prefix_stable_across_limits() {
             .collect::<Vec<_>>()
     };
 
-    let complete_ranking = find_names("4");
-    for limit in 1..=4 {
+    let complete_ranking = find_names("10");
+    assert_eq!(complete_ranking[0], "Spreadsheets");
+    assert!(
+        complete_ranking[..3]
+            .iter()
+            .any(|name| name == "local-data-quality")
+    );
+    assert!(complete_ranking.iter().any(|name| name == "Spreadsheets"));
+    assert!(
+        complete_ranking
+            .iter()
+            .any(|name| name == "analyze-data-quality")
+    );
+    for limit in 1..=10 {
         let bounded = find_names(&limit.to_string());
         assert_eq!(bounded, complete_ranking[..bounded.len()]);
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -255,6 +255,78 @@ fn public_find_hints_do_not_erase_a_native_task_match() {
 }
 
 #[test]
+fn public_find_hinted_ranking_is_prefix_stable_across_limits() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "analyze-data-quality",
+            "---\nname: analyze-data-quality\ndescription: Assess whether structured data and analytical evidence are trustworthy. Use when the task is to check data quality.\n---\n",
+        ),
+        (
+            "spreadsheets",
+            "---\nname: Spreadsheets\ndescription: Create, edit, analyze, and verify standalone spreadsheet files and workbooks, including Excel files.\n---\n",
+        ),
+        (
+            "cowork-publish",
+            "---\nname: cowork-publish\ndescription: 创建本地表格数据管理工具和数据质量可视化系统。\n---\n",
+        ),
+        (
+            "hi-pan",
+            "---\nname: hi-pan\ndescription: 管理本地表格数据和数据质量报告文件。\n---\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let task = "分析一个本地表格的数据质量";
+    let hint = "analyze standalone spreadsheet workbook data quality";
+    let find_names = |limit: &str| {
+        let found = json_output(&run(
+            &[
+                &common[..],
+                &[
+                    "find",
+                    task,
+                    "--hint",
+                    hint,
+                    "--hint",
+                    "Spreadsheets",
+                    "--limit",
+                    limit,
+                ],
+            ]
+            .concat(),
+            None,
+        ));
+        found["result"]["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|matched| matched["name"].as_str().unwrap().to_owned())
+            .collect::<Vec<_>>()
+    };
+
+    let complete_ranking = find_names("4");
+    for limit in 1..=4 {
+        let bounded = find_names(&limit.to_string());
+        assert_eq!(bounded, complete_ranking[..bounded.len()]);
+    }
+}
+
+#[test]
 fn public_find_routes_natural_cjk_paraphrases_against_cjk_metadata() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## Summary

- make hinted `find` ranking independent of the requested output bound
- use one fixed 100-capability fusion pool for every valid hinted `--limit`
- protect only the strongest evidence-backed original-task match and give it a stable maximum rank of 3 before truncation
- add a public CLI regression proving Top-K prefix stability
- document the stable ranking contract

## Why

Real Agent dogfood showed that `--limit 3` omitted `Spreadsheets` and returned weak `cowork-publish` / `hi-pan` matches, while `--limit 4` and `--limit 10` placed `Spreadsheets` at rank 2. The truncation bound was changing which task-channel matches were protected.

After the fix, the same 249-Skill Snapshot returns:

```text
1   analyze-data-quality
2   analyze-data-quality > Spreadsheets
3   analyze-data-quality > Spreadsheets
4   analyze-data-quality > Spreadsheets
10  analyze-data-quality > Spreadsheets
20  analyze-data-quality > Spreadsheets
```

All dogfood calls were read-only (`result.files_changed=false`).

## Test plan

- [x] regression observed red before implementation
- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked --all-targets --all-features` (142 unit + 7 acceptance + 38 CLI)
- [x] `git diff --check`
- [x] real local 249-Skill dogfood across limits 1/2/3/4/10/20

## Review closure

- Initial Standards and Spec reviews found the candidate pool still depended on `--limit`; fixed in `bdeea77`.
- The regression fixture now contains 28 matching Skills and checks limits 1–10 across the old 5→6 pool threshold.
- Final independent Standards review: PASS, no blocker / should-fix / nit.
- Final independent Spec review: PASS, no missing / partial / scope creep / wrong implementation.
- Cross-platform CI: Linux, Windows, macOS arm64, macOS x86_64, change-scope, and final gate all pass.

Closes #89
