### PR TITLE
fix: separate finding coverage dimensions

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -74,6 +74,12 @@ stage, quality, event count, and observation window together; the opaque Skill
 ID remains the stable identity, not the user-facing label. Incomplete coverage
 still forbids usage percentages and “unused” conclusions.
 
+Read each Finding's `coverage.basis` before explaining confidence.
+`skill_root_scan` qualifies structural counts using Skill-root states;
+`session_usage` qualifies usage or archive inference using observable-session
+states. Never use missing session history to discount an observed filesystem
+Finding, and never use a complete Skill-root scan to claim complete usage.
+
 Suggested actions are factual continuations, not generic guesses. Offer Plan
 only when the Finding explicitly reports `planning.supported: true`; otherwise
 follow the typed decision or open full detail. A paged Finding action preserves

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -78,6 +78,14 @@ Ambiguous Skills remain separate. SkillRoster never merges based only on a match
 
 Usage evidence is labeled `observed`, `inferred`, or `unknown`. Missing evidence never becomes proof that a Skill is useless. Raw prompts and responses are parsed read-only in place and are not copied into SkillRoster storage. Recent session selection happens after bounded discovery; large active JSONL files contribute bounded complete-line tails, large monolithic JSON files contribute bounded complete nested objects from their tails, and the fixed byte budget is spread across multiple recent sessions. Reports distinguish missing, inaccessible, sampled-but-limited, and complete observable session roots. A usage percentage is emitted only when the observable-session denominator is complete; bounded samples support observed event counts and stages, not an “unused” claim.
 
+Finding coverage never mixes filesystem discovery with session observation.
+Inventory, layout, exposure, overlap, routing, and structural lifecycle
+Findings use `skill_root_scan`; known-missing Skill roots are observed absence,
+while inaccessible roots make that structural denominator incomplete. Usage
+and usage-dependent archive Findings use `session_usage` and separately name
+reliable, sampled-limited, missing, excluded, and inaccessible Agents; those
+states are mutually exclusive for every supported Agent.
+
 A semantic-overlap Finding is candidate evidence, never a consolidation
 decision. Its compact and full detail carry the same bounded comparison bundle:
 the two stable Skill identities, names, descriptions, routing triggers,

