### PR TITLE
fix: reuse equivalent ready setup plans

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -121,7 +121,10 @@ for automatic planning. Unknown content is treated as a local modification and
 requires an explicit retain/adopt choice before any Plan is created. Links,
 non-files, and unreadable targets are blocked. In JSON mode setup never prompts
 or mutates; every write remains a normal Plan completed through Apply and
-recoverable through Undo.
+recoverable through Undo. Repeating an unchanged setup preview on the same
+Snapshot reuses an equivalent Ready Plan instead of accumulating duplicate
+pending Plans. Terminal Plans, newer Snapshots, and changed setup inputs are
+never reused.
 
 `find` preserves the user's original task and accepts repeatable Agent-authored
 retrieval hints. Hints let the semantic caller supply a cross-language or

--- a/src/app.rs
+++ b/src/app.rs
@@ -2725,6 +2725,7 @@ fn plan_command(store: &StateStore, state_dir: &Path) -> Result<Value> {
         state_dir,
         serde_json::from_str(&input)?,
         PlanOrigin::Agent,
+        None,
     )
 }
 
@@ -4164,6 +4165,7 @@ fn prepare_plan(
     state_dir: &Path,
     input: Value,
     origin: PlanOrigin,
+    reuse_identity: Option<Value>,
 ) -> Result<Value> {
     if store.recovery_required()? {
         bail!("recovery is required before another Plan can be prepared");
@@ -4236,12 +4238,14 @@ fn prepare_plan(
     validate_plan_evidence(store, &prepared, &scan_id)?;
     if matches!(effective_origin, PlanOrigin::BootstrapSetup) {
         let prepared_scan_id = ScanId::parse(prepared.scan_id.clone())?;
-        if let Some(existing) =
-            store.ready_plan_with_fingerprint(&prepared_scan_id, &prepared.digest)?
-            && existing.input.get("raw") == Some(&input)
-            && let Some(summary) = existing.input.get("summary")
-        {
-            return Ok(summary.clone());
+        for existing in store.ready_plans_with_fingerprint(&prepared_scan_id, &prepared.digest)? {
+            if existing.input.get("raw") == Some(&input)
+                && existing.input.get("reuse_identity") == reuse_identity.as_ref()
+            {
+                if let Some(summary) = existing.input.get("summary") {
+                    return Ok(summary.clone());
+                }
+            }
         }
     }
     let roster_before = capture_roster_state(store, &prepared)?;
@@ -4376,6 +4380,7 @@ fn prepare_plan(
         finding_ids.clone(),
         summary.clone(),
         selection_evidence_full,
+        reuse_identity,
     )?)?;
     Ok(summary)
 }
@@ -4931,6 +4936,13 @@ fn setup_command(
         state_dir,
         json!({"schema_version": 1, "scan_id": snapshot.id, "operations": operations}),
         PlanOrigin::BootstrapSetup,
+        Some(json!({
+            "modified_choice": match modified_choice {
+                None => Value::Null,
+                Some(ModifiedBootstrapChoice::RetainLocal) => json!("retain-local"),
+                Some(ModifiedBootstrapChoice::AdoptCurrent) => json!("adopt-current"),
+            }
+        })),
     )?;
     let operation_count = plan["change_summary"]["operation_count"]
         .as_u64()
@@ -5540,6 +5552,7 @@ fn plan_record(
     finding_ids: Vec<FindingId>,
     summary: Value,
     selection_evidence_full: Option<Value>,
+    reuse_identity: Option<Value>,
 ) -> Result<PlanRecord> {
     let operations = prepared
         .operations
@@ -5589,7 +5602,8 @@ fn plan_record(
             "roster_before": roster_before,
             "library_before": library_before,
             "summary": summary,
-            "selection_evidence_full": selection_evidence_full
+            "selection_evidence_full": selection_evidence_full,
+            "reuse_identity": reuse_identity
         }),
         fingerprint: prepared.digest.clone(),
         operations,

--- a/src/app.rs
+++ b/src/app.rs
@@ -4238,13 +4238,14 @@ fn prepare_plan(
     validate_plan_evidence(store, &prepared, &scan_id)?;
     if matches!(effective_origin, PlanOrigin::BootstrapSetup) {
         let prepared_scan_id = ScanId::parse(prepared.scan_id.clone())?;
-        for existing in store.ready_plans_with_fingerprint(&prepared_scan_id, &prepared.digest)? {
-            if existing.input.get("raw") == Some(&input)
-                && existing.input.get("reuse_identity") == reuse_identity.as_ref()
-            {
-                if let Some(summary) = existing.input.get("summary") {
-                    return Ok(summary.clone());
-                }
+        if let Some(existing) = store.ready_plan_with_reuse_identity(
+            &prepared_scan_id,
+            &prepared.digest,
+            &input,
+            reuse_identity.as_ref(),
+        )? {
+            if let Some(summary) = existing.input.get("summary") {
+                return Ok(summary.clone());
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -341,7 +341,7 @@ pub fn run(cli: Cli) -> Result<Output> {
 fn command_requires_exclusive_state_lock(command: Option<&Command>) -> bool {
     matches!(
         command,
-        Some(Command::Apply(_) | Command::Undo(_))
+        Some(Command::Apply(_) | Command::Undo(_) | Command::Setup(_))
             | Some(Command::Lifecycle(crate::cli::LifecycleArgs {
                 command: LifecycleCommand::Purge(_),
             }))
@@ -4234,6 +4234,16 @@ fn prepare_plan(
     validate_roster_changes(store, &prepared, &scan)?;
     validate_source_update_preconditions(&prepared, &scan)?;
     validate_plan_evidence(store, &prepared, &scan_id)?;
+    if matches!(effective_origin, PlanOrigin::BootstrapSetup) {
+        let prepared_scan_id = ScanId::parse(prepared.scan_id.clone())?;
+        if let Some(existing) =
+            store.ready_plan_with_fingerprint(&prepared_scan_id, &prepared.digest)?
+            && existing.input.get("raw") == Some(&input)
+            && let Some(summary) = existing.input.get("summary")
+        {
+            return Ok(summary.clone());
+        }
+    }
     let roster_before = capture_roster_state(store, &prepared)?;
     let library_before = capture_library_state(store, &prepared)?;
     let roster_after = serde_json::to_value(&prepared.roster_changes)?

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -981,29 +981,27 @@ impl StateStore {
             .transpose()
     }
 
-    pub fn ready_plan_with_fingerprint(
+    pub fn ready_plans_with_fingerprint(
         &self,
         scan_id: &ScanId,
         fingerprint: &str,
-    ) -> StorageResult<Option<PlanRecord>> {
-        let stored = self
-            .connection
-            .query_row(
-                "SELECT immutable_json, status FROM plans
-                 WHERE scan_id = ?1 AND fingerprint = ?2 AND status = 'ready'
-                 ORDER BY created_at DESC, id DESC
-                 LIMIT 1",
-                params![scan_id.as_str(), fingerprint],
-                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-            )
-            .optional()?;
-        stored
-            .map(|(encoded, status)| {
-                let mut plan: PlanRecord = from_json(&encoded)?;
-                plan.status = enum_from_text(&status)?;
-                Ok(plan)
-            })
-            .transpose()
+    ) -> StorageResult<Vec<PlanRecord>> {
+        let mut statement = self.connection.prepare(
+            "SELECT immutable_json, status FROM plans
+             WHERE scan_id = ?1 AND fingerprint = ?2 AND status = 'ready'
+             ORDER BY created_at DESC, id DESC",
+        )?;
+        let rows = statement.query_map(params![scan_id.as_str(), fingerprint], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        let mut plans = Vec::new();
+        for row in rows {
+            let (encoded, status) = row?;
+            let mut plan: PlanRecord = from_json(&encoded)?;
+            plan.status = enum_from_text(&status)?;
+            plans.push(plan);
+        }
+        Ok(plans)
     }
 
     pub fn update_plan_status(&self, id: &PlanId, next: PlanStatus) -> StorageResult<()> {

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -981,11 +981,13 @@ impl StateStore {
             .transpose()
     }
 
-    pub fn ready_plans_with_fingerprint(
+    pub fn ready_plan_with_reuse_identity(
         &self,
         scan_id: &ScanId,
         fingerprint: &str,
-    ) -> StorageResult<Vec<PlanRecord>> {
+        raw: &serde_json::Value,
+        reuse_identity: Option<&serde_json::Value>,
+    ) -> StorageResult<Option<PlanRecord>> {
         let mut statement = self.connection.prepare(
             "SELECT immutable_json, status FROM plans
              WHERE scan_id = ?1 AND fingerprint = ?2 AND status = 'ready'
@@ -994,14 +996,17 @@ impl StateStore {
         let rows = statement.query_map(params![scan_id.as_str(), fingerprint], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })?;
-        let mut plans = Vec::new();
         for row in rows {
             let (encoded, status) = row?;
             let mut plan: PlanRecord = from_json(&encoded)?;
             plan.status = enum_from_text(&status)?;
-            plans.push(plan);
+            if plan.input.get("raw") == Some(raw)
+                && plan.input.get("reuse_identity") == reuse_identity
+            {
+                return Ok(Some(plan));
+            }
         }
-        Ok(plans)
+        Ok(None)
     }
 
     pub fn update_plan_status(&self, id: &PlanId, next: PlanStatus) -> StorageResult<()> {

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -981,6 +981,31 @@ impl StateStore {
             .transpose()
     }
 
+    pub fn ready_plan_with_fingerprint(
+        &self,
+        scan_id: &ScanId,
+        fingerprint: &str,
+    ) -> StorageResult<Option<PlanRecord>> {
+        let stored = self
+            .connection
+            .query_row(
+                "SELECT immutable_json, status FROM plans
+                 WHERE scan_id = ?1 AND fingerprint = ?2 AND status = 'ready'
+                 ORDER BY created_at DESC, id DESC
+                 LIMIT 1",
+                params![scan_id.as_str(), fingerprint],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?;
+        stored
+            .map(|(encoded, status)| {
+                let mut plan: PlanRecord = from_json(&encoded)?;
+                plan.status = enum_from_text(&status)?;
+                Ok(plan)
+            })
+            .transpose()
+    }
+
     pub fn update_plan_status(&self, id: &PlanId, next: PlanStatus) -> StorageResult<()> {
         let current: Option<String> = self
             .connection

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1717,6 +1717,13 @@ fn repeated_setup_reuses_the_same_ready_plan() {
     );
     let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
     assert_eq!(status["result"]["pending_plan_count"], 2);
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let after_new_snapshot = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_ne!(
+        after_new_snapshot["result"]["plan_id"],
+        default_after_explicit["result"]["plan_id"]
+    );
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1640,6 +1640,59 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
 }
 
 #[test]
+fn repeated_setup_reuses_the_same_ready_plan() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    fs::create_dir_all(home.join(".codex/skills")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let first = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    let retry = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(first["result"]["state"], "preview_ready");
+    assert_eq!(retry["result"]["state"], "preview_ready");
+    assert_eq!(retry["result"]["plan_id"], first["result"]["plan_id"]);
+    assert_eq!(first["result"]["files_changed"], false);
+    assert_eq!(retry["result"]["files_changed"], false);
+
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["pending_plan_count"], 1);
+    assert_eq!(
+        status["result"]["pending_plans"][0]["plan_id"],
+        first["result"]["plan_id"]
+    );
+
+    let first_plan_id = first["result"]["plan_id"].as_str().unwrap();
+    let applied = json_output(&run(
+        &[&common[..], &["apply", first_plan_id]].concat(),
+        None,
+    ));
+    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+    assert_eq!(undone["result"]["verification"], "passed");
+
+    let after_terminal_state = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(after_terminal_state["result"]["state"], "preview_ready");
+    assert_ne!(
+        after_terminal_state["result"]["plan_id"],
+        first["result"]["plan_id"]
+    );
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["pending_plan_count"], 1);
+    assert_eq!(
+        status["result"]["pending_plans"][0]["plan_id"],
+        after_terminal_state["result"]["plan_id"]
+    );
+}
+
+#[test]
 fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1690,6 +1690,25 @@ fn repeated_setup_reuses_the_same_ready_plan() {
         status["result"]["pending_plans"][0]["plan_id"],
         after_terminal_state["result"]["plan_id"]
     );
+
+    let explicit_choice = json_output(&run(
+        &[&common[..], &["setup", "--modified-choice", "retain-local"]].concat(),
+        None,
+    ));
+    assert_ne!(
+        explicit_choice["result"]["plan_id"],
+        after_terminal_state["result"]["plan_id"]
+    );
+    let explicit_retry = json_output(&run(
+        &[&common[..], &["setup", "--modified-choice", "retain-local"]].concat(),
+        None,
+    ));
+    assert_eq!(
+        explicit_retry["result"]["plan_id"],
+        explicit_choice["result"]["plan_id"]
+    );
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["pending_plan_count"], 2);
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1709,6 +1709,14 @@ fn repeated_setup_reuses_the_same_ready_plan() {
     );
     let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
     assert_eq!(status["result"]["pending_plan_count"], 2);
+
+    let default_after_explicit = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(
+        default_after_explicit["result"]["plan_id"],
+        after_terminal_state["result"]["plan_id"]
+    );
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["pending_plan_count"], 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reuse an equivalent Ready bootstrap setup Plan on Agent retries
- require the same Snapshot, digest, normalized setup input, and explicit setup choice before reuse
- scan matching history newest-first and stop at the first exact identity match
- never reuse terminal or non-Ready Plans
- serialize setup planning with the existing state lock
- document and test the retry contract through the public CLI

## Why

Real dogfood showed that four unchanged `setup --json` previews created four pending Plans with different IDs but the same Snapshot, six operations, and SHA-256 digest. Agent retries therefore grew retained state and `status` context without creating a new decision.

After the fix, repeated previews against a copied real Snapshot return one stable Plan per setup choice. A real `default -> retain-local -> default` sequence returned to the original default Plan, kept the two identities distinct, left `pending_plan_count` at 2, and reported `files_changed=false` throughout.

## Safety boundary

Reuse happens only after the candidate Plan is derived and validated again. It requires an existing `ready` record with the same Snapshot, fingerprint, normalized raw setup request, and persisted `modified_choice` identity. After Apply and Undo, the public regression proves that setup creates a new Plan rather than reviving the terminal one. The lookup examines rows lazily and returns on the first exact match, so a large duplicate history is not collected in memory.

## Test plan

- [x] public CLI regression failed before implementation
- [x] repeated unchanged setup returns one stable Plan ID and one pending Plan
- [x] Applied/Undone Plan is not reused
- [x] different setup choices remain distinct; repeating the same choice is idempotent
- [x] `A -> B -> A` reuses the earlier A rather than checking only the newest Plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked --all-targets --all-features` (142 unit + 7 acceptance + 38 CLI)
- [x] `git diff --check`
- [x] copied-real-Snapshot dogfood with alternating choices and no Agent file changes

## Review closure

- Initial Spec review found Rust 1.85 incompatibility and missing `modified_choice` identity; both were fixed in `b398b9f`.
- Standards review then requested a true `A -> B -> A` regression and bounded lookup; both were fixed in `c156b60`.
- Copied-real-Snapshot dogfood now confirms the alternating-choice path and read-only behavior.

Closes #91
