### PR TITLE
fix: deduplicate usage across rescans

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,6 +54,12 @@ _Avoid_: Imported Skill, owned Skill
 A traceable fact supporting a Finding, such as a path, source declaration, symlink target, exposure record, or local usage event.
 _Avoid_: Proof, confidence
 
+**Usage Observation**:
+A privacy-preserving aggregate for one Skill, Agent, usage stage, quality, and
+session-source path. Its high-water count is stable across Scans; lifecycle
+history records only newly observed deltas and never raw conversation text.
+_Avoid_: Scan hit, invocation log
+
 **Finding**:
 An evidence-backed condition discovered during analysis. A Finding describes a condition; it does not authorize a change.
 _Avoid_: Error, recommendation

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,9 +55,10 @@ A traceable fact supporting a Finding, such as a path, source declaration, symli
 _Avoid_: Proof, confidence
 
 **Usage Observation**:
-A privacy-preserving aggregate for one Skill, Agent, usage stage, quality, and
-session-source path. Its high-water count is stable across Scans; lifecycle
-history records only newly observed deltas and never raw conversation text.
+A privacy-preserving bounded observation for one Skill, Agent, usage stage,
+quality, and session-source path. Unchanged observations deduplicate across
+Scans; lifecycle retention keeps the maximum observation per source and month.
+It does not infer additive events and never stores raw conversation text.
 _Avoid_: Scan hit, invocation log
 
 **Finding**:

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -173,6 +173,13 @@ Healthy `status` output with a completed Snapshot does not prescribe another
 Scan; it exposes `latest_snapshot_at` so the Agent can judge freshness from the
 user's task and current context.
 
+Lifecycle exports name their usage aggregation contract in `usage_history`.
+Agents sum `data.usage_events[].event_delta` for retained raw history and
+`data.usage_monthly[].event_count` for older history. Snapshot-scoped Usage
+Evidence is traceability context, not an additive history stream. Monthly
+`derivation` distinguishes source-delta rows from unrepairable legacy Scan
+aggregates.
+
 The Agent decides wording and information order from these fields. The CLI must not send ANSI, Markdown, localized prose, TUI frames, or an opaque “health score” through JSON. The first complete release does not include a human TUI.
 
 ## 10. Acceptance scenarios

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -174,11 +174,13 @@ Scan; it exposes `latest_snapshot_at` so the Agent can judge freshness from the
 user's task and current context.
 
 Lifecycle exports name their usage aggregation contract in `usage_history`.
-Agents sum `data.usage_events[].event_delta` for retained raw history and
-`data.usage_monthly[].event_count` for older history. Snapshot-scoped Usage
-Evidence is traceability context, not an additive history stream. Monthly
-`derivation` distinguishes source-delta rows from unrepairable legacy Scan
-aggregates.
+`data.usage_events[].observed_event_count` is a bounded source observation,
+not an additive event delta. Retention stores the maximum observation per
+source and month in `data.usage_monthly_sources`; those maxima are not
+cumulative across sources or months. Pre-v9 Scan aggregates remain separately
+labeled in `data.usage_monthly_legacy` and must not be combined with the new
+source observations. Snapshot-scoped Usage Evidence is traceability context,
+not an additive history stream.
 
 The Agent decides wording and information order from these fields. The CLI must not send ANSI, Markdown, localized prose, TUI frames, or an opaque “health score” through JSON. The first complete release does not include a human TUI.
 

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -174,6 +174,7 @@ Scan; it exposes `latest_snapshot_at` so the Agent can judge freshness from the
 user's task and current context.
 
 Lifecycle exports name their usage aggregation contract in `usage_history`.
+This source-observation contract is lifecycle export schema version 2.
 `data.usage_events[].observed_event_count` is a bounded source observation,
 not an additive event delta. Retention stores the maximum observation per
 source and month in `data.usage_monthly_sources`; those maxima are not

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -236,13 +236,13 @@ SkillRoster uses one SQLite database at `~/.skillroster/skillroster.db`, includi
 - Source sessions are read-only and remain in their original locations.
 - Derived event summaries are retained for 180 days by default.
 - Usage Observations have a stable identity across Scans. An unchanged rescan
-  does not increase historical counts; growth in the same observable source
-  contributes only the newly observed delta. Snapshot Evidence remains
-  immutable and traceable independently of this lifecycle high-water state.
-- Older usage is reduced to monthly aggregates.
-- Monthly rows created by the delta model expose `derivation=source_delta`.
-  Pre-v9 monthly rows cannot be safely reconstructed by source and are retained
-  with `derivation=legacy_scan_aggregate` instead of being presented as exact.
+  does not create another raw observation. A changed bounded source window is
+  recorded as a new observation, not inferred as an additive event delta.
+- Older usage is reduced to the maximum observed count per source and month.
+  These maxima are conservative source-window facts, not cumulative totals.
+- Pre-v9 monthly rows cannot be safely reconstructed by source. They are
+  retained separately with `derivation=legacy_scan_aggregate` and must not be
+  combined with source-month observations.
 - Plans and Receipts remain until explicitly purged.
 - Overflow source-confirmation details are versioned local artifacts retained until explicitly purged or local state is deleted.
 - `status` exposes storage location, retention state, and retained source-confirmation artifact counts and bytes.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -235,7 +235,14 @@ SkillRoster uses one SQLite database at `~/.skillroster/skillroster.db`, includi
 
 - Source sessions are read-only and remain in their original locations.
 - Derived event summaries are retained for 180 days by default.
+- Usage Observations have a stable identity across Scans. An unchanged rescan
+  does not increase historical counts; growth in the same observable source
+  contributes only the newly observed delta. Snapshot Evidence remains
+  immutable and traceable independently of this lifecycle high-water state.
 - Older usage is reduced to monthly aggregates.
+- Monthly rows created by the delta model expose `derivation=source_delta`.
+  Pre-v9 monthly rows cannot be safely reconstructed by source and are retained
+  with `derivation=legacy_scan_aggregate` instead of being presented as exact.
 - Plans and Receipts remain until explicitly purged.
 - Overflow source-confirmation details are versioned local artifacts retained until explicitly purged or local state is deleted.
 - `status` exposes storage location, retention state, and retained source-confirmation artifact counts and bytes.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -241,7 +241,8 @@ SkillRoster uses one SQLite database at `~/.skillroster/skillroster.db`, includi
 - Usage event windows use timestamps carried by the session record. Session
   file modification times describe coverage only and must not refresh old
   Skill events; when a record has no trustworthy timestamp, event time remains
-  unknown.
+  unknown. The local observation time may govern retention for that record but
+  is never presented as the event time.
 - Older usage is reduced to the maximum observed count per source and month.
   These maxima are conservative source-window facts, not cumulative totals.
 - Pre-v9 monthly rows cannot be safely reconstructed by source. They are

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -238,6 +238,10 @@ SkillRoster uses one SQLite database at `~/.skillroster/skillroster.db`, includi
 - Usage Observations have a stable identity across Scans. An unchanged rescan
   does not create another raw observation. A changed bounded source window is
   recorded as a new observation, not inferred as an additive event delta.
+- Usage event windows use timestamps carried by the session record. Session
+  file modification times describe coverage only and must not refresh old
+  Skill events; when a record has no trustworthy timestamp, event time remains
+  unknown.
 - Older usage is reduced to the maximum observed count per source and month.
   These maxima are conservative source-window facts, not cumulative totals.
 - Pre-v9 monthly rows cannot be safely reconstructed by source. They are

--- a/src/app.rs
+++ b/src/app.rs
@@ -672,7 +672,7 @@ fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> 
 fn lifecycle_export_command(store: &StateStore, state_dir: &Path, output: &Path) -> Result<Value> {
     let source_confirmation_details = read_source_confirmation_details(state_dir)?;
     let export = json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_at": Utc::now().timestamp(),
         "retention": {
             "raw_usage_days": 180,

--- a/src/app.rs
+++ b/src/app.rs
@@ -680,7 +680,8 @@ fn lifecycle_export_command(store: &StateStore, state_dir: &Path, output: &Path)
         },
         "usage_history": {
             "stable_identity_fields": [
-                "skill_id", "agent_id", "stage", "quality", "source_path_digest"
+                "skill_id", "agent_id", "stage", "quality", "source_path_digest",
+                "observed_event_count", "occurred_at"
             ],
             "raw_value_field": "observed_event_count",
             "monthly_value_field": "max_observed_event_count",
@@ -5206,13 +5207,7 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
             continue;
         };
         let agent_id = agent_ids[&usage.agent].clone();
-        let reference = format!(
-            "usage:{}:{}:{:?}:{}",
-            usage.agent.id(),
-            usage.skill_id,
-            usage.stage,
-            usage.source_path_digest
-        );
+        let reference = usage.evidence_reference();
         let evidence_id = save_reference_evidence(
             store,
             scan_id,
@@ -5232,6 +5227,7 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
                 "event_count": usage.event_count,
                 "first_seen_unix": usage.first_seen_unix,
                 "last_seen_unix": usage.last_seen_unix,
+                "month_start_unix": usage.month_start_unix,
                 "source_path_digest": usage.source_path_digest,
             }),
             observed_at,
@@ -5244,7 +5240,9 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
             quality: evidence_quality(usage.quality),
             source_path_digest: usage.source_path_digest.clone(),
             observed_event_count: usage.event_count,
-            occurred_at: usage.last_seen_unix.unwrap_or_default() as i64,
+            occurred_at: usage
+                .last_seen_unix
+                .and_then(|value| i64::try_from(value).ok()),
             outcome: None,
         })?;
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -682,9 +682,11 @@ fn lifecycle_export_command(store: &StateStore, state_dir: &Path, output: &Path)
             "stable_identity_fields": [
                 "skill_id", "agent_id", "stage", "quality", "source_path_digest"
             ],
-            "raw_value_field": "event_delta",
-            "monthly_value_field": "event_count",
-            "snapshot_evidence_additive": false,
+            "raw_value_field": "observed_event_count",
+            "monthly_value_field": "max_observed_event_count",
+            "aggregation": "maximum observation per source and month",
+            "observations_additive": false,
+            "legacy_monthly_combinable": false,
         },
         "data": store.export_lifecycle()?,
         "evidence_exclusions": store.evidence_exclusions()?,
@@ -5242,8 +5244,6 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
             quality: evidence_quality(usage.quality),
             source_path_digest: usage.source_path_digest.clone(),
             observed_event_count: usage.event_count,
-            first_seen_at: usage.first_seen_unix.unwrap_or_default() as i64,
-            last_seen_at: usage.last_seen_unix.unwrap_or_default() as i64,
             occurred_at: usage.last_seen_unix.unwrap_or_default() as i64,
             outcome: None,
         })?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -678,6 +678,14 @@ fn lifecycle_export_command(store: &StateStore, state_dir: &Path, output: &Path)
             "raw_usage_days": 180,
             "older_usage": "monthly_aggregates_retained",
         },
+        "usage_history": {
+            "stable_identity_fields": [
+                "skill_id", "agent_id", "stage", "quality", "source_path_digest"
+            ],
+            "raw_value_field": "event_delta",
+            "monthly_value_field": "event_count",
+            "snapshot_evidence_additive": false,
+        },
         "data": store.export_lifecycle()?,
         "evidence_exclusions": store.evidence_exclusions()?,
         "source_confirmation_details": source_confirmation_details,
