### PR TITLE
fix: front-load cold Skill routing

### DIFF
--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -452,6 +452,27 @@ read-only `plan --show` action instead of suggesting a Scan that would stale
 those Plans. The 40-column terminal view wrapped the opaque Plan ID and avoided
 printing a context-free command. No Plan was applied and no Agent file changed.
 
+## Real-Agent cold-routing canary
+
+The v1.8.20 pre-release cold-routing canary held the Pi harness, model
+(`seal/deepseek-v4-flash-0731-baidu`), natural Chinese task, isolated Library,
+CLI Snapshot, permissions, and oracle constant. The target Skill had no default
+Agent exposure and deterministic CLI preflight ranked it first. With the
+governance-first Bootstrap, the Agent classified the task as unrelated and
+never called Find. After only the general route trigger and minimal
+`find -> read returned SKILL.md` steps were moved to the front, a fresh session
+called Find, read the exact returned cold path, and produced the oracle result.
+
+The harness allowed only SkillRoster Find plus reads of the isolated fixture and
+the repository Bootstrap. The observed transcript stayed within those paths,
+and the filesystem sandbox denied writes under the real home. This is one
+canary, not the paired multi-task success claim tracked by Issue #129. It
+identifies the Bootstrap entry contract as the first defect and does not justify
+a new semantic engine or a routing-recall claim.
+
+The frozen inputs, hashes, event chain, and safety limitation are recorded in
+[the Pi cold-routing canary ledger](acceptance/cold-routing-canary-v1.8.20.md).
+
 ## Evidence boundary
 
 These checks establish deterministic routing and safe local governance; they do

--- a/docs/acceptance/artifacts/cold-routing-canary-v1.8.20.json
+++ b/docs/acceptance/artifacts/cold-routing-canary-v1.8.20.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-24",
+  "scope": "diagnostic_canary",
+  "issues": [129, 130],
+  "harness": {
+    "name": "pi",
+    "version": "0.84.2",
+    "model": "seal/deepseek-v4-flash-0731-baidu",
+    "offline_startup": true,
+    "tools": ["read", "bash"],
+    "filesystem_write_policy": "deny writes beneath /Users/tushaokun"
+  },
+  "inputs": {
+    "cli_commit": "e16d563",
+    "cli_path": "/Users/tushaokun/code/skillroster/target/debug/skillroster",
+    "cli_sha256_at_run": "0baa23cd2f099b9b4a94c84fd59f3df8dd446dc47ccc320a578bfcd88f6da539",
+    "snapshot_id": "scan_000000000001166718ce7ac23556d9d0",
+    "user_message_sha256": "70eb69bba67a41e1f549318b1c76578e3ba0bff79dbfa4b3555ffbaf4ddb4846",
+    "target_skill_sha256": "9b83a71b5934c8fc744bf0f6b3ea35702b15b0cb36e643b4532e08922477fe65"
+  },
+  "baseline": {
+    "bootstrap_sha256": "11c9074ec790c4ce7820aa9bb8fe112b2fba607f847c3efbfca268e6686f54cf",
+    "transcript_sha256": "1a4776006335d0c0941b892dfc12ea8d0edbf912e457c4118a82646ecf15b384",
+    "deepest_stage": "no_retrieval_call"
+  },
+  "treatment": {
+    "bootstrap_sha256": "fc1318f0a8587ce193ab1f54462374508026cf8c50a382b613dc18b48f9d09f2",
+    "transcript_sha256": "32111bed04c5e24ade7b082b82c7fe9803cefb129d44146a30614a9a860ad80a",
+    "tool_sequence_after_bootstrap_load": [
+      "skillroster_find",
+      "read_returned_skill_path"
+    ],
+    "find": {
+      "task": "把记录 L-7 / amber / east 按 Lunar Registry 规范转换成规范标签，只返回结果。",
+      "retrieval_hints": ["convert a Lunar Registry record into its canonical label"],
+      "ranking_strategy": "task_hint_reciprocal_rank_fusion",
+      "files_changed": false,
+      "selected_name": "lunar-registry",
+      "selected_rank": 1
+    },
+    "oracle": {
+      "expected_sha256": "788658a39fdeeff799f4053d5b332ff45d8343dd027ce26327646bc49260eb91",
+      "passed": true
+    },
+    "deepest_stage": "task_succeeded"
+  },
+  "limitations": [
+    "single diagnostic task, not the full paired pilot",
+    "raw transcripts and executed development binary are not committed",
+    "temporary read policy used string-prefix checks and is not a general sandbox proof"
+  ]
+}

