### PR TITLE
fix: respect shared physical roster placements

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -99,7 +99,9 @@ retaining every logical Agent/placement impact fact. If the linked logical
 placements request incompatible Core and non-Core exposure, planning fails
 closed with a typed conflict. No Ready Plan may contain duplicate destructive
 sources or operation targets. Before deriving operations, planning revalidates
-each captured physical source against the current logical entrypoint. A
+each captured physical source against the current logical entrypoint and stores
+those logical-entrypoint-to-physical-source bindings in the immutable Plan.
+Apply revalidates the complete binding set before entering Applying. A
 physical object shared with any provider-managed placement remains read-only,
 and a non-Agent source link that would be broken blocks the Plan. These
 blockers expose stable reasons, IDs, paths, and next actions in `error.details`;

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -98,7 +98,12 @@ physical filesystem object. A Plan operates on that object at most once while
 retaining every logical Agent/placement impact fact. If the linked logical
 placements request incompatible Core and non-Core exposure, planning fails
 closed with a typed conflict. No Ready Plan may contain duplicate destructive
-sources or operation targets.
+sources or operation targets. Before deriving operations, planning revalidates
+each captured physical source against the current logical entrypoint. A
+physical object shared with any provider-managed placement remains read-only,
+and a non-Agent source link that would be broken blocks the Plan. These
+blockers expose stable reasons, IDs, paths, and next actions in `error.details`;
+Agent callers never need to parse the human message.
 
 Apply fails closed when paths, fingerprints, links, or configuration have drifted. Every successful mutation writes a Receipt. `undo <receipt-id>` is bounded to that Receipt and refuses ambiguous restoration. Canonical deletion is outside normal Apply, requires separate confirmation, and should prefer recoverable archive.
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -93,6 +93,13 @@ Read-only commands never mutate Agent configuration or Skill contents. Agent rec
 
 The CLI validates targets, ownership, conflicts, and current fingerprints, then stores an immutable Plan. `apply <plan-id>` executes only the approved scope. Cross-filesystem operations use a journal and compensating steps; the CLI never claims atomicity it cannot provide.
 
+Logical placements reached through symlinked Agent roots may resolve to one
+physical filesystem object. A Plan operates on that object at most once while
+retaining every logical Agent/placement impact fact. If the linked logical
+placements request incompatible Core and non-Core exposure, planning fails
+closed with a typed conflict. No Ready Plan may contain duplicate destructive
+sources or operation targets.
+
 Apply fails closed when paths, fingerprints, links, or configuration have drifted. Every successful mutation writes a Receipt. `undo <receipt-id>` is bounded to that Receipt and refuses ambiguous restoration. Canonical deletion is outside normal Apply, requires separate confirmation, and should prefer recoverable archive.
 
 ### 4.5 Source updates

--- a/src/app.rs
+++ b/src/app.rs
@@ -431,25 +431,32 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
         };
     }
     if let Some(blocker) = error.downcast_ref::<crate::roster_plan::RosterSafetyBlocker>() {
-        let (code, reason, skill_id, placement_ids, next_action) = match blocker {
+        let (code, reason, skill_id, placement_ids, paths, providers, next_action) = match blocker {
             crate::roster_plan::RosterSafetyBlocker::ProviderManaged {
                 skill_id,
                 placement_ids,
+                paths,
+                providers,
             } => (
                 "roster_provider_managed_read_only",
                 "provider_managed_placement_is_read_only",
                 skill_id,
                 placement_ids,
+                paths,
+                Some(providers),
                 "exclude_provider_managed_placement",
             ),
             crate::roster_plan::RosterSafetyBlocker::DependentSource {
                 skill_id,
                 placement_ids,
+                paths,
             } => (
                 "roster_dependent_source_conflict",
                 "dependent_source_would_break",
                 skill_id,
                 placement_ids,
+                paths,
+                None,
                 "preserve_or_retarget_dependent_source",
             ),
         };
@@ -460,6 +467,8 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
                 "reason": reason,
                 "skill_id": skill_id,
                 "placement_ids": placement_ids,
+                "paths": paths,
+                "providers": providers,
                 "files_changed": false,
                 "next_action": next_action
             })),