@@ -5232,6 +5240,10 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
             agent_id,
             stage: usage_stage(usage.stage),
             quality: evidence_quality(usage.quality),
+            source_path_digest: usage.source_path_digest.clone(),
+            observed_event_count: usage.event_count,
+            first_seen_at: usage.first_seen_unix.unwrap_or_default() as i64,
+            last_seen_at: usage.last_seen_unix.unwrap_or_default() as i64,
             occurred_at: usage.last_seen_unix.unwrap_or_default() as i64,
             outcome: None,
         })?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -371,8 +371,6 @@ pub struct UsageEvent {
     pub quality: EvidenceQuality,
     pub source_path_digest: String,
     pub observed_event_count: u64,
-    pub first_seen_at: i64,
-    pub last_seen_at: i64,
     pub occurred_at: i64,
     pub outcome: Option<String>,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -371,7 +371,7 @@ pub struct UsageEvent {
     pub quality: EvidenceQuality,
     pub source_path_digest: String,
     pub observed_event_count: u64,
-    pub occurred_at: i64,
+    pub occurred_at: Option<i64>,
     pub outcome: Option<String>,
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -369,6 +369,10 @@ pub struct UsageEvent {
     pub agent_id: AgentId,
     pub stage: UsageStage,
     pub quality: EvidenceQuality,
+    pub source_path_digest: String,
+    pub observed_event_count: u64,
+    pub first_seen_at: i64,
+    pub last_seen_at: i64,
     pub occurred_at: i64,
     pub outcome: Option<String>,
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -824,15 +824,7 @@ fn usage_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     let evidence = scan
         .usage
         .iter()
-        .map(|usage| {
-            format!(
-                "usage:{}:{}:{:?}:{}",
-                usage.agent.id(),
-                usage.skill_id,
-                usage.stage,
-                usage.source_path_digest
-            )
-        })
+        .map(crate::scan::UsageEvidence::evidence_reference)
         .chain(
             scan.coverage
                 .iter()
@@ -2148,6 +2140,7 @@ mod tests {
                 event_count,
                 first_seen_unix: Some(1),
                 last_seen_unix,
+                month_start_unix: None,
                 source_path_digest: format!("source-{event_count}"),
             });
         }
@@ -2162,6 +2155,7 @@ mod tests {
             event_count: 7,
             first_seen_unix: Some(2),
             last_seen_unix: Some(30),
+            month_start_unix: None,
             source_path_digest: "source-distinct".into(),
         });
 
@@ -2754,6 +2748,7 @@ mod tests {
             event_count: 1,
             first_seen_unix: Some(1),
             last_seen_unix: Some(1),
+            month_start_unix: None,
             source_path_digest: "fixture".into(),
         });
 

