### PR TITLE
fix: stop healthy status rescan loops

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -168,6 +168,11 @@ Machine results should expose facts, not preformatted prose:
 - risk, reversibility, drift, confirmation, and recovery state;
 - typed `suggested_actions` containing argv, mutation status, confirmation requirement, and reason code.
 
+Suggested actions must represent a required or evidence-backed transition.
+Healthy `status` output with a completed Snapshot does not prescribe another
+Scan; it exposes `latest_snapshot_at` so the Agent can judge freshness from the
+user's task and current context.
+
 The Agent decides wording and information order from these fields. The CLI must not send ANSI, Markdown, localized prose, TUI frames, or an opaque “health score” through JSON. The first complete release does not include a human TUI.
 
 ## 10. Acceptance scenarios

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -239,6 +239,9 @@ SkillRoster uses one SQLite database at `~/.skillroster/skillroster.db`, includi
 - Plans and Receipts remain until explicitly purged.
 - Overflow source-confirmation details are versioned local artifacts retained until explicitly purged or local state is deleted.
 - `status` exposes storage location, retention state, and retained source-confirmation artifact counts and bytes.
+- `status` suggests Scan only when no completed Snapshot exists. A healthy
+  state with a Snapshot exposes its timestamp and leaves refresh judgment to
+  the Agent instead of creating an unconditional Status-to-Scan loop.
 - Users can inspect, export, purge, or delete retained local state and rebuild inventory by scanning again.
 
 Reports may identify structural and provenance risks—unknown source, changed content, executable scripts, declaration mismatch, and escaping links—but must not claim malware detection or runtime safety.

--- a/src/app.rs
+++ b/src/app.rs
@@ -84,14 +84,16 @@ pub fn run(cli: Cli) -> Result<Output> {
                     false,
                     "recovery_required",
                 )]
-            } else {
+            } else if result["latest_snapshot_id"].is_null() {
                 vec![action(
                     "scan",
                     &["scan", "--json"],
                     false,
                     false,
-                    "refresh_facts",
+                    "snapshot_required",
                 )]
+            } else {
+                Vec::new()
             };
             ("status", result, vec![], actions)
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -55,6 +55,37 @@ fn report_help_names_the_safe_default_and_explicit_exhaustive_export() {
 }
 
 #[test]
+fn healthy_status_does_not_suggest_an_unconditional_rescan() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    fs::create_dir_all(home.join(".codex/skills")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    let missing_snapshot = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(
+        missing_snapshot["suggested_actions"][0]["argv"],
+        json!(["skillroster", "scan", "--json"])
+    );
+    assert_eq!(
+        missing_snapshot["suggested_actions"][0]["reason_code"],
+        "snapshot_required"
+    );
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let healthy = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert!(healthy["result"]["latest_snapshot_id"].is_string());
+    assert_eq!(healthy["result"]["recovery_state"], "clear");
+    assert_eq!(healthy["suggested_actions"], json!([]));
+}
+
+#[test]
 fn public_cli_exits_quietly_when_the_output_consumer_closes() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## Summary

- suggest `scan --json` from Status only when no completed Snapshot exists
- keep recovery inspection as the priority when recovery is required
- leave refresh judgment to the Agent when Status already exposes a healthy Snapshot and timestamp
- document the Agent navigation contract and cover it through the public CLI

## Why

Real `v1.8.18` dogfood found that healthy `status --json` always prescribed another Scan, even 33 seconds after a successful Scan. Following the typed action took another 11.93 seconds, created another Snapshot, added 1,229 raw-usage rows and 2,278 Evidence rows in the isolated state, then returned the same Scan action again.

There was no freshness threshold or drift evidence behind `refresh_facts`. The Agent already receives `latest_snapshot_at` and can decide whether the user's task needs fresher facts.

## Behavior

- no completed Snapshot: one non-mutating Scan action with `reason_code=snapshot_required`
- healthy completed Snapshot: no unconditional suggested action
- recovery required: existing recovery-inspection action remains unchanged
- Status stays read-only and preserves all state, retention, Plan, Receipt, and recovery facts

## Test plan

- [x] public CLI regression failed before implementation
- [x] public CLI verifies no-Snapshot and healthy-Snapshot branches
- [x] real copied-state Status returns no action and changes no files
- [x] fresh-state Status returns typed `snapshot_required` Scan and changes no files
- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked --all-targets --all-features` (142 unit + 7 acceptance + 38 CLI)
- [x] `git diff --check`

Closes #93