--- a/docs/acceptance/cold-routing-canary-v1.8.20.md
+++ b/docs/acceptance/cold-routing-canary-v1.8.20.md
@@ -1,6 +1,7 @@
 # Pi cold-routing canary ledger
 
-Date: 2026-08-24 (Asia/Shanghai)  
+Date: 2026-08-24 (Asia/Shanghai)
+
 Scope: diagnostic canary for Issues #129 and #130; not the full paired pilot.
 
 ## Frozen inputs

--- a/docs/acceptance/cold-routing-canary-v1.8.20.md
+++ b/docs/acceptance/cold-routing-canary-v1.8.20.md
@@ -1,0 +1,67 @@
+# Pi cold-routing canary ledger
+
+Date: 2026-08-24 (Asia/Shanghai)  
+Scope: diagnostic canary for Issues #129 and #130; not the full paired pilot.
+
+## Frozen inputs
+
+| Input | Value |
+|---|---|
+| Pi | `0.84.2` |
+| Model | `seal/deepseek-v4-flash-0731-baidu` |
+| CLI commit | `e16d563` |
+| CLI binary SHA-256 | `0baa23cd2f099b9b4a94c84fd59f3df8dd446dc47ccc320a578bfcd88f6da539` |
+| Snapshot | `scan_000000000001166718ce7ac23556d9d0` |
+| User-message SHA-256 | `70eb69bba67a41e1f549318b1c76578e3ba0bff79dbfa4b3555ffbaf4ddb4846` |
+| Target Skill SHA-256 | `9b83a71b5934c8fc744bf0f6b3ea35702b15b0cb36e643b4532e08922477fe65` |
+
+The target was present only in the isolated source Library. CLI preflight
+ranked it first; no supported Agent root exposed it.
+
+The invoked CLI path was
+`/Users/tushaokun/code/skillroster/target/debug/skillroster`, resolved by
+prepending its directory to `PATH`. The recorded binary digest was captured
+immediately after the run; that development binary was not retained and later
+test builds may replace it. Pi used isolated `PI_CODING_AGENT_DIR`,
+`SKILLROSTER_STATE_DIR`, and `SKILLROSTER_HOME` values, `--offline`, a fresh
+`--session-dir`, explicit Bootstrap `--skill`, and only the `read,bash` tools
+under `sandbox-exec`.
+
+## Paired observation
+
+The governance-first Bootstrap at `origin/main` had SHA-256
+`11c9074ec790c4ce7820aa9bb8fe112b2fba607f847c3efbfca268e6686f54cf`.
+Its fresh transcript (SHA-256
+`1a4776006335d0c0941b892dfc12ea8d0edbf912e457c4118a82646ecf15b384`)
+ended at `no_retrieval_call`.
+
+The route-first Bootstrap had SHA-256
+`fc1318f0a8587ce193ab1f54462374508026cf8c50a382b613dc18b48f9d09f2`.
+Its fresh transcript (SHA-256
+`32111bed04c5e24ade7b082b82c7fe9803cefb129d44146a30614a9a860ad80a`)
+loaded that exact repository file, then produced this evidence chain:
+
+1. `skillroster find` received the complete original Chinese message and the
+   faithful hint `convert a Lunar Registry record into its canonical label`.
+2. JSON reported `task_hint_reciprocal_rank_fusion`, `files_changed: false`,
+   and `lunar-registry` at rank 1.
+3. Pi read the exact returned cold `SKILL.md` path.
+4. The deterministic oracle matched `selene:a3:e9`.
+
+Classification: `task_succeeded`; retrieval and load both correct.
+
+The raw transcripts were intentionally not committed because they include model
+reasoning and harness context. Their hashes bind the locally retained originals;
+the committed [redacted event artifact](artifacts/cold-routing-canary-v1.8.20.json)
+preserves the review-relevant inputs, tool sequence, structured Find facts,
+oracle result, and limitations.
+
+## Safety boundary
+
+Pi ran in a fresh session with only `read` and `bash`. A tool-call extension
+blocked Bash except SkillRoster Find and limited reads to the isolated fixture
+plus the repository Bootstrap. The observed transcript stayed within those
+paths. A macOS sandbox denied writes beneath `/Users/tushaokun`; no real Agent,
+Skill, repository, or configuration file changed. The temporary extension used
+string-prefix path checks, so this canary does not establish a general sandbox
+security claim. The full pilot must canonicalize permitted paths first.

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -157,6 +157,9 @@ The Agent uses stable IDs internally and displays them where they help follow-up
 
 The single `skillroster` bootstrap Skill must instruct every supported Agent to:
 