@@ -3497,14 +3506,8 @@ fn expand_finding_roster_changes(
     let supported =
         crate::roster_plan::exclude_unpreservable_demotions(scan, recommendation.changes.clone())?;
     if !supported.exclusions.is_empty() {
-        if supported
-            .exclusions
-            .iter()
-            .any(|exclusion| exclusion.reason == "non_agent_source_link_depends_on_removal")
-        {
-            bail!(
-                "Finding {finding_id} is blocked because a non-Agent source link depends on a placement scheduled for removal; resolve the reported source dependency, rescan, and use the new Finding"
-            );
+        if let Some(blocker) = finding_roster_safety_blocker(scan, &supported.exclusions) {
+            return Err(blocker.into());
         }
         return Err(crate::roster_plan::source_confirmation_block(
             finding_id.as_str(),
@@ -3530,6 +3533,63 @@ fn expand_finding_roster_changes(
             uncertainty: selection_evidence.uncertainty,
         }),
     ))
+}
+
+fn finding_roster_safety_blocker(
+    scan: &ScanResult,
+    exclusions: &[crate::roster_plan::RosterChangeExclusion],
+) -> Option<crate::roster_plan::RosterSafetyBlocker> {
+    for exclusion in exclusions {
+        let placements = scan
+            .placements
+            .iter()
+            .filter(|placement| placement.skill_id == exclusion.skill_id)
+            .collect::<Vec<_>>();
+        match exclusion.reason {
+            "provider_managed_placement_is_read_only" => {
+                let protected = placements
+                    .into_iter()
+                    .filter(|placement| !placement.governable)
+                    .collect::<Vec<_>>();
+                return Some(crate::roster_plan::RosterSafetyBlocker::ProviderManaged {
+                    skill_id: exclusion.skill_id.clone(),
+                    placement_ids: protected
+                        .iter()
+                        .map(|placement| placement.id.clone())
+                        .collect(),
+                    paths: protected
+                        .iter()
+                        .map(|placement| placement.directory.clone())
+                        .collect(),
+                    providers: protected
+                        .iter()
+                        .filter_map(|placement| placement.provider.clone())
+                        .collect::<BTreeSet<_>>()
+                        .into_iter()
+                        .collect(),
+                });
+            }
+            "non_agent_source_link_depends_on_removal" => {
+                let dependent = placements
+                    .into_iter()
+                    .filter(|placement| placement.agent.is_none())
+                    .collect::<Vec<_>>();
+                return Some(crate::roster_plan::RosterSafetyBlocker::DependentSource {
+                    skill_id: exclusion.skill_id.clone(),
+                    placement_ids: dependent
+                        .iter()
+                        .map(|placement| placement.id.clone())
+                        .collect(),
+                    paths: dependent
+                        .iter()
+                        .map(|placement| placement.directory.clone())
+                        .collect(),
+                });
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 fn exact_duplicate_finding_scope(
@@ -4446,6 +4506,7 @@ fn prepare_plan(
     if let Some(uncertainty) = uncertainty {
         summary_object.insert("uncertainty".into(), uncertainty);
     }
+    let physical_bindings = capture_physical_placement_bindings(&prepared, &scan);
     store.save_plan(&plan_record(
         &prepared,
         input,
@@ -4456,6 +4517,7 @@ fn prepare_plan(
         summary.clone(),
         selection_evidence_full,
         reuse_identity,
+        physical_bindings,
     )?)?;
     Ok(summary)
 }
@@ -4477,6 +4539,7 @@ fn apply_command(store: &StateStore, id: &str) -> Result<Value> {
     if latest_scan_id != record.scan_id {
         bail!("Plan {id} is stale; a newer Snapshot exists");
     }
+    validate_physical_placement_bindings(&record, &prepared, &scan)?;
     validate_roster_changes(store, &prepared, &scan)?;
     validate_source_update_preconditions(&prepared, &scan)?;
     validate_plan_evidence(store, &prepared, &latest_scan_id)?;
@@ -5395,6 +5458,81 @@ fn validate_roster_changes(
     Ok(())
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct PhysicalPlacementBinding {
+    placement_id: String,
+    entrypoint: PathBuf,
+    expected_physical_directory: PathBuf,
+}
+
+fn capture_physical_placement_bindings(
+    plan: &PreparedPlan,
+    scan: &ScanResult,
+) -> Vec<PhysicalPlacementBinding> {
+    let skill_ids = plan
+        .roster_changes
+        .iter()
+        .map(|change| change.skill_id.as_str())
+        .chain(
+            plan.library_changes
+                .iter()
+                .map(|change| change.skill_id.as_str()),
+        )
+        .collect::<BTreeSet<_>>();
+    let mut bindings = scan
+        .placements
+        .iter()
+        .filter(|placement| skill_ids.contains(placement.skill_id.as_str()))
+        .filter_map(|placement| {
+            Some(PhysicalPlacementBinding {
+                placement_id: placement.id.clone(),
+                entrypoint: placement.entrypoint.clone(),
+                expected_physical_directory: placement.physical_directory.clone()?,
+            })
+        })
+        .collect::<Vec<_>>();
+    bindings.sort_by(|left, right| left.placement_id.cmp(&right.placement_id));
+    bindings
+}
+
+fn validate_physical_placement_bindings(
+    record: &PlanRecord,
+    plan: &PreparedPlan,
+    scan: &ScanResult,
+) -> Result<()> {
+    let expected = capture_physical_placement_bindings(plan, scan);
+    let Some(stored) = record.input.get("physical_placement_bindings").cloned() else {
+        if expected.is_empty() {
+            return Ok(());
+        }
+        bail!("Plan {} has no physical placement bindings", record.id);
+    };
+    let stored: Vec<PhysicalPlacementBinding> = serde_json::from_value(stored)?;
+    if stored != expected {
+        bail!(
+            "Plan {} physical placement bindings are incomplete or stale",
+            record.id
+        );
+    }
+    for binding in stored {
+        let placement = scan
+            .placements
+            .iter()
+            .find(|placement| placement.id == binding.placement_id)
+            .ok_or_else(|| anyhow!("Plan placement {} disappeared", binding.placement_id))?;
+        if placement.entrypoint != binding.entrypoint
+            || placement.physical_directory.as_ref() != Some(&binding.expected_physical_directory)
+        {
+            bail!(
+                "Plan placement {} no longer matches its physical binding",
+                binding.placement_id
+            );
+        }
+        placement.validated_physical_directory()?;
+    }
+    Ok(())
+}
+
 fn validate_source_update_preconditions(plan: &PreparedPlan, scan: &ScanResult) -> Result<()> {
     for update in &plan.source_updates {
         let placement = scan
@@ -5627,6 +5765,7 @@ fn plan_record(
     summary: Value,
     selection_evidence_full: Option<Value>,
     reuse_identity: Option<Value>,
+    physical_bindings: Vec<PhysicalPlacementBinding>,
 ) -> Result<PlanRecord> {
     let operations = prepared
         .operations
@@ -5678,6 +5817,7 @@ fn plan_record(
             "summary": summary,
             "selection_evidence_full": selection_evidence_full,
             "reuse_identity": reuse_identity
+            ,"physical_placement_bindings": physical_bindings
         }),
         fingerprint: prepared.digest.clone(),
         operations,
@@ -6169,6 +6309,35 @@ mod recovery_tests {
         assert_eq!(planning["supported"], false);
         assert_eq!(planning["reason"], "external_observed_placements");
         assert_eq!(planning["protected_placement_count"], 1);
+
+        let blocker = finding_roster_safety_blocker(
+            &scan,
+            &[crate::roster_plan::RosterChangeExclusion {
+                agent: "codex".into(),
+                skill_id: "skill_shared".into(),
+                name: "shared".into(),
+                reason: "provider_managed_placement_is_read_only",
+                observed_source_target: None,
+            }],
+        )
+        .unwrap();
+        let blocked: Value = serde_json::from_str(&error_json("plan", &blocker)).unwrap();
+        assert_eq!(
+            blocked["error"]["code"],
+            "roster_provider_managed_read_only"
+        );
+        assert_eq!(
+            blocked["error"]["details"]["placement_ids"],
+            json!(["placement_plugin"])
+        );
+        assert_eq!(
+            blocked["error"]["details"]["paths"],
+            json!(["/fixture/placement_plugin"])
+        );
+        assert_eq!(
+            blocked["error"]["details"]["providers"],
+            json!(["plugin@market"])
+        );
     }
 
     #[test]
@@ -6689,6 +6858,8 @@ mod recovery_tests {
         let provider = crate::roster_plan::RosterSafetyBlocker::ProviderManaged {
             skill_id: "skill_fixture".into(),
             placement_ids: vec!["placement_provider".into()],
+            paths: vec![PathBuf::from("/provider/skill")],
+            providers: vec!["fixture-provider".into()],
         };
         let provider: Value = serde_json::from_str(&error_json("plan", &provider)).unwrap();
         assert_eq!(
@@ -6704,6 +6875,14 @@ mod recovery_tests {
             json!(["placement_provider"])
         );
         assert_eq!(
+            provider["error"]["details"]["paths"],
+            json!(["/provider/skill"])
+        );
+        assert_eq!(
+            provider["error"]["details"]["providers"],
+            json!(["fixture-provider"])
+        );
+        assert_eq!(
             provider["error"]["details"]["next_action"],
             "exclude_provider_managed_placement"
         );
@@ -6711,6 +6890,7 @@ mod recovery_tests {
         let dependent = crate::roster_plan::RosterSafetyBlocker::DependentSource {
             skill_id: "skill_fixture".into(),
             placement_ids: vec!["placement_source".into()],
+            paths: vec![PathBuf::from("/sources/skill")],
         };
         let dependent: Value = serde_json::from_str(&error_json("plan", &dependent)).unwrap();
         assert_eq!(

--- a/src/app.rs
+++ b/src/app.rs
@@ -385,10 +385,10 @@ pub fn error_json(command: &str, error: &(dyn std::error::Error + 'static)) -> S
     serde_json::to_string(&JsonEnvelope::<Value>::failure(
         command,
         ApiError {
-            code: classified.0.into(),
+            code: classified.code.into(),
             message: error.to_string(),
-            retryable: classified.1,
-            details: structured_error_details(error),
+            retryable: classified.retryable,
+            details: classified.details,
             relevant_ids: extract_relevant_ids(&error.to_string()),
             paths: extract_paths(&error.to_string()),
         },
@@ -396,27 +396,98 @@ pub fn error_json(command: &str, error: &(dyn std::error::Error + 'static)) -> S
     .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into())
 }
 
-fn structured_error_details(error: &(dyn std::error::Error + 'static)) -> Option<Value> {
-    if let Some(conflict) = error.downcast_ref::<crate::roster_plan::RosterPhysicalConflict>() {
-        return Some(json!({
-            "reason": "shared_physical_state_conflict",
-            "skill_id": conflict.skill_id,
-            "agents": conflict.agents,
-            "files_changed": false
-        }));
-    }
-    if let Some(conflict) = error.downcast_ref::<crate::roster_plan::RosterOperationConflict>() {
-        return Some(json!({
-            "reason": "duplicate_physical_operation_identity",
-            "operation_kind": conflict.operation_kind,
-            "path": conflict.path,
-            "files_changed": false
-        }));
-    }
-    None
+struct ClassifiedError {
+    code: &'static str,
+    retryable: bool,
+    details: Option<Value>,
 }
 
-fn classify_error(error: &(dyn std::error::Error + 'static)) -> (&'static str, bool) {
+fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError {
+    if let Some(conflict) = error.downcast_ref::<crate::roster_plan::RosterPhysicalConflict>() {
+        return ClassifiedError {
+            code: "roster_physical_state_conflict",
+            retryable: false,
+            details: Some(json!({
+                "reason": "shared_physical_state_conflict",
+                "skill_id": conflict.skill_id,
+                "agents": conflict.agents,
+                "files_changed": false,
+                "next_action": "request_consistent_exposure_or_separate_shared_roots"
+            })),
+        };
+    }
+    if let Some(conflict) = error.downcast_ref::<crate::roster_plan::RosterOperationConflict>() {
+        return ClassifiedError {
+            code: "roster_operation_identity_conflict",
+            retryable: false,
+            details: Some(json!({
+                "reason": "duplicate_physical_operation_identity",
+                "identity_role": conflict.identity_role,
+                "conflicting_operation_kinds": conflict.operation_kinds,
+                "path": conflict.path,
+                "files_changed": false,
+                "next_action": "resolve_same_name_variant_or_shared_ownership"
+            })),
+        };
+    }
+    if let Some(blocker) = error.downcast_ref::<crate::roster_plan::RosterSafetyBlocker>() {
+        let (code, reason, skill_id, placement_ids, next_action) = match blocker {
+            crate::roster_plan::RosterSafetyBlocker::ProviderManaged {
+                skill_id,
+                placement_ids,
+            } => (
+                "roster_provider_managed_read_only",
+                "provider_managed_placement_is_read_only",
+                skill_id,
+                placement_ids,
+                "exclude_provider_managed_placement",
+            ),
+            crate::roster_plan::RosterSafetyBlocker::DependentSource {
+                skill_id,
+                placement_ids,
+            } => (
+                "roster_dependent_source_conflict",
+                "dependent_source_would_break",
+                skill_id,
+                placement_ids,
+                "preserve_or_retarget_dependent_source",
+            ),
+        };
+        return ClassifiedError {
+            code,
+            retryable: false,
+            details: Some(json!({
+                "reason": reason,
+                "skill_id": skill_id,
+                "placement_ids": placement_ids,
+                "files_changed": false,
+                "next_action": next_action
+            })),
+        };
+    }
+    if let Some(drift) = error.downcast_ref::<crate::scan::PhysicalDirectoryDrift>() {
+        return ClassifiedError {
+            code: "state_drift",
+            retryable: false,
+            details: Some(json!({
+                "reason": "physical_source_drift",
+                "placement_id": drift.placement_id,
+                "expected_path": drift.expected,
+                "current_path": drift.current,
+                "files_changed": false,
+                "next_action": "scan"
+            })),
+        };
+    }
+    let (code, retryable) = classify_generic_error(error);
+    ClassifiedError {
+        code,
+        retryable,
+        details: None,
+    }
+}
+
+fn classify_generic_error(error: &(dyn std::error::Error + 'static)) -> (&'static str, bool) {
     let message = error.to_string().to_lowercase();
     if error
         .downcast_ref::<crate::roster_plan::RosterPlanBlocked>()
@@ -432,18 +503,6 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> (&'static str, b
     }
     if let Some(change) = error.downcast_ref::<crate::change::ChangeError>() {
         return (change.code, change.retryable);
-    }
-    if error
-        .downcast_ref::<crate::roster_plan::RosterPhysicalConflict>()
-        .is_some()
-    {
-        return ("roster_physical_state_conflict", false);
-    }
-    if error
-        .downcast_ref::<crate::roster_plan::RosterOperationConflict>()
-        .is_some()
-    {
-        return ("roster_operation_identity_conflict", false);
     }
     if let Some(storage) = error.downcast_ref::<crate::sqlite::StorageError>() {
         return match storage {
@@ -3898,36 +3957,6 @@ fn normalized_digest(value: &str) -> Result<String> {
     Ok(digest.to_ascii_lowercase())
 }
 
-fn validated_physical_directory(placement: &scan::SkillPlacement) -> Result<PathBuf> {
-    let expected = placement.physical_directory.as_ref().ok_or_else(|| {
-        anyhow!(
-            "Placement {} has no captured physical source; state may have drifted, run skillroster scan",
-            placement.id
-        )
-    })?;
-    let current_entrypoint = std::fs::canonicalize(&placement.entrypoint).map_err(|error| {
-        anyhow!(
-            "Placement {} physical source drifted; run skillroster scan: {error}",
-            placement.id
-        )
-    })?;
-    let current = current_entrypoint.parent().ok_or_else(|| {
-        anyhow!(
-            "Placement {} physical source drifted; run skillroster scan",
-            placement.id
-        )
-    })?;
-    if current != expected {
-        bail!(
-            "Placement {} physical source drifted from {} to {}; run skillroster scan",
-            placement.id,
-            expected.display(),
-            current.display()
-        );
-    }
-    Ok(expected.clone())
-}
-
 fn normalize_library_plan(
     mut input: Value,
     scan: &ScanResult,
@@ -4002,11 +4031,11 @@ fn normalize_library_plan(
             std::collections::BTreeMap::<PathBuf, Vec<&scan::SkillPlacement>>::new();
         for placement in &all_placements {
             physical_groups
-                .entry(validated_physical_directory(placement)?)
+                .entry(placement.validated_physical_directory()?)
                 .or_default()
                 .push(*placement);
         }
-        let canonical_physical = validated_physical_directory(canonical)?;
+        let canonical_physical = canonical.validated_physical_directory()?;
         if !placement_owns_physical_source(canonical) {
             bail!("canonical placement must be the owned physical source directory");
         }
@@ -6629,9 +6658,10 @@ mod recovery_tests {
     }
 
     #[test]
-    fn roster_operation_conflict_exposes_agent_facts_as_json() {
+    fn roster_operation_conflict_exposes_operation_facts_as_json() {
         let error = crate::roster_plan::RosterOperationConflict {
-            operation_kind: "target (move_recoverable and create_symlink)".into(),
+            identity_role: "target",
+            operation_kinds: vec!["move_recoverable".into(), "create_symlink".into()],
             path: PathBuf::from("/tmp/library/shared"),
         };
 
@@ -6646,10 +6676,82 @@ mod recovery_tests {
             "duplicate_physical_operation_identity"
         );
         assert_eq!(
-            output["error"]["details"]["operation_kind"],
-            "target (move_recoverable and create_symlink)"
+            output["error"]["details"]["conflicting_operation_kinds"],
+            json!(["move_recoverable", "create_symlink"])
         );
+        assert_eq!(output["error"]["details"]["identity_role"], "target");
         assert_eq!(output["error"]["details"]["path"], "/tmp/library/shared");
+        assert_eq!(output["error"]["details"]["files_changed"], false);
+    }
+
+    #[test]
+    fn roster_safety_blockers_expose_stable_agent_actions() {
+        let provider = crate::roster_plan::RosterSafetyBlocker::ProviderManaged {
+            skill_id: "skill_fixture".into(),
+            placement_ids: vec!["placement_provider".into()],
+        };
+        let provider: Value = serde_json::from_str(&error_json("plan", &provider)).unwrap();
+        assert_eq!(
+            provider["error"]["code"],
+            "roster_provider_managed_read_only"
+        );
+        assert_eq!(
+            provider["error"]["details"]["reason"],
+            "provider_managed_placement_is_read_only"
+        );
+        assert_eq!(
+            provider["error"]["details"]["placement_ids"],
+            json!(["placement_provider"])
+        );
+        assert_eq!(
+            provider["error"]["details"]["next_action"],
+            "exclude_provider_managed_placement"
+        );
+
+        let dependent = crate::roster_plan::RosterSafetyBlocker::DependentSource {
+            skill_id: "skill_fixture".into(),
+            placement_ids: vec!["placement_source".into()],
+        };
+        let dependent: Value = serde_json::from_str(&error_json("plan", &dependent)).unwrap();
+        assert_eq!(
+            dependent["error"]["code"],
+            "roster_dependent_source_conflict"
+        );
+        assert_eq!(
+            dependent["error"]["details"]["next_action"],
+            "preserve_or_retarget_dependent_source"
+        );
+        assert_eq!(dependent["error"]["details"]["files_changed"], false);
+    }
+
+    #[test]
+    fn physical_drift_exposes_expected_and_current_paths() {
+        let drift = crate::scan::PhysicalDirectoryDrift {
+            placement_id: "placement_fixture".into(),
+            expected: Some(PathBuf::from("/tmp/shared-a/skill")),
+            current: Some(PathBuf::from("/tmp/shared-b/skill")),
+        };
+
+        let output: Value = serde_json::from_str(&error_json("plan", &drift)).unwrap();
+
+        assert_eq!(output["error"]["code"], "state_drift");
+        assert_eq!(
+            output["error"]["details"]["reason"],
+            "physical_source_drift"
+        );
+        assert_eq!(
+            output["error"]["details"]["placement_id"],
+            "placement_fixture"
+        );
+        assert_eq!(
+            output["error"]["details"]["expected_path"],
+            "/tmp/shared-a/skill"
+        );
+        assert_eq!(
+            output["error"]["details"]["current_path"],
+            "/tmp/shared-b/skill"
+        );
+        assert_eq!(output["error"]["details"]["next_action"], "scan");
         assert_eq!(output["error"]["details"]["files_changed"], false);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -388,12 +388,32 @@ pub fn error_json(command: &str, error: &(dyn std::error::Error + 'static)) -> S
             code: classified.0.into(),
             message: error.to_string(),
             retryable: classified.1,
+            details: structured_error_details(error),
             relevant_ids: extract_relevant_ids(&error.to_string()),
             paths: extract_paths(&error.to_string()),
-            details: None,
         },
     ))
     .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into())
+}
+
+fn structured_error_details(error: &(dyn std::error::Error + 'static)) -> Option<Value> {
+    if let Some(conflict) = error.downcast_ref::<crate::roster_plan::RosterPhysicalConflict>() {
+        return Some(json!({
+            "reason": "shared_physical_state_conflict",
+            "skill_id": conflict.skill_id,
+            "agents": conflict.agents,
+            "files_changed": false
+        }));
+    }
+    if let Some(conflict) = error.downcast_ref::<crate::roster_plan::RosterOperationConflict>() {
+        return Some(json!({
+            "reason": "duplicate_physical_operation_identity",
+            "operation_kind": conflict.operation_kind,
+            "path": conflict.path,
+            "files_changed": false
+        }));
+    }
+    None
 }
 
 fn classify_error(error: &(dyn std::error::Error + 'static)) -> (&'static str, bool) {
@@ -6606,6 +6626,31 @@ mod recovery_tests {
                 "missing complete --source-root {root} in {complete_argv:?}"
             );
         }
+    }
+
+    #[test]
+    fn roster_operation_conflict_exposes_agent_facts_as_json() {
+        let error = crate::roster_plan::RosterOperationConflict {
+            operation_kind: "target (move_recoverable and create_symlink)".into(),
+            path: PathBuf::from("/tmp/library/shared"),
+        };
+
+        let output: Value = serde_json::from_str(&error_json("plan", &error)).unwrap();
+
+        assert_eq!(
+            output["error"]["code"],
+            "roster_operation_identity_conflict"
+        );
+        assert_eq!(
+            output["error"]["details"]["reason"],
+            "duplicate_physical_operation_identity"
+        );
+        assert_eq!(
+            output["error"]["details"]["operation_kind"],
+            "target (move_recoverable and create_symlink)"
+        );
+        assert_eq!(output["error"]["details"]["path"], "/tmp/library/shared");
+        assert_eq!(output["error"]["details"]["files_changed"], false);
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3506,7 +3506,7 @@ fn expand_finding_roster_changes(
     let supported =
         crate::roster_plan::exclude_unpreservable_demotions(scan, recommendation.changes.clone())?;
     if !supported.exclusions.is_empty() {
-        if let Some(blocker) = finding_roster_safety_blocker(scan, &supported.exclusions) {
+        if let Some(blocker) = finding_roster_safety_blocker(&supported.exclusions) {
             return Err(blocker.into());
         }
         return Err(crate::roster_plan::source_confirmation_block(
@@ -3536,60 +3536,11 @@ fn expand_finding_roster_changes(
 }
 
 fn finding_roster_safety_blocker(
-    scan: &ScanResult,
     exclusions: &[crate::roster_plan::RosterChangeExclusion],
 ) -> Option<crate::roster_plan::RosterSafetyBlocker> {
-    for exclusion in exclusions {
-        let placements = scan
-            .placements
-            .iter()
-            .filter(|placement| placement.skill_id == exclusion.skill_id)
-            .collect::<Vec<_>>();
-        match exclusion.reason {
-            "provider_managed_placement_is_read_only" => {
-                let protected = placements
-                    .into_iter()
-                    .filter(|placement| !placement.governable)
-                    .collect::<Vec<_>>();
-                return Some(crate::roster_plan::RosterSafetyBlocker::ProviderManaged {
-                    skill_id: exclusion.skill_id.clone(),
-                    placement_ids: protected
-                        .iter()
-                        .map(|placement| placement.id.clone())
-                        .collect(),
-                    paths: protected
-                        .iter()
-                        .map(|placement| placement.directory.clone())
-                        .collect(),
-                    providers: protected
-                        .iter()
-                        .filter_map(|placement| placement.provider.clone())
-                        .collect::<BTreeSet<_>>()
-                        .into_iter()
-                        .collect(),
-                });
-            }
-            "non_agent_source_link_depends_on_removal" => {
-                let dependent = placements
-                    .into_iter()
-                    .filter(|placement| placement.agent.is_none())
-                    .collect::<Vec<_>>();
-                return Some(crate::roster_plan::RosterSafetyBlocker::DependentSource {
-                    skill_id: exclusion.skill_id.clone(),
-                    placement_ids: dependent
-                        .iter()
-                        .map(|placement| placement.id.clone())
-                        .collect(),
-                    paths: dependent
-                        .iter()
-                        .map(|placement| placement.directory.clone())
-                        .collect(),
-                });
-            }
-            _ => {}
-        }
-    }
-    None
+    exclusions
+        .iter()
+        .find_map(|exclusion| exclusion.safety_blocker.clone())
 }
 
 fn exact_duplicate_finding_scope(
@@ -6310,16 +6261,19 @@ mod recovery_tests {
         assert_eq!(planning["reason"], "external_observed_placements");
         assert_eq!(planning["protected_placement_count"], 1);
 
-        let blocker = finding_roster_safety_blocker(
-            &scan,
-            &[crate::roster_plan::RosterChangeExclusion {
-                agent: "codex".into(),
+        let blocker = finding_roster_safety_blocker(&[crate::roster_plan::RosterChangeExclusion {
+            agent: "codex".into(),
+            skill_id: "skill_shared".into(),
+            name: "shared".into(),
+            reason: "provider_managed_placement_is_read_only",
+            observed_source_target: None,
+            safety_blocker: Some(crate::roster_plan::RosterSafetyBlocker::ProviderManaged {
                 skill_id: "skill_shared".into(),
-                name: "shared".into(),
-                reason: "provider_managed_placement_is_read_only",
-                observed_source_target: None,
-            }],
-        )
+                placement_ids: vec!["placement_plugin".into()],
+                paths: vec![PathBuf::from("/fixture/placement_plugin")],
+                providers: vec!["plugin@market".into()],
+            }),
+        }])
         .unwrap();
         let blocked: Value = serde_json::from_str(&error_json("plan", &blocker)).unwrap();
         assert_eq!(
@@ -6754,6 +6708,7 @@ mod recovery_tests {
                 observed_source_target: Some(crate::roster_plan::test_absolute_path(&format!(
                     "opt/root-{index:02}/pkg"
                 ))),
+                safety_blocker: None,
             })
             .collect::<Vec<_>>();
         let blocked = crate::roster_plan::source_confirmation_block(

--- a/src/app.rs
+++ b/src/app.rs
@@ -413,6 +413,18 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> (&'static str, b
     if let Some(change) = error.downcast_ref::<crate::change::ChangeError>() {
         return (change.code, change.retryable);
     }
+    if error
+        .downcast_ref::<crate::roster_plan::RosterPhysicalConflict>()
+        .is_some()
+    {
+        return ("roster_physical_state_conflict", false);
+    }
+    if error
+        .downcast_ref::<crate::roster_plan::RosterOperationConflict>()
+        .is_some()
+    {
+        return ("roster_operation_identity_conflict", false);
+    }
     if let Some(storage) = error.downcast_ref::<crate::sqlite::StorageError>() {
         return match storage {
             crate::sqlite::StorageError::Sql(rusqlite::Error::SqliteFailure(code, _))

--- a/src/app.rs
+++ b/src/app.rs
@@ -5816,8 +5816,8 @@ fn plan_record(
             "library_before": library_before,
             "summary": summary,
             "selection_evidence_full": selection_evidence_full,
-            "reuse_identity": reuse_identity
-            ,"physical_placement_bindings": physical_bindings
+            "reuse_identity": reuse_identity,
+            "physical_placement_bindings": physical_bindings
         }),
         fingerprint: prepared.digest.clone(),
         operations,

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -270,6 +271,8 @@ pub struct ApiError {
     pub code: String,
     pub message: String,
     pub retryable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
     #[serde(default)]
     pub relevant_ids: Vec<String>,
     #[serde(default)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,7 +4,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -271,8 +270,6 @@ pub struct ApiError {
     pub code: String,
     pub message: String,
     pub retryable: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub details: Option<Value>,
     #[serde(default)]
     pub relevant_ids: Vec<String>,
     #[serde(default)]

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -65,10 +65,13 @@ pub enum RosterSafetyBlocker {
     ProviderManaged {
         skill_id: String,
         placement_ids: Vec<String>,
+        paths: Vec<PathBuf>,
+        providers: Vec<String>,
     },
     DependentSource {
         skill_id: String,
         placement_ids: Vec<String>,
+        paths: Vec<PathBuf>,
     },
 }
 
@@ -503,6 +506,16 @@ pub fn derive(
                     .iter()
                     .map(|placement| placement.id.clone())
                     .collect(),
+                paths: placements
+                    .iter()
+                    .map(|placement| placement.directory.clone())
+                    .collect(),
+                providers: placements
+                    .iter()
+                    .filter_map(|placement| placement.provider.clone())
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect(),
             }
             .into());
         }
@@ -536,7 +549,19 @@ pub fn derive(
         if !provider_placement_ids.is_empty() {
             return Err(RosterSafetyBlocker::ProviderManaged {
                 skill_id: skill_id.to_owned(),
-                placement_ids: provider_placement_ids,
+                placement_ids: provider_placement_ids.clone(),
+                paths: placements
+                    .iter()
+                    .filter(|placement| provider_placement_ids.contains(&placement.id))
+                    .map(|placement| placement.directory.clone())
+                    .collect(),
+                providers: placements
+                    .iter()
+                    .filter(|placement| provider_placement_ids.contains(&placement.id))
+                    .filter_map(|placement| placement.provider.clone())
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect(),
             }
             .into());
         }
@@ -603,6 +628,11 @@ pub fn derive(
                     .iter()
                     .filter(|placement| placement.agent.is_none())
                     .map(|placement| placement.id.clone())
+                    .collect(),
+                paths: dependent_links
+                    .iter()
+                    .filter(|placement| placement.agent.is_none())
+                    .map(|placement| placement.directory.clone())
                     .collect(),
             }
             .into());

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -60,7 +60,7 @@ impl std::fmt::Display for RosterOperationConflict {
 
 impl std::error::Error for RosterOperationConflict {}
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum RosterSafetyBlocker {
     ProviderManaged {
         skill_id: String,
@@ -99,6 +99,7 @@ pub struct RosterChangeExclusion {
     pub name: String,
     pub reason: &'static str,
     pub observed_source_target: Option<PathBuf>,
+    pub safety_blocker: Option<RosterSafetyBlocker>,
 }
 
 pub struct SupportedRosterChanges {
@@ -392,10 +393,8 @@ pub fn exclude_unpreservable_demotions(
                     .is_some_and(|agent| demoted_agents.contains(&agent))
             })
             .collect::<Vec<_>>();
-        let provider_managed_removal =
-            provider_placements_on_physical_removal(&placements, &removable)
-                .next()
-                .is_some();
+        let provider_managed_removals =
+            provider_placements_on_physical_removal(&placements, &removable).collect::<Vec<_>>();
         let skill = scan
             .skills
             .iter()
@@ -412,19 +411,52 @@ pub fn exclude_unpreservable_demotions(
             .iter()
             .copied()
             .any(|placement| is_real_exact(placement, exact_digest));
-        let non_agent_source_dependency = placements
+        let non_agent_source_dependencies = placements
             .iter()
             .copied()
             .filter(|placement| placement.agent.is_none())
-            .any(|placement| depends_on_physical_removal(placement, &removable));
-        let reason = if provider_managed_removal {
-            "provider_managed_placement_is_read_only"
-        } else if non_agent_source_dependency {
-            "non_agent_source_link_depends_on_removal"
+            .filter(|placement| depends_on_physical_removal(placement, &removable))
+            .collect::<Vec<_>>();
+        let (reason, safety_blocker) = if !provider_managed_removals.is_empty() {
+            (
+                "provider_managed_placement_is_read_only",
+                Some(RosterSafetyBlocker::ProviderManaged {
+                    skill_id: skill_id.to_owned(),
+                    placement_ids: provider_managed_removals
+                        .iter()
+                        .map(|placement| placement.id.clone())
+                        .collect(),
+                    paths: provider_managed_removals
+                        .iter()
+                        .map(|placement| placement.directory.clone())
+                        .collect(),
+                    providers: provider_managed_removals
+                        .iter()
+                        .filter_map(|placement| placement.provider.clone())
+                        .collect::<BTreeSet<_>>()
+                        .into_iter()
+                        .collect(),
+                }),
+            )
+        } else if !non_agent_source_dependencies.is_empty() {
+            (
+                "non_agent_source_link_depends_on_removal",
+                Some(RosterSafetyBlocker::DependentSource {
+                    skill_id: skill_id.to_owned(),
+                    placement_ids: non_agent_source_dependencies
+                        .iter()
+                        .map(|placement| placement.id.clone())
+                        .collect(),
+                    paths: non_agent_source_dependencies
+                        .iter()
+                        .map(|placement| placement.directory.clone())
+                        .collect(),
+                }),
+            )
         } else if retained_owned || migratable_owned {
             continue;
         } else {
-            "no_owned_exact_content_to_preserve"
+            ("no_owned_exact_content_to_preserve", None)
         };
         for request in requests
             .into_iter()
@@ -437,6 +469,7 @@ pub fn exclude_unpreservable_demotions(
                 name: name.to_owned(),
                 reason,
                 observed_source_target: safe_observed_source_target(&removable),
+                safety_blocker: safety_blocker.clone(),
             });
         }
     }
@@ -1335,7 +1368,24 @@ mod tests {
         provider.agent = None;
         provider.governable = false;
         provider.provider = Some("fixture-provider".into());
-        snapshot.placements.push(provider);
+        let provider_directory = provider.directory.clone();
+        snapshot.placements.push(provider.clone());
+        let unrelated_directory = temp.path().join("provider-cache/unrelated");
+        fs::create_dir_all(&unrelated_directory).unwrap();
+        fs::write(
+            unrelated_directory.join("SKILL.md"),
+            "---\nname: shared\n---\nfixture\n",
+        )
+        .unwrap();
+        let mut unrelated_provider = provider;
+        unrelated_provider.id = "placement_unrelated_provider_fixture".into();
+        unrelated_provider.root = unrelated_directory.parent().unwrap().to_path_buf();
+        unrelated_provider.directory = unrelated_directory.clone();
+        unrelated_provider.entrypoint = unrelated_directory.join("SKILL.md");
+        unrelated_provider.physical_directory =
+            Some(fs::canonicalize(&unrelated_directory).unwrap());
+        unrelated_provider.provider = Some("unrelated-provider".into());
+        snapshot.placements.push(unrelated_provider);
         let skill_id = snapshot.skills[0].id.clone();
         let changes = ["codex", "claude-code", "pi"]
             .into_iter()
@@ -1345,6 +1395,21 @@ mod tests {
                 state: "on_demand".into(),
             })
             .collect::<Vec<_>>();
+        let supported = exclude_unpreservable_demotions(&snapshot, changes.clone()).unwrap();
+        let blocker = supported.exclusions[0].safety_blocker.as_ref().unwrap();
+        match blocker {
+            RosterSafetyBlocker::ProviderManaged {
+                placement_ids,
+                paths,
+                providers,
+                ..
+            } => {
+                assert_eq!(placement_ids, &["placement_provider_fixture"]);
+                assert_eq!(paths, &[provider_directory]);
+                assert_eq!(providers, &["fixture-provider"]);
+            }
+            other => panic!("expected provider-managed blocker, got {other:?}"),
+        }
         let state = temp.path().join("state");
         fs::create_dir(&state).unwrap();
 
@@ -1526,7 +1591,7 @@ mod tests {
         let mut options = ScanOptions::for_home(&home);
         options.include_session_evidence = false;
         options.explicit_source_roots.push(source_root);
-        let snapshot = scan(&options).unwrap();
+        let mut snapshot = scan(&options).unwrap();
         let skill_id = snapshot
             .placements
             .iter()
@@ -1534,6 +1599,29 @@ mod tests {
             .unwrap()
             .skill_id
             .clone();
+        let dependent = snapshot
+            .placements
+            .iter()
+            .find(|placement| placement.agent.is_none())
+            .unwrap()
+            .clone();
+        let dependent_id = dependent.id.clone();
+        let dependent_directory = dependent.directory.clone();
+        let unrelated_directory = temp.path().join("unrelated/shared");
+        fs::create_dir_all(&unrelated_directory).unwrap();
+        fs::write(
+            unrelated_directory.join("SKILL.md"),
+            "---\nname: shared\n---\nfixture\n",
+        )
+        .unwrap();
+        let mut unrelated_source = dependent;
+        unrelated_source.id = "placement_unrelated_source_fixture".into();
+        unrelated_source.root = unrelated_directory.parent().unwrap().to_path_buf();
+        unrelated_source.directory = unrelated_directory.clone();
+        unrelated_source.entrypoint = unrelated_directory.join("SKILL.md");
+        unrelated_source.physical_directory = Some(fs::canonicalize(&unrelated_directory).unwrap());
+        unrelated_source.link_target = Some(unrelated_directory.clone());
+        snapshot.placements.push(unrelated_source);
 
         let supported = exclude_unpreservable_demotions(
             &snapshot,
@@ -1553,6 +1641,17 @@ mod tests {
             "non_agent_source_link_depends_on_removal"
         );
         assert!(supported.exclusions[0].observed_source_target.is_none());
+        match supported.exclusions[0].safety_blocker.as_ref().unwrap() {
+            RosterSafetyBlocker::DependentSource {
+                placement_ids,
+                paths,
+                ..
+            } => {
+                assert_eq!(placement_ids, &[dependent_id]);
+                assert_eq!(paths, &[dependent_directory]);
+            }
+            other => panic!("expected dependent-source blocker, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1745,6 +1844,7 @@ mod tests {
                 name: "alpha".into(),
                 reason: "no_owned_exact_content_to_preserve",
                 observed_source_target: Some(test_absolute_path("opt/reviewed/alpha")),
+                safety_blocker: None,
             },
             RosterChangeExclusion {
                 agent: "codex".into(),
@@ -1752,6 +1852,7 @@ mod tests {
                 name: "beta".into(),
                 reason: "no_owned_exact_content_to_preserve",
                 observed_source_target: Some(test_absolute_path("opt/reviewed/beta")),
+                safety_blocker: None,
             },
         ];
         let blocked =
@@ -1796,6 +1897,7 @@ mod tests {
                 observed_source_target: Some(test_absolute_path(&format!(
                     "opt/root-{index:02}/pkg"
                 ))),
+                safety_blocker: None,
             })
             .collect::<Vec<_>>();
         let blocked =
@@ -1891,6 +1993,7 @@ mod tests {
                 observed_source_target: Some(test_absolute_path(&format!(
                     "opt/root-{index:02}/pkg"
                 ))),
+                safety_blocker: None,
             })
             .collect::<Vec<_>>();
 
@@ -1932,6 +2035,7 @@ mod tests {
             name: "rootish".into(),
             reason: "no_owned_exact_content_to_preserve",
             observed_source_target: Some(PathBuf::from("/")),
+            safety_blocker: None,
         }];
         let state = TempDir::new().unwrap();
         let blocked =

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -10,8 +10,10 @@ const SOURCE_CONFIRMATION_SCHEMA_VERSION: u32 = 1;
 
 use crate::change::{self, LibraryChangeAction, RosterChange};
 use crate::harness::AgentKind;
+use crate::model::RosterState;
 use crate::scan::{LinkStatus, RootKind, RootStatus, ScanResult, SkillPlacement};
 
+#[derive(Debug)]
 pub struct DerivedRosterPlan {
     pub operations: Vec<Value>,
     pub implicit_library_changes: Vec<LibraryChangeAction>,
@@ -356,6 +358,7 @@ pub fn exclude_unpreservable_demotions(
                     .is_some_and(|agent| demoted_agents.contains(&agent))
             })
             .collect::<Vec<_>>();
+        let provider_managed_removal = removable.iter().any(|placement| !placement.governable);
         let skill = scan
             .skills
             .iter()
@@ -376,14 +379,10 @@ pub fn exclude_unpreservable_demotions(
             .iter()
             .copied()
             .filter(|placement| placement.agent.is_none())
-            .any(|placement| {
-                placement.link_target.as_ref().is_some_and(|target| {
-                    removable.iter().any(|removed| {
-                        target == &removed.directory || target.starts_with(&removed.directory)
-                    })
-                })
-            });
-        let reason = if non_agent_source_dependency {
+            .any(|placement| depends_on_physical_removal(placement, &removable));
+        let reason = if provider_managed_removal {
+            "provider_managed_placement_is_read_only"
+        } else if non_agent_source_dependency {
             "non_agent_source_link_depends_on_removal"
         } else if retained_owned || migratable_owned {
             continue;
@@ -466,9 +465,12 @@ pub fn derive(
         if !placements.iter().any(|placement| placement.governable) {
             bail!("Skill {skill_id} is provider-managed and read-only");
         }
+        for placement in &placements {
+            validate_physical_directory(placement)?;
+        }
         let desired = requests
             .iter()
-            .map(|request| Ok((agent(&request.agent)?, request.state.as_str())))
+            .map(|request| Ok((agent(&request.agent)?, roster_state(&request.state)?)))
             .collect::<Result<BTreeMap<_, _>>>()?;
         ensure_physical_exposure_compatible(skill_id, &placements, &desired)?;
         let removal = placements
@@ -478,9 +480,12 @@ pub fn derive(
                 placement
                     .agent
                     .and_then(|agent| desired.get(&agent))
-                    .is_some_and(|state| *state != "core")
+                    .is_some_and(|state| state != &RosterState::Core)
             })
             .collect::<Vec<_>>();
+        if removal.iter().any(|placement| !placement.governable) {
+            bail!("Skill {skill_id} includes a provider-managed placement that is read-only");
+        }
         let mut source = verified_real_source(&placements, &removal, &skill.content_digest);
         let mut source_fingerprint = source
             .as_ref()
@@ -532,13 +537,7 @@ pub fn derive(
             .iter()
             .copied()
             .filter(|placement| !removal.iter().any(|removed| removed.id == placement.id))
-            .filter(|placement| {
-                placement.link_target.as_ref().is_some_and(|target| {
-                    removal.iter().any(|removed| {
-                        target == &removed.directory || target.starts_with(&removed.directory)
-                    })
-                })
-            })
+            .filter(|placement| depends_on_physical_removal(placement, &removal))
             .collect::<Vec<_>>();
         if dependent_links
             .iter()
@@ -753,7 +752,7 @@ pub fn derive(
 fn ensure_physical_exposure_compatible(
     skill_id: &str,
     placements: &[&SkillPlacement],
-    desired: &BTreeMap<AgentKind, &str>,
+    desired: &BTreeMap<AgentKind, RosterState>,
 ) -> Result<()> {
     let mut groups = BTreeMap::<PathBuf, Vec<&SkillPlacement>>::new();
     for placement in placements
@@ -771,12 +770,14 @@ fn ensure_physical_exposure_compatible(
             placement
                 .agent
                 .and_then(|agent| desired.get(&agent))
-                .is_some_and(|state| *state != "core")
+                .is_some_and(|state| state != &RosterState::Core)
         });
         let has_retained_exposure = placements.iter().any(|placement| {
-            placement
-                .agent
-                .is_some_and(|agent| desired.get(&agent).is_none_or(|state| *state == "core"))
+            placement.agent.is_some_and(|agent| {
+                desired
+                    .get(&agent)
+                    .is_none_or(|state| state == &RosterState::Core)
+            })
         });
         if has_demotion && has_retained_exposure {
             let agents = placements
@@ -797,20 +798,49 @@ fn ensure_physical_exposure_compatible(
 }
 
 fn physical_mutation_path(placement: &SkillPlacement) -> PathBuf {
-    if std::fs::symlink_metadata(&placement.directory)
-        .is_ok_and(|metadata| metadata.file_type().is_symlink())
-    {
-        let Some(parent) = placement.directory.parent() else {
-            return placement.directory.clone();
-        };
-        let Some(name) = placement.directory.file_name() else {
-            return placement.directory.clone();
-        };
-        return std::fs::canonicalize(parent)
-            .unwrap_or_else(|_| parent.to_path_buf())
-            .join(name);
+    if is_symlink(&placement.directory) {
+        return physical_entry_path(&placement.directory);
     }
     placement.physical_directory_or_logical().to_path_buf()
+}
+
+fn validate_physical_directory(placement: &SkillPlacement) -> Result<()> {
+    let expected = placement.physical_directory.as_ref().ok_or_else(|| {
+        anyhow!(
+            "Placement {} has no captured physical source; state may have drifted, run skillroster scan",
+            placement.id
+        )
+    })?;
+    let current_entrypoint = std::fs::canonicalize(&placement.entrypoint).map_err(|error| {
+        anyhow!(
+            "Placement {} physical source drifted; run skillroster scan: {error}",
+            placement.id
+        )
+    })?;
+    let current = current_entrypoint.parent().ok_or_else(|| {
+        anyhow!(
+            "Placement {} physical source drifted; run skillroster scan",
+            placement.id
+        )
+    })?;
+    if current != expected {
+        bail!(
+            "Placement {} physical source drifted from {} to {}; run skillroster scan",
+            placement.id,
+            expected.display(),
+            current.display()
+        );
+    }
+    Ok(())
+}
+
+fn depends_on_physical_removal(placement: &SkillPlacement, removal: &[&SkillPlacement]) -> bool {
+    placement.link_target.is_some()
+        && removal.iter().any(|removed| {
+            let dependency = placement.physical_directory_or_logical();
+            let removed = removed.physical_directory_or_logical();
+            dependency == removed || dependency.starts_with(removed)
+        })
 }
 
 fn ensure_unique_operation_paths(operations: &[Value]) -> Result<()> {
@@ -847,20 +877,20 @@ fn ensure_unique_operation_paths(operations: &[Value]) -> Result<()> {
 }
 
 fn physical_operation_path(path: &Path) -> PathBuf {
-    if std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
-        let Some(parent) = path.parent() else {
-            return path.to_path_buf();
-        };
-        let Some(name) = path.file_name() else {
-            return path.to_path_buf();
-        };
-        return std::fs::canonicalize(parent)
-            .unwrap_or_else(|_| parent.to_path_buf())
-            .join(name);
+    if is_symlink(path) {
+        return physical_entry_path(path);
     }
     if let Ok(resolved) = std::fs::canonicalize(path) {
         return resolved;
     }
+    physical_entry_path(path)
+}
+
+fn is_symlink(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
+}
+
+fn physical_entry_path(path: &Path) -> PathBuf {
     let Some(parent) = path.parent() else {
         return path.to_path_buf();
     };
@@ -914,6 +944,16 @@ fn agent(value: &str) -> Result<AgentKind> {
         .into_iter()
         .find(|agent| agent.id() == value)
         .ok_or_else(|| anyhow!("unsupported Agent in Roster change: {value}"))
+}
+
+fn roster_state(value: &str) -> Result<RosterState> {
+    match value {
+        "core" => Ok(RosterState::Core),
+        "on_demand" => Ok(RosterState::OnDemand),
+        "explicit_only" => Ok(RosterState::ExplicitOnly),
+        "archived" => Ok(RosterState::Archived),
+        _ => bail!("unsupported Roster state: {value}"),
+    }
 }
 
 fn safe_name(name: &str) -> Result<String> {
@@ -1046,6 +1086,138 @@ mod tests {
         };
 
         assert!(error.downcast_ref::<RosterPhysicalConflict>().is_some());
+        assert!(shared_skill.join("SKILL.md").is_file());
+        assert!(fs::read_dir(&state).unwrap().next().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_physical_root_drift_requires_a_new_scan() {
+        use std::os::unix::fs::symlink;
+
+        let (temp, snapshot, shared_skill) = shared_agent_root_fixture();
+        let home = shared_skill.parent().unwrap().parent().unwrap();
+        let replacement_root = home.join(".replacement_skills");
+        let replacement_skill = replacement_root.join("shared");
+        fs::create_dir_all(&replacement_skill).unwrap();
+        fs::write(
+            replacement_skill.join("SKILL.md"),
+            "---\nname: shared\n---\nreplacement\n",
+        )
+        .unwrap();
+        for root in [
+            home.join(".codex/skills"),
+            home.join(".claude/skills"),
+            home.join(".pi/agent/skills"),
+        ] {
+            fs::remove_file(&root).unwrap();
+            symlink(&replacement_root, root).unwrap();
+        }
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+        let skill_id = snapshot.skills[0].id.clone();
+        let changes = ["codex", "claude-code", "pi"]
+            .into_iter()
+            .map(|agent| RosterChange {
+                agent: agent.into(),
+                skill_id: skill_id.clone(),
+                state: "on_demand".into(),
+            })
+            .collect::<Vec<_>>();
+
+        let error = derive(&snapshot, &state, &changes).unwrap_err();
+
+        assert!(error.to_string().contains("physical source drifted"));
+        assert!(error.to_string().contains("run skillroster scan"));
+        assert!(shared_skill.join("SKILL.md").is_file());
+        assert!(replacement_skill.join("SKILL.md").is_file());
+        assert!(fs::read_dir(&state).unwrap().next().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_physical_demotion_blocks_a_dependent_source_link() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let shared_root = home.join(".agents_skills");
+        let shared_skill = shared_root.join("shared");
+        fs::create_dir_all(&shared_skill).unwrap();
+        fs::write(
+            shared_skill.join("SKILL.md"),
+            "---\nname: shared\n---\nfixture\n",
+        )
+        .unwrap();
+        for (parent, root) in [
+            (home.join(".codex"), home.join(".codex/skills")),
+            (home.join(".claude"), home.join(".claude/skills")),
+            (home.join(".pi/agent"), home.join(".pi/agent/skills")),
+        ] {
+            fs::create_dir_all(parent).unwrap();
+            symlink(&shared_root, root).unwrap();
+        }
+        let source_root = temp.path().join("sources");
+        fs::create_dir(&source_root).unwrap();
+        symlink(&shared_skill, source_root.join("shared")).unwrap();
+        let mut options = ScanOptions::for_home(&home);
+        options.include_session_evidence = false;
+        options.explicit_source_roots.push(source_root.clone());
+        let snapshot = scan(&options).unwrap();
+        let skill_id = snapshot.skills[0].id.clone();
+        let changes = ["codex", "claude-code", "pi"]
+            .into_iter()
+            .map(|agent| RosterChange {
+                agent: agent.into(),
+                skill_id: skill_id.clone(),
+                state: "on_demand".into(),
+            })
+            .collect::<Vec<_>>();
+        let supported = exclude_unpreservable_demotions(&snapshot, changes.clone()).unwrap();
+        assert!(supported.changes.is_empty());
+        assert!(
+            supported
+                .exclusions
+                .iter()
+                .all(|item| item.reason == "non_agent_source_link_depends_on_removal")
+        );
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+
+        let error = derive(&snapshot, &state, &changes).unwrap_err();
+
+        assert!(error.to_string().contains("non-Agent source link"));
+        assert!(shared_skill.join("SKILL.md").is_file());
+        assert!(source_root.join("shared/SKILL.md").is_file());
+        assert!(fs::read_dir(&state).unwrap().next().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mixed_provider_managed_shared_placement_is_read_only() {
+        let (temp, mut snapshot, shared_skill) = shared_agent_root_fixture();
+        let codex = snapshot
+            .placements
+            .iter_mut()
+            .find(|placement| placement.agent == Some(AgentKind::Codex))
+            .unwrap();
+        codex.governable = false;
+        codex.provider = Some("fixture-provider".into());
+        let skill_id = snapshot.skills[0].id.clone();
+        let changes = ["codex", "claude-code", "pi"]
+            .into_iter()
+            .map(|agent| RosterChange {
+                agent: agent.into(),
+                skill_id: skill_id.clone(),
+                state: "on_demand".into(),
+            })
+            .collect::<Vec<_>>();
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+
+        let error = derive(&snapshot, &state, &changes).unwrap_err();
+
+        assert!(error.to_string().contains("provider-managed placement"));
         assert!(shared_skill.join("SKILL.md").is_file());
         assert!(fs::read_dir(&state).unwrap().next().is_none());
     }

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -41,7 +41,8 @@ impl std::error::Error for RosterPhysicalConflict {}
 
 #[derive(Debug)]
 pub struct RosterOperationConflict {
-    pub operation_kind: String,
+    pub identity_role: &'static str,
+    pub operation_kinds: Vec<String>,
     pub path: PathBuf,
 }
 
@@ -49,14 +50,44 @@ impl std::fmt::Display for RosterOperationConflict {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             formatter,
-            "Roster Plan contains more than one {} operation for physical path {}; resolve overlapping physical ownership or the same-name variant Finding before retrying",
-            self.operation_kind,
+            "Roster Plan contains conflicting {} operations ({}) for physical path {}; resolve overlapping physical ownership or the same-name variant Finding before retrying",
+            self.identity_role,
+            self.operation_kinds.join(", "),
             self.path.display()
         )
     }
 }
 
 impl std::error::Error for RosterOperationConflict {}
+
+#[derive(Debug)]
+pub enum RosterSafetyBlocker {
+    ProviderManaged {
+        skill_id: String,
+        placement_ids: Vec<String>,
+    },
+    DependentSource {
+        skill_id: String,
+        placement_ids: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for RosterSafetyBlocker {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProviderManaged { skill_id, .. } => write!(
+                formatter,
+                "Skill {skill_id} includes a provider-managed placement that is read-only"
+            ),
+            Self::DependentSource { skill_id, .. } => write!(
+                formatter,
+                "Skill {skill_id} has a non-Agent source link that depends on a placement scheduled for removal"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RosterSafetyBlocker {}
 
 #[derive(Clone, Debug)]
 pub struct RosterChangeExclusion {
@@ -358,7 +389,10 @@ pub fn exclude_unpreservable_demotions(
                     .is_some_and(|agent| demoted_agents.contains(&agent))
             })
             .collect::<Vec<_>>();
-        let provider_managed_removal = removable.iter().any(|placement| !placement.governable);
+        let provider_managed_removal =
+            provider_placements_on_physical_removal(&placements, &removable)
+                .next()
+                .is_some();
         let skill = scan
             .skills
             .iter()
@@ -463,10 +497,17 @@ pub fn derive(
             bail!("Skill {skill_id} has no verified placement");
         }
         if !placements.iter().any(|placement| placement.governable) {
-            bail!("Skill {skill_id} is provider-managed and read-only");
+            return Err(RosterSafetyBlocker::ProviderManaged {
+                skill_id: skill_id.to_owned(),
+                placement_ids: placements
+                    .iter()
+                    .map(|placement| placement.id.clone())
+                    .collect(),
+            }
+            .into());
         }
         for placement in &placements {
-            validate_physical_directory(placement)?;
+            placement.validated_physical_directory()?;
         }
         let desired = requests
             .iter()
@@ -483,8 +524,15 @@ pub fn derive(
                     .is_some_and(|state| state != &RosterState::Core)
             })
             .collect::<Vec<_>>();
-        if removal.iter().any(|placement| !placement.governable) {
-            bail!("Skill {skill_id} includes a provider-managed placement that is read-only");
+        let provider_placement_ids = provider_placements_on_physical_removal(&placements, &removal)
+            .map(|placement| placement.id.clone())
+            .collect::<Vec<_>>();
+        if !provider_placement_ids.is_empty() {
+            return Err(RosterSafetyBlocker::ProviderManaged {
+                skill_id: skill_id.to_owned(),
+                placement_ids: provider_placement_ids,
+            }
+            .into());
         }
         let mut source = verified_real_source(&placements, &removal, &skill.content_digest);
         let mut source_fingerprint = source
@@ -543,9 +591,15 @@ pub fn derive(
             .iter()
             .any(|placement| placement.agent.is_none())
         {
-            bail!(
-                "Skill {skill_id} has a non-Agent source link that depends on a placement scheduled for removal"
-            );
+            return Err(RosterSafetyBlocker::DependentSource {
+                skill_id: skill_id.to_owned(),
+                placement_ids: dependent_links
+                    .iter()
+                    .filter(|placement| placement.agent.is_none())
+                    .map(|placement| placement.id.clone())
+                    .collect(),
+            }
+            .into());
         }
         if !dependent_links.is_empty() {
             let source = source
@@ -804,36 +858,6 @@ fn physical_mutation_path(placement: &SkillPlacement) -> PathBuf {
     placement.physical_directory_or_logical().to_path_buf()
 }
 
-fn validate_physical_directory(placement: &SkillPlacement) -> Result<()> {
-    let expected = placement.physical_directory.as_ref().ok_or_else(|| {
-        anyhow!(
-            "Placement {} has no captured physical source; state may have drifted, run skillroster scan",
-            placement.id
-        )
-    })?;
-    let current_entrypoint = std::fs::canonicalize(&placement.entrypoint).map_err(|error| {
-        anyhow!(
-            "Placement {} physical source drifted; run skillroster scan: {error}",
-            placement.id
-        )
-    })?;
-    let current = current_entrypoint.parent().ok_or_else(|| {
-        anyhow!(
-            "Placement {} physical source drifted; run skillroster scan",
-            placement.id
-        )
-    })?;
-    if current != expected {
-        bail!(
-            "Placement {} physical source drifted from {} to {}; run skillroster scan",
-            placement.id,
-            expected.display(),
-            current.display()
-        );
-    }
-    Ok(())
-}
-
 fn depends_on_physical_removal(placement: &SkillPlacement, removal: &[&SkillPlacement]) -> bool {
     placement.link_target.is_some()
         && removal.iter().any(|removed| {
@@ -841,6 +865,19 @@ fn depends_on_physical_removal(placement: &SkillPlacement, removal: &[&SkillPlac
             let removed = removed.physical_directory_or_logical();
             dependency == removed || dependency.starts_with(removed)
         })
+}
+
+fn provider_placements_on_physical_removal<'a>(
+    placements: &'a [&SkillPlacement],
+    removal: &[&SkillPlacement],
+) -> impl Iterator<Item = &'a SkillPlacement> {
+    let removal_paths = removal
+        .iter()
+        .map(|placement| physical_mutation_path(placement))
+        .collect::<BTreeSet<_>>();
+    placements.iter().copied().filter(move |placement| {
+        !placement.governable && removal_paths.contains(&physical_mutation_path(placement))
+    })
 }
 
 fn ensure_unique_operation_paths(operations: &[Value]) -> Result<()> {
@@ -854,7 +891,8 @@ fn ensure_unique_operation_paths(operations: &[Value]) -> Result<()> {
             let source = physical_operation_path(Path::new(source));
             if !move_sources.insert(source.clone()) {
                 return Err(RosterOperationConflict {
-                    operation_kind: "destructive-source".into(),
+                    identity_role: "source",
+                    operation_kinds: vec!["move_recoverable".into(), "move_recoverable".into()],
                     path: source,
                 }
                 .into());
@@ -867,7 +905,8 @@ fn ensure_unique_operation_paths(operations: &[Value]) -> Result<()> {
         let kind = operation["kind"].as_str().unwrap_or("unknown");
         if let Some(first_kind) = targets.insert(target.clone(), kind) {
             return Err(RosterOperationConflict {
-                operation_kind: format!("target ({first_kind} and {kind})"),
+                identity_role: "target",
+                operation_kinds: vec![first_kind.into(), kind.into()],
                 path: target,
             }
             .into());
@@ -1196,13 +1235,17 @@ mod tests {
     #[test]
     fn mixed_provider_managed_shared_placement_is_read_only() {
         let (temp, mut snapshot, shared_skill) = shared_agent_root_fixture();
-        let codex = snapshot
+        let mut provider = snapshot
             .placements
-            .iter_mut()
+            .iter()
             .find(|placement| placement.agent == Some(AgentKind::Codex))
-            .unwrap();
-        codex.governable = false;
-        codex.provider = Some("fixture-provider".into());
+            .unwrap()
+            .clone();
+        provider.id = "placement_provider_fixture".into();
+        provider.agent = None;
+        provider.governable = false;
+        provider.provider = Some("fixture-provider".into());
+        snapshot.placements.push(provider);
         let skill_id = snapshot.skills[0].id.clone();
         let changes = ["codex", "claude-code", "pi"]
             .into_iter()
@@ -1455,7 +1498,11 @@ mod tests {
             Err(error) => error,
         };
 
-        assert!(error.to_string().contains("provider-managed and read-only"));
+        let blocker = error.downcast_ref::<RosterSafetyBlocker>().unwrap();
+        assert!(matches!(
+            blocker,
+            RosterSafetyBlocker::ProviderManaged { .. }
+        ));
         assert!(!codex_root.join("control-browser").exists());
     }
 

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -18,6 +18,44 @@ pub struct DerivedRosterPlan {
     pub impact: Value,
 }
 
+#[derive(Debug)]
+pub struct RosterPhysicalConflict {
+    pub skill_id: String,
+    pub agents: Vec<String>,
+}
+
+impl std::fmt::Display for RosterPhysicalConflict {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Skill {} has incompatible Core and non-Core requests across one shared physical placement for Agents {}; separate the shared Agent roots or request a consistent exposure state",
+            self.skill_id,
+            self.agents.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for RosterPhysicalConflict {}
+
+#[derive(Debug)]
+pub struct RosterOperationConflict {
+    pub operation_kind: String,
+    pub path: PathBuf,
+}
+
+impl std::fmt::Display for RosterOperationConflict {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Roster Plan contains more than one {} operation for physical path {}; resolve overlapping physical ownership or the same-name variant Finding before retrying",
+            self.operation_kind,
+            self.path.display()
+        )
+    }
+}
+
+impl std::error::Error for RosterOperationConflict {}
+
 #[derive(Clone, Debug)]
 pub struct RosterChangeExclusion {
     pub agent: String,
@@ -432,6 +470,7 @@ pub fn derive(
             .iter()
             .map(|request| Ok((agent(&request.agent)?, request.state.as_str())))
             .collect::<Result<BTreeMap<_, _>>>()?;
+        ensure_physical_exposure_compatible(skill_id, &placements, &desired)?;
         let removal = placements
             .iter()
             .copied()
@@ -447,7 +486,7 @@ pub fn derive(
             .as_ref()
             .map(|path| change::fingerprint(path))
             .transpose()?;
-        let mut migrated_id = None;
+        let mut migrated_source = None;
 
         if source.is_none() && !removal.is_empty() {
             let canonical = removal
@@ -464,17 +503,18 @@ pub fn derive(
                 bail!("Library target {} already exists", library_path.display());
             }
             needs_library_root |= !library_root.exists();
-            let canonical_fingerprint = change::fingerprint(&canonical.directory)?;
+            let canonical_source = physical_mutation_path(canonical);
+            let canonical_fingerprint = change::fingerprint(&canonical_source)?;
             operations.push(json!({
                 "kind": "move_recoverable",
-                "source": canonical.directory,
+                "source": canonical_source,
                 "target": library_path,
                 "expected_fingerprint": canonical_fingerprint
             }));
             *operation_groups.entry("host_canonical").or_default() += 1;
             source = Some(library_path.clone());
             source_fingerprint = Some(canonical_fingerprint);
-            migrated_id = Some(canonical.id.as_str());
+            migrated_source = Some(physical_mutation_path(canonical));
             implicit_library_changes.push(LibraryChangeAction {
                 skill_id: skill_id.to_string(),
                 canonical_placement_id: canonical.id.clone(),
@@ -483,7 +523,7 @@ pub fn derive(
                     .map(|placement| placement.id.clone())
                     .collect(),
                 requested_state: "hosted".into(),
-                canonical_path: canonical.directory.clone(),
+                canonical_path: physical_mutation_path(canonical),
                 library_path: Some(library_path),
             });
         }
@@ -546,19 +586,26 @@ pub fn derive(
             }
         }
 
+        let mut physical_removals = BTreeMap::<PathBuf, &SkillPlacement>::new();
         for placement in &removal {
             before_exposure += usize::from(placement.default_exposed);
             affected_placements.insert(placement.id.clone());
-            if migrated_id == Some(placement.id.as_str()) {
+            physical_removals
+                .entry(physical_mutation_path(placement))
+                .or_insert(placement);
+        }
+        for (physical_source, placement) in physical_removals {
+            if migrated_source.as_ref() == Some(&physical_source) {
                 continue;
             }
             needs_backup_root |= !backup_root.exists();
             let backup = backup_root.join(format!("{nonce}-{}", placement.id));
+            let expected_fingerprint = change::fingerprint(&physical_source)?;
             operations.push(json!({
                 "kind": "move_recoverable",
-                "source": placement.directory,
+                "source": physical_source,
                 "target": backup,
-                "expected_fingerprint": change::fingerprint(&placement.directory)?
+                "expected_fingerprint": expected_fingerprint
             }));
             *operation_groups.entry("remove_exposure").or_default() += 1;
         }
@@ -664,6 +711,7 @@ pub fn derive(
         );
         *operation_groups.entry("create_library").or_default() += 1;
     }
+    ensure_unique_operation_paths(&operations)?;
 
     for placement in &scan.placements {
         if placement.default_exposed
@@ -702,17 +750,143 @@ pub fn derive(
     })
 }
 
+fn ensure_physical_exposure_compatible(
+    skill_id: &str,
+    placements: &[&SkillPlacement],
+    desired: &BTreeMap<AgentKind, &str>,
+) -> Result<()> {
+    let mut groups = BTreeMap::<PathBuf, Vec<&SkillPlacement>>::new();
+    for placement in placements
+        .iter()
+        .copied()
+        .filter(|placement| placement.default_exposed)
+    {
+        groups
+            .entry(physical_mutation_path(placement))
+            .or_default()
+            .push(placement);
+    }
+    for placements in groups.into_values().filter(|group| group.len() > 1) {
+        let has_demotion = placements.iter().any(|placement| {
+            placement
+                .agent
+                .and_then(|agent| desired.get(&agent))
+                .is_some_and(|state| *state != "core")
+        });
+        let has_retained_exposure = placements.iter().any(|placement| {
+            placement
+                .agent
+                .is_some_and(|agent| desired.get(&agent).is_none_or(|state| *state == "core"))
+        });
+        if has_demotion && has_retained_exposure {
+            let agents = placements
+                .iter()
+                .filter_map(|placement| placement.agent.map(AgentKind::id))
+                .map(str::to_owned)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            return Err(RosterPhysicalConflict {
+                skill_id: skill_id.to_owned(),
+                agents,
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn physical_mutation_path(placement: &SkillPlacement) -> PathBuf {
+    if std::fs::symlink_metadata(&placement.directory)
+        .is_ok_and(|metadata| metadata.file_type().is_symlink())
+    {
+        let Some(parent) = placement.directory.parent() else {
+            return placement.directory.clone();
+        };
+        let Some(name) = placement.directory.file_name() else {
+            return placement.directory.clone();
+        };
+        return std::fs::canonicalize(parent)
+            .unwrap_or_else(|_| parent.to_path_buf())
+            .join(name);
+    }
+    placement.physical_directory_or_logical().to_path_buf()
+}
+
+fn ensure_unique_operation_paths(operations: &[Value]) -> Result<()> {
+    let mut move_sources = BTreeSet::new();
+    let mut targets = BTreeMap::<PathBuf, &str>::new();
+    for operation in operations {
+        if operation["kind"] == "move_recoverable" {
+            let source = operation["source"]
+                .as_str()
+                .ok_or_else(|| anyhow!("Roster move operation has no source"))?;
+            let source = physical_operation_path(Path::new(source));
+            if !move_sources.insert(source.clone()) {
+                return Err(RosterOperationConflict {
+                    operation_kind: "destructive-source".into(),
+                    path: source,
+                }
+                .into());
+            }
+        }
+        let Some(target) = operation["target"].as_str() else {
+            continue;
+        };
+        let target = physical_operation_path(Path::new(target));
+        let kind = operation["kind"].as_str().unwrap_or("unknown");
+        if let Some(first_kind) = targets.insert(target.clone(), kind) {
+            return Err(RosterOperationConflict {
+                operation_kind: format!("target ({first_kind} and {kind})"),
+                path: target,
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn physical_operation_path(path: &Path) -> PathBuf {
+    if std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        let Some(parent) = path.parent() else {
+            return path.to_path_buf();
+        };
+        let Some(name) = path.file_name() else {
+            return path.to_path_buf();
+        };
+        return std::fs::canonicalize(parent)
+            .unwrap_or_else(|_| parent.to_path_buf())
+            .join(name);
+    }
+    if let Ok(resolved) = std::fs::canonicalize(path) {
+        return resolved;
+    }
+    let Some(parent) = path.parent() else {
+        return path.to_path_buf();
+    };
+    let Some(name) = path.file_name() else {
+        return path.to_path_buf();
+    };
+    std::fs::canonicalize(parent)
+        .unwrap_or_else(|_| parent.to_path_buf())
+        .join(name)
+}
+
 fn verified_real_source(
     placements: &[&SkillPlacement],
     excluded: &[&SkillPlacement],
     digest: &str,
 ) -> Option<PathBuf> {
+    let excluded_sources = excluded
+        .iter()
+        .map(|placement| physical_mutation_path(placement))
+        .collect::<BTreeSet<_>>();
     placements
         .iter()
         .copied()
-        .filter(|placement| !excluded.iter().any(|item| item.id == placement.id))
+        .filter(|placement| !excluded_sources.contains(&physical_mutation_path(placement)))
         .find(|placement| is_real_exact(placement, digest))
-        .map(|placement| placement.directory.clone())
+        .map(physical_mutation_path)
 }
 
 fn is_real_exact(placement: &SkillPlacement, digest: &str) -> bool {
@@ -767,6 +941,156 @@ mod tests {
 
     use super::*;
     use crate::scan::{ScanOptions, scan};
+
+    #[cfg(unix)]
+    fn shared_agent_root_fixture() -> (TempDir, ScanResult, PathBuf) {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let shared_root = home.join(".agents_skills");
+        let shared_skill = shared_root.join("shared");
+        fs::create_dir_all(&shared_skill).unwrap();
+        fs::write(
+            shared_skill.join("SKILL.md"),
+            "---\nname: shared\n---\nfixture\n",
+        )
+        .unwrap();
+        for (parent, logical_root) in [
+            (home.join(".codex"), home.join(".codex/skills")),
+            (home.join(".claude"), home.join(".claude/skills")),
+            (home.join(".pi/agent"), home.join(".pi/agent/skills")),
+        ] {
+            fs::create_dir_all(parent).unwrap();
+            symlink(&shared_root, logical_root).unwrap();
+        }
+        let mut options = ScanOptions::for_home(&home);
+        options.include_session_evidence = false;
+        let snapshot = scan(&options).unwrap();
+        assert_eq!(
+            snapshot
+                .placements
+                .iter()
+                .filter(|placement| placement.default_exposed)
+                .count(),
+            3
+        );
+        (temp, snapshot, shared_skill)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_physical_demotion_emits_one_recoverable_move() {
+        let (temp, snapshot, shared_skill) = shared_agent_root_fixture();
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+        let skill_id = snapshot.skills[0].id.clone();
+        let changes = ["codex", "claude-code", "pi"]
+            .into_iter()
+            .map(|agent| RosterChange {
+                agent: agent.into(),
+                skill_id: skill_id.clone(),
+                state: "on_demand".into(),
+            })
+            .collect::<Vec<_>>();
+
+        let plan = derive(&snapshot, &state, &changes).unwrap();
+        let moves = plan
+            .operations
+            .iter()
+            .filter(|operation| operation["kind"] == "move_recoverable")
+            .collect::<Vec<_>>();
+
+        assert_eq!(moves.len(), 1);
+        assert_eq!(
+            moves[0]["source"],
+            json!(fs::canonicalize(shared_skill).unwrap())
+        );
+        assert_eq!(plan.impact["before_default_exposure"], 3);
+        assert_eq!(plan.impact["after_default_exposure"], 0);
+        assert_eq!(
+            plan.impact["affected_placement_ids"]
+                .as_array()
+                .unwrap()
+                .len(),
+            3
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_physical_core_and_demotion_fail_closed() {
+        let (temp, snapshot, shared_skill) = shared_agent_root_fixture();
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+        let skill_id = snapshot.skills[0].id.clone();
+
+        let error = match derive(
+            &snapshot,
+            &state,
+            &[
+                RosterChange {
+                    agent: "codex".into(),
+                    skill_id: skill_id.clone(),
+                    state: "core".into(),
+                },
+                RosterChange {
+                    agent: "claude-code".into(),
+                    skill_id,
+                    state: "on_demand".into(),
+                },
+            ],
+        ) {
+            Ok(_) => panic!("conflicting shared physical states unexpectedly produced a Plan"),
+            Err(error) => error,
+        };
+
+        assert!(error.downcast_ref::<RosterPhysicalConflict>().is_some());
+        assert!(shared_skill.join("SKILL.md").is_file());
+        assert!(fs::read_dir(&state).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn same_name_variants_cannot_share_one_library_target() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let state = temp.path().join("state");
+        for (root, body) in [
+            (home.join(".codex/skills/shared"), "codex variant"),
+            (home.join(".hermes/skills/shared"), "hermes variant"),
+        ] {
+            fs::create_dir_all(&root).unwrap();
+            fs::write(
+                root.join("SKILL.md"),
+                format!("---\nname: shared\n---\n{body}\n"),
+            )
+            .unwrap();
+        }
+        fs::create_dir(&state).unwrap();
+        let mut options = ScanOptions::for_home(&home);
+        options.include_session_evidence = false;
+        let snapshot = scan(&options).unwrap();
+        let changes = snapshot
+            .placements
+            .iter()
+            .filter_map(|placement| {
+                placement.agent.map(|agent| RosterChange {
+                    agent: agent.id().into(),
+                    skill_id: placement.skill_id.clone(),
+                    state: "on_demand".into(),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let error = match derive(&snapshot, &state, &changes) {
+            Ok(_) => panic!("same-name variants unexpectedly shared one Library target"),
+            Err(error) => error,
+        };
+
+        assert!(error.downcast_ref::<RosterOperationConflict>().is_some());
+        assert!(error.to_string().contains("same-name variant Finding"));
+        assert!(fs::read_dir(&state).unwrap().next().is_none());
+    }
 
     #[test]
     fn large_roster_proposal_removes_more_than_half_of_default_exposure() {

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -506,6 +506,12 @@ pub fn derive(
             }
             .into());
         }
+        for placement in placements
+            .iter()
+            .filter(|placement| placement.physical_directory.is_some())
+        {
+            placement.validated_physical_directory()?;
+        }
         let desired = requests
             .iter()
             .map(|request| Ok((agent(&request.agent)?, roster_state(&request.state)?)))
@@ -1170,6 +1176,60 @@ mod tests {
         assert!(error.to_string().contains("run skillroster scan"));
         assert!(shared_skill.join("SKILL.md").is_file());
         assert!(replacement_skill.join("SKILL.md").is_file());
+        assert!(fs::read_dir(&state).unwrap().next().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_source_drift_into_a_removal_requires_a_new_scan() {
+        use std::os::unix::fs::symlink;
+
+        let (temp, mut snapshot, shared_skill) = shared_agent_root_fixture();
+        let source_skill = temp.path().join("sources/shared");
+        fs::create_dir_all(&source_skill).unwrap();
+        fs::write(
+            source_skill.join("SKILL.md"),
+            "---\nname: shared\n---\nfixture\n",
+        )
+        .unwrap();
+        let mut source = snapshot
+            .placements
+            .iter()
+            .find(|placement| placement.agent == Some(AgentKind::Codex))
+            .unwrap()
+            .clone();
+        source.id = "placement_source_fixture".into();
+        source.agent = None;
+        source.root = source_skill.parent().unwrap().to_path_buf();
+        source.directory = source_skill.clone();
+        source.entrypoint = source_skill.join("SKILL.md");
+        source.physical_directory = Some(fs::canonicalize(&source_skill).unwrap());
+        source.link_target = None;
+        source.default_exposed = false;
+        snapshot.placements.push(source);
+        fs::remove_dir_all(&source_skill).unwrap();
+        symlink(&shared_skill, &source_skill).unwrap();
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+        let skill_id = snapshot.skills[0].id.clone();
+        let changes = ["codex", "claude-code", "pi"]
+            .into_iter()
+            .map(|agent| RosterChange {
+                agent: agent.into(),
+                skill_id: skill_id.clone(),
+                state: "on_demand".into(),
+            })
+            .collect::<Vec<_>>();
+
+        let error = derive(&snapshot, &state, &changes).unwrap_err();
+
+        assert!(
+            error
+                .downcast_ref::<crate::scan::PhysicalDirectoryDrift>()
+                .is_some()
+        );
+        assert!(shared_skill.join("SKILL.md").is_file());
+        assert!(source_skill.join("SKILL.md").is_file());
         assert!(fs::read_dir(&state).unwrap().next().is_none());
     }
 

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -506,9 +506,6 @@ pub fn derive(
             }
             .into());
         }
-        for placement in &placements {
-            placement.validated_physical_directory()?;
-        }
         let desired = requests
             .iter()
             .map(|request| Ok((agent(&request.agent)?, roster_state(&request.state)?)))
@@ -524,6 +521,9 @@ pub fn derive(
                     .is_some_and(|state| state != &RosterState::Core)
             })
             .collect::<Vec<_>>();
+        for placement in &removal {
+            placement.validated_physical_directory()?;
+        }
         let provider_placement_ids = provider_placements_on_physical_removal(&placements, &removal)
             .map(|placement| placement.id.clone())
             .collect::<Vec<_>>();
@@ -1383,6 +1383,42 @@ mod tests {
             supported.exclusions[0].observed_source_target.as_deref(),
             Some(outside.as_path())
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_escaping_link_without_mutation_does_not_require_physical_validation() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let root = home.join(".codex/skills");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(
+            outside.join("SKILL.md"),
+            "---\nname: external\n---\nfixture\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("external")).unwrap();
+        let snapshot = scan(&ScanOptions::for_home(&home)).unwrap();
+        assert!(snapshot.placements[0].physical_directory.is_none());
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+
+        let plan = derive(
+            &snapshot,
+            &state,
+            &[RosterChange {
+                agent: "codex".into(),
+                skill_id: snapshot.skills[0].id.clone(),
+                state: "core".into(),
+            }],
+        )
+        .unwrap();
+
+        assert!(plan.operations.is_empty());
+        assert!(fs::read_dir(&state).unwrap().next().is_none());
+        assert!(outside.join("SKILL.md").is_file());
     }
 
     #[cfg(unix)]

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -123,11 +123,54 @@ pub struct SkillPlacement {
     pub declared_name_matches_directory: Option<bool>,
 }
 
+#[derive(Debug)]
+pub struct PhysicalDirectoryDrift {
+    pub placement_id: String,
+    pub expected: Option<PathBuf>,
+    pub current: Option<PathBuf>,
+}
+
+impl std::fmt::Display for PhysicalDirectoryDrift {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Placement {} physical source drifted; run skillroster scan",
+            self.placement_id
+        )
+    }
+}
+
+impl std::error::Error for PhysicalDirectoryDrift {}
+
 impl SkillPlacement {
     pub fn physical_directory_or_logical(&self) -> &Path {
         self.physical_directory
             .as_deref()
             .unwrap_or(&self.directory)
+    }
+
+    pub fn validated_physical_directory(
+        &self,
+    ) -> std::result::Result<PathBuf, PhysicalDirectoryDrift> {
+        let expected = self
+            .physical_directory
+            .clone()
+            .ok_or_else(|| PhysicalDirectoryDrift {
+                placement_id: self.id.clone(),
+                expected: None,
+                current: None,
+            })?;
+        let current = std::fs::canonicalize(&self.entrypoint)
+            .ok()
+            .and_then(|entrypoint| entrypoint.parent().map(Path::to_path_buf));
+        if current.as_ref() != Some(&expected) {
+            return Err(PhysicalDirectoryDrift {
+                placement_id: self.id.clone(),
+                expected: Some(expected),
+                current,
+            });
+        }
+        Ok(expected)
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3680,12 +3680,18 @@ fn large_roster_finding_reports_a_dependent_source_link_before_planning() {
     );
     assert!(!blocked.status.success());
     let blocked: Value = serde_json::from_slice(&blocked.stdout).unwrap();
-    assert!(
-        blocked["error"]["message"]
-            .as_str()
-            .unwrap()
-            .contains("source link depends on a placement scheduled for removal")
+    assert_eq!(blocked["error"]["code"], "roster_dependent_source_conflict");
+    assert_eq!(
+        blocked["error"]["details"]["reason"],
+        "dependent_source_would_break"
     );
+    assert_eq!(
+        blocked["error"]["details"]["paths"],
+        json!([fs::canonicalize(&source_root)
+            .unwrap()
+            .join("dependent-source")])
+    );
+    assert_eq!(blocked["error"]["details"]["files_changed"], false);
 }
 
 #[test]
@@ -4023,6 +4029,38 @@ fn shared_physical_roster_plan_moves_once_and_blocks_conflicting_states() {
             .count(),
         1
     );
+
+    let alternate_root = home.join("alternate-skills");
+    let alternate_skill = alternate_root.join("shared");
+    fs::create_dir_all(&alternate_skill).unwrap();
+    fs::write(
+        alternate_skill.join("SKILL.md"),
+        "---\nname: shared\n---\nalternate\n",
+    )
+    .unwrap();
+    let codex_root = home.join(".codex/skills");
+    fs::remove_file(&codex_root).unwrap();
+    symlink(&alternate_root, &codex_root).unwrap();
+    let drifted_apply = run(&[&common[..], &["apply", plan_id]].concat(), None);
+    assert!(!drifted_apply.status.success());
+    let drifted_apply: Value = serde_json::from_slice(&drifted_apply.stdout).unwrap();
+    assert_eq!(drifted_apply["error"]["code"], "state_drift");
+    assert_eq!(
+        drifted_apply["error"]["details"]["reason"],
+        "physical_source_drift"
+    );
+    assert_eq!(drifted_apply["error"]["details"]["files_changed"], false);
+    assert!(shared_skill.join("SKILL.md").is_file());
+    assert!(alternate_skill.join("SKILL.md").is_file());
+    assert_eq!(
+        database
+            .query_row("SELECT COUNT(*) FROM receipts", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    fs::remove_file(&codex_root).unwrap();
+    symlink(&shared_root, &codex_root).unwrap();
 
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
     assert_eq!(applied["result"]["verification"], "passed");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3968,6 +3968,16 @@ fn shared_physical_roster_plan_moves_once_and_blocks_conflicting_states() {
     assert_eq!(blocked["error"]["code"], "roster_physical_state_conflict");
     assert_eq!(blocked["error"]["retryable"], false);
     assert_eq!(
+        blocked["error"]["details"]["reason"],
+        "shared_physical_state_conflict"
+    );
+    assert_eq!(blocked["error"]["details"]["skill_id"], skill_id);
+    assert_eq!(
+        blocked["error"]["details"]["agents"],
+        json!(["claude-code", "codex", "pi"])
+    );
+    assert_eq!(blocked["error"]["details"]["files_changed"], false);
+    assert_eq!(
         database
             .query_row("SELECT COUNT(*) FROM plans", [], |row| row.get::<_, i64>(0))
             .unwrap(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3899,6 +3899,137 @@ fn large_roster_finding_prepares_and_reverses_a_semantic_layering_plan() {
     assert!(!state.join("library").exists());
 }
 
+#[cfg(unix)]
+#[test]
+fn shared_physical_roster_plan_moves_once_and_blocks_conflicting_states() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let shared_root = home.join(".agents_skills");
+    let shared_skill = shared_root.join("shared");
+    fs::create_dir_all(&shared_skill).unwrap();
+    fs::write(
+        shared_skill.join("SKILL.md"),
+        "---\nname: shared\n---\nfixture\n",
+    )
+    .unwrap();
+    for (parent, logical_root) in [
+        (home.join(".codex"), home.join(".codex/skills")),
+        (home.join(".claude"), home.join(".claude/skills")),
+        (home.join(".pi/agent"), home.join(".pi/agent/skills")),
+    ] {
+        fs::create_dir_all(parent).unwrap();
+        symlink(&shared_root, logical_root).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    let scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let snapshot = scan["result"]["snapshot_id"].as_str().unwrap();
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let payload: String = database
+        .query_row(
+            "SELECT payload_json FROM scan_payloads WHERE scan_id = ?1",
+            [snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let payload: Value = serde_json::from_str(&payload).unwrap();
+    let skill_id = payload["skills"][0]["id"].as_str().unwrap();
+    let evidence_id: String = database
+        .query_row(
+            "SELECT id FROM evidence WHERE scan_id = ?1 ORDER BY id LIMIT 1",
+            [snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let conflict = json!({
+        "schema_version": 1,
+        "scan_id": snapshot,
+        "evidence_ids": [evidence_id],
+        "roster_changes": [
+            {"agent": "codex", "skill_id": skill_id, "state": "core"},
+            {"agent": "claude-code", "skill_id": skill_id, "state": "on_demand"}
+        ]
+    });
+    let blocked = run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&conflict.to_string()),
+    );
+    assert!(!blocked.status.success());
+    let blocked: Value = serde_json::from_slice(&blocked.stdout).unwrap();
+    assert_eq!(blocked["error"]["code"], "roster_physical_state_conflict");
+    assert_eq!(blocked["error"]["retryable"], false);
+    assert_eq!(
+        database
+            .query_row("SELECT COUNT(*) FROM plans", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    assert!(shared_skill.join("SKILL.md").is_file());
+
+    let roster_changes = ["codex", "claude-code", "pi"]
+        .into_iter()
+        .map(|agent| {
+            json!({
+                "agent": agent,
+                "skill_id": skill_id,
+                "state": "on_demand"
+            })
+        })
+        .collect::<Vec<_>>();
+    let demotion = json!({
+        "schema_version": 1,
+        "scan_id": snapshot,
+        "evidence_ids": [evidence_id],
+        "roster_changes": roster_changes
+    });
+    let plan = json_output(&run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&demotion.to_string()),
+    ));
+    assert_eq!(plan["result"]["change_summary"]["roster_change_count"], 3);
+    assert_eq!(plan["result"]["affected"]["placement_count"], 4);
+    assert_eq!(plan["result"]["impact"]["before_default_exposure"], 3);
+    assert_eq!(plan["result"]["impact"]["after_default_exposure"], 0);
+    let plan_id = plan["result"]["plan_id"].as_str().unwrap();
+    let detail = json_output(&run(
+        &[&common[..], &["plan", "--show", plan_id]].concat(),
+        None,
+    ));
+    assert_eq!(
+        detail["result"]["operations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|operation| operation["kind"] == "move_recoverable")
+            .count(),
+        1
+    );
+
+    let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+    assert_eq!(applied["result"]["verification"], "passed");
+    assert!(!shared_skill.exists());
+    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert!(shared_skill.join("SKILL.md").is_file());
+    for logical_skill in [
+        home.join(".codex/skills/shared"),
+        home.join(".claude/skills/shared"),
+        home.join(".pi/agent/skills/shared"),
+    ] {
+        assert!(logical_skill.join("SKILL.md").is_file());
+    }
+}
+
 #[test]
 fn large_roster_plan_uses_exact_cross_agent_usage_before_fallback() {
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
Closes #98.

## What changed

- Separates logical Agent placements from physical mutation identity, so shared roots produce one destructive operation while retaining all logical impact facts.
- Fails closed on mixed Core/non-Core requests, duplicate operation sources or targets, provider-managed physical ownership, dependent non-Agent sources, and post-Scan physical drift.
- Returns stable typed `error.details` for Agent callers instead of requiring message parsing.
- Preserves Apply/Receipt/Undo behavior and verifies shared-root restoration.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (153 unit + 7 acceptance + 38 CLI)
- Real local read-only Scan: 249 Skills / 760 placements / no Agent files changed
- Independent Standards review: no hard violation or should-fix
- Independent Spec review: real shared-root, provider-cache drift, dependent-source drift, Core conflict, Apply, and Undo fixtures PASS
- Temporary integration of PRs #84, #86, #88, #90, #92, #94, #96 plus this branch: 163 unit + 7 acceptance + 45 CLI PASS

## Review note

Do not merge automatically. The temporary integration required a small manual reconciliation with #84 around the shared `ApiError.details` field and error classification; the combined contract is tested and documented in the review evidence.