### PR TITLE
feat: make semantic overlap details agent-complete

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -80,6 +80,11 @@ follow the typed decision or open full detail. A paged Finding action preserves
 the same compact/full mode and advances `page.next_offset`. Findings lists
 interleave category/severity/title families before repeating instances so the
 first page represents the available problem types without hiding any Finding.
+For a Semantic overlap candidate, use its bounded `comparison` bundle to bind
+the two Skill IDs to names, descriptions, triggers, summaries, readable paths,
+and the structured routing-vocabulary Jaccard basis. The Agent owns the
+semantic conclusion and may read a returned `SKILL.md` path when those facts
+are insufficient; candidate evidence never authorizes a Plan.
 For a blocked large Roster, present the named blocked Skill identities,
 affected Agents, dependent source paths, and every typed resolution choice.
 Never execute a confirmation-gated Core-protection template or source-link

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -78,6 +78,14 @@ Ambiguous Skills remain separate. SkillRoster never merges based only on a match
 
 Usage evidence is labeled `observed`, `inferred`, or `unknown`. Missing evidence never becomes proof that a Skill is useless. Raw prompts and responses are parsed read-only in place and are not copied into SkillRoster storage. Recent session selection happens after bounded discovery; large active JSONL files contribute bounded complete-line tails, large monolithic JSON files contribute bounded complete nested objects from their tails, and the fixed byte budget is spread across multiple recent sessions. Reports distinguish missing, inaccessible, sampled-but-limited, and complete observable session roots. A usage percentage is emitted only when the observable-session denominator is complete; bounded samples support observed event counts and stages, not an “unused” claim.
 
+A semantic-overlap Finding is candidate evidence, never a consolidation
+decision. Its compact and full detail carry the same bounded comparison bundle:
+the two stable Skill identities, names, descriptions, routing triggers,
+summaries, readable placement paths and governance facts, plus the structured
+routing-vocabulary Jaccard score, counts, and shared-term preview. Complete
+Skill bodies stay at the returned local paths. The calling Agent or person owns
+the semantic conclusion, and no Plan action is suggested from this evidence.
+
 ### 4.3 Library and Rosters
 
 The Library is logical and does not require moving every Skill. Each discovered Skill begins as Observed. After approval it may become:

--- a/src/app.rs
+++ b/src/app.rs
@@ -238,7 +238,7 @@ pub fn run(cli: Cli) -> Result<Output> {
             } else {
                 ReportRequest::Summary
             };
-            let result = report_command(&store, request)?;
+            let result = report_command(&store, &state_dir, request)?;
             let actions = report_actions(&result, request);
             ("report", result, vec![], actions)
         }
@@ -1669,7 +1669,11 @@ enum ReportRequest<'a> {
     Exhaustive,
 }
 
