### PR TITLE
fix: make large-Roster source blockers decision-complete

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1705,9 +1705,14 @@ fn report_command(store: &StateStore, request: ReportRequest<'_>) -> Result<Valu
                 finding_library_planning(&stored, &report.scan_id, &latest_scan_id, &scan)
             {
                 object.insert("planning".into(), planning);
-            } else if let Some(planning) =
-                finding_roster_planning(store, &stored, &report.scan_id, &latest_scan_id, &scan)?
-            {
+            } else if let Some(planning) = finding_roster_planning(
+                store,
+                &stored,
+                &report.scan_id,
+                &latest_scan_id,
+                &scan,
+                full,
+            )? {
                 object.insert("planning".into(), planning);
             }
             add_same_name_resolution(object, &scan);
@@ -2383,12 +2388,97 @@ fn finding_library_planning(
     }))
 }
 
+#[derive(Default)]
+struct BlockedSkillFacts {
+    name: String,
+    agents: BTreeSet<String>,
+    reasons: BTreeSet<&'static str>,
+    observed_source_targets: BTreeSet<String>,
+    dependent_source_paths: BTreeSet<String>,
+    dependent_placement_ids: BTreeSet<String>,
+}
+
+struct BlockedSkillPlanning {
+    count: usize,
+    items: Vec<Value>,
+    truncated: bool,
+    displayed_skill_ids: Vec<String>,
+    displayed_dependent_source_paths: Vec<String>,
+}
+
+fn blocked_skill_planning(
+    exclusions: &[crate::roster_plan::RosterChangeExclusion],
+    full: bool,
+) -> BlockedSkillPlanning {
+    let mut by_skill = BTreeMap::<String, BlockedSkillFacts>::new();
+    for exclusion in exclusions {
+        let facts = by_skill.entry(exclusion.skill_id.clone()).or_default();
+        facts.name = exclusion.name.clone();
+        facts.agents.insert(exclusion.agent.clone());
+        facts.reasons.insert(exclusion.reason);
+        if let Some(target) = &exclusion.observed_source_target {
+            facts
+                .observed_source_targets
+                .insert(target.display().to_string());
+        }
+        if let Some(crate::roster_plan::RosterSafetyBlocker::DependentSource {
+            placement_ids,
+            paths,
+            ..
+        }) = &exclusion.safety_blocker
+        {
+            facts
+                .dependent_placement_ids
+                .extend(placement_ids.iter().cloned());
+            facts
+                .dependent_source_paths
+                .extend(paths.iter().map(|path| path.display().to_string()));
+        }
+    }
+
+    let count = by_skill.len();
+    let limit = if full { usize::MAX } else { 5 };
+    let selected = by_skill.into_iter().take(limit).collect::<Vec<_>>();
+    let displayed_skill_ids = selected
+        .iter()
+        .map(|(skill_id, _)| skill_id.clone())
+        .collect::<Vec<_>>();
+    let displayed_dependent_source_paths = selected
+        .iter()
+        .flat_map(|(_, facts)| facts.dependent_source_paths.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let items = selected
+        .into_iter()
+        .map(|(skill_id, facts)| {
+            json!({
+                "skill_id": skill_id,
+                "name": facts.name,
+                "agents": facts.agents,
+                "reasons": facts.reasons,
+                "observed_source_targets": facts.observed_source_targets,
+                "dependent_source_paths": facts.dependent_source_paths,
+                "dependent_placement_ids": facts.dependent_placement_ids
+            })
+        })
+        .collect();
+    BlockedSkillPlanning {
+        count,
+        items,
+        truncated: count > limit,
+        displayed_skill_ids,
+        displayed_dependent_source_paths,
+    }
+}
+
 fn finding_roster_planning(
     store: &StateStore,
     finding: &FindingRecord,
     scan_id: &ScanId,
     latest_scan_id: &ScanId,
     scan: &ScanResult,
+    full: bool,
 ) -> Result<Option<Value>> {
     if !crate::roster_recommendation::is_large_roster_finding(finding) {
         return Ok(None);
@@ -2471,12 +2561,15 @@ fn finding_roster_planning(
             json!({
                 "agent": exclusion.agent,
                 "skill_id": exclusion.skill_id,
+                "name": exclusion.name,
                 "reason": exclusion.reason,
-                "state": "unchanged"
+                "state": "unchanged",
+                "observed_source_target": exclusion.observed_source_target
             })
         })
         .collect::<Vec<_>>();
     if blocked_change_count > 0 {
+        let blocked_skills = blocked_skill_planning(&supported.exclusions, full);
         let source_dependency = supported
             .exclusions
             .iter()
@@ -2494,6 +2587,39 @@ fn finding_roster_planning(
             .map(|path| path.display().to_string())
             .collect::<BTreeSet<_>>();
         if source_dependency {
+            let mut protect_choice = json!({
+                "choice": "protect_blocked_skills_as_core",
+                "requires_confirmation": true,
+                "protected_skill_ids": blocked_skills.displayed_skill_ids,
+                "protected_skill_ids_complete": !blocked_skills.truncated,
+                "plan_request_template_available": !blocked_skills.truncated,
+                "next": if blocked_skills.truncated {
+                    "open the full Finding before constructing a complete protected-Skill Plan request"
+                } else {
+                    "after user confirmation, retry Plan with these protected Skill identities; another independent blocker may still fail closed"
+                }
+            });
+            if !blocked_skills.truncated {
+                protect_choice["plan_request_template"] = json!({
+                    "schema_version": 1,
+                    "finding_roster_changes": [{
+                        "finding_id": finding.id,
+                        "core_budget": crate::roster_recommendation::MAX_CORE_BUDGET,
+                        "protected_skill_ids": blocked_skills.displayed_skill_ids
+                    }]
+                });
+            }
+            let source_choice = json!({
+                "choice": "preserve_or_retarget_dependent_sources",
+                "requires_confirmation": true,
+                "dependent_source_paths": blocked_skills.displayed_dependent_source_paths,
+                "dependent_source_paths_complete": !blocked_skills.truncated,
+                "next": if blocked_skills.truncated {
+                    "open the full Finding before changing any dependent source link"
+                } else {
+                    "after user-approved manual preservation or retargeting, rescan and reopen the new large-Roster Finding"
+                }
+            });
             return Ok(Some(json!({
                 "supported": false,
                 "reason": "source_dependency_blocks_roster_change",
@@ -2509,9 +2635,13 @@ fn finding_roster_planning(
                 "blocked_change_count": blocked_change_count,
                 "blocked_changes": blocked_changes,
                 "blocked_changes_truncated": blocked_change_count > 5,
+                "blocked_skill_count": blocked_skills.count,
+                "blocked_skills": blocked_skills.items,
+                "blocked_skills_truncated": blocked_skills.truncated,
                 "dependent_link_targets": observed_link_targets,
+                "resolution_choices": [protect_choice, source_choice],
                 "after_resolution": {
-                    "next": "move or retarget the dependent source link, then rescan and reopen the new large-Roster Finding"
+                    "next": "choose either explicit Core protection or user-approved source-link preservation, then retry from fresh evidence"
                 }
             })));
         }
@@ -2530,6 +2660,9 @@ fn finding_roster_planning(
             "blocked_change_count": blocked_change_count,
             "blocked_changes": blocked_changes,
             "blocked_changes_truncated": blocked_change_count > 5,
+            "blocked_skill_count": blocked_skills.count,
+            "blocked_skills": blocked_skills.items,
+            "blocked_skills_truncated": blocked_skills.truncated,
             "observed_link_targets": observed_link_targets,
             "after_confirmation": {
                 "repeatable_option": "--source-root",
@@ -6623,6 +6756,49 @@ mod recovery_tests {
         );
         assert_eq!(ids(&filtered), ["a1", "b1", "a2", "b2", "a3"]);
         assert_eq!(filtered["page"]["total"], 5);
+    }
+
+    #[test]
+    fn blocked_skill_planning_groups_pairs_and_expands_full_detail() {
+        let exclusions = (0..6)
+            .flat_map(|index| {
+                ["codex", "claude-code"].map(move |agent| {
+                    crate::roster_plan::RosterChangeExclusion {
+                        agent: agent.into(),
+                        skill_id: format!("skill_{index}"),
+                        name: format!("skill-name-{index}"),
+                        reason: "non_agent_source_link_depends_on_removal",
+                        observed_source_target: Some(PathBuf::from(format!(
+                            "/agent/skill-{index}"
+                        ))),
+                        safety_blocker: Some(
+                            crate::roster_plan::RosterSafetyBlocker::DependentSource {
+                                skill_id: format!("skill_{index}"),
+                                placement_ids: vec![format!("placement_{index}")],
+                                paths: vec![PathBuf::from(format!("/source/skill-{index}"))],
+                            },
+                        ),
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let compact = blocked_skill_planning(&exclusions, false);
+        assert_eq!(compact.count, 6);
+        assert_eq!(compact.items.len(), 5);
+        assert!(compact.truncated);
+        assert_eq!(compact.items[0]["name"], "skill-name-0");
+        assert_eq!(compact.items[0]["agents"], json!(["claude-code", "codex"]));
+        assert_eq!(
+            compact.items[0]["dependent_source_paths"],
+            json!(["/source/skill-0"])
+        );
+
+        let full = blocked_skill_planning(&exclusions, true);
+        assert_eq!(full.count, 6);
+        assert_eq!(full.items.len(), 6);
+        assert!(!full.truncated);
+        assert_eq!(full.displayed_skill_ids.len(), 6);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2491,10 +2491,11 @@ fn finding_roster_planning(
             "latest_snapshot_id": latest_scan_id
         })));
     }
+    let declared_core = declared_core_pairs(store, scan)?;
     let recommendation = match crate::roster_recommendation::recommend(
         finding,
         scan,
-        &declared_core_pairs(store, scan)?,
+        &declared_core,
         &crate::roster_recommendation::RecommendationRequest {
             core_budget: crate::roster_recommendation::MAX_CORE_BUDGET,
             protected_skill_ids: BTreeSet::new(),
@@ -2587,26 +2588,41 @@ fn finding_roster_planning(
             .map(|path| path.display().to_string())
             .collect::<BTreeSet<_>>();
         if source_dependency {
-            let protection_available = !blocked_skills.truncated
-                && blocked_skills.count <= crate::roster_recommendation::MAX_CORE_BUDGET;
+            let protected_skill_ids = blocked_skills.displayed_skill_ids.clone();
+            let (protection_available, protection_unavailable_reason, protection_detail) =
+                if blocked_skills.truncated {
+                    (false, Some("blocked_skill_set_incomplete"), None)
+                } else {
+                    match crate::roster_recommendation::recommend(
+                        finding,
+                        scan,
+                        &declared_core,
+                        &crate::roster_recommendation::RecommendationRequest {
+                            core_budget: crate::roster_recommendation::MAX_CORE_BUDGET,
+                            protected_skill_ids: protected_skill_ids.iter().cloned().collect(),
+                        },
+                    ) {
+                        Ok(_) => (true, None, None),
+                        Err(error) => (
+                            false,
+                            Some("protected_core_selection_unavailable"),
+                            Some(error.to_string()),
+                        ),
+                    }
+                };
             let mut protect_choice = json!({
                 "choice": "protect_blocked_skills_as_core",
                 "requires_confirmation": true,
                 "available": protection_available,
-                "unavailable_reason": if blocked_skills.truncated {
-                    Some("blocked_skill_set_incomplete")
-                } else if blocked_skills.count > crate::roster_recommendation::MAX_CORE_BUDGET {
-                    Some("blocked_skill_count_exceeds_max_core_budget")
-                } else {
-                    None
-                },
-                "protected_skill_ids": blocked_skills.displayed_skill_ids,
+                "unavailable_reason": protection_unavailable_reason,
+                "unavailable_detail": protection_detail,
+                "protected_skill_ids": protected_skill_ids,
                 "protected_skill_ids_complete": !blocked_skills.truncated,
                 "plan_request_template_available": protection_available,
                 "next": if blocked_skills.truncated {
                     "open the full Finding before constructing a complete protected-Skill Plan request"
                 } else if !protection_available {
-                    "Core protection cannot contain every blocked Skill within the maximum budget; use the source-link preservation choice"
+                    "the production Recommendation constraints reject this Core protection set; use the source-link preservation choice"
                 } else {
                     "after user confirmation, retry Plan with these protected Skill identities; another independent blocker may still fail closed"
                 }
@@ -2617,7 +2633,7 @@ fn finding_roster_planning(
                     "finding_roster_changes": [{
                         "finding_id": finding.id,
                         "core_budget": crate::roster_recommendation::MAX_CORE_BUDGET,
-                        "protected_skill_ids": blocked_skills.displayed_skill_ids
+                        "protected_skill_ids": protected_skill_ids
                     }]
                 });
             }
@@ -2629,7 +2645,7 @@ fn finding_roster_planning(
                 "next": if blocked_skills.truncated {
                     "open the full Finding before changing any dependent source link"
                 } else {
-                    "after user-approved manual preservation or retargeting, rescan and reopen the new large-Roster Finding"
+                    "after user-approved manual preservation or retargeting, rescan and reopen the new large-Roster Finding; another independent blocker may still fail closed"
                 }
             });
             return Ok(Some(json!({
@@ -2653,7 +2669,11 @@ fn finding_roster_planning(
                 "dependent_link_targets": observed_link_targets,
                 "resolution_choices": [protect_choice, source_choice],
                 "after_resolution": {
-                    "next": "choose either explicit Core protection or user-approved source-link preservation, then retry from fresh evidence"
+                    "next": if protection_available {
+                        "choose either explicit Core protection or user-approved source-link preservation, then retry from fresh evidence; another independent blocker may still fail closed"
+                    } else {
+                        "use user-approved source-link preservation, then retry from fresh evidence; another independent blocker may still fail closed"
+                    }
                 }
             })));
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2587,19 +2587,31 @@ fn finding_roster_planning(
             .map(|path| path.display().to_string())
             .collect::<BTreeSet<_>>();
         if source_dependency {
+            let protection_available = !blocked_skills.truncated
+                && blocked_skills.count <= crate::roster_recommendation::MAX_CORE_BUDGET;
             let mut protect_choice = json!({
                 "choice": "protect_blocked_skills_as_core",
                 "requires_confirmation": true,
+                "available": protection_available,
+                "unavailable_reason": if blocked_skills.truncated {
+                    Some("blocked_skill_set_incomplete")
+                } else if blocked_skills.count > crate::roster_recommendation::MAX_CORE_BUDGET {
+                    Some("blocked_skill_count_exceeds_max_core_budget")
+                } else {
+                    None
+                },
                 "protected_skill_ids": blocked_skills.displayed_skill_ids,
                 "protected_skill_ids_complete": !blocked_skills.truncated,
-                "plan_request_template_available": !blocked_skills.truncated,
+                "plan_request_template_available": protection_available,
                 "next": if blocked_skills.truncated {
                     "open the full Finding before constructing a complete protected-Skill Plan request"
+                } else if !protection_available {
+                    "Core protection cannot contain every blocked Skill within the maximum budget; use the source-link preservation choice"
                 } else {
                     "after user confirmation, retry Plan with these protected Skill identities; another independent blocker may still fail closed"
                 }
             });
-            if !blocked_skills.truncated {
+            if protection_available {
                 protect_choice["plan_request_template"] = json!({
                     "schema_version": 1,
                     "finding_roster_changes": [{

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4221,6 +4221,92 @@ fn large_roster_finding_reports_a_dependent_source_link_before_planning() {
 }
 
 #[test]
+#[cfg(unix)]
+fn large_roster_core_protection_choice_uses_production_forced_core_constraints() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    let source_root = temp.path().join("sources");
+    fs::create_dir_all(&source_root).unwrap();
+    let bootstrap = root.join("skillroster");
+    fs::create_dir_all(&bootstrap).unwrap();
+    fs::write(
+        bootstrap.join("SKILL.md"),
+        "---\nname: skillroster\n---\nfixture\n",
+    )
+    .unwrap();
+    for index in 0..100 {
+        let name = format!("dependent-{index:03}");
+        let canonical = root.join(&name);
+        fs::create_dir_all(&canonical).unwrap();
+        fs::write(
+            canonical.join("SKILL.md"),
+            format!("---\nname: {name}\n---\nfixture\n"),
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&canonical, source_root.join(&name)).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--source-root",
+        source_root.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let report = json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Large default Rosters need review")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let full = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id, "--full"]].concat(),
+        None,
+    ));
+    let planning = &full["result"]["planning"];
+    let protect = &planning["resolution_choices"][0];
+
+    assert_eq!(planning["blocked_skill_count"], 51);
+    assert_eq!(planning["blocked_skills"].as_array().unwrap().len(), 51);
+    assert_eq!(planning["blocked_skills_truncated"], false);
+    assert_eq!(protect["protected_skill_ids_complete"], true);
+    assert_eq!(protect["available"], false);
+    assert_eq!(protect["plan_request_template_available"], false);
+    assert_eq!(
+        protect["unavailable_reason"],
+        "protected_core_selection_unavailable"
+    );
+    assert!(
+        protect["unavailable_detail"]
+            .as_str()
+            .unwrap()
+            .contains("protected, declared-Core, or bootstrap Skills")
+    );
+    assert!(protect.get("plan_request_template").is_none());
+    assert!(
+        planning["after_resolution"]["next"]
+            .as_str()
+            .unwrap()
+            .contains("use user-approved source-link preservation")
+    );
+    assert!(
+        full["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|action| action["action"] != "plan")
+    );
+}
+
+#[test]
 fn large_roster_finding_prepares_and_reverses_a_semantic_layering_plan() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4122,6 +4122,11 @@ fn large_roster_finding_reports_a_dependent_source_link_before_planning() {
         planning["resolution_choices"][0]["plan_request_template_available"],
         false
     );
+    assert_eq!(planning["resolution_choices"][0]["available"], false);
+    assert_eq!(
+        planning["resolution_choices"][0]["unavailable_reason"],
+        "blocked_skill_set_incomplete"
+    );
     assert!(
         planning["resolution_choices"][0]
             .get("plan_request_template")
@@ -4156,6 +4161,10 @@ fn large_roster_finding_reports_a_dependent_source_link_before_planning() {
     );
     assert_eq!(
         full["result"]["planning"]["resolution_choices"][0]["plan_request_template_available"],
+        true
+    );
+    assert_eq!(
+        full["result"]["planning"]["resolution_choices"][0]["available"],
         true
     );
     assert_eq!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4022,16 +4022,26 @@ fn large_roster_finding_reports_a_dependent_source_link_before_planning() {
     let home = temp.path().join("home");
     let state = temp.path().join("state");
     let root = home.join(".codex/skills");
-    let canonical = root.join("zzz-canonical");
     let source_root = temp.path().join("sources");
-    fs::create_dir_all(&canonical).unwrap();
     fs::create_dir_all(&source_root).unwrap();
-    fs::write(
-        canonical.join("SKILL.md"),
-        "---\nname: zzz-canonical\n---\nfixture\n",
-    )
-    .unwrap();
-    std::os::unix::fs::symlink(&canonical, source_root.join("dependent-source")).unwrap();
+    let canonicals = (0..6)
+        .map(|index| {
+            let name = format!("zzz-canonical-{index}");
+            let canonical = root.join(&name);
+            fs::create_dir_all(&canonical).unwrap();
+            fs::write(
+                canonical.join("SKILL.md"),
+                format!("---\nname: {name}\n---\nfixture\n"),
+            )
+            .unwrap();
+            std::os::unix::fs::symlink(
+                &canonical,
+                source_root.join(format!("dependent-source-{index}")),
+            )
+            .unwrap();
+            canonical
+        })
+        .collect::<Vec<_>>();
     for index in 0..51 {
         let directory = root.join(format!("skill-{index:03}"));
         fs::create_dir(&directory).unwrap();
@@ -4068,12 +4078,101 @@ fn large_roster_finding_reports_a_dependent_source_link_before_planning() {
     assert_eq!(planning["supported"], false);
     assert_eq!(planning["reason"], "source_dependency_blocks_roster_change");
     assert_eq!(planning["decision"], "resolve_source_dependency");
-    assert_eq!(planning["blocked_change_count"], 1);
+    assert_eq!(planning["blocked_change_count"], 6);
     assert_eq!(
         planning["blocked_changes"][0]["reason"],
         "non_agent_source_link_depends_on_removal"
     );
-    assert_eq!(planning["dependent_link_targets"], json!([canonical]));
+    assert_eq!(planning["dependent_link_targets"], json!(canonicals));
+    assert_eq!(planning["blocked_skill_count"], 6);
+    assert_eq!(planning["blocked_skills_truncated"], true);
+    assert_eq!(planning["blocked_skills"].as_array().unwrap().len(), 5);
+    let blocked_skill = &planning["blocked_skills"][0];
+    assert!(
+        blocked_skill["name"]
+            .as_str()
+            .unwrap()
+            .starts_with("zzz-canonical-")
+    );
+    assert_eq!(blocked_skill["agents"], json!(["codex"]));
+    assert_eq!(
+        blocked_skill["reasons"],
+        json!(["non_agent_source_link_depends_on_removal"])
+    );
+    assert_eq!(
+        blocked_skill["dependent_source_paths"],
+        json!([fs::canonicalize(&source_root).unwrap().join(format!(
+            "dependent-source-{}",
+            blocked_skill["name"]
+                .as_str()
+                .unwrap()
+                .strip_prefix("zzz-canonical-")
+                .unwrap()
+        ))])
+    );
+    assert_eq!(
+        planning["resolution_choices"][0]["choice"],
+        "protect_blocked_skills_as_core"
+    );
+    assert_eq!(
+        planning["resolution_choices"][0]["requires_confirmation"],
+        true
+    );
+    assert_eq!(
+        planning["resolution_choices"][0]["plan_request_template_available"],
+        false
+    );
+    assert!(
+        planning["resolution_choices"][0]
+            .get("plan_request_template")
+            .is_none()
+    );
+    assert_eq!(
+        planning["resolution_choices"][1]["choice"],
+        "preserve_or_retarget_dependent_sources"
+    );
+    assert_eq!(
+        planning["resolution_choices"][1]["dependent_source_paths"]
+            .as_array()
+            .unwrap()
+            .len(),
+        5
+    );
+    let full = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id, "--full"]].concat(),
+        None,
+    ));
+    assert_eq!(full["result"]["planning"]["blocked_skill_count"], 6);
+    assert_eq!(
+        full["result"]["planning"]["blocked_skills"]
+            .as_array()
+            .unwrap()
+            .len(),
+        6
+    );
+    assert_eq!(
+        full["result"]["planning"]["blocked_skills_truncated"],
+        false
+    );
+    assert_eq!(
+        full["result"]["planning"]["resolution_choices"][0]["plan_request_template_available"],
+        true
+    );
+    assert_eq!(
+        full["result"]["planning"]["resolution_choices"][0]["plan_request_template"]
+            ["finding_roster_changes"][0]["protected_skill_ids"]
+            .as_array()
+            .unwrap()
+            .len(),
+        6
+    );
+    assert!(
+        full["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|action| action["action"] != "plan")
+    );
     assert!(
         detail["suggested_actions"]
             .as_array()
@@ -4101,11 +4200,13 @@ fn large_roster_finding_reports_a_dependent_source_link_before_planning() {
         blocked["error"]["details"]["reason"],
         "dependent_source_would_break"
     );
-    assert_eq!(
-        blocked["error"]["details"]["paths"],
-        json!([fs::canonicalize(&source_root)
+    let blocked_paths = blocked["error"]["details"]["paths"].as_array().unwrap();
+    assert_eq!(blocked_paths.len(), 1);
+    assert!(
+        blocked_paths[0]
+            .as_str()
             .unwrap()
-            .join("dependent-source")])
+            .starts_with(fs::canonicalize(&source_root).unwrap().to_str().unwrap())
     );
     assert_eq!(blocked["error"]["details"]["files_changed"], false);
 }


### PR DESCRIPTION
Closes #109.

## What changed

- retain pair-level blocker fields while adding unique blocked-Skill facts
- include Skill name, affected Agents, reasons, observed targets, dependent source-link paths, and placement IDs
- bound compact output to 5 unique Skills; `--full` expands the complete set
- present both confirmation-gated choices: explicitly protect the complete Skill set as Core, or manually preserve/retarget dependent source links and rescan
- omit the Plan request template when compact data is truncated; only emit it when the protected ID set is complete
- continue suppressing Plan suggested actions while planning is unsupported

## Agent dogfood evidence

The isolated real 8-Agent report now explains that 8 pair-level blockers are 2 Skill identities: `repo-learning` and `ego-browser`, each affecting Claude Code, Codex, Hermes, and Pi. It exposes the two dependent non-Agent source paths and both safe choices in one report call.

No choice was automatically made, no Apply ran, and no real Agent file changed.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (172 unit + 7 acceptance + 47 CLI)
- real compact/full cached-report replay
- `git diff --check`