### PR TITLE
release: prepare SkillRoster v1.8.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.18"
+version = "1.8.19"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.18"
+version = "1.8.19"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "227ae37a9209d098742aa3524ec88214fa0f1602"
+      revision: "457ca26b33d9f8668f83fd8a4821b884af4943c8"
   version "1.8.19"
 
   depends_on "rust" => :build

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -3,7 +3,7 @@ class Skillroster < Formula
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "227ae37a9209d098742aa3524ec88214fa0f1602"
-  version "1.8.18"
+  version "1.8.19"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.18", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.19", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -419,6 +419,26 @@ proposed exposure from 548 to 82, reported zero canonical deletions, and kept
 views preserved `target Agent`, `cross-Agent`, and `elsewhere loaded` while
 shortening long Skill names first.
 
+The v1.8.19 Agent decision-loop dogfood used an isolated state directory and
+four explicitly reviewed source roots against the current real home. Its
+read-only Snapshot contained 236 independent Skills, 763 placements, 564
+default exposures, and 173 Findings. The Usage Finding first page now placed
+all eight coverage records and 35 observed non-Exposure rows before inferred
+Exposure, omitted the invalid Plan action, and replayed its full-detail next
+page with the same home and state context. The suggested unfiltered Findings
+page improved from three titles across three categories to all eleven rollup
+titles across five categories; nine pages still enumerated exactly 173 unique
+Finding IDs.
+
+The same Snapshot exposed eight large-Roster source-dependency pairs. The
+decision view grouped them into the two actual Skills, `repo-learning` and
+`ego-browser`, named all four affected Agents, and returned the two dependent
+non-Agent source paths. It exposed confirmation-gated Core protection only
+after the production per-Agent Recommendation constraints accepted the
+complete identity set; a 100-dependent-Skill plus bootstrap regression proves
+an over-budget set is typed unavailable and has no Plan template. No choice was
+made, no Apply ran, and no real Agent file changed.
+
 ## Evidence boundary
 
 These checks establish deterministic routing and safe local governance; they do

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -74,6 +74,17 @@ stage, quality, event count, and observation window together; the opaque Skill
 ID remains the stable identity, not the user-facing label. Incomplete coverage
 still forbids usage percentages and “unused” conclusions.
 