+- route a task through `skillroster find` before acting when its required
+  specialized instructions are not already visible, then read the selected
+  result's exact `SKILL.md` path;
 - invoke commands with explicit `--json`;
 - validate `schema_version` and `ok` before reading `result`;
 - set `schema_version: 1` on every declarative Plan request;
@@ -176,6 +179,15 @@ The single `skillroster` bootstrap Skill must instruct every supported Agent to:
 - preserve the same report/Snapshot across follow-up questions;
 - state whether files changed in every final response;
 - stop when drift, ambiguity, unsupported scope, or recovery-required state appears.
+
+The model-visible description and the minimal `find` then read route must
+precede governance instructions. Once the Bootstrap is invoked for such a
+task, Find is its first task action after loading the Bootstrap and before
+further workspace exploration. Retrieval remains read-only: it neither
+activates nor authorizes a Skill. Detailed ranking interpretation may remain in
+the later Find reference section, but the initial route cannot depend on the
+Agent discovering that section after it has already classified the task as
+unrelated.
 
 ## 9. CLI data needed by the Agent
 

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: skillroster
 description: >
-  Inspect and govern locally installed Agent Skills with the SkillRoster CLI.
-  Use for inventory and usage evidence, duplicate or broken-link analysis,
+  Route tasks to specialized local Core and On-demand Skills, then inspect and
+  govern those Skills with the SkillRoster CLI. Use whenever a task may need
+  instructions that are not among the currently visible Skills: begin with
+  `skillroster find`, then read the returned SKILL.md before exploring the
+  workspace or doing the task.
+  Also use for inventory and usage evidence, duplicate or broken-link analysis,
   smaller Core and On-demand Rosters, capability search, approved Plans,
   Receipts, Apply, or Undo. Not for installing Skills or migrating,
   distributing, synchronizing, or repairing shared Skill directories and
@@ -15,6 +19,22 @@ metadata:
 # SkillRoster
 
 Use the local `skillroster` binary as the deterministic source of facts. Invoke every command with explicit `--json`; validate `schema_version` and `ok` before reading `result`. Treat typed `suggested_actions` as options, never authorization.
+
+## Route a task first
+
+When a task may require specialized instructions that are not already visible,
+the first task action after loading this Bootstrap must route it through
+SkillRoster:
+
+1. Run `skillroster find "TASK" --json`. `TASK` is the complete user message;
+   copy it verbatim without summarizing or dropping output constraints.
+2. For non-English or mixed-language input, add one faithful English capability
+   paraphrase with `--hint`; do not replace `TASK` or guess a Skill name.
+3. Read the selected result's exact `SKILL.md` path, then follow that Skill.
+
+Routing is complete only after the returned Skill path has been read. Find is
+read-only; it does not activate, install, or authorize a Skill. Do not inspect
+the workspace before this route is complete.
 
 ## Inspect and propose
 


### PR DESCRIPTION
## Problem

A real Pi cold-routing canary showed that the governance-first Bootstrap could classify a natural task as unrelated even though deterministic CLI preflight ranked the required On-demand Skill first.

## Solution

- lead the model-visible Bootstrap description with Core and On-demand routing
- make `find -> read returned SKILL.md` the first task action after loading the Bootstrap
- preserve the complete user message and add a faithful English hint for mixed-language tasks
- record the paired canary evidence and its safety/provenance limitations in a redacted ledger
- keep the full multi-task paired pilot open in #129

## Evidence

Using Pi 0.84.2 with `seal/deepseek-v4-flash-0731-baidu`, the fresh treatment session preserved the complete Chinese TASK, supplied a faithful hint, selected rank 1 with task/hint fusion, read the exact returned cold Skill path, and passed the deterministic oracle. Find reported `files_changed: false`; the macOS sandbox denied writes beneath the real home.

## Checks

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (189 unit + 7 acceptance + 53 CLI)
- `cargo test --locked --test cli setup_` after the final Bootstrap wording
- `git diff --check`
- redacted artifact JSON parse and two independent reviews

Closes #130
Relates to #129