### PR TITLE
fix: make Finding follow-ups truthful and decision-relevant

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1635,6 +1635,22 @@ fn compact_scan_warnings(warnings: Vec<String>) -> Vec<String> {
     remaining
 }
 
+fn usage_finding_evidence_priority(evidence: &EvidenceRecord) -> u8 {
+    if evidence.kind == EvidenceKind::Coverage {
+        return 0;
+    }
+    if evidence.kind != EvidenceKind::Usage {
+        return 5;
+    }
+    let exposed = evidence.details["stage"].as_str() == Some("exposed");
+    match (&evidence.quality, exposed) {
+        (EvidenceQuality::Observed, false) => 1,
+        (EvidenceQuality::Observed, true) => 2,
+        (_, false) => 3,
+        (_, true) => 4,
+    }
+}
+
 #[derive(Clone, Copy)]
 enum ReportRequest<'a> {
     Summary,
@@ -1705,6 +1721,40 @@ fn report_command(store: &StateStore, request: ReportRequest<'_>) -> Result<Valu
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
+            let ordered_evidence = if stored.title == "Five-stage usage evidence" {
+                let mut evidence = store.finding_evidence(&id)?;
+                evidence.sort_by(|left, right| {
+                    usage_finding_evidence_priority(left)
+                        .cmp(&usage_finding_evidence_priority(right))
+                        .then_with(|| {
+                            left.details["agent"]
+                                .as_str()
+                                .cmp(&right.details["agent"].as_str())
+                        })
+                        .then_with(|| {
+                            left.details["skill_id"]
+                                .as_str()
+                                .cmp(&right.details["skill_id"].as_str())
+                        })
+                        .then_with(|| {
+                            left.details["stage"]
+                                .as_str()
+                                .cmp(&right.details["stage"].as_str())
+                        })
+                        .then_with(|| left.id.as_str().cmp(right.id.as_str()))
+                });
+                evidence
+            } else {
+                Vec::new()
+            };
+            let ordered_evidence_ids = if ordered_evidence.is_empty() {
+                stored.evidence_ids.clone()
+            } else {
+                ordered_evidence
+                    .iter()
+                    .map(|evidence| evidence.id.clone())
+                    .collect()
+            };
             let end = offset.saturating_add(limit);
             let paged_skill_ids = affected_skill_ids
                 .iter()
@@ -1718,8 +1768,7 @@ fn report_command(store: &StateStore, request: ReportRequest<'_>) -> Result<Valu
                 .take(limit)
                 .cloned()
                 .collect::<Vec<_>>();
-            let paged_evidence_ids = stored
-                .evidence_ids
+            let paged_evidence_ids = ordered_evidence_ids
                 .iter()
                 .skip(offset)
                 .take(limit)
@@ -1750,24 +1799,32 @@ fn report_command(store: &StateStore, request: ReportRequest<'_>) -> Result<Valu
                 })
                 .collect::<Vec<_>>();
             placements.sort_by(|left, right| left["id"].as_str().cmp(&right["id"].as_str()));
-            let evidence = paged_evidence_ids
-                .iter()
-                .map(|id| store.get_evidence(id))
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>();
+            let evidence = if ordered_evidence.is_empty() {
+                paged_evidence_ids
+                    .iter()
+                    .map(|id| store.get_evidence(id))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+            } else {
+                ordered_evidence
+                    .into_iter()
+                    .skip(offset)
+                    .take(limit)
+                    .collect()
+            };
             let total = affected_skill_ids
                 .len()
                 .max(affected_placement_ids.len())
-                .max(stored.evidence_ids.len());
+                .max(ordered_evidence_ids.len());
             let next_offset = (end < total).then_some(end);
             object.insert("affected_skill_ids".into(), json!(paged_skill_ids));
             object.insert("affected_placement_ids".into(), json!(paged_placement_ids));
             object.insert("evidence_ids".into(), json!(paged_evidence_ids));
             object.insert(
                 "primary_evidence_id".into(),
-                json!(stored.evidence_ids.first()),
+                json!(ordered_evidence_ids.first()),
             );
             object.insert("placements".into(), json!(placements));
             object.insert("evidence".into(), json!(evidence));
@@ -1781,7 +1838,7 @@ fn report_command(store: &StateStore, request: ReportRequest<'_>) -> Result<Valu
                     "totals": {
                         "affected_skills": affected_skill_ids.len(),
                         "affected_placements": affected_placement_ids.len(),
-                        "evidence": stored.evidence_ids.len()
+                        "evidence": ordered_evidence_ids.len()
                     },
                     "returned": {
                         "affected_skills": object["affected_skill_ids"].as_array().map_or(0, Vec::len),
@@ -2140,9 +2197,30 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
                 result["resolution"]["decision"].as_str() == Some("confirm_trusted_source_roots");
             let requires_variant_decision =
                 result["resolution"]["decision"].as_str() == Some("choose_same_name_variant");
-            let planning_blocked = result["planning"]["supported"].as_bool() == Some(false);
+            let planning_supported = result["planning"]["supported"].as_bool() == Some(true);
             let mut actions = Vec::new();
-            if !requires_trust_decision && !requires_variant_decision && !planning_blocked {
+            if let Some(next_offset) = result["page"]["next_offset"].as_u64() {
+                let mut argv = vec!["report".to_owned(), "--finding".to_owned(), id.to_owned()];
+                if full {
+                    argv.push("--full".to_owned());
+                }
+                argv.extend([
+                    "--limit".to_owned(),
+                    limit.to_string(),
+                    "--offset".to_owned(),
+                    next_offset.to_string(),
+                    "--json".to_owned(),
+                ]);
+                let argv = argv.iter().map(String::as_str).collect::<Vec<_>>();
+                actions.push(action(
+                    "list_more_finding_detail",
+                    &argv,
+                    false,
+                    false,
+                    "more_finding_detail_available",
+                ));
+            }
+            if !requires_trust_decision && !requires_variant_decision && planning_supported {
                 actions.push(action(
                     "plan",
                     &["plan", "--stdin", "--json"],

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -702,6 +702,57 @@ impl StateStore {
             .transpose()
     }
 
+    pub fn finding_evidence(&self, id: &FindingId) -> StorageResult<Vec<EvidenceRecord>> {
+        let mut statement = self.connection.prepare(
+            "SELECT e.id, e.scan_id, e.kind, e.quality, e.subject_type, e.subject_id,
+                    e.path, e.digest, e.details_json, e.observed_at
+             FROM finding_evidence fe
+             JOIN evidence e ON e.id = fe.evidence_id
+             WHERE fe.finding_id = ?1",
+        )?;
+        let rows = statement.query_map([id.as_str()], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+                row.get::<_, String>(8)?,
+                row.get::<_, i64>(9)?,
+            ))
+        })?;
+        rows.map(|row| {
+            let (
+                id,
+                scan_id,
+                kind,
+                quality,
+                subject_type,
+                subject_id,
+                path,
+                digest,
+                details,
+                observed_at,
+            ) = row?;
+            Ok(EvidenceRecord {
+                id: EvidenceId::parse(id).map_err(invalid_id)?,
+                scan_id: ScanId::parse(scan_id).map_err(invalid_id)?,
+                kind: enum_from_text(&kind)?,
+                quality: enum_from_text(&quality)?,
+                subject_type,
+                subject_id,
+                path,
+                digest,
+                details: from_json(&details)?,
+                observed_at,
+            })
+        })
+        .collect()
+    }
+
     pub fn save_roster_entry(&self, entry: &RosterEntry) -> StorageResult<()> {
         self.connection.execute(
             "INSERT INTO roster_entries (agent_id, skill_id, state, updated_at)

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -363,6 +363,13 @@ fn usage_finding_names_skills_and_uses_public_agent_ids() {
         .expect("compact Claude Code Loaded evidence");
     assert_eq!(compact_claude["facts"]["skill_name"], "claude-code-fixture");
     let overview = &compact["result"]["usage_overview"];
+    assert!(
+        compact["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|action| action["action"] != "plan")
+    );
     assert_eq!(overview["stages"].as_array().unwrap().len(), 5);
     assert_eq!(overview["coverage"]["supported_agent_count"], 8);
     assert_eq!(overview["coverage"]["roots_present_agent_count"], 8);
@@ -408,6 +415,31 @@ fn usage_finding_names_skills_and_uses_public_agent_ids() {
         })
         .expect("full Claude Code Loaded evidence");
     assert_eq!(full_claude["details"]["skill_name"], "claude-code-fixture");
+    let full_evidence = full["result"]["evidence"].as_array().unwrap();
+    let first_observed_activity = full_evidence
+        .iter()
+        .position(|evidence| {
+            evidence["kind"] == "usage"
+                && evidence["quality"] == "observed"
+                && evidence["details"]["stage"] != "exposed"
+        })
+        .expect("observed non-exposure usage evidence");
+    let first_inferred_exposure = full_evidence
+        .iter()
+        .position(|evidence| {
+            evidence["kind"] == "usage"
+                && evidence["quality"] != "observed"
+                && evidence["details"]["stage"] == "exposed"
+        })
+        .expect("inferred exposure evidence");
+    assert!(first_observed_activity < first_inferred_exposure);
+    assert!(
+        full["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|action| action["action"] != "plan")
+    );
     assert_eq!(
         compact["result"]["usage_overview"],
         full["result"]["usage_overview"]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -621,6 +621,27 @@ fn finding_drilldown_is_bounded_and_pageable() {
     assert!(first["result"].get("placements").is_none());
     assert!(first["result"].get("affected_placement_ids").is_none());
     assert!(first["result"].get("evidence_ids").is_none());
+    assert_eq!(
+        first["suggested_actions"][0]["action"],
+        "list_more_finding_detail"
+    );
+    assert_eq!(
+        first["suggested_actions"][0]["argv"],
+        context_action_argv(
+            &home,
+            &state,
+            &[
+                "report",
+                "--finding",
+                finding_id,
+                "--limit",
+                "20",
+                "--offset",
+                "20",
+                "--json",
+            ]
+        )
+    );
 
     let second = json_output(&run(
         &[
@@ -654,6 +675,28 @@ fn finding_drilldown_is_bounded_and_pageable() {
     assert!(full["result"]["evidence"].is_array());
     assert!(full["result"]["affected_placement_ids"].is_array());
     assert!(full_output.stdout.len() > first_output.stdout.len());
+    assert_eq!(
+        full["suggested_actions"][0]["action"],
+        "list_more_finding_detail"
+    );
+    assert_eq!(
+        full["suggested_actions"][0]["argv"],
+        context_action_argv(
+            &home,
+            &state,
+            &[
+                "report",
+                "--finding",
+                finding_id,
+                "--full",
+                "--limit",
+                "20",
+                "--offset",
+                "20",
+                "--json",
+            ]
+        )
+    );
 }
 
 #[test]
@@ -3434,6 +3477,13 @@ fn exact_duplicate_finding_prepares_library_plan_from_semantic_choices() {
     ));
     let planning = &detail["result"]["planning"];
     assert_eq!(planning["supported"], true);
+    assert!(
+        detail["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|action| action["action"] == "plan")
+    );
     assert_eq!(planning["snapshot_id"], report["result"]["snapshot_id"]);
     assert_eq!(planning["request_field"], "finding_library_changes");
     let candidates = planning["canonical_candidates"].as_array().unwrap();


### PR DESCRIPTION
Closes #105.

## What changed

- only suggest `plan --stdin` when the Finding explicitly has `planning.supported=true`
- add replayable `list_more_finding_detail` actions for compact and full Finding pages
- rank Usage Finding evidence before pagination: coverage boundaries, observed activity, then weaker signals and inferred exposure
- preserve this ordering when reading persisted reports, including reports created before this change

## Agent dogfood evidence

On the isolated real 8-Agent state used to discover #105, the first 100-row page now contains all 8 coverage records and 35 observed non-exposure rows before inferred exposure. The Usage Finding no longer suggests Plan. Its next-page argv replayed successfully with the same state/home/finding/full/limit context.

No Apply ran and no real Agent files changed.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (170 unit + 7 acceptance + 47 CLI)
- `git diff --check`