### PR TITLE
fix: fail closed on incomplete scan evidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,6 +54,10 @@ _Avoid_: Imported Skill, owned Skill
 A traceable fact supporting a Finding, such as a path, source declaration, symlink target, exposure record, or local usage event.
 _Avoid_: Proof, confidence
 
+**Fingerprint Completeness**:
+The typed coverage of a Skill package digest: Complete, Bounded, Unreadable, or Unknown. Only Complete may authorize an exact-content governance decision; the other states remain inventory facts.
+_Avoid_: Best-effort exact hash
+
 **Usage Observation**:
 A privacy-preserving bounded observation for one Skill, Agent, usage stage,
 quality, and session-source path. Unchanged observations deduplicate across

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -56,6 +56,8 @@ Use this placement test for every capability: local truth, stable identity, repr
 
 A read-only Scan discovers Skill roots, `SKILL.md` entry points, source metadata, links, configuration exposure, and supported local session sources. It normalizes paths without following links outside approved roots silently.
 
+Skill-root discovery and package fingerprints carry explicit completeness facts. A configured root whose depth limit was reached remains Included but is marked discovery-incomplete, making structural coverage unreliable. Each placement fingerprint is `complete`, `bounded`, `unreadable`, or `unknown`; payloads created before this contract default to `unknown`. Only a complete package fingerprint may support an exact-duplicate Finding or any Library/Roster Plan that relies on exact content. Bounded or unreadable packages remain inventory facts and require a new complete Scan before governance. Apply repeats this check so a Ready Plan created by an older binary cannot bypass the boundary.
+
 Skill identity uses this precedence:
 
 1. declared source plus version or revision;

--- a/src/app.rs
+++ b/src/app.rs
@@ -578,7 +578,96 @@ impl std::fmt::Display for LibraryRootConflict {
 
 impl std::error::Error for LibraryRootConflict {}
 
+#[derive(Debug)]
+struct IncompleteFingerprintBlocker {
+    skill_id: String,
+    placement_id: String,
+    path: PathBuf,
+    completeness: scan::FingerprintCompleteness,
+    stage: &'static str,
+}
+
+impl std::fmt::Display for IncompleteFingerprintBlocker {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Skill {} placement {} has a {} package fingerprint; resolve fingerprint incompleteness before governance",
+            self.skill_id,
+            self.placement_id,
+            self.completeness.id()
+        )
+    }
+}
+
+impl std::error::Error for IncompleteFingerprintBlocker {}
+
+fn incomplete_fingerprint_blocker<'a>(
+    placements: impl IntoIterator<Item = &'a scan::SkillPlacement>,
+    stage: &'static str,
+) -> Option<IncompleteFingerprintBlocker> {
+    placements
+        .into_iter()
+        .find(|placement| {
+            placement.fingerprint_completeness != scan::FingerprintCompleteness::Complete
+        })
+        .map(|placement| IncompleteFingerprintBlocker {
+            skill_id: placement.skill_id.clone(),
+            placement_id: placement.id.clone(),
+            path: placement.entrypoint.clone(),
+            completeness: placement.fingerprint_completeness,
+            stage,
+        })
+}
+
+fn fingerprint_remediation(completeness: scan::FingerprintCompleteness) -> Value {
+    let (reason, required_before_rescan, options) = match completeness {
+        scan::FingerprintCompleteness::Complete => ("none", false, Vec::<&str>::new()),
+        scan::FingerprintCompleteness::Bounded => (
+            "package_exceeds_fingerprint_bounds",
+            true,
+            vec![
+                "reduce_package_below_fingerprint_byte_limit",
+                "move_relevant_content_within_supported_depth",
+            ],
+        ),
+        scan::FingerprintCompleteness::Unreadable => (
+            "package_could_not_be_read_completely",
+            true,
+            vec!["repair_local_read_access", "confirm_safe_source_boundary"],
+        ),
+        scan::FingerprintCompleteness::Unknown => (
+            "legacy_snapshot_has_no_completeness_fact",
+            false,
+            vec!["scan_with_current_skillroster"],
+        ),
+    };
+    json!({
+        "automatic_change_supported": false,
+        "reason": reason,
+        "required_before_rescan": required_before_rescan,
+        "options": options,
+        "then": "scan"
+    })
+}
+
 fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError {
+    if let Some(blocker) = error.downcast_ref::<IncompleteFingerprintBlocker>() {
+        return ClassifiedError {
+            code: "incomplete_package_fingerprint",
+            retryable: false,
+            details: Some(json!({
+                "reason": "exact_content_evidence_incomplete",
+                "skill_id": blocker.skill_id,
+                "placement_id": blocker.placement_id,
+                "path": blocker.path,
+                "completeness": blocker.completeness,
+                "stage": blocker.stage,
+                "remediation": fingerprint_remediation(blocker.completeness),
+                "files_changed": false,
+                "next_action": "resolve_fingerprint_incompleteness_then_scan"
+            })),
+        };
+    }
     if let Some(conflict) = error.downcast_ref::<LibraryRootConflict>() {
         let agent_root_count = conflict.agent_roots.len();
         return ClassifiedError {
@@ -631,6 +720,20 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
                 "agents": conflict.agents,
                 "files_changed": false,
                 "next_action": "request_consistent_exposure_or_separate_shared_roots"
+            })),
+        };
+    }
+    if let Some(blocker) = error.downcast_ref::<crate::roster_plan::RosterDiscoveryIncomplete>() {
+        return ClassifiedError {
+            code: "roster_skill_root_discovery_incomplete",
+            retryable: false,
+            details: Some(json!({
+                "reason": "skill_root_discovery_bounded",
+                "agent": blocker.agent,
+                "path": blocker.path,
+                "detail": blocker.detail,
+                "files_changed": false,
+                "next_action": "scan"
             })),
         };
     }
@@ -1892,7 +1995,9 @@ fn report_command(
                         "default_exposed": placement.default_exposed,
                         "governable": placement.governable,
                         "provider": placement.provider,
-                        "content_digest": placement.content_digest
+                        "content_digest": placement.content_digest,
+                        "fingerprint_completeness": placement.fingerprint_completeness,
+                        "fingerprint_detail": placement.fingerprint_detail
                     })
                 })
                 .collect::<Vec<_>>();
@@ -2341,7 +2446,9 @@ fn add_semantic_overlap_comparison(
                         "provider_truncated": provider_truncated,
                         "governable": placement.governable,
                         "default_exposed": placement.default_exposed,
-                        "link_status": placement.link_status
+                        "link_status": placement.link_status,
+                        "fingerprint_completeness": placement.fingerprint_completeness,
+                        "fingerprint_detail": placement.fingerprint_detail
                     })
                 })
                 .collect::<Vec<_>>();