--- a/src/roster_recommendation.rs
+++ b/src/roster_recommendation.rs
@@ -502,6 +502,7 @@ mod tests {
             event_count: 3,
             first_seen_unix: Some(10),
             last_seen_unix: Some(20),
+            month_start_unix: None,
             source_path_digest: "sha256:usage".into(),
         });
         let recommendation = recommend(
@@ -788,6 +789,7 @@ mod tests {
             event_count: 1,
             first_seen_unix: Some(10),
             last_seen_unix: Some(20),
+            month_start_unix: None,
             source_path_digest: "sha256:usage".into(),
         }
     }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,6 +1,6 @@
 use crate::harness::{AgentKind, SessionSignal, known_agent_roots, session_record_observations};
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
-use chrono::DateTime;
+use chrono::{DateTime, Datelike, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -172,8 +172,26 @@ pub struct UsageEvidence {
     pub event_count: u64,
     pub first_seen_unix: Option<u64>,
     pub last_seen_unix: Option<u64>,
+    /// UTC month containing the observed records, or `None` when their event
+    /// time could not be established without guessing.
+    #[serde(default)]
+    pub month_start_unix: Option<u64>,
     /// A stable digest of the source path, never session content.
     pub source_path_digest: String,
+}
+
+impl UsageEvidence {
+    pub fn evidence_reference(&self) -> String {
+        format!(
+            "usage:{}:{}:{:?}:{}:{}",
+            self.agent.id(),
+            self.skill_id,
+            self.stage,
+            self.source_path_digest,
+            self.month_start_unix
+                .map_or_else(|| "unknown".to_owned(), |month| month.to_string())
+        )
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1417,7 +1435,7 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
         .ascii_case_insensitive(true)
         .build(&reference_patterns)
         .ok();
-    let mut events = BTreeMap::<(String, UsageStage, String), UsageEvidence>::new();
+    let mut events = BTreeMap::<(String, UsageStage, String, Option<u64>), UsageEvidence>::new();
     let mut bytes_observed = 0_u64;
     let mut lines_observed = 0_usize;
 
@@ -1542,7 +1560,8 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                     break;
                 }
                 lines_observed += physical_lines;
-                let record_timestamp = session_record_timestamp(&line);
+                let record_timestamp = session_record_timestamp(agent, &line);
+                let record_month = record_timestamp.and_then(month_start_unix);
                 let observations = session_record_observations(agent, &line);
                 if !observations.is_empty() {
                     let mut seen_event_skill_stages = BTreeSet::new();
@@ -1578,7 +1597,12 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                             )) {
                                 continue;
                             }
-                            let key = (skill_id.clone(), stage, source_path_digest.clone());
+                            let key = (
+                                skill_id.clone(),
+                                stage,
+                                source_path_digest.clone(),
+                                record_month,
+                            );
                             let event = events.entry(key).or_insert_with(|| UsageEvidence {
                                 agent,
                                 skill_id,
@@ -1587,6 +1611,7 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                                 event_count: 0,
                                 first_seen_unix: None,
                                 last_seen_unix: None,
+                                month_start_unix: record_month,
                                 source_path_digest: source_path_digest.clone(),
                             });
                             event.event_count += 1;
@@ -1605,7 +1630,12 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                     let (skill_id, _) = &skill_lookup[matched.pattern().as_usize()];
                     let stage = UsageStage::Exposed;
                     let quality = EvidenceQuality::Inferred;
-                    let key = (skill_id.clone(), stage, source_path_digest.clone());
+                    let key = (
+                        skill_id.clone(),
+                        stage,
+                        source_path_digest.clone(),
+                        record_month,
+                    );
                     let event = events.entry(key).or_insert_with(|| UsageEvidence {
                         agent,
                         skill_id: skill_id.clone(),
@@ -1614,6 +1644,7 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                         event_count: 0,
                         first_seen_unix: None,
                         last_seen_unix: None,
+                        month_start_unix: record_month,
                         source_path_digest: source_path_digest.clone(),
                     });
                     event.event_count += 1;
@@ -1835,34 +1866,76 @@ fn update_window(first: &mut Option<u64>, last: &mut Option<u64>, timestamp: Opt
     *last = Some(last.map_or(timestamp, |current| current.max(timestamp)));
 }
 
-fn session_record_timestamp(record: &str) -> Option<u64> {
+fn session_record_timestamp(agent: AgentKind, record: &str) -> Option<u64> {
     let value = serde_json::from_str::<serde_json::Value>(record).ok()?;
-    let object = value.as_object()?;
-    ["timestamp", "created_at", "createdAt", "time"]
-        .into_iter()
-        .find_map(|field| object.get(field).and_then(timestamp_value_unix))
+    let mut timestamps = BTreeSet::new();
+    for field in ["timestamp", "created_at", "createdAt"] {
+        if let Some(timestamp) = value.get(field).and_then(timestamp_value_unix) {
+            timestamps.insert(timestamp);
+        }
+    }
+    // Codex wraps some JSONL record metadata in `payload`. This is an Agent
+    // envelope, unlike arbitrary tool arguments or message content, which must
+    // never be treated as event time.
+    if agent == AgentKind::Codex {
+        if let Some(payload) = value.get("payload") {
+            for field in ["timestamp", "created_at", "createdAt"] {
+                if let Some(timestamp) = payload.get(field).and_then(timestamp_value_unix) {
+                    timestamps.insert(timestamp);
+                }
+            }
+        }
+    }
+    (timestamps.len() == 1).then(|| *timestamps.iter().next().expect("length checked"))
 }
 
 fn timestamp_value_unix(value: &serde_json::Value) -> Option<u64> {
-    if let Some(value) = value.as_u64() {
-        return Some(normalize_unix_timestamp(value));
+    if let Some(value) = value.as_f64() {
+        return normalize_numeric_unix_timestamp(value);
     }
     let value = value.as_str()?;
-    if let Ok(timestamp) = value.parse::<u64>() {
-        return Some(normalize_unix_timestamp(timestamp));
-    }
     DateTime::parse_from_rfc3339(value)
-        .ok()?
+        .ok()
+        .and_then(|timestamp| timestamp.timestamp().try_into().ok())
+        .or_else(|| {
+            value
+                .parse::<f64>()
+                .ok()
+                .and_then(normalize_numeric_unix_timestamp)
+        })
+}
+
+fn normalize_numeric_unix_timestamp(value: f64) -> Option<u64> {
+    // Numeric timestamp units are not self-describing. Accept only the single
+    // seconds/milliseconds/microseconds/nanoseconds interpretation that lands
+    // in the era in which local coding-agent sessions can exist.
+    if !value.is_finite() || value <= 0.0 {
+        return None;
+    }
+    const EARLIEST_AGENT_SESSION: f64 = 946_684_800.0; // 2000-01-01 UTC
+    const LATEST_AGENT_SESSION: f64 = 4_102_444_800.0; // 2100-01-01 UTC
+    let candidates = [
+        value,
+        value / 1_000.0,
+        value / 1_000_000.0,
+        value / 1_000_000_000.0,
+    ]
+    .into_iter()
+    .filter(|candidate| *candidate >= EARLIEST_AGENT_SESSION && *candidate < LATEST_AGENT_SESSION)
+    .map(|candidate| candidate.floor() as u64)
+    .collect::<BTreeSet<_>>();
+    (candidates.len() == 1).then(|| *candidates.iter().next().expect("length checked"))
+}
+
+fn month_start_unix(timestamp: u64) -> Option<u64> {
+    let timestamp = i64::try_from(timestamp).ok()?;
+    let date = Utc.timestamp_opt(timestamp, 0).single()?.date_naive();
+    date.with_day(1)?
+        .and_hms_opt(0, 0, 0)?
+        .and_utc()
         .timestamp()
         .try_into()
         .ok()
-}
-
-fn normalize_unix_timestamp(mut timestamp: u64) -> u64 {
-    while timestamp >= 100_000_000_000 {
-        timestamp /= 1_000;
-    }
-    timestamp
 }
 
 pub fn skill_search_text(skill: &ScannedSkill) -> String {
@@ -2598,6 +2671,80 @@ enabled = true
     }
 
     #[test]
+    fn record_timestamps_are_nested_unit_aware_and_fail_closed() {
+        assert_eq!(
+            session_record_timestamp(
+                AgentKind::Codex,
+                r#"{"payload":{"createdAt":"2024-02-03T04:05:06Z"}}"#
+            ),
+            Some(1_706_933_106)
+        );
+        assert_eq!(
+            session_record_timestamp(AgentKind::ClaudeCode, r#"{"timestamp":1706933106000.0}"#),
+            Some(1_706_933_106)
+        );
+        assert_eq!(
+            session_record_timestamp(AgentKind::Pi, r#"{"timestamp":"1706933106000000"}"#),
+            Some(1_706_933_106)
+        );
+        assert_eq!(
+            session_record_timestamp(AgentKind::OpenCode, r#"{"time":30}"#),
+            None
+        );
+        assert_eq!(
+            session_record_timestamp(AgentKind::Hermes, r#"{"timestamp":0}"#),
+            None
+        );
+        assert_eq!(
+            session_record_timestamp(
+                AgentKind::Codex,
+                r#"{"timestamp":"2024-01-01T00:00:00Z","payload":{"created_at":"2024-02-01T00:00:00Z"}}"#
+            ),
+            None
+        );
+        assert_eq!(
+            session_record_timestamp(
+                AgentKind::Codex,
+                r#"{"tool":{"arguments":{"created_at":"2024-02-03T04:05:06Z"}}}"#
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn session_usage_is_partitioned_by_event_month_before_persistence() {
+        let home = temp_directory("usage-event-months");
+        let skill = home.join(".codex/skills/example");
+        let sessions = home.join(".codex/sessions");
+        fs::create_dir_all(&skill).unwrap();
+        fs::create_dir_all(&sessions).unwrap();
+        fs::write(skill.join("SKILL.md"), "---\nname: example\n---\n").unwrap();
+        fs::write(
+            sessions.join("session.jsonl"),
+            [
+                r#"{"timestamp":"2024-01-15T00:00:00Z","invoked_skill":"example"}"#,
+                r#"{"timestamp":"2024-02-15T00:00:00Z","invoked_skill":"example"}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let result = scan(&ScanOptions::for_home(&home)).unwrap();
+        let observed = result
+            .usage
+            .iter()
+            .filter(|usage| usage.stage == UsageStage::Applied)
+            .map(|usage| (usage.month_start_unix, usage.event_count))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            observed,
+            BTreeSet::from([(Some(1_704_067_200), 1), (Some(1_706_745_600), 1)])
+        );
+
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
     fn large_current_session_tail_contributes_observed_usage() {
         let home = temp_directory("large-current-session");
         let skill = home.join(".codex/skills/research");
@@ -3151,6 +3298,7 @@ enabled = true
             event_count: 1,
             first_seen_unix: None,
             last_seen_unix: None,
+            month_start_unix: None,
             source_path_digest: "sha256:fixture".into(),
         });
         assert!(agents_with_usage(&result).is_empty());
@@ -3163,6 +3311,7 @@ enabled = true
             event_count: 1,
             first_seen_unix: None,
             last_seen_unix: None,
+            month_start_unix: None,
             source_path_digest: "sha256:fixture".into(),
         });
         assert_eq!(

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,5 +1,6 @@
 use crate::harness::{AgentKind, SessionSignal, known_agent_roots, session_record_observations};
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
+use chrono::DateTime;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -1541,6 +1542,7 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                     break;
                 }
                 lines_observed += physical_lines;
+                let record_timestamp = session_record_timestamp(&line);
                 let observations = session_record_observations(agent, &line);
                 if !observations.is_empty() {
                     let mut seen_event_skill_stages = BTreeSet::new();
@@ -1583,11 +1585,16 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                                 stage,
                                 quality,
                                 event_count: 0,
-                                first_seen_unix: timestamp,
-                                last_seen_unix: timestamp,
+                                first_seen_unix: None,
+                                last_seen_unix: None,
                                 source_path_digest: source_path_digest.clone(),
                             });
                             event.event_count += 1;
+                            update_window(
+                                &mut event.first_seen_unix,
+                                &mut event.last_seen_unix,
+                                record_timestamp,
+                            );
                         }
                     }
                     continue;
@@ -1605,11 +1612,16 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                         stage,
                         quality,
                         event_count: 0,
-                        first_seen_unix: timestamp,
-                        last_seen_unix: timestamp,
+                        first_seen_unix: None,
+                        last_seen_unix: None,
                         source_path_digest: source_path_digest.clone(),
                     });
                     event.event_count += 1;
+                    update_window(
+                        &mut event.first_seen_unix,
+                        &mut event.last_seen_unix,
+                        record_timestamp,
+                    );
                 }
             }
             if file_partially_observed {
@@ -1821,6 +1833,36 @@ fn update_window(first: &mut Option<u64>, last: &mut Option<u64>, timestamp: Opt
     let Some(timestamp) = timestamp else { return };
     *first = Some(first.map_or(timestamp, |current| current.min(timestamp)));
     *last = Some(last.map_or(timestamp, |current| current.max(timestamp)));
+}
+
+fn session_record_timestamp(record: &str) -> Option<u64> {
+    let value = serde_json::from_str::<serde_json::Value>(record).ok()?;
+    let object = value.as_object()?;
+    ["timestamp", "created_at", "createdAt", "time"]
+        .into_iter()
+        .find_map(|field| object.get(field).and_then(timestamp_value_unix))
+}
+
+fn timestamp_value_unix(value: &serde_json::Value) -> Option<u64> {
+    if let Some(value) = value.as_u64() {
+        return Some(normalize_unix_timestamp(value));
+    }
+    let value = value.as_str()?;
+    if let Ok(timestamp) = value.parse::<u64>() {
+        return Some(normalize_unix_timestamp(timestamp));
+    }
+    DateTime::parse_from_rfc3339(value)
+        .ok()?
+        .timestamp()
+        .try_into()
+        .ok()
+}
+
+fn normalize_unix_timestamp(mut timestamp: u64) -> u64 {
+    while timestamp >= 100_000_000_000 {
+        timestamp /= 1_000;
+    }
+    timestamp
 }
 
 pub fn skill_search_text(skill: &ScannedSkill) -> String {

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1363,7 +1363,7 @@ impl StateStore {
             monthly_usage_rows: table_count(&self.connection, "usage_monthly")?
                 + table_count(&self.connection, "usage_monthly_sources")?,
             oldest_raw_usage_at: self.connection.query_row(
-                "SELECT MIN(occurred_at) FROM usage_events",
+                "SELECT MIN(NULLIF(occurred_at, 0)) FROM usage_events",
                 [],
                 |row| row.get(0),
             )?,
@@ -1414,7 +1414,7 @@ impl StateStore {
                 'evidence_id', evidence_id, 'skill_id', skill_id, 'agent_id', agent_id,
                 'stage', stage, 'quality', quality, 'source_path_digest', source_path_digest,
                 'observed_event_count', observed_event_count,
-                'occurred_at', occurred_at, 'outcome', outcome)
+                'occurred_at', NULLIF(occurred_at, 0), 'outcome', outcome)
              FROM usage_events ORDER BY occurred_at, evidence_id",
         )?;
         let monthly_sources = query_json_rows(
@@ -1448,7 +1448,9 @@ impl StateStore {
     pub fn purge_usage_before(&self, cutoff: i64) -> StorageResult<PurgeCounts> {
         let transaction = self.connection.unchecked_transaction()?;
         let aggregated_raw_usage_rows: u64 = transaction.query_row(
-            "SELECT COUNT(*) FROM usage_events WHERE occurred_at < ?1",
+            "SELECT COUNT(*)
+             FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
+             WHERE COALESCE(NULLIF(u.occurred_at, 0), e.observed_at) < ?1",
             [cutoff],
             |row| row.get(0),
         )?;
@@ -1456,12 +1458,16 @@ impl StateStore {
             "INSERT INTO usage_monthly_sources
                 (month_start, skill_id, agent_id, stage, quality, source_path_digest,
                  max_observed_event_count, first_seen_at, last_seen_at)
-             SELECT CAST(strftime('%s', strftime('%Y-%m-01', u.occurred_at, 'unixepoch')) AS INTEGER),
+             SELECT CAST(strftime('%s', strftime('%Y-%m-01', u.retention_at, 'unixepoch')) AS INTEGER),
                     u.skill_id, u.agent_id, u.stage, u.quality, u.source_path_digest,
-                    MAX(u.observed_event_count), MIN(u.occurred_at), MAX(u.occurred_at)
-             FROM usage_events u
-             WHERE u.occurred_at < ?1
-             GROUP BY strftime('%Y-%m', u.occurred_at, 'unixepoch'),
+                    MAX(u.observed_event_count), MIN(u.retention_at), MAX(u.retention_at)
+             FROM (
+                SELECT u.*,
+                       COALESCE(NULLIF(u.occurred_at, 0), e.observed_at) AS retention_at
+                FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
+             ) u
+             WHERE u.retention_at < ?1
+             GROUP BY strftime('%Y-%m', u.retention_at, 'unixepoch'),
                       u.skill_id, u.agent_id, u.stage, u.quality, u.source_path_digest
              ON CONFLICT(month_start, skill_id, agent_id, stage, quality, source_path_digest)
              DO UPDATE SET
@@ -1479,7 +1485,9 @@ impl StateStore {
         )?;
         transaction.execute(
             "INSERT INTO purge_usage_evidence (evidence_id)
-             SELECT evidence_id FROM usage_events WHERE occurred_at < ?1
+             SELECT u.evidence_id
+             FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
+             WHERE COALESCE(NULLIF(u.occurred_at, 0), e.observed_at) < ?1
              UNION
              SELECT id FROM evidence
              WHERE kind = 'usage'
@@ -1491,9 +1499,11 @@ impl StateStore {
              WHERE evidence_id IN (SELECT evidence_id FROM purge_usage_evidence)",
             [],
         )?;
-        let deleted_raw_usage_rows = transaction
-            .execute("DELETE FROM usage_events WHERE occurred_at < ?1", [cutoff])?
-            as u64;
+        let deleted_raw_usage_rows = transaction.execute(
+            "DELETE FROM usage_events
+                 WHERE evidence_id IN (SELECT evidence_id FROM purge_usage_evidence)",
+            [],
+        )? as u64;
         let deleted_evidence_rows = transaction.execute(
             "DELETE FROM evidence
              WHERE id IN (SELECT evidence_id FROM purge_usage_evidence)",
@@ -1504,7 +1514,8 @@ impl StateStore {
         let deleted_payload_usage_summaries: u64 = transaction.query_row(
             "SELECT COALESCE(SUM((
                 SELECT COUNT(*) FROM json_each(p.payload_json, '$.usage') AS usage
-                WHERE COALESCE(json_extract(usage.value, '$.last_seen_unix'), 0) < ?1
+                WHERE COALESCE(
+                    json_extract(usage.value, '$.last_seen_unix'), p.updated_at) < ?1
              )), 0) FROM scan_payloads p",
             [cutoff],
             |row| row.get(0),
@@ -1517,13 +1528,17 @@ impl StateStore {
                     COALESCE((
                         SELECT json_group_array(json(usage.value))
                         FROM json_each(scan_payloads.payload_json, '$.usage') AS usage
-                        WHERE COALESCE(json_extract(usage.value, '$.last_seen_unix'), 0) >= ?1
+                        WHERE COALESCE(
+                            json_extract(usage.value, '$.last_seen_unix'),
+                            scan_payloads.updated_at) >= ?1
                     ), json('[]'))
                  ),
                  updated_at = CAST(strftime('%s', 'now') AS INTEGER) + 1
              WHERE EXISTS (
                 SELECT 1 FROM json_each(scan_payloads.payload_json, '$.usage') AS usage
-                WHERE COALESCE(json_extract(usage.value, '$.last_seen_unix'), 0) < ?1
+                WHERE COALESCE(
+                    json_extract(usage.value, '$.last_seen_unix'),
+                    scan_payloads.updated_at) < ?1
              )",
             [cutoff],
         )?;
@@ -2719,5 +2734,109 @@ mod tests {
             store.latest_scan_payload().unwrap().unwrap();
         assert_eq!(payload["usage"], serde_json::json!([]));
         assert_eq!(payload["coverage"][0]["denominator_reliable"], false);
+    }
+
+    #[test]
+    fn unknown_event_time_uses_observation_time_only_for_retention() {
+        let store = StateStore::open_in_memory().unwrap();
+        let scan = scan();
+        store.save_scan(&scan).unwrap();
+        store
+            .save_scan_payload(
+                &scan.id,
+                &serde_json::json!({
+                    "usage": [{
+                        "agent": "codex",
+                        "skill_id": "skill_fixture",
+                        "stage": "loaded",
+                        "quality": "observed",
+                        "event_count": 1,
+                        "first_seen_unix": null,
+                        "last_seen_unix": null,
+                        "source_path_digest": "private"
+                    }]
+                }),
+            )
+            .unwrap();
+        store
+            .connection
+            .execute("UPDATE scan_payloads SET updated_at = 200", [])
+            .unwrap();
+        let agent_id = store
+            .save_agent(&AgentRecord {
+                id: AgentId::new(),
+                kind: AgentKind::Codex,
+                display_name: "Codex".to_owned(),
+            })
+            .unwrap();
+        let skill_id = store
+            .save_skill(&SkillRecord {
+                id: SkillId::new(),
+                identity_key: "content:unknown-time".to_owned(),
+                name: "unknown-time".to_owned(),
+                description: None,
+                declared_source: None,
+                declared_revision: None,
+                content_digest: "sha256:unknown-time".to_owned(),
+                digest_version: 1,
+                governance_state: GovernanceState::Observed,
+                canonical_path: None,
+            })
+            .unwrap();
+        let evidence = EvidenceRecord {
+            id: EvidenceId::new(),
+            scan_id: scan.id,
+            kind: EvidenceKind::Usage,
+            quality: EvidenceQuality::Observed,
+            subject_type: "skill".to_owned(),
+            subject_id: skill_id.to_string(),
+            path: None,
+            digest: None,
+            details: serde_json::json!({
+                "event_count": 1,
+                "first_seen_unix": null,
+                "last_seen_unix": null
+            }),
+            observed_at: 200,
+        };
+        store.save_evidence(&evidence).unwrap();
+        store
+            .save_usage_event(&UsageEvent {
+                evidence_id: evidence.id,
+                skill_id,
+                agent_id,
+                stage: UsageStage::Loaded,
+                quality: EvidenceQuality::Observed,
+                source_path_digest: "sha256:unknown-time-source".to_owned(),
+                observed_event_count: 1,
+                occurred_at: 0,
+                outcome: None,
+            })
+            .unwrap();
+
+        assert_eq!(store.lifecycle_counts().unwrap().oldest_raw_usage_at, None);
+        assert_eq!(
+            store.export_lifecycle().unwrap()["usage_events"][0]["occurred_at"],
+            serde_json::Value::Null
+        );
+        assert_eq!(
+            store
+                .purge_usage_before(100)
+                .unwrap()
+                .deleted_raw_usage_rows,
+            0
+        );
+        assert_eq!(store.lifecycle_counts().unwrap().raw_usage_rows, 1);
+
+        let purged = store.purge_usage_before(300).unwrap();
+        assert_eq!(purged.aggregated_raw_usage_rows, 1);
+        assert_eq!(purged.deleted_raw_usage_rows, 1);
+        assert_eq!(purged.deleted_evidence_rows, 1);
+        let export = store.export_lifecycle().unwrap();
+        assert_eq!(export["usage_monthly_sources"][0]["first_seen_at"], 200);
+        assert_eq!(export["usage_monthly_sources"][0]["last_seen_at"], 200);
+        let (_, payload): (ScanId, serde_json::Value) =
+            store.latest_scan_payload().unwrap().unwrap();
+        assert_eq!(payload["usage"], serde_json::json!([]));
     }
 }

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -606,60 +606,24 @@ impl StateStore {
         let event_count = i64::try_from(event.observed_event_count).map_err(|_| {
             StorageError::InvalidData("usage event count exceeds SQLite range".to_owned())
         })?;
-        let previous: Option<i64> = self
-            .connection
-            .query_row(
-                "SELECT event_count FROM usage_observation_totals
-                 WHERE skill_id = ?1 AND agent_id = ?2 AND stage = ?3
-                   AND quality = ?4 AND source_path_digest = ?5",
-                params![
-                    event.skill_id.as_str(),
-                    event.agent_id.as_str(),
-                    stage,
-                    quality,
-                    event.source_path_digest,
-                ],
-                |row| row.get(0),
-            )
-            .optional()?;
-        let delta = event_count.saturating_sub(previous.unwrap_or_default());
-        if delta > 0 {
-            self.connection.execute(
-                "INSERT INTO usage_events
-                    (evidence_id, skill_id, agent_id, stage, quality, source_path_digest,
-                     event_delta, occurred_at, outcome)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-                params![
-                    event.evidence_id.as_str(),
-                    event.skill_id.as_str(),
-                    event.agent_id.as_str(),
-                    stage,
-                    quality,
-                    event.source_path_digest,
-                    delta,
-                    event.occurred_at,
-                    event.outcome,
-                ],
-            )?;
-        }
         self.connection.execute(
-            "INSERT INTO usage_observation_totals
-                (skill_id, agent_id, stage, quality, source_path_digest,
-                 event_count, first_seen_at, last_seen_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-             ON CONFLICT(skill_id, agent_id, stage, quality, source_path_digest)
-             DO UPDATE SET event_count = MAX(event_count, excluded.event_count),
-                first_seen_at = MIN(first_seen_at, excluded.first_seen_at),
-                last_seen_at = MAX(last_seen_at, excluded.last_seen_at)",
+            "INSERT INTO usage_events
+                (evidence_id, skill_id, agent_id, stage, quality, source_path_digest,
+                 observed_event_count, occurred_at, outcome)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             ON CONFLICT(skill_id, agent_id, stage, quality, source_path_digest,
+                         observed_event_count, occurred_at)
+             DO NOTHING",
             params![
+                event.evidence_id.as_str(),
                 event.skill_id.as_str(),
                 event.agent_id.as_str(),
                 stage,
                 quality,
                 event.source_path_digest,
                 event_count,
-                event.first_seen_at,
-                event.last_seen_at,
+                event.occurred_at,
+                event.outcome,
             ],
         )?;
         Ok(())
@@ -1396,7 +1360,8 @@ impl StateStore {
         Ok(LifecycleCounts {
             evidence_rows: table_count(&self.connection, "evidence")?,
             raw_usage_rows: table_count(&self.connection, "usage_events")?,
-            monthly_usage_rows: table_count(&self.connection, "usage_monthly")?,
+            monthly_usage_rows: table_count(&self.connection, "usage_monthly")?
+                + table_count(&self.connection, "usage_monthly_sources")?,
             oldest_raw_usage_at: self.connection.query_row(
                 "SELECT MIN(occurred_at) FROM usage_events",
                 [],
@@ -1448,10 +1413,22 @@ impl StateStore {
             "SELECT json_object(
                 'evidence_id', evidence_id, 'skill_id', skill_id, 'agent_id', agent_id,
                 'stage', stage, 'quality', quality, 'source_path_digest', source_path_digest,
-                'event_delta', event_delta, 'occurred_at', occurred_at, 'outcome', outcome)
+                'observed_event_count', observed_event_count,
+                'occurred_at', occurred_at, 'outcome', outcome)
              FROM usage_events ORDER BY occurred_at, evidence_id",
         )?;
-        let monthly = query_json_rows(
+        let monthly_sources = query_json_rows(
+            &self.connection,
+            "SELECT json_object(
+                'month_start', month_start, 'skill_id', skill_id, 'agent_id', agent_id,
+                'stage', stage, 'quality', quality,
+                'source_path_digest', source_path_digest,
+                'max_observed_event_count', max_observed_event_count,
+                'first_seen_at', first_seen_at, 'last_seen_at', last_seen_at)
+             FROM usage_monthly_sources
+             ORDER BY month_start, skill_id, agent_id, stage, quality, source_path_digest",
+        )?;
+        let monthly_legacy = query_json_rows(
             &self.connection,
             "SELECT json_object(
                 'month_start', month_start, 'skill_id', skill_id, 'agent_id', agent_id,
@@ -1463,7 +1440,8 @@ impl StateStore {
         Ok(serde_json::json!({
             "evidence": evidence,
             "usage_events": usage,
-            "usage_monthly": monthly,
+            "usage_monthly_sources": monthly_sources,
+            "usage_monthly_legacy": monthly_legacy,
         }))
     }
 
@@ -1475,26 +1453,23 @@ impl StateStore {
             |row| row.get(0),
         )?;
         transaction.execute(
-            "INSERT INTO usage_monthly
-                (month_start, skill_id, agent_id, stage, quality, event_count,
-                 first_seen_at, last_seen_at, derivation)
+            "INSERT INTO usage_monthly_sources
+                (month_start, skill_id, agent_id, stage, quality, source_path_digest,
+                 max_observed_event_count, first_seen_at, last_seen_at)
              SELECT CAST(strftime('%s', strftime('%Y-%m-01', u.occurred_at, 'unixepoch')) AS INTEGER),
-                    u.skill_id, u.agent_id, u.stage, u.quality,
-                    SUM(u.event_delta),
-                    MIN(u.occurred_at), MAX(u.occurred_at), 'source_delta'
-             FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
+                    u.skill_id, u.agent_id, u.stage, u.quality, u.source_path_digest,
+                    MAX(u.observed_event_count), MIN(u.occurred_at), MAX(u.occurred_at)
+             FROM usage_events u
              WHERE u.occurred_at < ?1
              GROUP BY strftime('%Y-%m', u.occurred_at, 'unixepoch'),
-                      u.skill_id, u.agent_id, u.stage, u.quality
-             ON CONFLICT(month_start, skill_id, agent_id, stage, quality) DO UPDATE SET
-                event_count = usage_monthly.event_count + excluded.event_count,
-                first_seen_at = MIN(usage_monthly.first_seen_at, excluded.first_seen_at),
-                last_seen_at = MAX(usage_monthly.last_seen_at, excluded.last_seen_at),
-                derivation = CASE
-                    WHEN usage_monthly.derivation = excluded.derivation
-                    THEN usage_monthly.derivation
-                    ELSE 'mixed_legacy_and_source_delta'
-                END",
+                      u.skill_id, u.agent_id, u.stage, u.quality, u.source_path_digest
+             ON CONFLICT(month_start, skill_id, agent_id, stage, quality, source_path_digest)
+             DO UPDATE SET
+                max_observed_event_count = MAX(
+                    usage_monthly_sources.max_observed_event_count,
+                    excluded.max_observed_event_count),
+                first_seen_at = MIN(usage_monthly_sources.first_seen_at, excluded.first_seen_at),
+                last_seen_at = MAX(usage_monthly_sources.last_seen_at, excluded.last_seen_at)",
             [cutoff],
         )?;
         transaction.execute_batch(
@@ -1857,52 +1832,47 @@ fn migration_v9(transaction: &Transaction<'_>) -> StorageResult<()> {
             stage TEXT NOT NULL,
             quality TEXT NOT NULL,
             source_path_digest TEXT NOT NULL,
-            event_delta INTEGER NOT NULL,
+            observed_event_count INTEGER NOT NULL,
             occurred_at INTEGER NOT NULL,
-            outcome TEXT
+            outcome TEXT,
+            UNIQUE(skill_id, agent_id, stage, quality, source_path_digest,
+                   observed_event_count, occurred_at)
          );
          INSERT INTO usage_events
             (evidence_id, skill_id, agent_id, stage, quality, source_path_digest,
-             event_delta, occurred_at, outcome)
+             observed_event_count, occurred_at, outcome)
          SELECT evidence_id, skill_id, agent_id, stage, quality, source_path_digest,
-                event_delta, occurred_at, outcome
+                observed_event_count, occurred_at, outcome
          FROM (
             SELECT u.evidence_id, u.skill_id, u.agent_id, u.stage, u.quality,
                    COALESCE(json_extract(e.details_json, '$.source_path_digest'), e.digest, '')
                        AS source_path_digest,
-                   COALESCE(json_extract(e.details_json, '$.event_count'), 1) AS event_delta,
+                   COALESCE(json_extract(e.details_json, '$.event_count'), 1)
+                       AS observed_event_count,
                    u.occurred_at, u.outcome,
                    ROW_NUMBER() OVER (
                        PARTITION BY u.skill_id, u.agent_id, u.stage, u.quality,
-                           COALESCE(json_extract(e.details_json, '$.source_path_digest'), e.digest, '')
-                       ORDER BY COALESCE(json_extract(e.details_json, '$.event_count'), 1) DESC,
-                                u.occurred_at DESC, u.evidence_id DESC
+                           COALESCE(json_extract(e.details_json, '$.source_path_digest'), e.digest, ''),
+                           COALESCE(json_extract(e.details_json, '$.event_count'), 1),
+                           u.occurred_at
+                       ORDER BY u.evidence_id DESC
                    ) AS rank
             FROM usage_events_v8 u JOIN evidence e ON e.id = u.evidence_id
          ) WHERE rank = 1;
          DROP TABLE usage_events_v8;
          CREATE INDEX usage_events_skill_time ON usage_events(skill_id, occurred_at);
-         CREATE TABLE usage_observation_totals (
+         CREATE TABLE usage_monthly_sources (
+            month_start INTEGER NOT NULL,
             skill_id TEXT NOT NULL REFERENCES skills(id),
             agent_id TEXT NOT NULL REFERENCES agents(id),
             stage TEXT NOT NULL,
             quality TEXT NOT NULL,
             source_path_digest TEXT NOT NULL,
-            event_count INTEGER NOT NULL,
+            max_observed_event_count INTEGER NOT NULL,
             first_seen_at INTEGER NOT NULL,
             last_seen_at INTEGER NOT NULL,
-            PRIMARY KEY(skill_id, agent_id, stage, quality, source_path_digest)
-         );
-         INSERT INTO usage_observation_totals
-            (skill_id, agent_id, stage, quality, source_path_digest,
-             event_count, first_seen_at, last_seen_at)
-         SELECT u.skill_id, u.agent_id, u.stage, u.quality, u.source_path_digest,
-                u.event_delta,
-                MIN(COALESCE(json_extract(e.details_json, '$.first_seen_unix'), u.occurred_at)),
-                MAX(COALESCE(json_extract(e.details_json, '$.last_seen_unix'), u.occurred_at))
-         FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
-         GROUP BY u.skill_id, u.agent_id, u.stage, u.quality,
-                  u.source_path_digest;",
+            PRIMARY KEY(month_start, skill_id, agent_id, stage, quality, source_path_digest)
+         );",
     )?;
     Ok(())
 }
@@ -2168,7 +2138,7 @@ mod tests {
     }
 
     #[test]
-    fn migration_deduplicates_unchanged_v8_usage_observations_conservatively() {
+    fn migration_preserves_distinct_v8_observations_without_combining_legacy_totals() {
         let mut connection = Connection::open_in_memory().unwrap();
         connection
             .pragma_update(None, "foreign_keys", true)
@@ -2250,10 +2220,11 @@ mod tests {
 
         let store = StateStore::initialize(connection).unwrap();
         let export = store.export_lifecycle().unwrap();
-        assert_eq!(export["usage_events"].as_array().unwrap().len(), 1);
-        assert_eq!(export["usage_events"][0]["event_delta"], 2);
+        assert_eq!(export["usage_events"].as_array().unwrap().len(), 2);
+        assert_eq!(export["usage_events"][0]["observed_event_count"], 1);
+        assert_eq!(export["usage_events"][1]["observed_event_count"], 2);
         assert_eq!(
-            export["usage_monthly"][0]["derivation"],
+            export["usage_monthly_legacy"][0]["derivation"],
             "legacy_scan_aggregate"
         );
         assert_eq!(
@@ -2261,16 +2232,18 @@ mod tests {
                 .purge_usage_before(100)
                 .unwrap()
                 .aggregated_raw_usage_rows,
-            1
+            2
         );
         let retained = store.export_lifecycle().unwrap();
-        let source_delta = retained["usage_monthly"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .find(|row| row["derivation"] == "source_delta")
-            .unwrap();
-        assert_eq!(source_delta["event_count"], 2);
+        assert_eq!(
+            retained["usage_monthly_sources"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(
+            retained["usage_monthly_sources"][0]["max_observed_event_count"],
+            2
+        );
+        assert_eq!(retained["usage_monthly_legacy"][0]["event_count"], 7);
     }
 
     #[test]
@@ -2684,14 +2657,12 @@ mod tests {
         store
             .save_usage_event(&UsageEvent {
                 evidence_id: evidence.id,
-                skill_id,
-                agent_id,
+                skill_id: skill_id.clone(),
+                agent_id: agent_id.clone(),
                 stage: UsageStage::Loaded,
                 quality: EvidenceQuality::Observed,
                 source_path_digest: "sha256:retention-source".to_owned(),
                 observed_event_count: 3,
-                first_seen_at: 10,
-                last_seen_at: 10,
                 occurred_at: 10,
                 outcome: None,
             })
@@ -2706,7 +2677,44 @@ mod tests {
         assert_eq!(counts.raw_usage_rows, 0);
         assert_eq!(counts.monthly_usage_rows, 1);
         let export = store.export_lifecycle().unwrap();
-        assert_eq!(export["usage_monthly"][0]["event_count"], 3);
+        assert_eq!(
+            export["usage_monthly_sources"][0]["max_observed_event_count"],
+            3
+        );
+
+        let repeated_evidence = EvidenceRecord {
+            id: EvidenceId::new(),
+            scan_id: scan.id.clone(),
+            kind: EvidenceKind::Usage,
+            quality: EvidenceQuality::Observed,
+            subject_type: "skill".to_owned(),
+            subject_id: skill_id.to_string(),
+            path: None,
+            digest: None,
+            details: serde_json::json!({"event_count": 3}),
+            observed_at: 20,
+        };
+        store.save_evidence(&repeated_evidence).unwrap();
+        store
+            .save_usage_event(&UsageEvent {
+                evidence_id: repeated_evidence.id,
+                skill_id,
+                agent_id,
+                stage: UsageStage::Loaded,
+                quality: EvidenceQuality::Observed,
+                source_path_digest: "sha256:retention-source".to_owned(),
+                observed_event_count: 3,
+                occurred_at: 20,
+                outcome: None,
+            })
+            .unwrap();
+        store.purge_usage_before(100).unwrap();
+        let repeated_export = store.export_lifecycle().unwrap();
+        assert_eq!(
+            repeated_export["usage_monthly_sources"][0]["max_observed_event_count"],
+            3
+        );
+
         let (_, payload): (ScanId, serde_json::Value) =
             store.latest_scan_payload().unwrap().unwrap();
         assert_eq!(payload["usage"], serde_json::json!([]));

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -606,14 +606,21 @@ impl StateStore {
         let event_count = i64::try_from(event.observed_event_count).map_err(|_| {
             StorageError::InvalidData("usage event count exceeds SQLite range".to_owned())
         })?;
+        let conflict_clause = if event.occurred_at.is_some() {
+            "ON CONFLICT(skill_id, agent_id, stage, quality, source_path_digest,
+                         observed_event_count, occurred_at) DO NOTHING"
+        } else {
+            "ON CONFLICT(skill_id, agent_id, stage, quality, source_path_digest,
+                         observed_event_count) WHERE occurred_at IS NULL DO NOTHING"
+        };
         self.connection.execute(
-            "INSERT INTO usage_events
+            &format!(
+                "INSERT INTO usage_events
                 (evidence_id, skill_id, agent_id, stage, quality, source_path_digest,
                  observed_event_count, occurred_at, outcome)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-             ON CONFLICT(skill_id, agent_id, stage, quality, source_path_digest,
-                         observed_event_count, occurred_at)
-             DO NOTHING",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 {conflict_clause}"
+            ),
             params![
                 event.evidence_id.as_str(),
                 event.skill_id.as_str(),
@@ -1363,7 +1370,7 @@ impl StateStore {
             monthly_usage_rows: table_count(&self.connection, "usage_monthly")?
                 + table_count(&self.connection, "usage_monthly_sources")?,
             oldest_raw_usage_at: self.connection.query_row(
-                "SELECT MIN(NULLIF(occurred_at, 0)) FROM usage_events",
+                "SELECT MIN(occurred_at) FROM usage_events",
                 [],
                 |row| row.get(0),
             )?,
@@ -1414,7 +1421,7 @@ impl StateStore {
                 'evidence_id', evidence_id, 'skill_id', skill_id, 'agent_id', agent_id,
                 'stage', stage, 'quality', quality, 'source_path_digest', source_path_digest,
                 'observed_event_count', observed_event_count,
-                'occurred_at', NULLIF(occurred_at, 0), 'outcome', outcome)
+                'occurred_at', occurred_at, 'outcome', outcome)
              FROM usage_events ORDER BY occurred_at, evidence_id",
         )?;
         let monthly_sources = query_json_rows(
@@ -1450,7 +1457,7 @@ impl StateStore {
         let aggregated_raw_usage_rows: u64 = transaction.query_row(
             "SELECT COUNT(*)
              FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
-             WHERE COALESCE(NULLIF(u.occurred_at, 0), e.observed_at) < ?1",
+             WHERE COALESCE(u.occurred_at, e.observed_at) < ?1",
             [cutoff],
             |row| row.get(0),
         )?;
@@ -1463,7 +1470,7 @@ impl StateStore {
                     MAX(u.observed_event_count), MIN(u.retention_at), MAX(u.retention_at)
              FROM (
                 SELECT u.*,
-                       COALESCE(NULLIF(u.occurred_at, 0), e.observed_at) AS retention_at
+                       COALESCE(u.occurred_at, e.observed_at) AS retention_at
                 FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
              ) u
              WHERE u.retention_at < ?1
@@ -1487,7 +1494,7 @@ impl StateStore {
             "INSERT INTO purge_usage_evidence (evidence_id)
              SELECT u.evidence_id
              FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
-             WHERE COALESCE(NULLIF(u.occurred_at, 0), e.observed_at) < ?1
+             WHERE COALESCE(u.occurred_at, e.observed_at) < ?1
              UNION
              SELECT id FROM evidence
              WHERE kind = 'usage'
@@ -1848,11 +1855,15 @@ fn migration_v9(transaction: &Transaction<'_>) -> StorageResult<()> {
             quality TEXT NOT NULL,
             source_path_digest TEXT NOT NULL,
             observed_event_count INTEGER NOT NULL,
-            occurred_at INTEGER NOT NULL,
+            occurred_at INTEGER,
             outcome TEXT,
             UNIQUE(skill_id, agent_id, stage, quality, source_path_digest,
                    observed_event_count, occurred_at)
          );
+         CREATE UNIQUE INDEX usage_events_unknown_identity
+            ON usage_events(skill_id, agent_id, stage, quality, source_path_digest,
+                            observed_event_count)
+            WHERE occurred_at IS NULL;
          INSERT INTO usage_events
             (evidence_id, skill_id, agent_id, stage, quality, source_path_digest,
              observed_event_count, occurred_at, outcome)
@@ -2678,7 +2689,7 @@ mod tests {
                 quality: EvidenceQuality::Observed,
                 source_path_digest: "sha256:retention-source".to_owned(),
                 observed_event_count: 3,
-                occurred_at: 10,
+                occurred_at: Some(10),
                 outcome: None,
             })
             .unwrap();
@@ -2719,7 +2730,7 @@ mod tests {
                 quality: EvidenceQuality::Observed,
                 source_path_digest: "sha256:retention-source".to_owned(),
                 observed_event_count: 3,
-                occurred_at: 20,
+                occurred_at: Some(20),
                 outcome: None,
             })
             .unwrap();
@@ -2785,7 +2796,7 @@ mod tests {
             .unwrap();
         let evidence = EvidenceRecord {
             id: EvidenceId::new(),
-            scan_id: scan.id,
+            scan_id: scan.id.clone(),
             kind: EvidenceKind::Usage,
             quality: EvidenceQuality::Observed,
             subject_type: "skill".to_owned(),
@@ -2802,17 +2813,33 @@ mod tests {
         store.save_evidence(&evidence).unwrap();
         store
             .save_usage_event(&UsageEvent {
-                evidence_id: evidence.id,
-                skill_id,
-                agent_id,
+                evidence_id: evidence.id.clone(),
+                skill_id: skill_id.clone(),
+                agent_id: agent_id.clone(),
                 stage: UsageStage::Loaded,
                 quality: EvidenceQuality::Observed,
                 source_path_digest: "sha256:unknown-time-source".to_owned(),
                 observed_event_count: 1,
-                occurred_at: 0,
+                occurred_at: None,
                 outcome: None,
             })
             .unwrap();
+        assert!(
+            store
+                .save_usage_event(&UsageEvent {
+                    evidence_id: evidence.id,
+                    skill_id: skill_id.clone(),
+                    agent_id: agent_id.clone(),
+                    stage: UsageStage::Loaded,
+                    quality: EvidenceQuality::Observed,
+                    source_path_digest: "sha256:different-identity".to_owned(),
+                    observed_event_count: 2,
+                    occurred_at: None,
+                    outcome: None,
+                })
+                .is_err(),
+            "a primary-key collision with a different observation identity must fail closed"
+        );
 
         assert_eq!(store.lifecycle_counts().unwrap().oldest_raw_usage_at, None);
         assert_eq!(
@@ -2828,13 +2855,60 @@ mod tests {
         );
         assert_eq!(store.lifecycle_counts().unwrap().raw_usage_rows, 1);
 
+        let epoch_evidence = EvidenceRecord {
+            id: EvidenceId::new(),
+            scan_id: scan.id,
+            kind: EvidenceKind::Usage,
+            quality: EvidenceQuality::Observed,
+            subject_type: "skill".to_owned(),
+            subject_id: skill_id.to_string(),
+            path: None,
+            digest: None,
+            details: serde_json::json!({"event_count": 1, "last_seen_unix": 0}),
+            observed_at: 200,
+        };
+        store.save_evidence(&epoch_evidence).unwrap();
+        store
+            .save_usage_event(&UsageEvent {
+                evidence_id: epoch_evidence.id,
+                skill_id,
+                agent_id,
+                stage: UsageStage::Loaded,
+                quality: EvidenceQuality::Observed,
+                source_path_digest: "sha256:epoch-time-source".to_owned(),
+                observed_event_count: 1,
+                occurred_at: Some(0),
+                outcome: None,
+            })
+            .unwrap();
+        assert_eq!(
+            store.lifecycle_counts().unwrap().oldest_raw_usage_at,
+            Some(0)
+        );
+        assert!(
+            store.export_lifecycle().unwrap()["usage_events"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|event| event["occurred_at"] == 0)
+        );
+        let epoch_purge = store.purge_usage_before(100).unwrap();
+        assert_eq!(epoch_purge.deleted_raw_usage_rows, 1);
+        assert_eq!(store.lifecycle_counts().unwrap().raw_usage_rows, 1);
+
         let purged = store.purge_usage_before(300).unwrap();
         assert_eq!(purged.aggregated_raw_usage_rows, 1);
         assert_eq!(purged.deleted_raw_usage_rows, 1);
         assert_eq!(purged.deleted_evidence_rows, 1);
         let export = store.export_lifecycle().unwrap();
-        assert_eq!(export["usage_monthly_sources"][0]["first_seen_at"], 200);
-        assert_eq!(export["usage_monthly_sources"][0]["last_seen_at"], 200);
+        let unknown_month = export["usage_monthly_sources"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["source_path_digest"] == "sha256:unknown-time-source")
+            .unwrap();
+        assert_eq!(unknown_month["first_seen_at"], 200);
+        assert_eq!(unknown_month["last_seen_at"], 200);
         let (_, payload): (ScanId, serde_json::Value) =
             store.latest_scan_payload().unwrap().unwrap();
         assert_eq!(payload["usage"], serde_json::json!([]));

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -10,7 +10,7 @@ use crate::model::{
     RosterEntry, ScanId, ScanRun, SkillId, SkillRecord, UsageEvent,
 };
 
-const SCHEMA_VERSION: i64 = 8;
+const SCHEMA_VERSION: i64 = 9;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct LifecycleCounts {
@@ -210,6 +210,13 @@ impl StateStore {
         if current == 7 {
             let transaction = self.connection.transaction()?;
             migration_v8(&transaction)?;
+            transaction.pragma_update(None, "user_version", 8_i64)?;
+            transaction.commit()?;
+            current = 8;
+        }
+        if current == 8 {
+            let transaction = self.connection.transaction()?;
+            migration_v9(&transaction)?;
             transaction.pragma_update(None, "user_version", SCHEMA_VERSION)?;
             transaction.commit()?;
         }
@@ -594,18 +601,65 @@ impl StateStore {
     }
 
     pub fn save_usage_event(&self, event: &UsageEvent) -> StorageResult<()> {
+        let stage = enum_text(&event.stage)?;
+        let quality = enum_text(&event.quality)?;
+        let event_count = i64::try_from(event.observed_event_count).map_err(|_| {
+            StorageError::InvalidData("usage event count exceeds SQLite range".to_owned())
+        })?;
+        let previous: Option<i64> = self
+            .connection
+            .query_row(
+                "SELECT event_count FROM usage_observation_totals
+                 WHERE skill_id = ?1 AND agent_id = ?2 AND stage = ?3
+                   AND quality = ?4 AND source_path_digest = ?5",
+                params![
+                    event.skill_id.as_str(),
+                    event.agent_id.as_str(),
+                    stage,
+                    quality,
+                    event.source_path_digest,
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let delta = event_count.saturating_sub(previous.unwrap_or_default());
+        if delta > 0 {
+            self.connection.execute(
+                "INSERT INTO usage_events
+                    (evidence_id, skill_id, agent_id, stage, quality, source_path_digest,
+                     event_delta, occurred_at, outcome)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    event.evidence_id.as_str(),
+                    event.skill_id.as_str(),
+                    event.agent_id.as_str(),
+                    stage,
+                    quality,
+                    event.source_path_digest,
+                    delta,
+                    event.occurred_at,
+                    event.outcome,
+                ],
+            )?;
+        }
         self.connection.execute(
-            "INSERT INTO usage_events
-                (evidence_id, skill_id, agent_id, stage, quality, occurred_at, outcome)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO usage_observation_totals
+                (skill_id, agent_id, stage, quality, source_path_digest,
+                 event_count, first_seen_at, last_seen_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(skill_id, agent_id, stage, quality, source_path_digest)
+             DO UPDATE SET event_count = MAX(event_count, excluded.event_count),
+                first_seen_at = MIN(first_seen_at, excluded.first_seen_at),
+                last_seen_at = MAX(last_seen_at, excluded.last_seen_at)",
             params![
-                event.evidence_id.as_str(),
                 event.skill_id.as_str(),
                 event.agent_id.as_str(),
-                enum_text(&event.stage)?,
-                enum_text(&event.quality)?,
-                event.occurred_at,
-                event.outcome,
+                stage,
+                quality,
+                event.source_path_digest,
+                event_count,
+                event.first_seen_at,
+                event.last_seen_at,
             ],
         )?;
         Ok(())
@@ -1393,8 +1447,8 @@ impl StateStore {
             &self.connection,
             "SELECT json_object(
                 'evidence_id', evidence_id, 'skill_id', skill_id, 'agent_id', agent_id,
-                'stage', stage, 'quality', quality, 'occurred_at', occurred_at,
-                'outcome', outcome)
+                'stage', stage, 'quality', quality, 'source_path_digest', source_path_digest,
+                'event_delta', event_delta, 'occurred_at', occurred_at, 'outcome', outcome)
              FROM usage_events ORDER BY occurred_at, evidence_id",
         )?;
         let monthly = query_json_rows(
@@ -1402,7 +1456,8 @@ impl StateStore {
             "SELECT json_object(
                 'month_start', month_start, 'skill_id', skill_id, 'agent_id', agent_id,
                 'stage', stage, 'quality', quality, 'event_count', event_count,
-                'first_seen_at', first_seen_at, 'last_seen_at', last_seen_at)
+                'first_seen_at', first_seen_at, 'last_seen_at', last_seen_at,
+                'derivation', derivation)
              FROM usage_monthly ORDER BY month_start, skill_id, agent_id, stage, quality",
         )?;
         Ok(serde_json::json!({
@@ -1422,11 +1477,11 @@ impl StateStore {
         transaction.execute(
             "INSERT INTO usage_monthly
                 (month_start, skill_id, agent_id, stage, quality, event_count,
-                 first_seen_at, last_seen_at)
+                 first_seen_at, last_seen_at, derivation)
              SELECT CAST(strftime('%s', strftime('%Y-%m-01', u.occurred_at, 'unixepoch')) AS INTEGER),
                     u.skill_id, u.agent_id, u.stage, u.quality,
-                    SUM(COALESCE(json_extract(e.details_json, '$.event_count'), 1)),
-                    MIN(u.occurred_at), MAX(u.occurred_at)
+                    SUM(u.event_delta),
+                    MIN(u.occurred_at), MAX(u.occurred_at), 'source_delta'
              FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
              WHERE u.occurred_at < ?1
              GROUP BY strftime('%Y-%m', u.occurred_at, 'unixepoch'),
@@ -1434,7 +1489,12 @@ impl StateStore {
              ON CONFLICT(month_start, skill_id, agent_id, stage, quality) DO UPDATE SET
                 event_count = usage_monthly.event_count + excluded.event_count,
                 first_seen_at = MIN(usage_monthly.first_seen_at, excluded.first_seen_at),
-                last_seen_at = MAX(usage_monthly.last_seen_at, excluded.last_seen_at)",
+                last_seen_at = MAX(usage_monthly.last_seen_at, excluded.last_seen_at),
+                derivation = CASE
+                    WHEN usage_monthly.derivation = excluded.derivation
+                    THEN usage_monthly.derivation
+                    ELSE 'mixed_legacy_and_source_delta'
+                END",
             [cutoff],
         )?;
         transaction.execute_batch(
@@ -1444,7 +1504,11 @@ impl StateStore {
         )?;
         transaction.execute(
             "INSERT INTO purge_usage_evidence (evidence_id)
-             SELECT evidence_id FROM usage_events WHERE occurred_at < ?1",
+             SELECT evidence_id FROM usage_events WHERE occurred_at < ?1
+             UNION
+             SELECT id FROM evidence
+             WHERE kind = 'usage'
+               AND COALESCE(json_extract(details_json, '$.last_seen_unix'), observed_at) < ?1",
             [cutoff],
         )?;
         transaction.execute(
@@ -1780,6 +1844,69 @@ fn migration_v8(transaction: &Transaction<'_>) -> StorageResult<()> {
     Ok(())
 }
 
+fn migration_v9(transaction: &Transaction<'_>) -> StorageResult<()> {
+    transaction.execute_batch(
+        "ALTER TABLE usage_monthly ADD COLUMN derivation TEXT NOT NULL
+            DEFAULT 'legacy_scan_aggregate';
+         DROP INDEX usage_events_skill_time;
+         ALTER TABLE usage_events RENAME TO usage_events_v8;
+         CREATE TABLE usage_events (
+            evidence_id TEXT PRIMARY KEY REFERENCES evidence(id),
+            skill_id TEXT NOT NULL REFERENCES skills(id),
+            agent_id TEXT NOT NULL REFERENCES agents(id),
+            stage TEXT NOT NULL,
+            quality TEXT NOT NULL,
+            source_path_digest TEXT NOT NULL,
+            event_delta INTEGER NOT NULL,
+            occurred_at INTEGER NOT NULL,
+            outcome TEXT
+         );
+         INSERT INTO usage_events
+            (evidence_id, skill_id, agent_id, stage, quality, source_path_digest,
+             event_delta, occurred_at, outcome)
+         SELECT evidence_id, skill_id, agent_id, stage, quality, source_path_digest,
+                event_delta, occurred_at, outcome
+         FROM (
+            SELECT u.evidence_id, u.skill_id, u.agent_id, u.stage, u.quality,
+                   COALESCE(json_extract(e.details_json, '$.source_path_digest'), e.digest, '')
+                       AS source_path_digest,
+                   COALESCE(json_extract(e.details_json, '$.event_count'), 1) AS event_delta,
+                   u.occurred_at, u.outcome,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY u.skill_id, u.agent_id, u.stage, u.quality,
+                           COALESCE(json_extract(e.details_json, '$.source_path_digest'), e.digest, '')
+                       ORDER BY COALESCE(json_extract(e.details_json, '$.event_count'), 1) DESC,
+                                u.occurred_at DESC, u.evidence_id DESC
+                   ) AS rank
+            FROM usage_events_v8 u JOIN evidence e ON e.id = u.evidence_id
+         ) WHERE rank = 1;
+         DROP TABLE usage_events_v8;
+         CREATE INDEX usage_events_skill_time ON usage_events(skill_id, occurred_at);
+         CREATE TABLE usage_observation_totals (
+            skill_id TEXT NOT NULL REFERENCES skills(id),
+            agent_id TEXT NOT NULL REFERENCES agents(id),
+            stage TEXT NOT NULL,
+            quality TEXT NOT NULL,
+            source_path_digest TEXT NOT NULL,
+            event_count INTEGER NOT NULL,
+            first_seen_at INTEGER NOT NULL,
+            last_seen_at INTEGER NOT NULL,
+            PRIMARY KEY(skill_id, agent_id, stage, quality, source_path_digest)
+         );
+         INSERT INTO usage_observation_totals
+            (skill_id, agent_id, stage, quality, source_path_digest,
+             event_count, first_seen_at, last_seen_at)
+         SELECT u.skill_id, u.agent_id, u.stage, u.quality, u.source_path_digest,
+                u.event_delta,
+                MIN(COALESCE(json_extract(e.details_json, '$.first_seen_unix'), u.occurred_at)),
+                MAX(COALESCE(json_extract(e.details_json, '$.last_seen_unix'), u.occurred_at))
+         FROM usage_events u JOIN evidence e ON e.id = u.evidence_id
+         GROUP BY u.skill_id, u.agent_id, u.stage, u.quality,
+                  u.source_path_digest;",
+    )?;
+    Ok(())
+}
+
 fn table_count(connection: &Connection, table: &str) -> StorageResult<u64> {
     let query = format!("SELECT COUNT(*) FROM {table}");
     Ok(connection.query_row(&query, [], |row| row.get(0))?)
@@ -2004,7 +2131,7 @@ mod tests {
 
     #[test]
     fn migration_upgrades_prior_states_sequentially() {
-        for starting_version in [1_i64, 2, 3, 4, 5] {
+        for starting_version in [1_i64, 2, 3, 4, 5, 6, 7, 8] {
             let mut connection = Connection::open_in_memory().unwrap();
             let transaction = connection.transaction().unwrap();
             migration_v1(&transaction).unwrap();
@@ -2020,6 +2147,15 @@ mod tests {
             if starting_version >= 5 {
                 migration_v5(&transaction).unwrap();
             }
+            if starting_version >= 6 {
+                migration_v6(&transaction).unwrap();
+            }
+            if starting_version >= 7 {
+                migration_v7(&transaction).unwrap();
+            }
+            if starting_version >= 8 {
+                migration_v8(&transaction).unwrap();
+            }
             transaction
                 .pragma_update(None, "user_version", starting_version)
                 .unwrap();
@@ -2029,6 +2165,112 @@ mod tests {
             assert_eq!(store.schema_version().unwrap(), SCHEMA_VERSION);
             assert_eq!(store.lifecycle_counts().unwrap().monthly_usage_rows, 0);
         }
+    }
+
+    #[test]
+    fn migration_deduplicates_unchanged_v8_usage_observations_conservatively() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", true)
+            .unwrap();
+        let transaction = connection.transaction().unwrap();
+        migration_v1(&transaction).unwrap();
+        migration_v2(&transaction).unwrap();
+        migration_v3(&transaction).unwrap();
+        migration_v4(&transaction).unwrap();
+        migration_v5(&transaction).unwrap();
+        migration_v6(&transaction).unwrap();
+        migration_v7(&transaction).unwrap();
+        migration_v8(&transaction).unwrap();
+        transaction
+            .execute(
+                "INSERT INTO scans VALUES ('scan_v8', 1, 2, 'completed', '[]')",
+                [],
+            )
+            .unwrap();
+        transaction
+            .execute(
+                "INSERT INTO agents VALUES ('agent_v8', 'codex', 'Codex')",
+                [],
+            )
+            .unwrap();
+        transaction
+            .execute(
+                "INSERT INTO skills
+                    (id, identity_key, name, content_digest, digest_version, governance_state)
+                 VALUES ('skill_v8', 'content:v8', 'v8', 'sha256:v8', 1, 'observed')",
+                [],
+            )
+            .unwrap();
+        for (evidence_id, event_count, observed_at) in
+            [("evidence_v8_a", 1_i64, 10_i64), ("evidence_v8_b", 2, 20)]
+        {
+            transaction
+                .execute(
+                    "INSERT INTO evidence
+                        (id, scan_id, kind, quality, subject_type, subject_id, digest,
+                         details_json, observed_at)
+                     VALUES (?1, 'scan_v8', 'usage', 'observed', 'skill', 'skill_v8',
+                             'sha256:source', ?2, ?3)",
+                    params![
+                        evidence_id,
+                        serde_json::json!({
+                            "source_path_digest": "sha256:source",
+                            "event_count": event_count,
+                            "first_seen_unix": 10,
+                            "last_seen_unix": observed_at,
+                        })
+                        .to_string(),
+                        observed_at,
+                    ],
+                )
+                .unwrap();
+            transaction
+                .execute(
+                    "INSERT INTO usage_events
+                        (evidence_id, skill_id, agent_id, stage, quality, occurred_at)
+                     VALUES (?1, 'skill_v8', 'agent_v8', 'loaded', 'observed', ?2)",
+                    params![evidence_id, observed_at],
+                )
+                .unwrap();
+        }
+        transaction
+            .execute(
+                "INSERT INTO usage_monthly
+                    (month_start, skill_id, agent_id, stage, quality, event_count,
+                     first_seen_at, last_seen_at)
+                 VALUES (1000, 'skill_v8', 'agent_v8', 'loaded', 'observed', 7, 1, 2)",
+                [],
+            )
+            .unwrap();
+        transaction
+            .pragma_update(None, "user_version", 8_i64)
+            .unwrap();
+        transaction.commit().unwrap();
+
+        let store = StateStore::initialize(connection).unwrap();
+        let export = store.export_lifecycle().unwrap();
+        assert_eq!(export["usage_events"].as_array().unwrap().len(), 1);
+        assert_eq!(export["usage_events"][0]["event_delta"], 2);
+        assert_eq!(
+            export["usage_monthly"][0]["derivation"],
+            "legacy_scan_aggregate"
+        );
+        assert_eq!(
+            store
+                .purge_usage_before(100)
+                .unwrap()
+                .aggregated_raw_usage_rows,
+            1
+        );
+        let retained = store.export_lifecycle().unwrap();
+        let source_delta = retained["usage_monthly"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["derivation"] == "source_delta")
+            .unwrap();
+        assert_eq!(source_delta["event_count"], 2);
     }
 
     #[test]
@@ -2446,6 +2688,10 @@ mod tests {
                 agent_id,
                 stage: UsageStage::Loaded,
                 quality: EvidenceQuality::Observed,
+                source_path_digest: "sha256:retention-source".to_owned(),
+                observed_event_count: 3,
+                first_seen_at: 10,
+                last_seen_at: 10,
                 occurred_at: 10,
                 outcome: None,
             })

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2124,7 +2124,7 @@ fn unchanged_rescans_do_not_multiply_exported_usage_observations() {
     fs::write(skill.join("SKILL.md"), "---\nname: example\n---\nbody\n").unwrap();
     fs::write(
         &session,
-        "{\"type\":\"invoke_skill\",\"invoked_skill\":\"example\"}\n",
+        "{\"timestamp\":\"1970-01-01T00:00:10Z\",\"type\":\"invoke_skill\",\"invoked_skill\":\"example\"}\n",
     )
     .unwrap();
     fs::File::options()
@@ -2158,7 +2158,14 @@ fn unchanged_rescans_do_not_multiply_exported_usage_observations() {
     ));
     let first: Value = serde_json::from_slice(&fs::read(&first_export).unwrap()).unwrap();
     assert_eq!(first["data"]["usage_events"].as_array().unwrap().len(), 1);
+    assert_eq!(first["data"]["usage_events"][0]["occurred_at"], 10);
 
+    fs::File::options()
+        .write(true)
+        .open(&session)
+        .unwrap()
+        .set_times(FileTimes::new().set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(15)))
+        .unwrap();
     json_output(&run(&[&common[..], &["scan"]].concat(), None));
     let second_export = temp.path().join("second-export.json");
     json_output(&run(
@@ -2180,7 +2187,7 @@ fn unchanged_rescans_do_not_multiply_exported_usage_observations() {
     let mut session_file = OpenOptions::new().append(true).open(&session).unwrap();
     writeln!(
         session_file,
-        "{{\"type\":\"invoke_skill\",\"invoked_skill\":\"example\"}}"
+        "{{\"timestamp\":\"1970-01-01T00:00:20Z\",\"type\":\"invoke_skill\",\"invoked_skill\":\"example\"}}"
     )
     .unwrap();
     session_file

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2224,6 +2224,7 @@ fn unchanged_rescans_do_not_multiply_exported_usage_observations() {
         None,
     ));
     let retained: Value = serde_json::from_slice(&fs::read(&retained_export).unwrap()).unwrap();
+    assert_eq!(retained["schema_version"], 2);
     assert_eq!(
         retained["usage_history"]["raw_value_field"],
         "observed_event_count"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,8 +1,9 @@
 use std::fs;
-use std::fs::OpenOptions;
+use std::fs::{FileTimes, OpenOptions};
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime};
 
 use fs2::FileExt;
 use serde_json::{Value, json};
@@ -2109,6 +2110,142 @@ fn lifecycle_exclusion_and_database_delete_preserve_user_files() {
     let rebuilt = json_output(&run(&[&common[..], &["scan"]].concat(), None));
     assert_eq!(rebuilt["result"]["skill_count"], 1);
     assert!(state.join("skillroster.db").is_file());
+}
+
+#[test]
+fn unchanged_rescans_do_not_multiply_exported_usage_observations() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill = home.join(".codex/skills/example");
+    let session = home.join(".codex/sessions/session.jsonl");
+    fs::create_dir_all(&skill).unwrap();
+    fs::create_dir_all(session.parent().unwrap()).unwrap();
+    fs::write(skill.join("SKILL.md"), "---\nname: example\n---\nbody\n").unwrap();
+    fs::write(
+        &session,
+        "{\"type\":\"invoke_skill\",\"invoked_skill\":\"example\"}\n",
+    )
+    .unwrap();
+    fs::File::options()
+        .write(true)
+        .open(&session)
+        .unwrap()
+        .set_times(FileTimes::new().set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(10)))
+        .unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let first_export = temp.path().join("first-export.json");
+    json_output(&run(
+        &[
+            &common[..],
+            &[
+                "lifecycle",
+                "export",
+                "--output",
+                first_export.to_str().unwrap(),
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let first: Value = serde_json::from_slice(&fs::read(&first_export).unwrap()).unwrap();
+    assert_eq!(first["data"]["usage_events"].as_array().unwrap().len(), 1);
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let second_export = temp.path().join("second-export.json");
+    json_output(&run(
+        &[
+            &common[..],
+            &[
+                "lifecycle",
+                "export",
+                "--output",
+                second_export.to_str().unwrap(),
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let second: Value = serde_json::from_slice(&fs::read(&second_export).unwrap()).unwrap();
+    assert_eq!(second["data"]["usage_events"].as_array().unwrap().len(), 1);
+
+    let mut session_file = OpenOptions::new().append(true).open(&session).unwrap();
+    writeln!(
+        session_file,
+        "{{\"type\":\"invoke_skill\",\"invoked_skill\":\"example\"}}"
+    )
+    .unwrap();
+    session_file
+        .set_times(FileTimes::new().set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(20)))
+        .unwrap();
+    drop(session_file);
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let third_export = temp.path().join("third-export.json");
+    json_output(&run(
+        &[
+            &common[..],
+            &[
+                "lifecycle",
+                "export",
+                "--output",
+                third_export.to_str().unwrap(),
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let third: Value = serde_json::from_slice(&fs::read(&third_export).unwrap()).unwrap();
+    assert_eq!(third["data"]["usage_events"].as_array().unwrap().len(), 2);
+
+    json_output(&run(
+        &[&common[..], &["lifecycle", "purge", "--raw-days", "1"]].concat(),
+        None,
+    ));
+    let retained_export = temp.path().join("retained-export.json");
+    json_output(&run(
+        &[
+            &common[..],
+            &[
+                "lifecycle",
+                "export",
+                "--output",
+                retained_export.to_str().unwrap(),
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let retained: Value = serde_json::from_slice(&fs::read(&retained_export).unwrap()).unwrap();
+    assert_eq!(retained["usage_history"]["raw_value_field"], "event_delta");
+    assert_eq!(
+        retained["usage_history"]["snapshot_evidence_additive"],
+        false
+    );
+    assert_eq!(retained["data"]["usage_events"], json!([]));
+    assert!(
+        retained["data"]["evidence"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|evidence| evidence["kind"] != "usage")
+    );
+    assert_eq!(
+        retained["data"]["usage_monthly"].as_array().unwrap().len(),
+        1
+    );
+    assert_eq!(retained["data"]["usage_monthly"][0]["event_count"], 2);
+    assert_eq!(
+        retained["data"]["usage_monthly"][0]["derivation"],
+        "source_delta"
+    );
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2224,11 +2224,11 @@ fn unchanged_rescans_do_not_multiply_exported_usage_observations() {
         None,
     ));
     let retained: Value = serde_json::from_slice(&fs::read(&retained_export).unwrap()).unwrap();
-    assert_eq!(retained["usage_history"]["raw_value_field"], "event_delta");
     assert_eq!(
-        retained["usage_history"]["snapshot_evidence_additive"],
-        false
+        retained["usage_history"]["raw_value_field"],
+        "observed_event_count"
     );
+    assert_eq!(retained["usage_history"]["observations_additive"], false);
     assert_eq!(retained["data"]["usage_events"], json!([]));
     assert!(
         retained["data"]["evidence"]
@@ -2238,14 +2238,17 @@ fn unchanged_rescans_do_not_multiply_exported_usage_observations() {
             .all(|evidence| evidence["kind"] != "usage")
     );
     assert_eq!(
-        retained["data"]["usage_monthly"].as_array().unwrap().len(),
+        retained["data"]["usage_monthly_sources"]
+            .as_array()
+            .unwrap()
+            .len(),
         1
     );
-    assert_eq!(retained["data"]["usage_monthly"][0]["event_count"], 2);
     assert_eq!(
-        retained["data"]["usage_monthly"][0]["derivation"],
-        "source_delta"
+        retained["data"]["usage_monthly_sources"][0]["max_observed_event_count"],
+        2
     );
+    assert_eq!(retained["data"]["usage_monthly_legacy"], json!([]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- model usage history as bounded source observations, not inferred event deltas
- deduplicate unchanged observations across rescans by source identity, count, and event time
- retain old raw history as the maximum observed count per source and month
- keep pre-v9 monthly Scan aggregates separate and explicitly non-combinable
- remove the permanent private high-water table so export and purge cover all fine-grained state
- preserve immutable Snapshot Evidence and remove expired Usage Evidence during lifecycle purge
- use trustworthy session-record timestamps for usage windows; session-file mtime remains coverage metadata and cannot refresh old Skill events
- expose missing event time as JSON `null`; use local observation time only for retention

## Why

Real dogfood showed that one unchanged rescan added 1,229 raw-usage rows. A representative 8-Agent fixture scanned twice produced 40 source observations but the old lifecycle model reported 80 events solely because it summed every Scan.

A later real-session audit found a second failure mode: appending unrelated data to a session file changed its mtime and made an old loaded event appear newly used. The event count stayed one, but `last_seen` advanced and created another raw observation.

The scanner reads bounded file windows; it does not own an event stream or stable event cursor. Therefore it cannot truthfully derive additive deltas or use a container file mtime as an event timestamp.

## Contract

Lifecycle export `schema_version: 2` is a breaking Agent contract. V1 `usage_monthly` / additive fields are replaced by v2 `usage_monthly_sources`, `usage_monthly_legacy`, and bounded observations; callers must branch on `schema_version`.

Raw `usage_events[].observed_event_count` values are observation snapshots and are never additive. Retention writes `usage_monthly_sources[].max_observed_event_count` per `(month, skill, agent, stage, quality, source_path_digest)`. These maxima are not cumulative across sources or months.

Usage event windows accept explicit RFC3339 or Unix timestamps carried by the session record. If no trustworthy event timestamp exists, event fields remain `null`; observation time may govern retention but is never presented as event time. Session-file mtime is used only for coverage and newest-file selection.

Pre-v9 `usage_monthly` rows remain under `usage_monthly_legacy` with `derivation=legacy_scan_aggregate`; Agent callers must not combine them with source-month observations.

## Verification

- Public CLI regression: first Scan=1 raw observation; changing only session mtime keeps exactly 1 observation and the original `occurred_at`; appending a second timestamped event creates a second observation; purge retains monthly maximum 2 and removes expired Usage Evidence.
- Core unknown-time regression: lifecycle export returns `occurred_at: null`; status does not report Unix epoch; retention preserves the observation until its actual local observation age crosses the cutoff.
- Core retention regression: rescanning and purging an already-retained source leaves the source-month maximum unchanged rather than adding it again.
- v8 migration regression preserves distinct observation states, separates legacy monthly rows, and creates no hidden high-water state.
- Real v8 database copy: schema 8 with 2,451 raw rows and 1,664 exact observation states migrated to schema 9 with exactly 1,664 raw rows; no `usage_observation_totals` table.
- Real-home read-only timestamp dogfood: after the active Codex session continued growing, repeated Scan kept the observed `diagnose` load at event_count=1 and first/last/occurred_at=1787466845; no old-event refresh.
- Real-home read-only dedupe dogfood on the migrated copy: first current Scan changed raw rows 1,664 -> 2,136; an immediate unchanged Scan stayed exactly 2,136; both returned `files_changed=false`.
- Migrated real Snapshot still reports successfully; recovery is clear and no Agent files changed.
- Branch checks: `cargo fmt --check`; strict Clippy; 144 unit + 7 acceptance + 38 CLI tests; `git diff --check`.
- Seven-PR local integration audit: clean merge; strict Clippy; 154 unit + 7 acceptance + 44 CLI tests; `git diff --check`.

Closes #95
