### PR TITLE
feat: link summary findings to detail

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -184,6 +184,11 @@ Machine results should expose facts, not preformatted prose:
 - risk, reversibility, drift, confirmation, and recovery state;
 - typed `suggested_actions` containing argv, mutation status, confirmation requirement, and reason code.
 
+The bounded Summary exposes one read-only `view_finding` action for each of its
+at most three selected Findings. When more Findings exist, the established
+`list_findings` pagination action remains first; direct drilldowns follow in
+Summary order and bind each stable Finding ID without implying Plan or Apply.
+
 Suggested action argv retains any effective `--state-dir`, `--home`, `--root`,
 and `--source-root` overrides so an Agent can execute the transition against
 the same local Snapshot and discovery trust boundary. It never broadens source

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -216,7 +216,10 @@ IDs for Agents, Scans, reports, Skills, placements, Evidence, Findings, Plans, o
 
 Selector-free `report --json` returns the bounded three-Finding Summary view;
 `--summary` is an explicit alias. The exhaustive diagnostic report requires
-top-level `report --full --json`.
+top-level `report --full --json`. Each selected Summary Finding has a bounded,
+read-only `view_finding` suggested action bound to its stable ID. When the
+Snapshot has more Findings than the Summary, `list_findings` remains the first
+action for pagination and the direct drilldowns follow in Summary order.
 
 `report --finding ID --json` returns compact paged Evidence items by default.
 Each item contains the Evidence ID, subject, path, quality, and decision facts;

--- a/src/app.rs
+++ b/src/app.rs
@@ -2356,27 +2356,43 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
     match request {
         ReportRequest::Summary => {
             let total = result["finding_count"].as_u64().unwrap_or_default();
-            let returned = result["findings"]
-                .as_array()
-                .map_or(0, |findings| findings.len() as u64);
-            if total <= returned {
-                return Vec::new();
+            let findings = result["findings"].as_array();
+            let returned = findings.map_or(0, |findings| findings.len() as u64);
+            let mut actions = Vec::new();
+            if total > returned {
+                actions.push(action(
+                    "list_findings",
+                    &[
+                        "report",
+                        "--findings",
+                        "--limit",
+                        "20",
+                        "--offset",
+                        "0",
+                        "--json",
+                    ],
+                    false,
+                    false,
+                    "more_findings_available",
+                ));
             }
-            vec![action(
-                "list_findings",
-                &[
-                    "report",
-                    "--findings",
-                    "--limit",
-                    "20",
-                    "--offset",
-                    "0",
-                    "--json",
-                ],
-                false,
-                false,
-                "more_findings_available",
-            )]
+            actions.extend(
+                findings
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|finding| finding["id"].as_str())
+                    .take(3)
+                    .map(|id| {
+                        action(
+                            "view_finding",
+                            &["report", "--finding", id, "--json"],
+                            false,
+                            false,
+                            "top_finding_selected",
+                        )
+                    }),
+            );
+            actions
         }
         ReportRequest::Findings {
             category,
@@ -6897,6 +6913,43 @@ fn action(
 mod recovery_tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn summary_actions_keep_direct_drilldowns_when_every_finding_fits() {
+        let result = json!({
+            "finding_count": 2,
+            "findings": [{"id": "finding_one"}, {"id": "finding_two"}]
+        });
+        let actions = report_actions(&result, ReportRequest::Summary);
+        assert_eq!(actions.len(), 2);
+        assert!(actions.iter().all(|action| action.action == "view_finding"));
+        assert_eq!(
+            actions[0].argv,
+            [
+                "skillroster",
+                "report",
+                "--finding",
+                "finding_one",
+                "--json"
+            ]
+        );
+        assert_eq!(
+            actions[1].argv,
+            [
+                "skillroster",
+                "report",
+                "--finding",
+                "finding_two",
+                "--json"
+            ]
+        );
+
+        let empty = report_actions(
+            &json!({"finding_count": 0, "findings": []}),
+            ReportRequest::Summary,
+        );
+        assert!(empty.is_empty());
+    }
 
     #[test]
     fn action_context_absolutizes_a_relative_state_directory() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -974,6 +974,36 @@ fn finding_list_is_paged_filterable_and_leads_to_evidence() {
             ]
         )
     );
+    assert_eq!(summary["suggested_actions"].as_array().unwrap().len(), 4);
+    for (finding, suggested_action) in summary["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .zip(
+            summary["suggested_actions"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .skip(1),
+        )
+    {
+        let finding_id = finding["id"].as_str().unwrap();
+        assert_eq!(suggested_action["action"], "view_finding");
+        assert_eq!(suggested_action["mutates"], false);
+        assert_eq!(suggested_action["requires_confirmation"], false);
+        assert_eq!(suggested_action["reason_code"], "top_finding_selected");
+        assert_eq!(
+            suggested_action["argv"],
+            context_action_argv(
+                &home,
+                &state,
+                &["report", "--finding", finding_id, "--json"]
+            )
+        );
+        let detail = json_output(&run_suggested_action(suggested_action));
+        assert_eq!(detail["result"]["id"], finding_id);
+        assert_eq!(detail["result"]["files_changed"], false);
+    }
 
     let first_output = run(
         &[


### PR DESCRIPTION
## Problem

The bounded Summary selected three actionable Findings but only exposed a list_findings transition. Agent callers had to reconstruct report --finding ID instead of following typed evidence.

## Solution

- Append one read-only view_finding action for each returned Summary Finding.
- Preserve list_findings as the first action when pagination is needed.
- Keep actions bounded to optional list plus three details.
- Reuse ActionContext so state, home, root, and source-root trust boundaries survive replay.
- Emit no fabricated action for an empty Summary and never imply Plan or Apply.

## Real dogfood

Executed the returned first view_finding argv unchanged against the existing real Snapshot. It opened the exact top high-severity escaping-link Finding; ID matched, files_changed was false, and Plan count remained zero.

## Verification

- cargo test --locked --all-targets --all-features
- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- git diff --check
- Standards review: PASS
- Spec review: PASS

Closes #117