@@ -3443,7 +3550,15 @@ fn structural_finding_coverage(
     let included_agents = agents_for_status(scan::RootStatus::Included);
     let missing_agents = agents_for_status(scan::RootStatus::Missing);
     let inaccessible_agents = agents_for_status(scan::RootStatus::Inaccessible);
-    let limited_agents = inaccessible_agents.clone();
+    let bounded_agents = roots
+        .iter()
+        .filter(|root| root.status == scan::RootStatus::Included && !root.discovery_complete)
+        .filter_map(|root| root.agent.map(AgentKind::id))
+        .collect::<BTreeSet<_>>();
+    let limited_agents = inaccessible_agents
+        .union(&bounded_agents)
+        .copied()
+        .collect::<BTreeSet<_>>();
     let reliable_agents = AgentKind::ALL
         .iter()
         .copied()
@@ -3452,6 +3567,10 @@ fn structural_finding_coverage(
         .collect::<Vec<_>>();
     let root_count = |status| roots.iter().filter(|root| root.status == status).count();
     let inaccessible_root_count = root_count(scan::RootStatus::Inaccessible);
+    let bounded_root_count = roots
+        .iter()
+        .filter(|root| root.status == scan::RootStatus::Included && !root.discovery_complete)
+        .count();
     json!({
         "basis": basis,
         "evidence_quality": evidence_quality,
@@ -3461,11 +3580,13 @@ fn structural_finding_coverage(
         "included_agents": included_agents,
         "missing_agents": missing_agents,
         "inaccessible_agents": inaccessible_agents,
+        "bounded_agents": bounded_agents,
         "supported_agent_count": AgentKind::ALL.len(),
         "included_root_count": root_count(scan::RootStatus::Included),
         "missing_root_count": root_count(scan::RootStatus::Missing),
         "inaccessible_root_count": inaccessible_root_count,
-        "denominator_reliable": inaccessible_root_count == 0
+        "bounded_root_count": bounded_root_count,
+        "denominator_reliable": inaccessible_root_count == 0 && bounded_root_count == 0
     })
 }
 
@@ -4818,6 +4939,11 @@ fn exact_duplicate_finding_scope(
         .iter()
         .filter(|placement| placement.skill_id == *skill_id)
         .collect::<Vec<_>>();
+    if let Some(blocker) =
+        incomplete_fingerprint_blocker(all_placements.iter().copied(), "finding_plan")
+    {
+        return Err(blocker.into());
+    }
     let all_ids = all_placements
         .iter()
         .map(|placement| placement.id.as_str())
@@ -5278,6 +5404,11 @@ fn normalize_library_plan(
             .iter()
             .filter(|placement| placement.skill_id == request.skill_id)
             .collect::<Vec<_>>();
+        if let Some(blocker) =
+            incomplete_fingerprint_blocker(all_placements.iter().copied(), "plan")
+        {
+            return Err(blocker.into());
+        }
         if all_placements.iter().any(|placement| !placement.governable) {
             bail!(
                 "Library change for {} includes provider-managed read-only placements",
@@ -5800,6 +5931,7 @@ fn apply_command(store: &StateStore, id: &str) -> Result<Value> {
         }
         .into());
     }
+    validate_governance_fingerprint_completeness(&prepared, &scan)?;
     validate_physical_placement_bindings(&record, &prepared, &scan)?;
     validate_roster_changes(store, &prepared, &scan)?;
     validate_source_update_preconditions(&prepared, &scan)?;
@@ -6418,6 +6550,7 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
                 "explicit": root.explicit,
                 "agent": root.agent.map(AgentKind::id),
                 "detail": root.detail,
+                "discovery_complete": root.discovery_complete,
             }),
             observed_at,
         )?;
@@ -6550,6 +6683,8 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
                 "default_exposed": placement.default_exposed,
                 "governable": placement.governable,
                 "provider": placement.provider,
+                "fingerprint_completeness": placement.fingerprint_completeness,
+                "fingerprint_detail": placement.fingerprint_detail,
             }),
             observed_at,
         )?;
@@ -6567,6 +6702,8 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
                 "algorithm": "sha256-v1",
                 "skill_id": skill_id,
                 "placement_id": placement_id,
+                "completeness": placement.fingerprint_completeness,
+                "detail": placement.fingerprint_detail,
             }),
             observed_at,
         )?;
@@ -6724,6 +6861,37 @@ fn validate_roster_changes(
             );
         }
         roster_state(&change.state)?;
+    }
+    Ok(())
+}
+
+fn validate_governance_fingerprint_completeness(
+    plan: &PreparedPlan,
+    scan: &ScanResult,
+) -> Result<()> {
+    if plan.operations.is_empty() {
+        return Ok(());
+    }
+    let governed_skill_ids = plan
+        .roster_changes
+        .iter()
+        .map(|change| change.skill_id.as_str())
+        .chain(
+            plan.library_changes
+                .iter()
+                .map(|change| change.skill_id.as_str()),
+        )
+        .collect::<BTreeSet<_>>();
+    if governed_skill_ids.is_empty() {
+        return Ok(());
+    }
+    if let Some(blocker) = incomplete_fingerprint_blocker(
+        scan.placements
+            .iter()
+            .filter(|placement| governed_skill_ids.contains(placement.skill_id.as_str())),
+        "apply",
+    ) {
+        return Err(blocker.into());
     }
     Ok(())
 }