--- a/src/app.rs
+++ b/src/app.rs
@@ -529,7 +529,37 @@ impl std::fmt::Display for PlanSnapshotDrift {
 
 impl std::error::Error for PlanSnapshotDrift {}
 
+#[derive(Debug)]
+struct StoredFindingCoverageInvalid {
+    finding_id: FindingId,
+    reason: &'static str,
+}
+
+impl std::fmt::Display for StoredFindingCoverageInvalid {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Finding {} has invalid stored coverage facts; run scan again",
+            self.finding_id
+        )
+    }
+}
+
+impl std::error::Error for StoredFindingCoverageInvalid {}
+
 fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError {
+    if let Some(invalid) = error.downcast_ref::<StoredFindingCoverageInvalid>() {
+        return ClassifiedError {
+            code: "stored_finding_coverage_invalid",
+            retryable: false,
+            details: Some(json!({
+                "finding_id": invalid.finding_id,
+                "reason": invalid.reason,
+                "files_changed": false,
+                "next_action": "scan"
+            })),
+        };
+    }
     if let Some(drift) = error.downcast_ref::<PlanSnapshotDrift>() {
         return ClassifiedError {
             code: "state_drift",
@@ -1701,6 +1731,15 @@ fn report_command(
             let scan: ScanResult = store
                 .scan_payload(&report.scan_id)?
                 .ok_or_else(|| anyhow!("Snapshot {} is no longer retained", report.scan_id))?;
+            let coverage_basis = stored_finding_coverage_basis(&stored, object)?;
+            let evidence_quality = object
+                .get("evidence_quality")
+                .cloned()
+                .unwrap_or_else(|| json!("unknown"));
+            object.insert(
+                "coverage".into(),
+                finding_coverage_facts(coverage_basis, evidence_quality, &scan),
+            );
             let latest_scan_id = store
                 .latest_completed_scan()?
                 .ok_or_else(|| anyhow!("no completed Snapshot exists"))?
@@ -3264,24 +3303,185 @@ fn finding_impact(finding: &crate::query::Finding) -> Value {
 }
 
 fn finding_coverage(finding: &crate::query::Finding, scan: &ScanResult) -> Value {
-    let reliable_agents = scan
-        .coverage
+    finding_coverage_facts(
+        finding.coverage_basis,
+        json!(finding.evidence_quality),
+        scan,
+    )
+}
+
+fn stored_finding_coverage_basis(
+    finding: &FindingRecord,
+    details: &serde_json::Map<String, Value>,
+) -> Result<crate::query::FindingCoverageBasis> {
+    let stored_basis = match details.get("coverage") {
+        None => None,
+        Some(Value::Object(coverage)) => coverage.get("basis"),
+        Some(_) => {
+            return Err(StoredFindingCoverageInvalid {
+                finding_id: finding.id.clone(),
+                reason: "malformed_coverage",
+            }
+            .into());
+        }
+    };
+    match stored_basis {
+        Some(Value::String(basis)) if basis == "skill_root_scan" => {
+            return Ok(crate::query::FindingCoverageBasis::SkillRootScan);
+        }
+        Some(Value::String(basis)) if basis == "session_usage" => {
+            return Ok(crate::query::FindingCoverageBasis::SessionUsage);
+        }
+        Some(_) => {
+            return Err(StoredFindingCoverageInvalid {
+                finding_id: finding.id.clone(),
+                reason: "unsupported_coverage_basis",
+            }
+            .into());
+        }
+        None => {}
+    }
+
+    // Records written before coverage dimensions were introduced have no typed basis.
+    // Reconstruct only those legacy records from the stable Finding identity.
+    Ok(match finding.category {
+        FindingCategory::Usage => crate::query::FindingCoverageBasis::SessionUsage,
+        FindingCategory::Lifecycle
+            if matches!(
+                finding.title.as_str(),
+                crate::query::STALE_ARCHIVE_FINDING_TITLE
+                    | crate::query::UNKNOWN_ARCHIVE_FINDING_TITLE
+            ) =>
+        {
+            crate::query::FindingCoverageBasis::SessionUsage
+        }
+        _ => crate::query::FindingCoverageBasis::SkillRootScan,
+    })
+}
+
+fn finding_coverage_facts(
+    basis: crate::query::FindingCoverageBasis,
+    evidence_quality: Value,
+    scan: &ScanResult,
+) -> Value {
+    match basis {
+        crate::query::FindingCoverageBasis::SkillRootScan => {
+            structural_finding_coverage(basis, evidence_quality, scan)
+        }
+        crate::query::FindingCoverageBasis::SessionUsage => {
+            session_finding_coverage(basis, evidence_quality, scan)
+        }
+    }
+}
+
+fn structural_finding_coverage(
+    basis: crate::query::FindingCoverageBasis,
+    evidence_quality: Value,
+    scan: &ScanResult,
+) -> Value {
+    let roots = scan
+        .roots
         .iter()
-        .filter(|coverage| coverage.denominator_reliable)
-        .map(|coverage| coverage.agent.id())
+        .filter(|root| root.kind == RootKind::Skills)
         .collect::<Vec<_>>();
-    let limited_agents = scan
-        .coverage
+    let agents_for_status = |status: scan::RootStatus| {
+        roots
+            .iter()
+            .filter(|root| root.status == status)
+            .filter_map(|root| root.agent.map(AgentKind::id))
+            .collect::<BTreeSet<_>>()
+    };
+    let included_agents = agents_for_status(scan::RootStatus::Included);
+    let missing_agents = agents_for_status(scan::RootStatus::Missing);
+    let inaccessible_agents = agents_for_status(scan::RootStatus::Inaccessible);
+    let limited_agents = inaccessible_agents.clone();
+    let reliable_agents = AgentKind::ALL
         .iter()
-        .filter(|coverage| !coverage.denominator_reliable)
-        .map(|coverage| coverage.agent.id())
+        .copied()
+        .filter(|agent| !limited_agents.contains(agent.id()))
+        .map(AgentKind::id)
         .collect::<Vec<_>>();
+    let root_count = |status| roots.iter().filter(|root| root.status == status).count();
+    let inaccessible_root_count = root_count(scan::RootStatus::Inaccessible);
     json!({
-        "evidence_quality": finding.evidence_quality,
+        "basis": basis,
+        "evidence_quality": evidence_quality,
+        "scope": "configured_and_discovered_skill_roots",
         "reliable_agents": reliable_agents,
         "limited_agents": limited_agents,
+        "included_agents": included_agents,
+        "missing_agents": missing_agents,
+        "inaccessible_agents": inaccessible_agents,
         "supported_agent_count": AgentKind::ALL.len(),
-        "denominator_reliable": limited_agents.is_empty()
+        "included_root_count": root_count(scan::RootStatus::Included),
+        "missing_root_count": root_count(scan::RootStatus::Missing),
+        "inaccessible_root_count": inaccessible_root_count,
+        "denominator_reliable": inaccessible_root_count == 0
+    })
+}
+
+fn session_finding_coverage(
+    basis: crate::query::FindingCoverageBasis,
+    evidence_quality: Value,
+    scan: &ScanResult,
+) -> Value {
+    let session_roots = scan
+        .roots
+        .iter()
+        .filter(|root| root.kind == RootKind::Sessions)
+        .collect::<Vec<_>>();
+    let mut reliable_agents = Vec::new();
+    let mut limited_agents = Vec::new();
+    let mut missing_agents = Vec::new();
+    let mut excluded_agents = Vec::new();
+    let mut inaccessible_agents = Vec::new();
+    for agent in AgentKind::ALL {
+        let has_status = |status| {
+            session_roots
+                .iter()
+                .any(|root| root.agent == Some(agent) && root.status == status)
+        };
+        if has_status(scan::RootStatus::Inaccessible) {
+            inaccessible_agents.push(agent.id());
+        } else if has_status(scan::RootStatus::Excluded) {
+            excluded_agents.push(agent.id());
+        } else if has_status(scan::RootStatus::Missing) {
+            missing_agents.push(agent.id());
+        } else {
+            match scan
+                .coverage
+                .iter()
+                .find(|coverage| coverage.agent == agent)
+            {
+                Some(coverage) if coverage.denominator_reliable => {
+                    reliable_agents.push(agent.id());
+                }
+                Some(_) => limited_agents.push(agent.id()),
+                None => missing_agents.push(agent.id()),
+            }
+        }
+    }
+    let denominator_reliable = reliable_agents.len() == AgentKind::ALL.len();
+    let root_count = |status| {
+        session_roots
+            .iter()
+            .filter(|root| root.status == status)
+            .count()
+    };
+    json!({
+        "basis": basis,
+        "evidence_quality": evidence_quality,
+        "reliable_agents": reliable_agents,
+        "limited_agents": limited_agents,
+        "missing_agents": missing_agents,
+        "excluded_agents": excluded_agents,
+        "inaccessible_agents": inaccessible_agents,
+        "supported_agent_count": AgentKind::ALL.len(),
+        "included_root_count": root_count(scan::RootStatus::Included),
+        "missing_root_count": root_count(scan::RootStatus::Missing),
+        "excluded_root_count": root_count(scan::RootStatus::Excluded),
+        "inaccessible_root_count": root_count(scan::RootStatus::Inaccessible),
+        "denominator_reliable": denominator_reliable
     })
 }
 
@@ -6913,6 +7113,204 @@ fn action(
 mod recovery_tests {
     use super::*;
     use tempfile::TempDir;
+
+    fn coverage_finding(basis: crate::query::FindingCoverageBasis) -> crate::query::Finding {
+        crate::query::Finding {
+            id: "finding_coverage".into(),
+            category: crate::query::FindingCategory::Overlap,
+            severity: crate::query::Severity::Medium,
+            title: "Exact duplicate Skill placements".into(),
+            summary: String::new(),
+            affected_skill_ids: vec!["skill_one".into()],
+            affected_placement_ids: vec!["placement_one".into()],
+            evidence: Vec::new(),
+            evidence_quality: scan::EvidenceQuality::Observed,
+            coverage_basis: basis,
+        }
+    }
+
+    #[test]
+    fn finding_coverage_keeps_skill_roots_separate_from_sessions() {
+        let root = |agent, status, suffix: &str| scan::RootObservation {
+            agent,
+            kind: RootKind::Skills,
+            path: PathBuf::from(format!("/fixture/{suffix}")),
+            status,
+            explicit: false,
+            detail: None,
+        };
+        let session_root = |agent, status, suffix: &str| scan::RootObservation {
+            agent: Some(agent),
+            kind: RootKind::Sessions,
+            path: PathBuf::from(format!("/fixture/{suffix}")),
+            status,
+            explicit: false,
+            detail: None,
+        };
+        let session =
+            |agent, roots_present, roots_missing, roots_inaccessible| scan::SessionCoverage {
+                agent,
+                roots_present,
+                roots_missing,
+                roots_inaccessible,
+                files_discovered: 0,
+                files_observed: 0,
+                files_partially_observed: 0,
+                files_skipped: 0,
+                denominator_reliable: false,
+                bytes_observed: 0,
+                lines_observed: 0,
+                truncated: false,
+                discovery_truncated: false,
+                first_seen_unix: None,
+                last_seen_unix: None,
+            };
+        let mut scan = ScanResult {
+            roots: vec![
+                root(Some(AgentKind::Codex), scan::RootStatus::Included, "codex"),
+                root(Some(AgentKind::Cursor), scan::RootStatus::Missing, "cursor"),
+                session_root(
+                    AgentKind::Codex,
+                    scan::RootStatus::Included,
+                    "codex-sessions",
+                ),
+                session_root(
+                    AgentKind::Cursor,
+                    scan::RootStatus::Missing,
+                    "cursor-sessions",
+                ),
+            ],
+            coverage: vec![
+                session(AgentKind::Codex, 1, 0, 0),
+                session(AgentKind::Cursor, 0, 1, 0),
+            ],
+            ..ScanResult::default()
+        };
+
+        let structural = finding_coverage(
+            &coverage_finding(crate::query::FindingCoverageBasis::SkillRootScan),
+            &scan,
+        );
+        assert_eq!(structural["basis"], "skill_root_scan");
+        assert_eq!(structural["denominator_reliable"], true);
+        assert_eq!(structural["missing_root_count"], 1);
+        assert_eq!(structural["limited_agents"], json!([]));
+
+        let usage = finding_coverage(
+            &coverage_finding(crate::query::FindingCoverageBasis::SessionUsage),
+            &scan,
+        );
+        assert_eq!(usage["basis"], "session_usage");
+        assert_eq!(usage["denominator_reliable"], false);
+        assert_eq!(usage["limited_agents"], json!(["codex"]));
+        assert!(
+            usage["missing_agents"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("cursor"))
+        );
+
+        scan.roots.extend([
+            session_root(
+                AgentKind::ClaudeCode,
+                scan::RootStatus::Inaccessible,
+                "claude-sessions",
+            ),
+            session_root(AgentKind::Pi, scan::RootStatus::Excluded, "pi-sessions"),
+        ]);
+        let mixed_sessions = finding_coverage(
+            &coverage_finding(crate::query::FindingCoverageBasis::SessionUsage),
+            &scan,
+        );
+        assert_eq!(
+            mixed_sessions["inaccessible_agents"],
+            json!(["claude-code"])
+        );
+        assert_eq!(mixed_sessions["excluded_agents"], json!(["pi"]));
+        let classified_agents = [
+            "reliable_agents",
+            "limited_agents",
+            "missing_agents",
+            "excluded_agents",
+            "inaccessible_agents",
+        ]
+        .into_iter()
+        .flat_map(|key| mixed_sessions[key].as_array().unwrap())
+        .collect::<Vec<_>>();
+        assert_eq!(classified_agents.len(), AgentKind::ALL.len());
+        assert_eq!(
+            classified_agents
+                .iter()
+                .map(|value| value.as_str().unwrap())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            AgentKind::ALL.len()
+        );
+
+        scan.roots.push(root(
+            Some(AgentKind::ClaudeCode),
+            scan::RootStatus::Inaccessible,
+            "claude",
+        ));
+        let inaccessible = finding_coverage(
+            &coverage_finding(crate::query::FindingCoverageBasis::SkillRootScan),
+            &scan,
+        );
+        assert_eq!(inaccessible["denominator_reliable"], false);
+        assert_eq!(inaccessible["inaccessible_root_count"], 1);
+        assert_eq!(inaccessible["limited_agents"], json!(["claude-code"]));
+    }
+
+    #[test]
+    fn stored_coverage_basis_prefers_typed_details_and_only_infers_legacy_records() {
+        let finding = FindingRecord {
+            id: FindingId::parse("finding_coverage-basis").unwrap(),
+            report_id: ReportId::parse("report_coverage-basis").unwrap(),
+            category: FindingCategory::Usage,
+            severity: Severity::Warning,
+            title: "Five-stage usage evidence".into(),
+            summary: String::new(),
+            details: Value::Null,
+            evidence_ids: Vec::new(),
+        };
+
+        let typed = json!({"coverage": {"basis": "skill_root_scan"}});
+        assert_eq!(
+            stored_finding_coverage_basis(&finding, typed.as_object().unwrap()).unwrap(),
+            crate::query::FindingCoverageBasis::SkillRootScan
+        );
+
+        let legacy = json!({});
+        assert_eq!(
+            stored_finding_coverage_basis(&finding, legacy.as_object().unwrap()).unwrap(),
+            crate::query::FindingCoverageBasis::SessionUsage
+        );
+
+        for (invalid, reason) in [
+            (
+                json!({"coverage": {"basis": "future_basis"}}),
+                "unsupported_coverage_basis",
+            ),
+            (
+                json!({"coverage": {"basis": 7}}),
+                "unsupported_coverage_basis",
+            ),
+            (json!({"coverage": []}), "malformed_coverage"),
+        ] {
+            let error =
+                stored_finding_coverage_basis(&finding, invalid.as_object().unwrap()).unwrap_err();
+            let output: Value =
+                serde_json::from_str(&error_json("report", error.as_ref())).unwrap();
+            assert_eq!(output["error"]["code"], "stored_finding_coverage_invalid");
+            assert_eq!(
+                output["error"]["details"]["finding_id"],
+                finding.id.to_string()
+            );
+            assert_eq!(output["error"]["details"]["reason"], reason);
+            assert_eq!(output["error"]["details"]["files_changed"], false);
+            assert_eq!(output["error"]["details"]["next_action"], "scan");
+        }
+    }
 
     #[test]
     fn summary_actions_keep_direct_drilldowns_when_every_finding_fits() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -11,6 +11,8 @@ use std::path::{Path, PathBuf};
 pub const SAME_NAME_DIVERGENT_FINDING_KIND: &str = "same_name_divergent_content";
 pub const SAME_NAME_DIVERGENT_FINDING_TITLE: &str = "Same-name Skills have different content";
 pub const SEMANTIC_OVERLAP_FINDING_TITLE: &str = "Semantic overlap candidate";
+pub const STALE_ARCHIVE_FINDING_TITLE: &str = "Stale archive candidates require review";
+pub const UNKNOWN_ARCHIVE_FINDING_TITLE: &str = "Archive candidacy is unknown";
 
 const SEMANTIC_SHARED_TERM_PREVIEW_LIMIT: usize = 20;
 const SEMANTIC_SHARED_TERM_CHARACTER_LIMIT: usize = 64;
@@ -85,6 +87,14 @@ pub enum FindingCategory {
     Lifecycle,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingCoverageBasis {
+    #[default]
+    SkillRootScan,
+    SessionUsage,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Severity {
@@ -94,7 +104,7 @@ pub enum Severity {
     High,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Finding {
     pub id: String,
     pub category: FindingCategory,
@@ -106,6 +116,7 @@ pub struct Finding {
     /// Stable path/digest/root references that let callers drill into the fact.
     pub evidence: Vec<String>,
     pub evidence_quality: EvidenceQuality,
+    pub coverage_basis: FindingCoverageBasis,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -178,7 +189,7 @@ pub struct PrimaryMetrics {
     pub agents_with_inaccessible_session_roots: usize,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Report {
     pub metrics: PrimaryMetrics,
     pub findings: Vec<Finding>,
@@ -441,6 +452,7 @@ fn inventory_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     let unavailable = scan
         .roots
         .iter()
+        .filter(|root| root.kind == crate::scan::RootKind::Skills)
         .filter(|root| matches!(root.status, crate::scan::RootStatus::Inaccessible))
         .collect::<Vec<_>>();
     if !unavailable.is_empty() {
@@ -932,7 +944,7 @@ fn usage_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
         )
         .collect();
     let coverage = &overview.coverage;
-    push_finding(
+    push_session_finding(
         findings,
         FindingCategory::Usage,
         Severity::Info,
@@ -977,7 +989,7 @@ fn usage_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
         .supported_agent_count
         .saturating_sub(coverage.complete_agent_count);
     if incomplete_count != 0 {
-        push_finding(
+        push_session_finding(
             findings,
             FindingCategory::Usage,
             Severity::Info,
@@ -1390,11 +1402,11 @@ fn lifecycle_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
         })
         .collect::<Vec<_>>();
     if !stale_candidates.is_empty() {
-        push_finding(
+        push_session_finding(
             findings,
             FindingCategory::Lifecycle,
             Severity::Low,
-            "Stale archive candidates require review",
+            STALE_ARCHIVE_FINDING_TITLE,
             format!(
                 "{} Skills are older than 180 days with no observed use in reliable covered Agent windows. This is candidate evidence only.",
                 stale_candidates.len()
@@ -1411,11 +1423,11 @@ fn lifecycle_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             EvidenceQuality::Inferred,
         );
     } else if reliable_agents.len() < AgentKind::ALL.len() {
-        push_finding(
+        push_session_finding(
             findings,
             FindingCategory::Lifecycle,
             Severity::Info,
-            "Archive candidacy is unknown",
+            UNKNOWN_ARCHIVE_FINDING_TITLE,
             "Coverage is insufficient to treat missing usage as evidence for archive. No archive action was suggested.",
             Vec::new(),
             Vec::new(),
@@ -1457,10 +1469,63 @@ fn push_finding(
     severity: Severity,
     title: impl Into<String>,
     summary: impl Into<String>,
+    affected_skill_ids: Vec<String>,
+    affected_placement_ids: Vec<String>,
+    evidence: Vec<String>,
+    evidence_quality: EvidenceQuality,
+) {
+    push_finding_with_coverage(
+        findings,
+        category,
+        severity,
+        title,
+        summary,
+        affected_skill_ids,
+        affected_placement_ids,
+        evidence,
+        evidence_quality,
+        FindingCoverageBasis::SkillRootScan,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_session_finding(
+    findings: &mut Vec<Finding>,
+    category: FindingCategory,
+    severity: Severity,
+    title: impl Into<String>,
+    summary: impl Into<String>,
+    affected_skill_ids: Vec<String>,
+    affected_placement_ids: Vec<String>,
+    evidence: Vec<String>,
+    evidence_quality: EvidenceQuality,
+) {
+    push_finding_with_coverage(
+        findings,
+        category,
+        severity,
+        title,
+        summary,
+        affected_skill_ids,
+        affected_placement_ids,
+        evidence,
+        evidence_quality,
+        FindingCoverageBasis::SessionUsage,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_finding_with_coverage(
+    findings: &mut Vec<Finding>,
+    category: FindingCategory,
+    severity: Severity,
+    title: impl Into<String>,
+    summary: impl Into<String>,
     mut affected_skill_ids: Vec<String>,
     mut affected_placement_ids: Vec<String>,
     mut evidence: Vec<String>,
     evidence_quality: EvidenceQuality,
+    coverage_basis: FindingCoverageBasis,
 ) {
     affected_skill_ids.sort();
     affected_skill_ids.dedup();
@@ -1486,6 +1551,7 @@ fn push_finding(
         affected_placement_ids,
         evidence,
         evidence_quality,
+        coverage_basis,
     });
 }
 
@@ -2144,6 +2210,41 @@ fn fnv1a64(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inventory_coverage_ignores_session_root_availability() {
+        let root = |kind| crate::scan::RootObservation {
+            agent: Some(AgentKind::Codex),
+            kind,
+            path: PathBuf::from("/fixture/unavailable"),
+            status: crate::scan::RootStatus::Inaccessible,
+            explicit: false,
+            detail: None,
+        };
+        let mut scan = ScanResult {
+            roots: vec![root(crate::scan::RootKind::Sessions)],
+            ..ScanResult::default()
+        };
+        let session_only = build_report(&scan);
+        assert!(
+            session_only
+                .findings
+                .iter()
+                .all(|finding| finding.title != "Some configured roots were inaccessible")
+        );
+
+        scan.roots.push(root(crate::scan::RootKind::Skills));
+        let with_skill_root = build_report(&scan);
+        let inventory = with_skill_root
+            .findings
+            .iter()
+            .find(|finding| finding.title == "Some configured roots were inaccessible")
+            .unwrap();
+        assert_eq!(
+            inventory.coverage_basis,
+            FindingCoverageBasis::SkillRootScan
+        );
+    }
     use crate::scan::{ScanOptions, scan};
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -3099,6 +3200,7 @@ mod tests {
                     .collect(),
                 evidence: Vec::new(),
                 evidence_quality: EvidenceQuality::Observed,
+                coverage_basis: FindingCoverageBasis::SkillRootScan,
             }
         }
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1706,6 +1706,8 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
     coverage.bytes_observed = bytes_observed;
     coverage.lines_observed = lines_observed;
     coverage.denominator_reliable = coverage.roots_present > 0
+        && coverage.roots_missing == 0
+        && coverage.roots_inaccessible == 0
         && coverage.files_skipped == 0
         && coverage.files_partially_observed == 0
         && !coverage.discovery_truncated;
@@ -2824,6 +2826,29 @@ enabled = true
         assert_eq!(result.coverage[0].files_partially_observed, 1);
         assert!(result.coverage[0].truncated);
         assert!(!result.coverage[0].denominator_reliable);
+
+        fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn session_denominator_requires_every_known_root_to_be_observable() {
+        let home = temp_directory("mixed-session-roots");
+        let included = home.join("included");
+        let missing = home.join("missing");
+        fs::create_dir_all(&included).unwrap();
+        let mut result = ScanResult::default();
+
+        scan_sessions(AgentKind::Codex, &[included.clone(), missing], &mut result);
+
+        let coverage = result
+            .coverage
+            .iter()
+            .find(|coverage| coverage.agent == AgentKind::Codex)
+            .unwrap();
+        assert_eq!(coverage.roots_present, 1);
+        assert_eq!(coverage.roots_missing, 1);
+        assert_eq!(coverage.roots_inaccessible, 0);
+        assert!(!coverage.denominator_reliable);
 
         fs::remove_dir_all(home).unwrap();
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1093,6 +1093,105 @@ fn finding_list_is_paged_filterable_and_leads_to_evidence() {
         None,
     ));
     assert!(!detail["result"]["items"].as_array().unwrap().is_empty());
+    assert_eq!(detail["result"]["coverage"]["basis"], "skill_root_scan");
+    assert_eq!(detail["result"]["coverage"]["denominator_reliable"], true);
+    assert!(
+        detail["result"]["coverage"]["missing_root_count"]
+            .as_u64()
+            .unwrap()
+            > 0
+    );
+    let connection = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let stored_details: String = connection
+        .query_row(
+            "SELECT details_json FROM findings WHERE id = ?1",
+            [finding_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut stored_details: Value = serde_json::from_str(&stored_details).unwrap();
+    stored_details["coverage"] = json!({
+        "denominator_reliable": false,
+        "limited_agents": ["codex", "claude-code"]
+    });
+    connection
+        .execute(
+            "UPDATE findings SET details_json = ?1 WHERE id = ?2",
+            (serde_json::to_string(&stored_details).unwrap(), finding_id),
+        )
+        .unwrap();
+    drop(connection);
+    let migrated_detail = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id]].concat(),
+        None,
+    ));
+    assert_eq!(
+        migrated_detail["result"]["coverage"]["basis"],
+        "skill_root_scan"
+    );
+    assert_eq!(
+        migrated_detail["result"]["coverage"]["denominator_reliable"],
+        true
+    );
+
+    let usage_findings = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "report",
+                "--findings",
+                "--category",
+                "usage",
+                "--limit",
+                "20",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let usage_finding_id = usage_findings["result"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Usage coverage is incomplete")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let connection = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let stored_usage_details: String = connection
+        .query_row(
+            "SELECT details_json FROM findings WHERE id = ?1",
+            [usage_finding_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut stored_usage_details: Value = serde_json::from_str(&stored_usage_details).unwrap();
+    stored_usage_details["coverage"] = json!({"denominator_reliable": true});
+    connection
+        .execute(
+            "UPDATE findings SET details_json = ?1 WHERE id = ?2",
+            (
+                serde_json::to_string(&stored_usage_details).unwrap(),
+                usage_finding_id,
+            ),
+        )
+        .unwrap();
+    drop(connection);
+    let usage_detail = json_output(&run(
+        &[&common[..], &["report", "--finding", usage_finding_id]].concat(),
+        None,
+    ));
+    assert_eq!(usage_detail["result"]["coverage"]["basis"], "session_usage");
+    assert_eq!(
+        usage_detail["result"]["coverage"]["denominator_reliable"],
+        false
+    );
+    assert!(
+        !usage_detail["result"]["coverage"]["missing_agents"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
 
     for invalid in [
         vec!["report", "--category", "overlap"],


### PR DESCRIPTION
Closes #119

## What changed

- Give every Finding an explicit evidence dimension: skill_root_scan or session_usage.
- Keep Skill-root coverage independent from Session availability; usage and usage-dependent archive Findings use Session coverage.
- Classify all eight supported Agents into mutually exclusive Session coverage states.
- Repair legacy persisted Finding details from the retained Snapshot while treating current typed basis as authoritative.
- Fail closed with a structured Agent-facing error when persisted coverage facts are malformed or use an unsupported basis.

## Dogfood evidence

- Fresh real-home scan: exact duplicates report structural coverage as reliable even with missing Session roots; usage reports remain limited with five limited and three missing Agents.
- Existing retained real Snapshot is repaired at read time without a rescan.
- No Agent files changed; no Plan or Receipt created.
- Cross-Finding analysis rejected a speculative causal graph: escaping links do not overlap duplicate placements, and cross-Agent physical duplicates do not explain per-Agent exposure size.

## Verification

- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features: 178 unit + 7 acceptance + 49 CLI passed
- git diff --check; clean worktree
- Independent Spec and Standards reviews: PASS, 0 blocker / 0 should-fix / 0 nit