### PR TITLE
fix: hide stale ready plans from status

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -273,6 +273,8 @@ SkillRoster uses one SQLite database at `~/.skillroster/skillroster.db`, includi
 - `status.pending_plans` contains only actionable Ready Plans for the latest
   Snapshot plus any Applying or Recovery-required Plans. Ready Plans from older
   Snapshots remain inspectable history but are not presented as pending work.
+  The total count remains exact while the returned list is capped and reports
+  whether additional pending Plans were truncated.
 - `status` suggests Scan only when no completed Snapshot exists. A healthy
   state with a Snapshot exposes its timestamp and leaves refresh judgment to
   the Agent instead of creating an unconditional Status-to-Scan loop.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -270,6 +270,9 @@ SkillRoster uses one SQLite database at `~/.skillroster/skillroster.db`, includi
 - Plans and Receipts remain until explicitly purged.
 - Overflow source-confirmation details are versioned local artifacts retained until explicitly purged or local state is deleted.
 - `status` exposes storage location, retention state, and retained source-confirmation artifact counts and bytes.
+- `status.pending_plans` contains only actionable Ready Plans for the latest
+  Snapshot plus any Applying or Recovery-required Plans. Ready Plans from older
+  Snapshots remain inspectable history but are not presented as pending work.
 - `status` suggests Scan only when no completed Snapshot exists. A healthy
   state with a Snapshot exposes its timestamp and leaves refresh judgment to
   the Agent instead of creating an unconditional Status-to-Scan loop.

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,8 @@ use crate::model::{
 use crate::scan::{self, ExplicitSkillRoot, RootKind, ScanOptions, ScanResult};
 use crate::sqlite::StateStore;
 
+const STATUS_PENDING_PLAN_LIMIT: usize = 20;
+
 pub struct Output {
     pub json: String,
     pub human: String,
@@ -400,7 +402,40 @@ struct ClassifiedError {
     details: Option<Value>,
 }
 
+#[derive(Debug)]
+struct PlanSnapshotDrift {
+    plan_id: PlanId,
+    expected_snapshot_id: ScanId,
+    current_snapshot_id: ScanId,
+}
+
+impl std::fmt::Display for PlanSnapshotDrift {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Plan {} is stale; a newer Snapshot exists",
+            self.plan_id
+        )
+    }
+}
+
+impl std::error::Error for PlanSnapshotDrift {}
+
 fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError {
+    if let Some(drift) = error.downcast_ref::<PlanSnapshotDrift>() {
+        return ClassifiedError {
+            code: "state_drift",
+            retryable: false,
+            details: Some(json!({
+                "reason": "plan_snapshot_stale",
+                "plan_id": drift.plan_id,
+                "expected_snapshot_id": drift.expected_snapshot_id,
+                "current_snapshot_id": drift.current_snapshot_id,
+                "files_changed": false,
+                "next_action": "create_plan_for_current_snapshot"
+            })),
+        };
+    }
     if let Some(conflict) = error.downcast_ref::<crate::roster_plan::RosterPhysicalConflict>() {
         return ClassifiedError {
             code: "roster_physical_state_conflict",
@@ -727,10 +762,10 @@ fn home_result(store: &StateStore, state_dir: &Path) -> Result<Value> {
 fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> Result<Value> {
     let latest = store.latest_completed_scan()?;
     let latest_scan_id = latest.as_ref().map(|scan| &scan.id);
-    let pending_plans = store
-        .pending_plans()?
+    let (pending_plan_count, pending_plans) =
+        store.pending_plans(latest_scan_id, STATUS_PENDING_PLAN_LIMIT)?;
+    let pending_plans = pending_plans
         .into_iter()
-        .filter(|plan| plan.status != PlanStatus::Ready || latest_scan_id == Some(&plan.scan_id))
         .map(|plan| {
             json!({
                 "plan_id": plan.id,
@@ -754,7 +789,9 @@ fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> 
         "schema_version": store.schema_version()?,
         "latest_snapshot_id": latest.as_ref().map(|scan| scan.id.to_string()),
         "latest_snapshot_at": latest.and_then(|scan| scan.completed_at),
-        "pending_plan_count": pending_plans.len(),
+        "pending_plan_count": pending_plan_count,
+        "pending_plans_returned": pending_plans.len(),
+        "pending_plans_truncated": pending_plan_count > pending_plans.len(),
         "pending_plans": pending_plans,
         "last_receipt": last_receipt,
         "recovery_state": recovery_text(store, state_dir)?,
@@ -4701,7 +4738,12 @@ fn apply_command(store: &StateStore, id: &str) -> Result<Value> {
     require_clear_journals(store, &prepared.state_dir)?;
     let (latest_scan_id, scan) = latest_scan(store)?;
     if latest_scan_id != record.scan_id {
-        bail!("Plan {id} is stale; a newer Snapshot exists");
+        return Err(PlanSnapshotDrift {
+            plan_id: id,
+            expected_snapshot_id: record.scan_id,
+            current_snapshot_id: latest_scan_id,
+        }
+        .into());
     }
     validate_physical_placement_bindings(&record, &prepared, &scan)?;
     validate_roster_changes(store, &prepared, &scan)?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -726,12 +726,15 @@ fn home_result(store: &StateStore, state_dir: &Path) -> Result<Value> {
 
 fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> Result<Value> {
     let latest = store.latest_completed_scan()?;
+    let latest_scan_id = latest.as_ref().map(|scan| &scan.id);
     let pending_plans = store
         .pending_plans()?
         .into_iter()
+        .filter(|plan| plan.status != PlanStatus::Ready || latest_scan_id == Some(&plan.scan_id))
         .map(|plan| {
             json!({
                 "plan_id": plan.id,
+                "snapshot_id": plan.scan_id,
                 "status": plan.status,
                 "created_at": plan.created_at,
             })

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1308,13 +1308,32 @@ impl StateStore {
         Ok(count != 0)
     }
 
-    pub fn pending_plans(&self) -> StorageResult<Vec<PlanRecord>> {
+    pub fn pending_plans(
+        &self,
+        latest_scan_id: Option<&ScanId>,
+        limit: usize,
+    ) -> StorageResult<(usize, Vec<PlanRecord>)> {
+        let latest_scan_id = latest_scan_id.map(ScanId::as_str);
+        let count: i64 = self.connection.query_row(
+            "SELECT COUNT(*) FROM plans
+             WHERE status IN ('applying', 'recovery_required')
+                OR (status = 'ready' AND scan_id = ?1)",
+            params![latest_scan_id],
+            |row| row.get(0),
+        )?;
         let mut statement = self.connection.prepare(
             "SELECT immutable_json, status FROM plans
-             WHERE status IN ('ready', 'applying', 'recovery_required')
-             ORDER BY created_at ASC, id ASC",
+             WHERE status IN ('applying', 'recovery_required')
+                OR (status = 'ready' AND scan_id = ?1)
+             ORDER BY CASE status
+                 WHEN 'recovery_required' THEN 0
+                 WHEN 'applying' THEN 1
+                 ELSE 2
+             END,
+             created_at DESC, id DESC
+             LIMIT ?2",
         )?;
-        let rows = statement.query_map([], |row| {
+        let rows = statement.query_map(params![latest_scan_id, limit as i64], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })?;
         let mut plans = Vec::new();
@@ -1324,7 +1343,9 @@ impl StateStore {
             plan.status = enum_from_text(&status)?;
             plans.push(plan);
         }
-        Ok(plans)
+        let count = usize::try_from(count)
+            .map_err(|_| StorageError::InvalidData("pending Plan count is invalid".into()))?;
+        Ok((count, plans))
     }
 
     pub fn latest_receipt(&self) -> StorageResult<Option<ReceiptRecord>> {
@@ -2375,6 +2396,47 @@ mod tests {
             store.get_plan(&plan.id).unwrap().unwrap().status,
             PlanStatus::Ready
         );
+    }
+
+    #[test]
+    fn pending_plans_are_current_bounded_and_lifecycle_prioritized() {
+        let store = StateStore::open_in_memory().unwrap();
+        let old_scan = scan();
+        let mut current_scan = scan();
+        current_scan.started_at = 30;
+        current_scan.completed_at = Some(40);
+        store.save_scan(&old_scan).unwrap();
+        store.save_scan(&current_scan).unwrap();
+        let save_plan = |scan_id: ScanId, status: PlanStatus, created_at: i64| {
+            let plan = PlanRecord {
+                id: PlanId::new(),
+                scan_id,
+                report_id: None,
+                created_at,
+                status,
+                input: serde_json::json!({}),
+                fingerprint: format!("plan-{created_at}"),
+                operations: Vec::new(),
+            };
+            store.save_plan(&plan).unwrap();
+            plan.id
+        };
+        let stale_ready = save_plan(old_scan.id.clone(), PlanStatus::Ready, 1);
+        let applying = save_plan(old_scan.id.clone(), PlanStatus::Applying, 2);
+        let recovery = save_plan(old_scan.id, PlanStatus::RecoveryRequired, 3);
+        for created_at in 10..35 {
+            save_plan(current_scan.id.clone(), PlanStatus::Ready, created_at);
+        }
+
+        let (count, plans) = store.pending_plans(Some(&current_scan.id), 20).unwrap();
+
+        assert_eq!(count, 27);
+        assert_eq!(plans.len(), 20);
+        assert_eq!(plans[0].id, recovery);
+        assert_eq!(plans[0].status, PlanStatus::RecoveryRequired);
+        assert_eq!(plans[1].id, applying);
+        assert_eq!(plans[1].status, PlanStatus::Applying);
+        assert!(plans.iter().all(|plan| plan.id != stale_ready));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1950,11 +1950,40 @@ fn repeated_setup_reuses_the_same_ready_plan() {
     let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
     assert_eq!(status["result"]["pending_plan_count"], 2);
 
-    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let newer_scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
     let after_new_snapshot = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_ne!(
         after_new_snapshot["result"]["plan_id"],
         default_after_explicit["result"]["plan_id"]
+    );
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["pending_plan_count"], 1);
+    assert_eq!(
+        status["result"]["pending_plans"][0]["plan_id"],
+        after_new_snapshot["result"]["plan_id"]
+    );
+    assert_eq!(
+        status["result"]["pending_plans"][0]["snapshot_id"],
+        newer_scan["result"]["snapshot_id"]
+    );
+    assert_eq!(status["result"]["files_changed"], false);
+
+    let old_plan_id = default_after_explicit["result"]["plan_id"]
+        .as_str()
+        .unwrap();
+    let retained = json_output(&run(
+        &[&common[..], &["plan", "--show", old_plan_id]].concat(),
+        None,
+    ));
+    assert_eq!(retained["result"]["plan_id"], old_plan_id);
+    let stale_apply = run(&[&common[..], &["apply", old_plan_id]].concat(), None);
+    assert!(!stale_apply.status.success());
+    let stale_apply: Value = serde_json::from_slice(&stale_apply.stdout).unwrap();
+    assert!(
+        stale_apply["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("newer Snapshot exists")
     );
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1985,6 +1985,25 @@ fn repeated_setup_reuses_the_same_ready_plan() {
             .unwrap()
             .contains("newer Snapshot exists")
     );
+
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    for lifecycle_status in ["applying", "recovery_required"] {
+        database
+            .execute(
+                "UPDATE plans SET status = ?1 WHERE id = ?2",
+                rusqlite::params![lifecycle_status, old_plan_id],
+            )
+            .unwrap();
+        let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+        assert_eq!(status["result"]["pending_plan_count"], 2);
+        let retained_lifecycle = status["result"]["pending_plans"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|plan| plan["plan_id"] == old_plan_id)
+            .unwrap();
+        assert_eq!(retained_lifecycle["status"], lifecycle_status);
+    }
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1872,7 +1872,7 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
 }
 
 #[test]
-fn repeated_setup_reuses_the_same_ready_plan() {
+fn setup_reuse_and_status_actionability_follow_snapshot_lifecycle() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
     let state = temp.path().join("state");
@@ -1979,6 +1979,21 @@ fn repeated_setup_reuses_the_same_ready_plan() {
     let stale_apply = run(&[&common[..], &["apply", old_plan_id]].concat(), None);
     assert!(!stale_apply.status.success());
     let stale_apply: Value = serde_json::from_slice(&stale_apply.stdout).unwrap();
+    assert_eq!(stale_apply["error"]["code"], "state_drift");
+    assert_eq!(
+        stale_apply["error"]["details"]["reason"],
+        "plan_snapshot_stale"
+    );
+    assert_eq!(stale_apply["error"]["details"]["plan_id"], old_plan_id);
+    assert_eq!(
+        stale_apply["error"]["details"]["current_snapshot_id"],
+        newer_scan["result"]["snapshot_id"]
+    );
+    assert_ne!(
+        stale_apply["error"]["details"]["expected_snapshot_id"],
+        stale_apply["error"]["details"]["current_snapshot_id"]
+    );
+    assert_eq!(stale_apply["error"]["details"]["files_changed"], false);
     assert!(
         stale_apply["error"]["message"]
             .as_str()


### PR DESCRIPTION
Closes #97.

## What changed
- filters `status.pending_plans` so Ready Plans are actionable only when bound to the latest completed Snapshot
- keeps Applying and Recovery-required Plans visible regardless of Snapshot age
- includes each actionable Plan snapshot ID in structured Status output
- retains old Ready Plans unchanged for `plan --show`; Apply still rejects them as stale
- documents the pending-plan contract without adding a lifecycle state or migration

## Verification
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (167 unit + 7 acceptance + 46 CLI)
- `git diff --check`

The regression covers same-Snapshot Setup reuse, a newer Snapshot, filtered Status, retained Plan inspection, and stale Apply rejection.