@@ -7317,6 +7485,7 @@ mod recovery_tests {
             status,
             explicit: false,
             detail: None,
+            discovery_complete: true,
         };
         let session_root = |agent, status, suffix: &str| scan::RootObservation {
             agent: Some(agent),
@@ -7325,6 +7494,7 @@ mod recovery_tests {
             status,
             explicit: false,
             detail: None,
+            discovery_complete: true,
         };
         let session =
             |agent, roots_present, roots_missing, roots_inaccessible| scan::SessionCoverage {
@@ -7374,6 +7544,27 @@ mod recovery_tests {
         assert_eq!(structural["denominator_reliable"], true);
         assert_eq!(structural["missing_root_count"], 1);
         assert_eq!(structural["limited_agents"], json!([]));
+
+        scan.roots[0].discovery_complete = false;
+        let bounded_structural = finding_coverage(
+            &coverage_finding(crate::query::FindingCoverageBasis::SkillRootScan),
+            &scan,
+        );
+        assert_eq!(bounded_structural["denominator_reliable"], false);
+        assert_eq!(bounded_structural["bounded_root_count"], 1);
+        assert_eq!(bounded_structural["limited_agents"], json!(["codex"]));
+        let blocker = crate::roster_plan::RosterDiscoveryIncomplete {
+            agent: "codex".into(),
+            path: PathBuf::from("/fixture/codex"),
+            detail: Some("Skill discovery was bounded at depth 5".into()),
+        };
+        let blocked: Value = serde_json::from_str(&error_json("plan", &blocker)).unwrap();
+        assert_eq!(
+            blocked["error"]["code"],
+            "roster_skill_root_discovery_incomplete"
+        );
+        assert_eq!(blocked["error"]["details"]["files_changed"], false);
+        scan.roots[0].discovery_complete = true;
 
         let usage = finding_coverage(
             &coverage_finding(crate::query::FindingCoverageBasis::SessionUsage),
@@ -7915,6 +8106,8 @@ mod recovery_tests {
             entrypoint: PathBuf::from(format!("/fixture/{id}/SKILL.md")),
             physical_directory: None,
             content_digest: "digest_shared".into(),
+            fingerprint_completeness: scan::FingerprintCompleteness::Complete,
+            fingerprint_detail: None,
             link_target: None,
             link_status: scan::LinkStatus::NotLink,
             default_exposed: governable,
@@ -7981,6 +8174,137 @@ mod recovery_tests {
         assert_eq!(
             blocked["error"]["details"]["providers"],
             json!(["plugin@market"])
+        );
+    }
+
+    #[test]
+    fn raw_library_plan_rejects_incomplete_package_fingerprints() {
+        let placement = |id: &str, completeness| scan::SkillPlacement {
+            id: id.into(),
+            skill_id: "skill_bounded".into(),
+            agent: Some(AgentKind::Codex),
+            root: PathBuf::from("/fixture/root"),
+            directory: PathBuf::from(format!("/fixture/{id}")),
+            entrypoint: PathBuf::from(format!("/fixture/{id}/SKILL.md")),
+            physical_directory: None,
+            content_digest: "same-fallback-digest".into(),
+            fingerprint_completeness: completeness,
+            fingerprint_detail: Some("package exceeded fingerprint limit".into()),
+            link_target: None,
+            link_status: scan::LinkStatus::NotLink,
+            default_exposed: true,
+            governable: true,
+            provider: None,
+            executable_files: Vec::new(),
+            declared_name_matches_directory: Some(true),
+        };
+        let scan = ScanResult {
+            skills: vec![scan::ScannedSkill {
+                id: "skill_bounded".into(),
+                name: "bounded".into(),
+                metadata: scan::SkillMetadata::default(),
+                content_digest: "same-fallback-digest".into(),
+                digest_algorithm: "sha256-v1".into(),
+                summary: String::new(),
+                normalized_text: String::new(),
+                modified_at_unix: None,
+            }],
+            placements: vec![
+                placement("placement_a", scan::FingerprintCompleteness::Bounded),
+                placement("placement_b", scan::FingerprintCompleteness::Complete),
+            ],
+            ..ScanResult::default()
+        };
+        let request = LibraryChangeRequest {
+            skill_id: "skill_bounded".into(),
+            canonical_placement_id: "placement_b".into(),
+            placement_ids: vec!["placement_a".into(), "placement_b".into()],
+            requested_state: RequestedGovernanceState::Managed,
+        };
+
+        let error = match normalize_library_plan(
+            json!({}),
+            &scan,
+            Path::new("/fixture/state"),
+            vec![request],
+        ) {
+            Ok(_) => panic!("incomplete package fingerprints must block Library planning"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("resolve fingerprint incompleteness before governance")
+        );
+        let blocked: Value = serde_json::from_str(&error_json("plan", error.as_ref())).unwrap();
+        assert_eq!(blocked["error"]["code"], "incomplete_package_fingerprint");
+        assert_eq!(blocked["error"]["details"]["stage"], "plan");
+        assert_eq!(
+            blocked["error"]["details"]["next_action"],
+            "resolve_fingerprint_incompleteness_then_scan"
+        );
+        assert_eq!(
+            blocked["error"]["details"]["remediation"]["required_before_rescan"],
+            true
+        );
+        assert_eq!(blocked["error"]["details"]["files_changed"], false);
+    }
+
+    #[test]
+    fn apply_validation_rejects_legacy_unknown_governance_fingerprints() {
+        let prepared = PreparedPlan {
+            id: PlanId::new().to_string(),
+            scan_id: ScanId::new().to_string(),
+            evidence_ids: vec![],
+            digest: "sha256:test".into(),
+            operations: vec![Operation::CreateDirectory {
+                target: PathBuf::from("/fixture/new"),
+                expected_fingerprint: "missing".into(),
+            }],
+            roster_changes: vec![change::RosterChange {
+                agent: "codex".into(),
+                skill_id: "skill_legacy".into(),
+                state: "on_demand".into(),
+            }],
+            source_updates: vec![],
+            library_changes: vec![],
+            approved_roots: vec![PathBuf::from("/fixture")],
+            state_dir: PathBuf::from("/fixture/state"),
+        };
+        let scan = ScanResult {
+            placements: vec![scan::SkillPlacement {
+                id: "placement_legacy".into(),
+                skill_id: "skill_legacy".into(),
+                agent: Some(AgentKind::Codex),
+                root: PathBuf::from("/fixture/root"),
+                directory: PathBuf::from("/fixture/root/legacy"),
+                entrypoint: PathBuf::from("/fixture/root/legacy/SKILL.md"),
+                physical_directory: None,
+                content_digest: "legacy-digest".into(),
+                fingerprint_completeness: scan::FingerprintCompleteness::Unknown,
+                fingerprint_detail: None,
+                link_target: None,
+                link_status: scan::LinkStatus::NotLink,
+                default_exposed: true,
+                governable: true,
+                provider: None,
+                executable_files: vec![],
+                declared_name_matches_directory: Some(true),
+            }],
+            ..ScanResult::default()
+        };
+
+        let error = validate_governance_fingerprint_completeness(&prepared, &scan).unwrap_err();
+
+        let blocked: Value = serde_json::from_str(&error_json("apply", error.as_ref())).unwrap();
+        assert_eq!(
+            blocked["error"]["details"]["remediation"]["options"],
+            json!(["scan_with_current_skillroster"])
+        );
+        assert_eq!(
+            blocked["error"]["details"]["remediation"]["required_before_rescan"],
+            false
         );
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -480,6 +480,75 @@ fn inventory_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             EvidenceQuality::Observed,
         );
     }
+
+    let bounded = scan
+        .roots
+        .iter()
+        .filter(|root| root.kind == crate::scan::RootKind::Skills)
+        .filter(|root| root.status == crate::scan::RootStatus::Included && !root.discovery_complete)
+        .collect::<Vec<_>>();
+    if !bounded.is_empty() {
+        push_finding(
+            findings,
+            FindingCategory::Inventory,
+            Severity::Medium,
+            "Some configured roots had bounded discovery",
+            format!(
+                "{} known or explicit roots were included but not inspected to their full depth; inventory is partial.",
+                bounded.len()
+            ),
+            Vec::new(),
+            Vec::new(),
+            bounded
+                .iter()
+                .map(|root| {
+                    format!(
+                        "path:{}:{}",
+                        root.agent.map(AgentKind::id).unwrap_or("shared"),
+                        root.path.display()
+                    )
+                })
+                .collect(),
+            EvidenceQuality::Observed,
+        );
+    }
+
+    let incomplete_fingerprints = scan
+        .placements
+        .iter()
+        .filter(|placement| {
+            matches!(
+                placement.link_status,
+                LinkStatus::NotLink | LinkStatus::Valid
+            ) && placement.fingerprint_completeness
+                != crate::scan::FingerprintCompleteness::Complete
+        })
+        .collect::<Vec<_>>();
+    if !incomplete_fingerprints.is_empty() {
+        push_finding(
+            findings,
+            FindingCategory::Inventory,
+            Severity::Medium,
+            "Some Skill package fingerprints are incomplete",
+            format!(
+                "{} readable placements have bounded, unreadable, or legacy-unknown package fingerprints and cannot support exact-content governance.",
+                incomplete_fingerprints.len()
+            ),
+            incomplete_fingerprints
+                .iter()
+                .map(|placement| placement.skill_id.clone())
+                .collect(),
+            incomplete_fingerprints
+                .iter()
+                .map(|placement| placement.id.clone())
+                .collect(),
+            incomplete_fingerprints
+                .iter()
+                .map(|placement| format!("path:{}", placement.entrypoint.display()))
+                .collect(),
+            EvidenceQuality::Observed,
+        );
+    }
 }
 
 fn layout_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
@@ -1017,6 +1086,11 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
         let Some(skill) = scan.skills.iter().find(|skill| skill.id == skill_id) else {
             continue;
         };
+        if placements.iter().any(|placement| {
+            placement.fingerprint_completeness != crate::scan::FingerprintCompleteness::Complete
+        }) {
+            continue;
+        }
         let mut by_digest = BTreeMap::<&str, Vec<&crate::scan::SkillPlacement>>::new();
         for placement in placements {
             by_digest
@@ -2220,6 +2294,7 @@ mod tests {
             status: crate::scan::RootStatus::Inaccessible,
             explicit: false,
             detail: None,
+            discovery_complete: true,
         };
         let mut scan = ScanResult {
             roots: vec![root(crate::scan::RootKind::Sessions)],
@@ -2244,6 +2319,32 @@ mod tests {
             inventory.coverage_basis,
             FindingCoverageBasis::SkillRootScan
         );
+    }
+
+    #[test]
+    fn inventory_reports_included_roots_with_bounded_discovery() {
+        let scan = ScanResult {
+            roots: vec![crate::scan::RootObservation {
+                agent: Some(AgentKind::Codex),
+                kind: crate::scan::RootKind::Skills,
+                path: PathBuf::from("/fixture/bounded"),
+                status: crate::scan::RootStatus::Included,
+                explicit: false,
+                detail: Some("Skill discovery was bounded at depth 5".into()),
+                discovery_complete: false,
+            }],
+            ..ScanResult::default()
+        };
+
+        let report = build_report(&scan);
+        let finding = report
+            .findings
+            .iter()
+            .find(|finding| finding.title == "Some configured roots had bounded discovery")
+            .unwrap();
+
+        assert_eq!(finding.coverage_basis, FindingCoverageBasis::SkillRootScan);
+        assert_eq!(finding.evidence_quality, EvidenceQuality::Observed);
     }
     use crate::scan::{ScanOptions, scan};
     use std::fs;
@@ -2454,6 +2555,59 @@ mod tests {
 
         assert_eq!(finding.affected_placement_ids.len(), 3);
         assert!(finding.summary.contains("2 distinct physical sources"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn bounded_package_fingerprints_never_become_exact_duplicates() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("skillroster-bounded-duplicate-{nonce}"));
+        for (name, bytes) in [
+            ("copy-a", 16 * 1024 * 1024 + 1),
+            ("copy-b", 16 * 1024 * 1024 + 2),
+        ] {
+            let directory = root.join(name);
+            fs::create_dir_all(&directory).unwrap();
+            fs::write(
+                directory.join("SKILL.md"),
+                "---\nname: bounded-copy\n---\nSame entrypoint.",
+            )
+            .unwrap();
+            fs::File::create(directory.join("asset.bin"))
+                .unwrap()
+                .set_len(bytes)
+                .unwrap();
+        }
+        let mut options = ScanOptions::for_home(root.join("home"));
+        options
+            .explicit_skill_roots
+            .push(crate::scan::ExplicitSkillRoot {
+                agent: AgentKind::Codex,
+                path: root.clone(),
+            });
+        options.include_session_evidence = false;
+        let scan = scan(&options).unwrap();
+
+        assert_eq!(scan.placements.len(), 2);
+        assert!(scan.placements.iter().all(|placement| {
+            placement.fingerprint_completeness == crate::scan::FingerprintCompleteness::Bounded
+        }));
+        let report = build_report(&scan);
+        let incomplete = report
+            .findings
+            .iter()
+            .find(|finding| finding.title == "Some Skill package fingerprints are incomplete")
+            .unwrap();
+        assert_eq!(incomplete.affected_placement_ids.len(), 2);
+        assert!(
+            !report
+                .findings
+                .iter()
+                .any(|finding| { finding.title == "Exact duplicate Skill placements" })
+        );
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -3272,6 +3426,8 @@ mod tests {
                     entrypoint: PathBuf::from(format!("/{}/skills/{index}/SKILL.md", agent.id())),
                     physical_directory: None,
                     content_digest: format!("digest_{index}"),
+                    fingerprint_completeness: crate::scan::FingerprintCompleteness::Complete,
+                    fingerprint_detail: None,
                     link_target: None,
                     link_status: crate::scan::LinkStatus::NotLink,
                     default_exposed: true,

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -11,7 +11,9 @@ const SOURCE_CONFIRMATION_SCHEMA_VERSION: u32 = 2;
 use crate::change::{self, LibraryChangeAction, RosterChange};
 use crate::harness::AgentKind;
 use crate::model::RosterState;
-use crate::scan::{LinkStatus, RootKind, RootStatus, ScanResult, SkillPlacement};
+use crate::scan::{
+    FingerprintCompleteness, LinkStatus, RootKind, RootStatus, ScanResult, SkillPlacement,
+};
 
 #[derive(Debug)]
 pub struct DerivedRosterPlan {
@@ -25,6 +27,25 @@ pub struct RosterPhysicalConflict {
     pub skill_id: String,
     pub agents: Vec<String>,
 }
+
+#[derive(Debug)]
+pub struct RosterDiscoveryIncomplete {
+    pub agent: String,
+    pub path: PathBuf,
+    pub detail: Option<String>,
+}
+
+impl std::fmt::Display for RosterDiscoveryIncomplete {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Agent {} Skill root discovery is incomplete; run a new Scan before planning Roster changes",
+            self.agent
+        )
+    }
+}
+
+impl std::error::Error for RosterDiscoveryIncomplete {}
 
 impl std::fmt::Display for RosterPhysicalConflict {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -496,6 +517,7 @@ pub fn derive(
     let mut pairs = HashSet::new();
     for change in changes {
         let agent = agent(&change.agent)?;
+        agent_root(scan, agent)?;
         if !pairs.insert((change.skill_id.as_str(), agent)) {
             bail!(
                 "duplicate Roster request for Agent {} and Skill {}",
@@ -1033,6 +1055,7 @@ fn verified_real_source(
 
 fn is_real_exact(placement: &SkillPlacement, digest: &str) -> bool {
     placement.governable
+        && placement.fingerprint_completeness == FingerprintCompleteness::Complete
         && placement.content_digest == digest
         && placement.link_target.is_none()
         && std::fs::symlink_metadata(&placement.directory)
@@ -1040,15 +1063,24 @@ fn is_real_exact(placement: &SkillPlacement, digest: &str) -> bool {
 }
 
 fn agent_root(scan: &ScanResult, agent: AgentKind) -> Result<PathBuf> {
-    scan.roots
+    let root = scan
+        .roots
         .iter()
         .find(|root| {
             root.agent == Some(agent)
                 && root.kind == RootKind::Skills
                 && root.status == RootStatus::Included
         })
-        .map(|root| root.path.clone())
-        .ok_or_else(|| anyhow!("Agent {} has no included Skill root", agent.id()))
+        .ok_or_else(|| anyhow!("Agent {} has no included Skill root", agent.id()))?;
+    if !root.discovery_complete {
+        return Err(RosterDiscoveryIncomplete {
+            agent: agent.id().into(),
+            path: root.path.clone(),
+            detail: root.detail.clone(),
+        }
+        .into());
+    }
+    Ok(root.path.clone())
 }
 
 fn agent(value: &str) -> Result<AgentKind> {
@@ -1093,6 +1125,28 @@ mod tests {
 
     use super::*;
     use crate::scan::{ScanOptions, scan};
+
+    #[test]
+    fn roster_planning_types_bounded_root_discovery() {
+        let scan = ScanResult {
+            roots: vec![crate::scan::RootObservation {
+                agent: Some(AgentKind::Codex),
+                kind: RootKind::Skills,
+                path: PathBuf::from("/fixture/codex"),
+                status: RootStatus::Included,
+                explicit: false,
+                detail: Some("Skill discovery was bounded at depth 5".into()),
+                discovery_complete: false,
+            }],
+            ..ScanResult::default()
+        };
+
+        let error = agent_root(&scan, AgentKind::Codex).unwrap_err();
+
+        let blocker = error.downcast_ref::<RosterDiscoveryIncomplete>().unwrap();
+        assert_eq!(blocker.agent, "codex");
+        assert_eq!(blocker.path, PathBuf::from("/fixture/codex"));
+    }
 
     #[cfg(unix)]
     fn shared_agent_root_fixture() -> (TempDir, ScanResult, PathBuf) {

--- a/src/roster_recommendation.rs
+++ b/src/roster_recommendation.rs
@@ -759,6 +759,8 @@ mod tests {
                 )),
                 physical_directory: None,
                 content_digest: skill.content_digest.clone(),
+                fingerprint_completeness: crate::scan::FingerprintCompleteness::Complete,
+                fingerprint_detail: None,
                 link_target: None,
                 link_status: LinkStatus::NotLink,
                 default_exposed: true,

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -76,6 +76,10 @@ pub struct RootObservation {
     pub status: RootStatus,
     pub explicit: bool,
     pub detail: Option<String>,
+    /// Whether discovery inspected the complete configured Skill-root depth.
+    /// Session roots do not use this dimension and remain complete by default.
+    #[serde(default)]
+    pub discovery_complete: bool,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
@@ -97,6 +101,27 @@ pub enum LinkStatus {
     EscapesRoot,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FingerprintCompleteness {
+    Complete,
+    Bounded,
+    Unreadable,
+    #[default]
+    Unknown,
+}
+
+impl FingerprintCompleteness {
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Bounded => "bounded",
+            Self::Unreadable => "unreadable",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SkillPlacement {
     pub id: String,
@@ -110,6 +135,13 @@ pub struct SkillPlacement {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub physical_directory: Option<PathBuf>,
     pub content_digest: String,
+    /// Whether `content_digest` covers the complete Skill package. Bounded or
+    /// unreadable fingerprints are inventory facts only and cannot authorize
+    /// exact-duplicate governance.
+    #[serde(default)]
+    pub fingerprint_completeness: FingerprintCompleteness,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint_detail: Option<String>,
     pub link_target: Option<PathBuf>,
     pub link_status: LinkStatus,
     pub default_exposed: bool,
@@ -824,6 +856,7 @@ fn observe_excluded_session_roots(
             status: RootStatus::Excluded,
             explicit: false,
             detail: Some(detail.into()),
+            discovery_complete: true,
         });
     }
 }
@@ -848,12 +881,13 @@ fn observe_skill_root(
         status,
         explicit: policy.explicit,
         detail: policy.detail.clone(),
+        discovery_complete: true,
     });
     if status != RootStatus::Included {
         return;
     }
 
-    if let Err(error) = discover_entrypoints(
+    match discover_entrypoints(
         &policy,
         root,
         approved_roots,
@@ -862,13 +896,31 @@ fn observe_skill_root(
         max_depth,
         candidates,
     ) {
-        result.warnings.push(format!(
-            "could not completely inspect skill root {}: {error}",
-            root.display()
-        ));
-        if let Some(observation) = result.roots.last_mut() {
-            observation.status = RootStatus::Inaccessible;
-            observation.detail = Some(error.to_string());
+        Ok(true) => {}
+        Ok(false) => {
+            let detail = format!("Skill discovery was bounded at depth {max_depth}");
+            result.warnings.push(format!(
+                "could not completely inspect skill root {}: {detail}",
+                root.display()
+            ));
+            if let Some(observation) = result.roots.last_mut() {
+                observation.discovery_complete = false;
+                observation.detail = Some(match observation.detail.take() {
+                    Some(existing) => format!("{existing}; {detail}"),
+                    None => detail,
+                });
+            }
+        }
+        Err(error) => {
+            result.warnings.push(format!(
+                "could not completely inspect skill root {}: {error}",
+                root.display()
+            ));
+            if let Some(observation) = result.roots.last_mut() {
+                observation.status = RootStatus::Inaccessible;
+                observation.discovery_complete = false;
+                observation.detail = Some(error.to_string());
+            }
         }
     }
 }
@@ -881,10 +933,11 @@ fn discover_entrypoints(
     depth: usize,
     max_depth: usize,
     output: &mut Vec<EntryCandidate>,
-) -> io::Result<()> {
+) -> io::Result<bool> {
     if depth > max_depth {
-        return Ok(());
+        return Ok(false);
     }
+    let mut complete = true;
     let mut entries = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
     entries.sort_by_key(|entry| entry.file_name());
     for entry in entries {
@@ -903,7 +956,7 @@ fn discover_entrypoints(
                 link_status,
             });
         } else if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
-            discover_entrypoints(
+            complete &= discover_entrypoints(
                 policy,
                 placement_root,
                 approved_roots,
@@ -930,7 +983,7 @@ fn discover_entrypoints(
             }
         }
     }
-    Ok(())
+    Ok(complete)
 }
 
 fn inspect_link(
@@ -1032,19 +1085,36 @@ fn materialize_candidates(candidates: Vec<EntryCandidate>, result: &mut ScanResu
             (String::new(), None)
         };
         let metadata = parse_skill_markdown(&content);
-        let digest = if safe_to_read {
+        let (digest, fingerprint_completeness, fingerprint_detail) = if safe_to_read {
             match digest_skill_directory(&directory) {
-                Ok(digest) => digest,
+                Ok(fingerprint) => (
+                    fingerprint.digest,
+                    fingerprint.completeness,
+                    fingerprint.detail,
+                ),
                 Err(error) => {
+                    let completeness = if error.kind() == io::ErrorKind::InvalidData {
+                        FingerprintCompleteness::Bounded
+                    } else {
+                        FingerprintCompleteness::Unreadable
+                    };
                     result.warnings.push(format!(
                         "could not completely fingerprint Skill package {}: {error}",
                         directory.display()
                     ));
-                    stable_digest(content.as_bytes())
+                    (
+                        stable_digest(content.as_bytes()),
+                        completeness,
+                        Some(error.to_string()),
+                    )
                 }
             }
         } else {
-            stable_digest(candidate.entrypoint.to_string_lossy().as_bytes())
+            (
+                stable_digest(candidate.entrypoint.to_string_lossy().as_bytes()),
+                FingerprintCompleteness::Unreadable,
+                Some("Skill package was not read because its link is unsafe".into()),
+            )
         };
         let identity_basis = match (&metadata.source, &metadata.version, &metadata.revision) {
             (Some(source), Some(version), _) => format!("source:{source}@{version}"),
@@ -1107,6 +1177,8 @@ fn materialize_candidates(candidates: Vec<EntryCandidate>, result: &mut ScanResu
             entrypoint: candidate.entrypoint,
             physical_directory,
             content_digest: digest,
+            fingerprint_completeness,
+            fingerprint_detail,
             link_target: candidate.link_target,
             link_status: candidate.link_status,
             default_exposed: candidate.agent.is_some(),
@@ -1326,9 +1398,16 @@ fn stable_digest(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
-fn digest_skill_directory(directory: &Path) -> io::Result<String> {
+#[derive(Debug)]
+struct PackageFingerprint {
+    digest: String,
+    completeness: FingerprintCompleteness,
+    detail: Option<String>,
+}
+
+fn digest_skill_directory(directory: &Path) -> io::Result<PackageFingerprint> {
     let mut files = Vec::new();
-    collect_skill_files(directory, directory, 0, 8, &mut files)?;
+    let complete = collect_skill_files(directory, directory, 0, 8, &mut files)?;
     files.sort_by(|left, right| left.0.cmp(&right.0));
 
     let mut digest = Sha256::new();
@@ -1356,7 +1435,15 @@ fn digest_skill_directory(directory: &Path) -> io::Result<String> {
         }
         digest.update([0xff]);
     }
-    Ok(format!("{:x}", digest.finalize()))
+    Ok(PackageFingerprint {
+        digest: format!("{:x}", digest.finalize()),
+        completeness: if complete {
+            FingerprintCompleteness::Complete
+        } else {
+            FingerprintCompleteness::Bounded
+        },
+        detail: (!complete).then(|| "Skill package fingerprint was bounded at depth 8".into()),
+    })
 }
 
 fn collect_skill_files(
@@ -1365,10 +1452,11 @@ fn collect_skill_files(
     depth: usize,
     max_depth: usize,
     output: &mut Vec<(PathBuf, PathBuf, fs::FileType)>,
-) -> io::Result<()> {
+) -> io::Result<bool> {
     if depth > max_depth {
-        return Ok(());
+        return Ok(false);
     }
+    let mut complete = true;
     let mut entries = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
     entries.sort_by_key(|entry| entry.file_name());
     for entry in entries {
@@ -1383,7 +1471,7 @@ fn collect_skill_files(
         let metadata = fs::symlink_metadata(&path)?;
         let file_type = metadata.file_type();
         if file_type.is_dir() && !file_type.is_symlink() {
-            collect_skill_files(root, &path, depth + 1, max_depth, output)?;
+            complete &= collect_skill_files(root, &path, depth + 1, max_depth, output)?;
         } else if file_type.is_file() || file_type.is_symlink() {
             let relative = path
                 .strip_prefix(root)
@@ -1392,7 +1480,7 @@ fn collect_skill_files(
             output.push((relative, path, file_type));
         }
     }
-    Ok(())
+    Ok(complete)
 }
 
 struct DigestWriter<'a>(&'a mut Sha256);
@@ -1508,6 +1596,7 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
             status,
             explicit: false,
             detail: None,
+            discovery_complete: true,
         });
         if status != RootStatus::Included {
             continue;
@@ -2053,7 +2142,16 @@ pub(crate) fn inspect_skill_identity(entrypoint: &Path) -> io::Result<(String, S
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Skill has no directory"))?;
     let (content, _) = read_bounded(entrypoint, MAX_SKILL_FILE_BYTES)?;
     let metadata = parse_skill_markdown(&content);
-    let digest = digest_skill_directory(directory)?;
+    let fingerprint = digest_skill_directory(directory)?;
+    if fingerprint.completeness != FingerprintCompleteness::Complete {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            fingerprint
+                .detail
+                .unwrap_or_else(|| "Skill package fingerprint is incomplete".into()),
+        ));
+    }
+    let digest = fingerprint.digest;
     let identity_basis = match (&metadata.source, &metadata.version, &metadata.revision) {
         (Some(source), Some(version), _) => format!("source:{source}@{version}"),
         (Some(source), _, Some(revision)) => format!("source:{source}@{revision}"),
@@ -2489,6 +2587,138 @@ enabled = true
         assert_eq!(result.skills.len(), 1);
         assert_eq!(result.placements.len(), 2);
         assert!(result.roots.iter().any(|seen| seen.explicit));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn scan_marks_oversized_package_fingerprint_as_bounded() {
+        let root = temp_directory("bounded-package-size");
+        let skill = root.join("oversized");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "---\nname: oversized\n---\n").unwrap();
+        let asset = File::create(skill.join("asset.bin")).unwrap();
+        asset.set_len(MAX_SKILL_PACKAGE_BYTES + 1).unwrap();
+
+        let mut options = ScanOptions::for_home(root.join("empty-home"));
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: root.clone(),
+        });
+        options.include_session_evidence = false;
+        let result = scan(&options).unwrap();
+
+        assert_eq!(result.placements.len(), 1);
+        assert_eq!(
+            result.placements[0].fingerprint_completeness,
+            FingerprintCompleteness::Bounded
+        );
+        assert!(
+            result.placements[0]
+                .fingerprint_detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("fingerprint safety limit"))
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn scan_marks_deep_package_fingerprint_as_bounded() {
+        let root = temp_directory("bounded-package-depth");
+        let skill = root.join("deep-package");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "---\nname: deep-package\n---\n").unwrap();
+        let mut deep = skill.clone();
+        for index in 0..9 {
+            deep.push(format!("level-{index}"));
+        }
+        fs::create_dir_all(&deep).unwrap();
+        fs::write(deep.join("behavior.sh"), "echo distinct\n").unwrap();
+
+        let mut options = ScanOptions::for_home(root.join("empty-home"));
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: root.clone(),
+        });
+        options.include_session_evidence = false;
+        let result = scan(&options).unwrap();
+
+        assert_eq!(result.placements.len(), 1);
+        assert_eq!(
+            result.placements[0].fingerprint_completeness,
+            FingerprintCompleteness::Bounded
+        );
+        assert!(
+            result.placements[0]
+                .fingerprint_detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("bounded at depth 8"))
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn scan_reports_bounded_skill_root_discovery() {
+        let root = temp_directory("bounded-root-depth");
+        let skill = root.join("one/two/three");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "---\nname: too-deep\n---\n").unwrap();
+
+        let mut options = ScanOptions::for_home(root.join("empty-home"));
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: root.clone(),
+        });
+        options.include_session_evidence = false;
+        options.max_depth = 1;
+        let result = scan(&options).unwrap();
+
+        assert!(result.skills.is_empty());
+        let observed = result
+            .roots
+            .iter()
+            .find(|observed| observed.path == root)
+            .unwrap();
+        assert_eq!(observed.status, RootStatus::Included);
+        assert!(!observed.discovery_complete);
+        assert!(
+            observed
+                .detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("bounded at depth 1"))
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn legacy_scan_payloads_default_to_untrusted_coverage() {
+        let root = temp_directory("legacy-scan-payload");
+        let skill = root.join("legacy");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "---\nname: legacy\n---\n").unwrap();
+        let mut options = ScanOptions::for_home(root.join("empty-home"));
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: root.clone(),
+        });
+        options.include_session_evidence = false;
+        let current = scan(&options).unwrap();
+        let mut legacy = serde_json::to_value(current).unwrap();
+        legacy["roots"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("discovery_complete");
+        legacy["placements"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("fingerprint_completeness");
+
+        let restored: ScanResult = serde_json::from_value(legacy).unwrap();
+
+        assert!(!restored.roots[0].discovery_complete);
+        assert_eq!(
+            restored.placements[0].fingerprint_completeness,
+            FingerprintCompleteness::Unknown
+        );
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4977,6 +4977,280 @@ fn large_roster_core_protection_choice_uses_production_forced_core_constraints()
 }
 
 #[test]
+fn incomplete_fingerprint_plan_paths_are_typed_and_zero_mutation() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = temp.path().join("skills");
+    let content = "---\nname: bounded-copy\n---\nSame entrypoint.\n";
+    for (name, bytes) in [
+        ("copy-a", 16 * 1024 * 1024 + 1),
+        ("copy-b", 16 * 1024 * 1024 + 2),
+    ] {
+        let directory = root.join(name);
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(directory.join("SKILL.md"), content).unwrap();
+        fs::File::create(directory.join("asset.bin"))
+            .unwrap()
+            .set_len(bytes)
+            .unwrap();
+    }
+    let explicit_root = format!("codex={}", root.display());
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--root",
+        &explicit_root,
+        "--json",
+    ];
+    let scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let snapshot = scan["result"]["snapshot_id"].as_str().unwrap();
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let skill_id: String = database
+        .query_row(
+            "SELECT skill_id FROM placements WHERE scan_id = ?1 ORDER BY id LIMIT 1",
+            [snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let placement_ids = {
+        let mut statement = database
+            .prepare("SELECT id FROM placements WHERE scan_id = ?1 ORDER BY id")
+            .unwrap();
+        statement
+            .query_map([snapshot], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    let evidence_id: String = database
+        .query_row(
+            "SELECT fe.evidence_id FROM finding_evidence fe JOIN findings f ON f.id = fe.finding_id WHERE f.title = 'Some Skill package fingerprints are incomplete' ORDER BY fe.evidence_id LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let raw_request = json!({
+        "schema_version": 1,
+        "scan_id": snapshot,
+        "evidence_ids": [evidence_id],
+        "library_changes": [{
+            "skill_id": skill_id,
+            "canonical_placement_id": placement_ids[0],
+            "placement_ids": placement_ids,
+            "requested_state": "managed"
+        }]
+    });
+
+    let raw = run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&raw_request.to_string()),
+    );
+    assert!(!raw.status.success());
+    let raw: Value = serde_json::from_slice(&raw.stdout).unwrap();
+    assert_eq!(raw["error"]["code"], "incomplete_package_fingerprint");
+    assert_eq!(raw["error"]["details"]["stage"], "plan");
+    assert_eq!(
+        raw["error"]["details"]["next_action"],
+        "resolve_fingerprint_incompleteness_then_scan"
+    );
+    assert_eq!(
+        raw["error"]["details"]["remediation"]["required_before_rescan"],
+        true
+    );
+
+    let report_id: String = database
+        .query_row(
+            "SELECT id FROM reports WHERE scan_id = ?1 ORDER BY rowid DESC LIMIT 1",
+            [snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let legacy_finding_id = "finding_legacy_incomplete";
+    let details = json!({
+        "affected_skill_ids": [skill_id],
+        "affected_placement_ids": placement_ids,
+        "coverage": {"basis": "skill_root_scan"}
+    });
+    database
+        .execute(
+            "INSERT INTO findings (id, report_id, category, severity, title, summary, details_json) VALUES (?1, ?2, 'overlap', 'warning', 'Exact duplicate Skill placements', 'legacy fixture', ?3)",
+            rusqlite::params![legacy_finding_id, report_id, details.to_string()],
+        )
+        .unwrap();
+    database
+        .execute(
+            "INSERT INTO finding_evidence (finding_id, evidence_id) VALUES (?1, ?2)",
+            rusqlite::params![legacy_finding_id, evidence_id],
+        )
+        .unwrap();
+    let finding_request = json!({
+        "schema_version": 1,
+        "finding_library_changes": [{
+            "finding_id": legacy_finding_id,
+            "canonical_placement_id": placement_ids[0],
+            "requested_state": "managed"
+        }]
+    });
+    let finding = run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&finding_request.to_string()),
+    );
+    assert!(!finding.status.success());
+    let finding: Value = serde_json::from_slice(&finding.stdout).unwrap();
+    assert_eq!(finding["error"]["code"], "incomplete_package_fingerprint");
+    assert_eq!(finding["error"]["details"]["stage"], "finding_plan");
+
+    let plan_count: i64 = database
+        .query_row("SELECT COUNT(*) FROM plans", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(plan_count, 0);
+    assert!(!state.join("library").exists());
+    assert!(!state.join("plan-backups").exists());
+    assert_eq!(
+        fs::read_to_string(root.join("copy-a/SKILL.md")).unwrap(),
+        content
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("copy-b/SKILL.md")).unwrap(),
+        content
+    );
+}
+
+#[test]
+fn apply_rejects_a_legacy_ready_plan_without_mutation() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = temp.path().join("skills");
+    let content = "---\nname: legacy-ready\n---\nComplete fixture.\n";
+    for name in ["copy-a", "copy-b"] {
+        let directory = root.join(name);
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(directory.join("SKILL.md"), content).unwrap();
+    }
+    let explicit_root = format!("codex={}", root.display());
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--root",
+        &explicit_root,
+        "--json",
+    ];
+    let scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let snapshot = scan["result"]["snapshot_id"].as_str().unwrap();
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let skill_id: String = database
+        .query_row(
+            "SELECT skill_id FROM placements WHERE scan_id = ?1 ORDER BY id LIMIT 1",
+            [snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let placement_ids = {
+        let mut statement = database
+            .prepare("SELECT id FROM placements WHERE scan_id = ?1 ORDER BY id")
+            .unwrap();
+        statement
+            .query_map([snapshot], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    let evidence_id: String = database
+        .query_row(
+            "SELECT fe.evidence_id FROM finding_evidence fe JOIN findings f ON f.id = fe.finding_id WHERE f.title = 'Exact duplicate Skill placements' ORDER BY fe.evidence_id LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let request = json!({
+        "schema_version": 1,
+        "scan_id": snapshot,
+        "evidence_ids": [evidence_id],
+        "library_changes": [{
+            "skill_id": skill_id,
+            "canonical_placement_id": placement_ids[0],
+            "placement_ids": placement_ids,
+            "requested_state": "managed"
+        }]
+    });
+    let plan = json_output(&run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&request.to_string()),
+    ));
+    let plan_id = plan["result"]["plan_id"].as_str().unwrap();
+
+    let encoded: String = database
+        .query_row(
+            "SELECT payload_json FROM scan_payloads WHERE scan_id = ?1",
+            [snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut legacy: Value = serde_json::from_str(&encoded).unwrap();
+    for placement in legacy["placements"].as_array_mut().unwrap() {
+        placement
+            .as_object_mut()
+            .unwrap()
+            .remove("fingerprint_completeness");
+    }
+    database
+        .execute(
+            "UPDATE scan_payloads SET payload_json = ?1 WHERE scan_id = ?2",
+            rusqlite::params![legacy.to_string(), snapshot],
+        )
+        .unwrap();
+
+    let rejected = run(&[&common[..], &["apply", plan_id]].concat(), None);
+    assert!(!rejected.status.success());
+    let rejected: Value = serde_json::from_slice(&rejected.stdout).unwrap();
+    assert_eq!(rejected["error"]["code"], "incomplete_package_fingerprint");
+    assert_eq!(rejected["error"]["details"]["stage"], "apply");
+    assert_eq!(
+        rejected["error"]["details"]["remediation"]["options"],
+        json!(["scan_with_current_skillroster"])
+    );
+    let status: String = database
+        .query_row("SELECT status FROM plans WHERE id = ?1", [plan_id], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(status, "ready");
+    let receipt_count: i64 = database
+        .query_row("SELECT COUNT(*) FROM receipts", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(receipt_count, 0);
+    assert!(!state.join("plan-backups").exists());
+    assert_eq!(
+        fs::read_to_string(root.join("copy-a/SKILL.md")).unwrap(),
+        content
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("copy-b/SKILL.md")).unwrap(),
+        content
+    );
+    assert!(
+        !fs::symlink_metadata(root.join("copy-a"))
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        !fs::symlink_metadata(root.join("copy-b"))
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[test]
 fn large_roster_finding_prepares_and_reverses_a_semantic_layering_plan() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## Summary

- type Skill-root discovery and package-fingerprint completeness instead of treating bounded evidence as exact
- suppress exact duplicate claims and reject governance Plan/Apply paths when evidence is incomplete
- expose stable Agent JSON remediation without automatic mutation or repeated-scan loops
- preserve complete duplicate governance and retained unsafe-link no-op behavior

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (189 unit + 7 acceptance + 53 CLI)
- independent Standards review: PASS
- independent Spec review: PASS; 0 blocker / 0 should-fix / 0 nit

Closes #127