+Suggested actions are factual continuations, not generic guesses. Offer Plan
+only when the Finding explicitly reports `planning.supported: true`; otherwise
+follow the typed decision or open full detail. A paged Finding action preserves
+the same compact/full mode and advances `page.next_offset`. Findings lists
+interleave category/severity/title families before repeating instances so the
+first page represents the available problem types without hiding any Finding.
+For a blocked large Roster, present the named blocked Skill identities,
+affected Agents, dependent source paths, and every typed resolution choice.
+Never execute a confirmation-gated Core-protection template or source-link
+change on the user's behalf.
+
 ## 5. Ready Plan response
 
 ```text

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.18
+SKILLROSTER_VERSION=1.8.19
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -46,7 +46,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.18 skillroster
+  --tag v1.8.19 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -60,7 +60,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.18
+git checkout v1.8.19
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -8,7 +8,7 @@ description: >
   distributing, synchronizing, or repairing shared Skill directories and
   symlinks.
 metadata:
-  bootstrap-version: "1.8.18"
+  bootstrap-version: "1.8.19"
   skillroster-routing-triggers: "scan analyze duplicate unused local Agent Skills; inventory installed Agent Skills; analyze duplicate Agent Skills; evaluate possible unused local Agent Skills from usage evidence; govern a Skill Roster; prepare a Skill governance Plan; apply approved Skill Plan; create Skill Receipt; undo Skill organization"
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5474,6 +5474,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.8.17",
         "5c7cc974e0d83d82993ba1ca9227c0d542288ca3d7ef4e04165794cb41faec33",
     ),
+    (
+        "1.8.18",
+        "130cb488305b53dc3123633da50df6d3b843b24663861f7cc6b63964621b8718",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1882,6 +1882,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
         ("1.8.2", include_str!("fixtures/bootstrap-v1.8.2.md")),
         ("1.8.3", include_str!("fixtures/bootstrap-v1.8.3.md")),
         ("1.8.4", include_str!("fixtures/bootstrap-v1.8.4.md")),
+        ("1.8.18", include_str!("fixtures/bootstrap-v1.8.18.md")),
     ] {
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1853,7 +1853,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.18"
+        "1.8.19"
     );
 
     let undone = json_output(&run(
@@ -2173,7 +2173,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.18");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.19");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],

--- a/tests/fixtures/bootstrap-v1.8.18.md
+++ b/tests/fixtures/bootstrap-v1.8.18.md
@@ -1,0 +1,68 @@
+---
+name: skillroster
+description: >
+  Inspect and govern locally installed Agent Skills with the SkillRoster CLI.
+  Use for inventory and usage evidence, duplicate or broken-link analysis,
+  smaller Core and On-demand Rosters, capability search, approved Plans,
+  Receipts, Apply, or Undo. Not for installing Skills or migrating,
+  distributing, synchronizing, or repairing shared Skill directories and
+  symlinks.
+metadata:
+  bootstrap-version: "1.8.18"
+  skillroster-routing-triggers: "scan analyze duplicate unused local Agent Skills; inventory installed Agent Skills; analyze duplicate Agent Skills; evaluate possible unused local Agent Skills from usage evidence; govern a Skill Roster; prepare a Skill governance Plan; apply approved Skill Plan; create Skill Receipt; undo Skill organization"
+---
+
+# SkillRoster
+
+Use the local `skillroster` binary as the deterministic source of facts. Invoke every command with explicit `--json`; validate `schema_version` and `ok` before reading `result`. Treat typed `suggested_actions` as options, never authorization.
+
+## Inspect and propose
+
+1. Run `skillroster scan --json`, then `skillroster report --summary --json`. Use the compact result for the first user-facing diagnosis. Read `finding_rollups` to state the complete scale of each Finding group without loading the exhaustive report; use the three selected `findings` only for the highest-priority decisions.
+2. Distinguish observed, inferred, and unknown usage. Read `session_coverage` before presenting usage: `sampled_agents` have bounded local evidence, `complete_agents` alone support a complete observable-session denominator, `missing_root_agents` have no discovered session directory, and `inaccessible_agents` have a configured directory that could not be read. Limited samples may support observed event counts and stages, never a usage percentage or an “unused” claim. For `Five-stage usage evidence`, use `usage_overview` for the five typed stage counts, coverage boundary, and bounded high-signal `observed_skills`; `Exposed` counts placements while later stages count events. Individual items identify the Skill through `facts.skill_name` and use the canonical public `facts.agent`; keep stage, quality, event count, and observation window together when summarizing what was observed. When the three-item summary is insufficient, use `report --findings --limit 20 --json`; narrow it with one `--category` or `--severity` from the summary totals, and follow `page.next_offset` only while that category still affects the decision. This paged list is the enumeration path; keep the exhaustive report out of the Agent context.
+3. Use stable Finding and Evidence IDs for follow-up questions. The summary and paged list expose one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Its compact `items` combine the Evidence ID, subject, path, quality, and decision facts without repeating complete internal collections. Use `--full` only when an exact complete ID or record is needed. Exact-duplicate and large-Roster details include bounded `planning` choices independently of pagination; treat `planning.uncertainty.review_required` as a selection-quality warning that must remain visible through confirmation. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
+4. Make semantic governance choices in the conversation, then submit them to `skillroster plan --stdin --json`. For exact duplicates or a large default Roster, send `schema_version` plus the corresponding Finding request below; SkillRoster derives the current Snapshot, Evidence, Skills, placements, and complete changes. Other request families include the latest `scan_id` and relevant `evidence_ids`.
+5. Present the validated summary Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `operation_groups`, bounded `affected` facts, `impact` before/after facts, the semantic `diff_summary`, uncertainty, canonical deletion count, reversibility, and Plan ID. For a semantic Roster Plan, read `selection_evidence`: state the forced, target-Agent, cross-Agent, and stable-fallback Core counts, then present each Agent's bounded `core_preview` with names and reasons. `evidence_scope: target_agent` means that Agent used the Skill; `cross_agent` means only the Agents named in `evidence_agents` supplied evidence for the exact same stable Skill identity. Describe the latter as used elsewhere, never as target-Agent usage. When `uncertainty.review_required` is true, present the selection as review-required rather than evidence-backed. The diff contains at most three Roster, Library, and filesystem items, or bounded line facts for a source update. The full immutable representation stays in local state; use `skillroster plan --show PLAN_ID --json` only when every `core_selections` entry, an exact operation, path, or complete ID list is needed to answer the user. Do not load it by default.
+
+Use only these Plan request families:
+
+- `finding_roster_changes` (preferred for `Large default Rosters need review`): `finding_id`, a per-Agent `core_budget` from 1 through 50, and optional `protected_skill_ids`. Review `planning.agents`, especially direct-signal, cross-Agent-signal, and fallback counts, before choosing the budget. SkillRoster preserves requested, declared, and bootstrap Core Skills, then ranks target-Agent usage, usage from another local Agent for the exact same stable Skill ID, and finally stable fallback order. Same-name or similar Skills never transfer usage evidence. Remaining affected Skills become On-demand; this request never implies Explicit-only or Archived. If `planning.supported` is false, follow its typed `decision`: confirm reported source roots or resolve dependent source links, then rescan. Do not submit a partial Plan.
+- `finding_library_changes` (preferred for exact duplicates): `finding_id`, a `canonical_placement_id` chosen from `planning.canonical_candidates`, and `requested_state` (`managed` or `hosted`). Do not copy paged placement or Evidence IDs into this request.
+- `roster_changes`: the advanced raw form with `agent`, `skill_id`, and `state` (`core`, `on_demand`, `explicit_only`, or `archived`). Use it for deliberate exceptions or when no supported Finding can bind the complete scope.
+- `library_changes`: the advanced raw form with `skill_id`, `canonical_placement_id`, the complete `placement_ids` set, and `requested_state`. Use it only when there is no exact-duplicate Finding to bind.
+- `source_updates`: the latest Skill/placement/source/revision/fingerprint facts plus upstream content and SHA-256 digest. If local content changed, include the user's explicit `choice`: `retain_local`, `adopt_upstream`, or `preserve_both`.
+
+Keep Roster, source-update, and Library changes in separate Plans. Semantic Finding requests derive their Evidence internally. For raw requests, cite Evidence returned by the relevant Finding page; a convenient but unrelated Evidence ID is not support for a governance change. Treat a rejected stale Snapshot, Evidence ID, fingerprint, incomplete scope, or source revision as a reason to rescan or ask the user—not as permission to weaken the request.
+
+State explicitly that inspection and planning changed no Agent files. When evidence cannot justify a change, recommend keeping the current state.
+
+For `Skill links escape an approved root`, load one compact Finding page and
+show `resolution.observed_link_targets`. Treat each target as unread until the
+user confirms that its canonical source directory is intentional and trusted.
+Do not follow a generic Plan action for this Finding. After confirmation,
+rescan with one repeatable `--source-root ABSOLUTE_PATH` per canonical source
+directory; this approves reading without adding Agent exposure. Then prefer a
+reviewed Hosted or Managed Library Plan so future Scans no longer depend on
+the temporary source-root arguments. Keep unconfirmed targets unread.
+
+## Apply or undo
+
+Run `skillroster setup --json` when installing the Bootstrap Skill or after upgrading the CLI. An exact official older copy produces a normal upgrade Plan. If `state` is `modified_choice_required`, show the affected Agent targets and ask whether to `retain-local` or `adopt-current`; do not choose for the user. Adopting still only prepares a recoverable Plan and requires the usual Apply confirmation. Treat `unsupported_targets` as blocked rather than replacing links or non-files.
+
+Show the complete immutable Plan before requesting one explicit confirmation. After the user confirms, run `skillroster apply PLAN_ID --json`; do not substitute direct filesystem commands or bypass drift checks. Report verification, changed-path count, Receipt ID, and canonical deletion count.
+
+“Complete” means the summary accounts for every affected Agent, Skill, placement, operation group, exclusion, risk, and before/after delta by count; it does not require copying every internal operation into the conversation. If the user asks for an exact path or operation, load the stored detail with `plan --show` before confirmation.
+
+For Undo, first explain the bounded Receipt impact and obtain one explicit confirmation, then run `skillroster undo RECEIPT_ID --json`.
+
+Stop mutating when the result reports ambiguity, drift, unsupported scope, or recovery required. Make recovery the only mutating next action until cleared.
+
+Use `skillroster status --json` for pending Plans, the last Receipt, retention, and recovery state. Use `skillroster lifecycle recovery --json` to inspect an unresolved Receipt. Export or purge local lifecycle data only when the user asks; purge changes controlled SQLite history, not Agent files.
+
+## Find an on-demand Skill
+
+Run `skillroster find "TASK" --json`, keeping the user's task verbatim. For a non-English or mixed-language task, include one concise English capability paraphrase through `--hint "TEXT"` on the first call. Build the hint entirely from the desired target surface, object, operation, and state—for example, `control existing logged-in Chrome tabs` or `analyze standalone spreadsheet file workbook data`. Use terms implied by the task rather than a guessed Skill name. With hints, require `ranking_strategy: task_hint_reciprocal_rank_fusion`; use the numeric `task_channel_rank` and `augmented_channel_rank` fields to distinguish native task evidence from hint-expanded evidence. Retry once with a refined target description only when the result is empty or clearly about another domain. Explain the top matches and evidence. A `variant_count` above one is unresolved same-name content ambiguity: keep each returned variant's path and provider facts together, respect `variants_truncated`, show the warning, and inspect the corresponding layout Finding before choosing content. Otherwise read the selected `SKILL.md` directly from its returned path. Finding a Skill does not activate or install it.
+
+Treat `providers` with `governable: false` as locally discovered provider-managed Skills. They may come from explicit Codex configuration or a verified remote-plugin install marker. They are valid read-only search results, but must not be moved, updated, consolidated, or added to a governance Plan.
+
+Never parse styled terminal output, invent a health score, infer token savings, or claim files changed without a successful Receipt.


### PR DESCRIPTION
Part of #111. The release Issue remains open until candidate, tag, artifacts, checksums, and public Release gates complete.

## Included user-visible fixes

- suggested action argv preserves its actual state/home/root/source-root context
- Usage Finding pages lead with coverage and observed activity, only suggest Plan when supported, and provide replayable next-page actions
- Findings first pages expose every available problem family before repeating instances
- large-Roster source blockers are grouped into named Skill identities with affected Agents, paths, confirmation-gated choices, and production-validated Core protection templates

## Release preparation

- bump package, lockfile, Formula, install examples, and bootstrap metadata to 1.8.19
- pin the Formula to the first release-prep commit, which already reports package version 1.8.19
- record isolated real-home dogfood evidence and Agent contract guidance
- preserve historical v1.8.18 acceptance evidence

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (172 unit + 7 acceptance + 48 CLI)
- `ruby -c Formula/skillroster.rb`
- `git diff --check`

After review/CI, merge with a merge commit so the Formula revision remains an ancestor of the release tag. Then run the four-platform + WSL candidate workflow before tagging or publishing.