-fn report_command(store: &StateStore, request: ReportRequest<'_>) -> Result<Value> {
+fn report_command(
+    store: &StateStore,
+    state_dir: &Path,
+    request: ReportRequest<'_>,
+) -> Result<Value> {
     if let ReportRequest::Finding {
         id,
         full,
@@ -1715,6 +1719,7 @@ fn report_command(store: &StateStore, request: ReportRequest<'_>) -> Result<Valu
             )? {
                 object.insert("planning".into(), planning);
             }
+            add_semantic_overlap_comparison(object, &scan, state_dir)?;
             add_same_name_resolution(object, &scan);
             let affected_skill_ids = object
                 .get("affected_skill_ids")
@@ -2091,6 +2096,219 @@ fn add_same_name_resolution(object: &mut serde_json::Map<String, Value>, scan: &
             "next_step": "compare_variant_content_and_choose_canonical"
         }),
     );
+}
+
+const SEMANTIC_COMPARISON_NAME_LIMIT: usize = 160;
+const SEMANTIC_COMPARISON_DESCRIPTION_LIMIT: usize = 512;
+const SEMANTIC_COMPARISON_METADATA_LIMIT: usize = 256;
+const SEMANTIC_COMPARISON_LIST_LIMIT: usize = 10;
+const SEMANTIC_COMPARISON_LIST_ITEM_LIMIT: usize = 160;
+
+fn bounded_semantic_text(value: &str, limit: usize) -> (String, bool) {
+    let bounded = value.chars().take(limit).collect::<String>();
+    let truncated = value.chars().count() > limit;
+    (bounded, truncated)
+}
+
+fn bounded_semantic_optional_text(value: Option<&str>, limit: usize) -> (Option<String>, bool) {
+    value
+        .map(|value| {
+            let (bounded, truncated) = bounded_semantic_text(value, limit);
+            (Some(bounded), truncated)
+        })
+        .unwrap_or((None, false))
+}
+
+fn bounded_semantic_list<'a>(
+    values: impl IntoIterator<Item = &'a str>,
+    item_limit: usize,
+    character_limit: usize,
+) -> (Vec<String>, usize, bool) {
+    let values = values.into_iter().collect::<Vec<_>>();
+    let count = values.len();
+    let mut truncated = count > item_limit;
+    let bounded = values
+        .into_iter()
+        .take(item_limit)
+        .map(|value| {
+            let (bounded, value_truncated) = bounded_semantic_text(value, character_limit);
+            truncated |= value_truncated;
+            bounded
+        })
+        .collect::<Vec<_>>();
+    (bounded, count, truncated)
+}
+
+fn add_semantic_overlap_comparison(
+    object: &mut serde_json::Map<String, Value>,
+    scan: &ScanResult,
+    state_dir: &Path,
+) -> Result<()> {
+    if object.get("title").and_then(Value::as_str)
+        != Some(crate::query::SEMANTIC_OVERLAP_FINDING_TITLE)
+    {
+        return Ok(());
+    }
+    let affected_skill_ids = object
+        .get("affected_skill_ids")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    if affected_skill_ids.len() != 2 {
+        return Ok(());
+    }
+    let Some(left) = scan
+        .skills
+        .iter()
+        .find(|skill| skill.id == affected_skill_ids[0])
+    else {
+        return Ok(());
+    };
+    let Some(right) = scan
+        .skills
+        .iter()
+        .find(|skill| skill.id == affected_skill_ids[1])
+    else {
+        return Ok(());
+    };
+    let Some(basis) = crate::query::semantic_overlap_basis(left, right) else {
+        return Ok(());
+    };
+    let skills = [left, right]
+        .into_iter()
+        .map(|skill| -> Result<Value> {
+            let placements = scan
+                .placements
+                .iter()
+                .filter(|placement| placement.skill_id == skill.id)
+                .collect::<Vec<_>>();
+            let agents = placements
+                .iter()
+                .filter_map(|placement| placement.agent.map(AgentKind::id))
+                .collect::<BTreeSet<_>>();
+            let providers = placements
+                .iter()
+                .filter_map(|placement| placement.provider.clone())
+                .collect::<BTreeSet<_>>();
+            let governable = placements.iter().any(|placement| placement.governable);
+            let (name, name_truncated) =
+                bounded_semantic_text(&skill.name, SEMANTIC_COMPARISON_NAME_LIMIT);
+            let (description, description_truncated) = bounded_semantic_optional_text(
+                skill.metadata.description.as_deref(),
+                SEMANTIC_COMPARISON_DESCRIPTION_LIMIT,
+            );
+            let (triggers, trigger_count, triggers_truncated) = bounded_semantic_list(
+                skill.metadata.triggers.iter().map(String::as_str),
+                SEMANTIC_COMPARISON_LIST_LIMIT,
+                SEMANTIC_COMPARISON_LIST_ITEM_LIMIT,
+            );
+            let (source, source_truncated) = bounded_semantic_optional_text(
+                skill.metadata.source.as_deref(),
+                SEMANTIC_COMPARISON_METADATA_LIMIT,
+            );
+            let (version, version_truncated) = bounded_semantic_optional_text(
+                skill.metadata.version.as_deref(),
+                SEMANTIC_COMPARISON_METADATA_LIMIT,
+            );
+            let (revision, revision_truncated) = bounded_semantic_optional_text(
+                skill.metadata.revision.as_deref(),
+                SEMANTIC_COMPARISON_METADATA_LIMIT,
+            );
+            let (agents, agent_count, agents_truncated) = bounded_semantic_list(
+                agents.iter().copied(),
+                SEMANTIC_COMPARISON_LIST_LIMIT,
+                SEMANTIC_COMPARISON_LIST_ITEM_LIMIT,
+            );
+            let (providers, provider_count, providers_truncated) = bounded_semantic_list(
+                providers.iter().map(String::as_str),
+                SEMANTIC_COMPARISON_LIST_LIMIT,
+                SEMANTIC_COMPARISON_LIST_ITEM_LIMIT,
+            );
+            let mut current_paths = current_readable_skill_paths(scan, state_dir, &skill.id)?;
+            let readable_path_count = current_paths.paths.len();
+            let visible_paths = current_paths
+                .paths
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            current_paths.paths.truncate(5);
+            let mut readable_placements = placements
+                .iter()
+                .filter(|placement| {
+                    let path = placement.entrypoint.display().to_string();
+                    visible_paths.contains(&path)
+                })
+                .map(|placement| {
+                    let (provider, provider_truncated) = bounded_semantic_optional_text(
+                        placement.provider.as_deref(),
+                        SEMANTIC_COMPARISON_LIST_ITEM_LIMIT,
+                    );
+                    json!({
+                        "placement_id": placement.id,
+                        "path": placement.entrypoint,
+                        "agent": placement.agent.map(AgentKind::id),
+                        "provider": provider,
+                        "provider_truncated": provider_truncated,
+                        "governable": placement.governable,
+                        "default_exposed": placement.default_exposed,
+                        "link_status": placement.link_status
+                    })
+                })
+                .collect::<Vec<_>>();
+            readable_placements
+                .sort_by(|left, right| left["path"].as_str().cmp(&right["path"].as_str()));
+            let readable_placement_count = readable_placements.len();
+            readable_placements.truncate(SEMANTIC_COMPARISON_LIST_LIMIT);
+            Ok(json!({
+                "skill_id": skill.id,
+                "name": name,
+                "name_truncated": name_truncated,
+                "description": description,
+                "description_truncated": description_truncated,
+                "triggers": triggers,
+                "trigger_count": trigger_count,
+                "triggers_truncated": triggers_truncated,
+                "summary": skill.summary,
+                "source": source,
+                "source_truncated": source_truncated,
+                "version": version,
+                "version_truncated": version_truncated,
+                "revision": revision,
+                "revision_truncated": revision_truncated,
+                "content_digest": skill.content_digest,
+                "digest_algorithm": skill.digest_algorithm,
+                "agents": agents,
+                "agent_count": agent_count,
+                "agents_truncated": agents_truncated,
+                "providers": providers,
+                "provider_count": provider_count,
+                "providers_truncated": providers_truncated,
+                "governable": governable,
+                "placement_count": placements.len(),
+                "readable_path_count": readable_path_count,
+                "readable_paths_truncated": readable_path_count > current_paths.paths.len(),
+                "current_content_available": !current_paths.drifted,
+                "readable_paths": current_paths.paths,
+                "readable_placement_count": readable_placement_count,
+                "readable_placements_truncated": readable_placement_count > readable_placements.len(),
+                "readable_placements": readable_placements
+            }))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    object.insert(
+        "comparison".into(),
+        json!({
+            "decision": "compare_skill_meaning",
+            "automatic_change_supported": false,
+            "semantic_conclusion_owner": "agent_or_user",
+            "basis": basis,
+            "skill_count": skills.len(),
+            "skills": skills
+        }),
+    );
+    Ok(())
 }
 
 fn compact_finding_detail(mut details: Value) -> Value {
@@ -3437,27 +3655,33 @@ fn current_readable_skill_paths(
         .iter()
         .find(|skill| skill.id == skill_id)
         .ok_or_else(|| anyhow!("Skill {skill_id} is not in the latest Snapshot"))?;
-    let directory_name = safe_skill_directory_name(&skill.name)?;
-    let mut candidates = vec![
-        state_dir
-            .join("library")
-            .join(&directory_name)
-            .join("SKILL.md"),
-    ];
+    let directory_name = safe_skill_directory_name(&skill.name).ok();
+    let mut candidates = directory_name
+        .as_ref()
+        .map(|directory_name| {
+            state_dir
+                .join("library")
+                .join(directory_name)
+                .join("SKILL.md")
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
     candidates.extend(
         scan.placements
             .iter()
             .filter(|placement| placement.skill_id == skill_id)
             .map(|placement| placement.entrypoint.clone()),
     );
-    candidates.extend(
-        scan.roots
-            .iter()
-            .filter(|root| {
-                root.kind == RootKind::Skills && root.status == scan::RootStatus::Included
-            })
-            .map(|root| root.path.join(&directory_name).join("SKILL.md")),
-    );
+    if let Some(directory_name) = directory_name {
+        candidates.extend(
+            scan.roots
+                .iter()
+                .filter(|root| {
+                    root.kind == RootKind::Skills && root.status == scan::RootStatus::Included
+                })
+                .map(|root| root.path.join(&directory_name).join("SKILL.md")),
+        );
+    }
     let mut approved_roots = scan
         .roots
         .iter()

--- a/src/query.rs
+++ b/src/query.rs
@@ -10,9 +10,67 @@ use std::path::{Path, PathBuf};
 
 pub const SAME_NAME_DIVERGENT_FINDING_KIND: &str = "same_name_divergent_content";
 pub const SAME_NAME_DIVERGENT_FINDING_TITLE: &str = "Same-name Skills have different content";
+pub const SEMANTIC_OVERLAP_FINDING_TITLE: &str = "Semantic overlap candidate";
+
+const SEMANTIC_SHARED_TERM_PREVIEW_LIMIT: usize = 20;
+const SEMANTIC_SHARED_TERM_CHARACTER_LIMIT: usize = 64;
 
 fn normalize_skill_name(name: &str) -> String {
     name.trim().to_lowercase()
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct SemanticOverlapBasis {
+    pub metric: &'static str,
+    pub score: f64,
+    pub intersection_count: usize,
+    pub union_count: usize,
+    pub shared_terms: Vec<String>,
+    pub shared_terms_truncated: bool,
+}
+
+fn semantic_overlap_basis_from_tokens(
+    left: &BTreeSet<String>,
+    right: &BTreeSet<String>,
+) -> Option<SemanticOverlapBasis> {
+    let shared = left.intersection(right).collect::<Vec<_>>();
+    let intersection_count = shared.len();
+    let union_count = left.union(right).count();
+    if intersection_count < 3 || union_count == 0 {
+        return None;
+    }
+    let shared_terms = shared
+        .iter()
+        .take(SEMANTIC_SHARED_TERM_PREVIEW_LIMIT)
+        .map(|term| {
+            term.chars()
+                .take(SEMANTIC_SHARED_TERM_CHARACTER_LIMIT)
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>();
+    let shared_terms_truncated = shared.len() > shared_terms.len()
+        || shared
+            .iter()
+            .take(shared_terms.len())
+            .any(|term| term.chars().count() > SEMANTIC_SHARED_TERM_CHARACTER_LIMIT);
+    Some(SemanticOverlapBasis {
+        metric: "routing_vocabulary_jaccard",
+        score: intersection_count as f64 / union_count as f64,
+        intersection_count,
+        union_count,
+        shared_terms,
+        shared_terms_truncated,
+    })
+}
+
+pub(crate) fn semantic_overlap_basis(
+    left: &ScannedSkill,
+    right: &ScannedSkill,
+) -> Option<SemanticOverlapBasis> {
+    semantic_overlap_basis_from_tokens(
+        &tokens(&skill_search_text(left)),
+        &tokens(&skill_search_text(right)),
+    )
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -1016,12 +1074,10 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
                 continue;
             }
             let right_tokens = &vocabularies[right_index];
-            let intersection = left_tokens.intersection(right_tokens).count();
-            let union = left_tokens.union(right_tokens).count();
-            if intersection < 3 || union == 0 {
+            let Some(basis) = semantic_overlap_basis_from_tokens(left_tokens, right_tokens) else {
                 continue;
-            }
-            let similarity = intersection as f64 / union as f64;
+            };
+            let similarity = basis.score;
             if similarity >= 0.45 {
                 candidates.push((similarity, left, right));
             }
@@ -1040,7 +1096,7 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             findings,
             FindingCategory::Overlap,
             Severity::Low,
-            "Semantic overlap candidate",
+            SEMANTIC_OVERLAP_FINDING_TITLE,
             format!(
                 "{} and {} share routing vocabulary (Jaccard {:.2}); this is review-only candidate evidence, not a confirmed duplicate.",
                 left.name, right.name, similarity
@@ -2310,6 +2366,12 @@ mod tests {
         let candidate_id = candidate.id.clone();
         candidate.name = "source-check".into();
         candidate.content_digest = "different_digest".into();
+        let basis = semantic_overlap_basis(&original, &candidate).unwrap();
+        assert_eq!(basis.metric, "routing_vocabulary_jaccard");
+        assert!(basis.score >= 0.45);
+        assert!(basis.intersection_count >= 3);
+        assert!(basis.union_count >= basis.intersection_count);
+        assert!(!basis.shared_terms.is_empty());
         scan.skills = vec![original, candidate];
         scan.placements.clear();
         scan.usage.clear();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -141,6 +141,201 @@ fn report_help_names_the_safe_default_and_explicit_exhaustive_export() {
 }
 
 #[test]
+fn semantic_overlap_detail_is_decision_complete_for_agent_comparison() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = temp.path().join("skills");
+    let left_path = root.join("browser-tabs/SKILL.md");
+    let right_path = root.join("browser-session/SKILL.md");
+    let long_description = " authenticated browser context".repeat(80);
+    let long_source = "source-system-".repeat(80);
+    let triggers = (0..12)
+        .map(|index| format!("inspect-page-{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let left = format!(
+        "---\nname: 浏览器标签\ndescription: Control existing logged in browser tabs and inspect page state{long_description}\nsource: {long_source}\ntriggers: [{triggers}]\n---\nOperate visible tabs safely.\n"
+    );
+    let right = format!(
+        "---\nname: 浏览器会话\ndescription: Inspect existing logged in browser session tabs and page state{long_description}\nsource: {long_source}\ntriggers: [{triggers}]\n---\nReview authenticated browser state.\n"
+    );
+    fs::create_dir_all(left_path.parent().unwrap()).unwrap();
+    fs::create_dir_all(right_path.parent().unwrap()).unwrap();
+    fs::write(&left_path, &left).unwrap();
+    fs::write(&right_path, &right).unwrap();
+    let mut explicit_roots = vec![format!("codex={}", root.display())];
+    for (index, agent) in ["claude-code", "pi", "opencode", "hermes", "cursor"]
+        .into_iter()
+        .enumerate()
+    {
+        let extra_root = temp.path().join(format!("skills-{index}"));
+        let extra_left = extra_root.join("browser-tabs/SKILL.md");
+        let extra_right = extra_root.join("browser-session/SKILL.md");
+        fs::create_dir_all(extra_left.parent().unwrap()).unwrap();
+        fs::create_dir_all(extra_right.parent().unwrap()).unwrap();
+        fs::write(extra_left, &left).unwrap();
+        fs::write(extra_right, &right).unwrap();
+        explicit_roots.push(format!("{agent}={}", extra_root.display()));
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    let mut scan_args = common.to_vec();
+    for explicit_root in &explicit_roots {
+        scan_args.extend(["--root", explicit_root]);
+    }
+    scan_args.push("scan");
+    json_output(&run(&scan_args, None));
+    let findings = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "report",
+                "--findings",
+                "--category",
+                "overlap",
+                "--severity",
+                "low",
+                "--limit",
+                "100",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let finding_id = findings["result"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Semantic overlap candidate")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let compact = json_output(&run(
+        &[
+            &common[..],
+            &["report", "--finding", finding_id, "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    ));
+    let comparison = &compact["result"]["comparison"];
+    assert_eq!(comparison["decision"], "compare_skill_meaning");
+    assert_eq!(comparison["automatic_change_supported"], false);
+    assert_eq!(comparison["semantic_conclusion_owner"], "agent_or_user");
+    assert_eq!(comparison["basis"]["metric"], "routing_vocabulary_jaccard");
+    assert!(comparison["basis"]["score"].as_f64().unwrap() >= 0.45);
+    assert!(comparison["basis"]["intersection_count"].as_u64().unwrap() >= 3);
+    assert!(
+        comparison["basis"]["union_count"].as_u64().unwrap()
+            >= comparison["basis"]["intersection_count"].as_u64().unwrap()
+    );
+    assert!(
+        comparison["basis"]["shared_terms"]
+            .as_array()
+            .unwrap()
+            .len()
+            <= 20
+    );
+    let skills = comparison["skills"].as_array().unwrap();
+    assert_eq!(skills.len(), 2);
+    let mut names = skills
+        .iter()
+        .map(|skill| skill["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    assert_eq!(names, ["浏览器会话", "浏览器标签"]);
+    assert!(skills.iter().all(|skill| {
+        skill["description"].as_str().unwrap().chars().count() == 512
+            && skill["description_truncated"] == true
+            && skill["trigger_count"] == 12
+            && skill["triggers"].as_array().unwrap().len() == 10
+            && skill["triggers_truncated"] == true
+            && skill["source"].as_str().unwrap().chars().count() == 256
+            && skill["source_truncated"] == true
+            && skill["summary"].as_str().is_some()
+            && skill["agents"]
+                == json!(["claude-code", "codex", "cursor", "hermes", "opencode", "pi"])
+            && skill["agent_count"] == 6
+            && skill["agents_truncated"] == false
+            && skill["providers"] == json!([])
+            && skill["provider_count"] == 0
+            && skill["providers_truncated"] == false
+            && skill["governable"] == true
+            && skill["readable_path_count"] == 6
+            && skill["readable_paths_truncated"] == true
+            && skill["current_content_available"] == true
+            && skill["readable_paths"].as_array().unwrap().len() == 5
+            && skill["readable_placement_count"] == 6
+            && skill["readable_placements_truncated"] == false
+            && skill["readable_placements"].as_array().unwrap().len() == 6
+            && skill["readable_placements"][0]["provider"].is_null()
+            && skill["readable_placements"][0]["provider_truncated"] == false
+            && skill["readable_placements"][0]["path"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("SKILL.md"))
+    }));
+    assert!(
+        compact["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|action| action["action"] != "plan")
+    );
+    let full = json_output(&run(
+        &[
+            &common[..],
+            &["report", "--finding", finding_id, "--full", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(
+        full["result"]["affected_skill_ids"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        full["result"]["comparison"]["skills"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+    let complete_full = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id, "--full"]].concat(),
+        None,
+    ));
+    let mut expected_skill_ids = complete_full["result"]["affected_skill_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|value| value.as_str().unwrap())
+        .collect::<Vec<_>>();
+    expected_skill_ids.sort_unstable();
+    let mut actual_skill_ids = skills
+        .iter()
+        .map(|skill| skill["skill_id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    actual_skill_ids.sort_unstable();
+    assert_eq!(actual_skill_ids, expected_skill_ids);
+    assert_eq!(
+        full["result"]["comparison"],
+        compact["result"]["comparison"]
+    );
+    assert_eq!(full["result"]["files_changed"], false);
+    assert_eq!(fs::read_to_string(left_path).unwrap(), left);
+    assert_eq!(fs::read_to_string(right_path).unwrap(), right);
+}
+
+#[test]
 fn healthy_status_does_not_suggest_an_unconditional_rescan() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## Problem

Semantic-overlap drilldown exposed opaque Skill IDs and digests, forcing the calling Agent to issue unrelated searches before it could judge whether the pair was actually redundant.

## Solution

- Bind the exact pair to bounded names, descriptions, triggers, summaries, current readable paths, Agent/provider placement facts, source metadata, and governability.
- Return the deterministic routing-vocabulary Jaccard basis with bounded shared terms.
- Keep semantic judgment with the Agent/user; never suggest Plan or Apply from candidate evidence.
- Preserve the complete pair in compact/full detail even when Evidence uses limit 1.
- Validate returned paths against current Skill identity and fingerprint; report honest counts and truncation for every bounded collection.

## Representative dogfood

- Real top candidate: Investment Committee Memo vs Experiment Analysis.
- Jaccard: 94/113 = 0.831858; 20 shared terms returned with truncation marked.
- Both current SKILL.md paths readable; providers and governance boundaries bound to each Skill.
- Compact/full comparison equal; Plan count stayed 0; source SHA-256 unchanged.

## Verification

- cargo test --locked --all-targets --all-features
- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- git diff --check
- Independent Standards review: PASS
- Independent Spec review: PASS

Closes #115