### PR TITLE
release: prepare SkillRoster v1.8.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.19"
+version = "1.8.20"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.19"
+version = "1.8.20"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "457ca26b33d9f8668f83fd8a4821b884af4943c8"
+      revision: "5e6c5fbb1db0886e890065c381e8163c6b55efd2"
   version "1.8.20"
 
   depends_on "rust" => :build

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -3,7 +3,7 @@ class Skillroster < Formula
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "457ca26b33d9f8668f83fd8a4821b884af4943c8"
-  version "1.8.19"
+  version "1.8.20"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.19", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.20", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -439,6 +439,19 @@ complete identity set; a 100-dependent-Skill plus bootstrap regression proves
 an over-budget set is typed unavailable and has no Plan template. No choice was
 made, no Apply ran, and no real Agent file changed.
 
+The v1.8.20 fact-and-routing dogfood reused a retained read-only Snapshot of
+the real home: 8 supported Agents, 180 independent Skills, 676 placements, and
+548 default exposures. Structural inventory coverage and session evidence
+coverage remained separate facts instead of allowing a present Skill root to
+imply observable usage. One exact-duplicate Plan now reported physical sources
+3→1, placements 6→6, default exposure 5→5, and two relinks; this rejected the
+earlier implication that consolidation also reduced exposure. With three Ready
+Plans retained for the same current Snapshot, Status selected the first item
+from its existing bounded lifecycle ordering and returned a context-preserving,
+read-only `plan --show` action instead of suggesting a Scan that would stale
+those Plans. The 40-column terminal view wrapped the opaque Plan ID and avoided
+printing a context-free command. No Plan was applied and no Agent file changed.
+
 ## Evidence boundary
 
 These checks establish deterministic routing and safe local governance; they do

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.19
+SKILLROSTER_VERSION=1.8.20
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -46,7 +46,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.19 skillroster
+  --tag v1.8.20 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -60,7 +60,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.19
+git checkout v1.8.20
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -6093,6 +6093,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.8.18",
         "130cb488305b53dc3123633da50df6d3b843b24663861f7cc6b63964621b8718",
     ),
+    (
+        "1.8.19",
+        "78aa0dbdf53c3f9f08fb5bf9805e33b2d5b8ffe4c63bac05d88391f608fab16c",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2186,7 +2186,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.19"
+        "1.8.20"
     );
 
     let undone = json_output(&run(
@@ -2216,6 +2216,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
         ("1.8.3", include_str!("fixtures/bootstrap-v1.8.3.md")),
         ("1.8.4", include_str!("fixtures/bootstrap-v1.8.4.md")),
         ("1.8.18", include_str!("fixtures/bootstrap-v1.8.18.md")),
+        ("1.8.19", include_str!("fixtures/bootstrap-v1.8.19.md")),
     ] {
         let temp = TempDir::new().unwrap();
         let home = temp.path().join("home");
@@ -2520,7 +2521,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.19");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.20");
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],

--- a/tests/fixtures/bootstrap-v1.8.19.md
+++ b/tests/fixtures/bootstrap-v1.8.19.md
@@ -8,7 +8,7 @@ description: >
   distributing, synchronizing, or repairing shared Skill directories and
   symlinks.
 metadata:
-  bootstrap-version: "1.8.20"
+  bootstrap-version: "1.8.19"
   skillroster-routing-triggers: "scan analyze duplicate unused local Agent Skills; inventory installed Agent Skills; analyze duplicate Agent Skills; evaluate possible unused local Agent Skills from usage evidence; govern a Skill Roster; prepare a Skill governance Plan; apply approved Skill Plan; create Skill Receipt; undo Skill organization"
 ---
 


### PR DESCRIPTION
Part of #125. This PR prepares but does not publish v1.8.20.

## Included Agent-facing changes

- suppress same-name semantic-overlap noise and make remaining overlap detail decision-complete
- link bounded Summary Findings directly to their exact detail
- separate structural Skill inventory coverage from session evidence coverage
- report Library consolidation as physical sources, placements, exposure, and relinks
- route Status to inspect a current pending Plan before rescanning

## Release preparation

- bump package, lockfile, Formula, install examples, and Bootstrap metadata to 1.8.20
- preserve exact v1.8.19 Bootstrap upgrades through an official fixture and digest
- pin the Formula to first prep commit `5e6c5fbb1db0886e890065c381e8163c6b55efd2`
- record aggregate, read-only real-home dogfood without local paths, Skill names/content, sessions, IDs, Plans, or configuration

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (180 unit + 7 acceptance + 51 CLI)
- `ruby -c Formula/skillroster.rb`
- `git diff main...HEAD --check`
- independent Spec review: PASS
- independent Standards/Correctness review: PASS (0 blocker, 0 should-fix, 0 nit)

## Merge requirement

Use a merge commit. Do not squash or rebase: the Formula revision must remain an ancestor of the eventual release tag.

After merge, run the four-platform + WSL release candidate workflow. Stop for explicit publication authorization before the final tag or GitHub Release.

Closes #125 only after the final Release is published.