### PR TITLE
feat: manage Bootstrap Skill as one package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.20"
+version = "1.8.21"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.20"
+version = "1.8.21"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -1,88 +1,79 @@
 ---
 name: skillroster
 description: >
-  Route tasks to specialized local Core and On-demand Skills, then inspect and
-  govern those Skills with the SkillRoster CLI. Use whenever a task may need
-  instructions that are not among the currently visible Skills: begin with
-  `skillroster find`, then read the returned SKILL.md before exploring the
-  workspace or doing the task.
-  Also use for inventory and usage evidence, duplicate or broken-link analysis,
-  smaller Core and On-demand Rosters, capability search, approved Plans,
-  Receipts, Apply, or Undo. Not for installing Skills or migrating,
-  distributing, synchronizing, or repairing shared Skill directories and
-  symlinks.
+  Route tasks to specialized local Core and On-demand Skills, and govern the
+  local Skill roster. Before reading or changing the workspace for a task that
+  may need instructions not already visible, preserve the complete user message
+  verbatim as TASK. For non-English or mixed input, run
+  `skillroster find "TASK" --hint "ONE FAITHFUL ENGLISH CAPABILITY PARAPHRASE" --json`;
+  for English input omit `--hint`. Then read the exact returned SKILL.md with
+  the harness file-read tool. There is no load or activation command. Also use
+  for inventory, usage evidence, duplicates, broken links, Core/On-demand
+  recommendations, Plans, Receipts, Apply, and Undo. Not for installing
+  third-party Skills or migrating, distributing, synchronizing, or repairing shared
+  Skill-manager directories.
 metadata:
-  bootstrap-version: "1.8.20"
-  skillroster-routing-triggers: "scan analyze duplicate unused local Agent Skills; inventory installed Agent Skills; analyze duplicate Agent Skills; evaluate possible unused local Agent Skills from usage evidence; govern a Skill Roster; prepare a Skill governance Plan; apply approved Skill Plan; create Skill Receipt; undo Skill organization"
+  bootstrap-version: "1.8.21"
+  skillroster-routing-triggers: "route task to local Skill; inventory installed Agent Skills; analyze duplicate or unused Agent Skills; govern a Skill Roster; prepare or apply approved Skill Plan; create or undo Skill Receipt"
 ---
 
 # SkillRoster
 
-Use the local `skillroster` binary as the deterministic source of facts. Invoke every command with explicit `--json`; validate `schema_version` and `ok` before reading `result`. Treat typed `suggested_actions` as options, never authorization.
+Use the local `skillroster` binary as the deterministic source of facts. Every
+command uses explicit `--json`. Validate `schema_version` and `ok` before using
+`result`. Typed `suggested_actions` are options, never authorization.
 
-## Route a task first
+## Choose one path
 
-When a task may require specialized instructions that are not already visible,
-the first task action after loading this Bootstrap must route it through
-SkillRoster:
+- For SkillRoster inventory, evidence, governance, setup, Apply, Undo, lifecycle,
+  or recovery requests, skip the Route gate and read the matching reference
+  below. Do not route SkillRoster back to itself.
+- For another task, follow an already-visible exact Skill when one clearly
+  applies. Otherwise complete the Route gate.
 
-1. Run `skillroster find "TASK" --json`. `TASK` is the complete user message;
-   copy it verbatim without summarizing or dropping output constraints.
-2. For non-English or mixed-language input, add one faithful English capability
-   paraphrase with `--hint`; do not replace `TASK` or guess a Skill name.
-3. Read the selected result's exact `SKILL.md` path, then follow that Skill.
+## Route gate
 
-Routing is complete only after the returned Skill path has been read. Find is
-read-only; it does not activate, install, or authorize a Skill. Do not inspect
-the workspace before this route is complete.
+The Find call below must be the first task tool call. Before it, do not read or
+change the workspace and do not execute a non-routing command:
 
-## Inspect and propose
+1. Keep the complete user message as `TASK`, byte-for-byte in its original
+   language, including paths, limits, and output requirements. Do not summarize,
+   translate, shorten, or quote only part of it.
+2. If `TASK` is non-English or mixed-language, create one concise English
+   capability paraphrase as `HINT`. It supplements `TASK`; it never replaces it.
+3. Invoke the fixed SkillRoster executable with `TASK` and `HINT` as separate,
+   literal argv values; never interpolate either into shell syntax. Use:
+   - English: `skillroster find "TASK" --json`
+   - Otherwise: `skillroster find "TASK" --hint "HINT" --json`
+4. When `HINT` was used, first require
+   `ranking_strategy: task_hint_reciprocal_rank_fusion`.
+5. For every unambiguous result, immediately read its exact returned `SKILL.md`
+   path with the harness's existing file-read tool. Do not call or invent
+   `load`, `activate`, `use`, `select`, or another SkillRoster command. For an
+   empty or wrong-domain result, `variant_count > 1`, `variants_truncated`, or
+   `report_required`, read `references/routing.md` and follow its typed branch.
+6. Only after that file is read, follow it and perform the original task.
 
-1. Run `skillroster scan --json`, then `skillroster report --json`, the bounded Summary view. Use the compact result for the first user-facing diagnosis. Read `finding_rollups` to state the complete scale of each Finding group without loading the exhaustive report; use the three selected `findings` only for the highest-priority decisions.
-2. Distinguish observed, inferred, and unknown usage. Read `session_coverage` before presenting usage: `sampled_agents` have bounded local evidence, `complete_agents` alone support a complete observable-session denominator, `missing_root_agents` have no discovered session directory, and `inaccessible_agents` have a configured directory that could not be read. Limited samples may support observed event counts and stages, never a usage percentage or an “unused” claim. For `Five-stage usage evidence`, use `usage_overview` for the five typed stage counts, coverage boundary, and bounded high-signal `observed_skills`; `Exposed` counts placements while later stages count events. Individual items identify the Skill through `facts.skill_name` and use the canonical public `facts.agent`; keep stage, quality, event count, and observation window together when summarizing what was observed. When the three-item summary is insufficient, use `report --findings --limit 20 --json`; narrow it with one `--category` or `--severity` from the summary totals, and follow `page.next_offset` only while that category still affects the decision. This paged list is the enumeration path; reserve top-level `report --full --json` for a deliberate exhaustive diagnostic export outside the normal Agent context.
-3. Use stable Finding and Evidence IDs for follow-up questions. The summary and paged list expose one `primary_evidence_id`; use `report --finding ID --limit 20 --json` when paths or Evidence affect the decision. Its compact `items` combine the Evidence ID, subject, path, quality, and decision facts without repeating complete internal collections. Use `--full` only when an exact complete ID or record is needed. Exact-duplicate and large-Roster details include bounded `planning` choices independently of pagination; treat `planning.uncertainty.review_required` as a selection-quality warning that must remain visible through confirmation. Continue with `--offset NEXT_OFFSET --limit 20` only when another decision still needs more evidence, and keep the same Snapshot rather than silently rescanning.
-4. Make semantic governance choices in the conversation, then submit them to `skillroster plan --stdin --json`. For exact duplicates or a large default Roster, send `schema_version` plus the corresponding Finding request below; SkillRoster derives the current Snapshot, Evidence, Skills, placements, and complete changes. Other request families include the latest `scan_id` and relevant `evidence_ids`.
-5. Present the validated summary Plan in one viewport: diagnosis, four core metrics, three main Findings, `change_summary`, `operation_groups`, bounded `affected` facts, `impact` before/after facts, the semantic `diff_summary`, uncertainty, canonical deletion count, reversibility, and Plan ID. For a semantic Roster Plan, read `selection_evidence`: state the forced, target-Agent, cross-Agent, and stable-fallback Core counts, then present each Agent's bounded `core_preview` with names and reasons. `evidence_scope: target_agent` means that Agent used the Skill; `cross_agent` means only the Agents named in `evidence_agents` supplied evidence for the exact same stable Skill identity. Describe the latter as used elsewhere, never as target-Agent usage. When `uncertainty.review_required` is true, present the selection as review-required rather than evidence-backed. The diff contains at most three Roster, Library, and filesystem items, or bounded line facts for a source update. The full immutable representation stays in local state; use `skillroster plan --show PLAN_ID --json` only when every `core_selections` entry, an exact operation, path, or complete ID list is needed to answer the user. Do not load it by default.
+If the result is empty or clearly from another domain, retry once. Keep `TASK`
+unchanged; refine the existing hint, or add one capability hint when the first
+English call had none. If no usable result remains, stop and report a routing
+failure.
 
-Use only these Plan request families:
+## Govern a roster
 
-- `finding_roster_changes` (preferred for `Large default Rosters need review`): `finding_id`, a per-Agent `core_budget` from 1 through 50, and optional `protected_skill_ids`. Review `planning.agents`, especially direct-signal, cross-Agent-signal, and fallback counts, before choosing the budget. SkillRoster preserves requested, declared, and bootstrap Core Skills, then ranks target-Agent usage, usage from another local Agent for the exact same stable Skill ID, and finally stable fallback order. Same-name or similar Skills never transfer usage evidence. Remaining affected Skills become On-demand; this request never implies Explicit-only or Archived. If `planning.supported` is false, follow its typed `decision`: confirm reported source roots or resolve dependent source links, then rescan. If `plan --stdin` fails with `trusted_canonical_sources_required`, use `error.details` for the affected Agents, Skill names, and reported `--source-root` directories. Ordinary JSON lists at most ten of each; when `blocked_changes_truncated` or `source_roots_truncated` is true, read `error.details.detail.path`, require `schema_version: 1`, then use the complete identities, directories, and repeatable argv to ask the user. Do not inspect the filesystem independently or follow untrusted targets. Do not submit a partial Plan.
-- `finding_library_changes` (preferred for exact duplicates): `finding_id`, a `canonical_placement_id` chosen from `planning.canonical_candidates`, and `requested_state` (`managed` or `hosted`). Do not copy paged placement or Evidence IDs into this request.
-- `roster_changes`: the advanced raw form with `agent`, `skill_id`, and `state` (`core`, `on_demand`, `explicit_only`, or `archived`). Use it for deliberate exceptions or when no supported Finding can bind the complete scope.
-- `library_changes`: the advanced raw form with `skill_id`, `canonical_placement_id`, the complete `placement_ids` set, and `requested_state`. Use it only when there is no exact-duplicate Finding to bind.
-- `source_updates`: the latest Skill/placement/source/revision/fingerprint facts plus upstream content and SHA-256 digest. If local content changed, include the user's explicit `choice`: `retain_local`, `adopt_upstream`, or `preserve_both`.
+For inventory, usage, exposure, duplicate, broken-link, Core/On-demand, or Plan
+requests, read `references/governance.md` before acting. Inspection and planning
+do not change Agent files. Prefer the bounded summary first; load exhaustive
+detail only for a decision that needs it.
 
-Keep Roster, source-update, and Library changes in separate Plans. Semantic Finding requests derive their Evidence internally. For raw requests, cite Evidence returned by the relevant Finding page; a convenient but unrelated Evidence ID is not support for a governance change. Treat a rejected stale Snapshot, Evidence ID, fingerprint, incomplete scope, or source revision as a reason to rescan or ask the user—not as permission to weaken the request.
+## Mutate or recover
 
-State explicitly that inspection and planning changed no Agent files. When evidence cannot justify a change, recommend keeping the current state.
+For setup, Apply, Undo, lifecycle cleanup, or recovery, read
+`references/mutation.md` before acting. A validated Plan is not permission to
+apply it. Show the complete bounded impact and obtain one explicit confirmation.
+Only a successful Receipt verifies that Agent files changed.
 
-For `Skill links escape an approved root`, load one compact Finding page and
-show `resolution.observed_link_targets`. Treat each target as unread until the
-user confirms that its canonical source directory is intentional and trusted.
-Do not follow a generic Plan action for this Finding. After confirmation,
-rescan with one repeatable `--source-root ABSOLUTE_PATH` per canonical source
-directory; this approves reading without adding Agent exposure. Then prefer a
-reviewed Hosted or Managed Library Plan so future Scans no longer depend on
-the temporary source-root arguments. Keep unconfirmed targets unread.
-
-## Apply or undo
-
-Run `skillroster setup --json` when installing the Bootstrap Skill or after upgrading the CLI. An exact official older copy produces a normal upgrade Plan. If `state` is `modified_choice_required`, show the affected Agent targets and ask whether to `retain-local` or `adopt-current`; do not choose for the user. Adopting still only prepares a recoverable Plan and requires the usual Apply confirmation. Treat `unsupported_targets` as blocked rather than replacing links or non-files.
-
-Show the complete immutable Plan before requesting one explicit confirmation. After the user confirms, run `skillroster apply PLAN_ID --json`; do not substitute direct filesystem commands or bypass drift checks. Report verification, changed-path count, Receipt ID, and canonical deletion count.
-
-“Complete” means the summary accounts for every affected Agent, Skill, placement, operation group, exclusion, risk, and before/after delta by count; it does not require copying every internal operation into the conversation. If the user asks for an exact path or operation, load the stored detail with `plan --show` before confirmation.
-
-For Undo, first explain the bounded Receipt impact and obtain one explicit confirmation, then run `skillroster undo RECEIPT_ID --json`.
-
-Stop mutating when the result reports ambiguity, drift, unsupported scope, or recovery required. Make recovery the only mutating next action until cleared.
-
-Use `skillroster status --json` for pending Plans, the last Receipt, retention, and recovery state. Use `skillroster lifecycle recovery --json` to inspect an unresolved Receipt. Export or purge local lifecycle data only when the user asks; purge changes controlled SQLite history, not Agent files.
-
-## Find an on-demand Skill
-
-Run `skillroster find "TASK" --json`, keeping the user's task verbatim. For a non-English or mixed-language task, include one concise English capability paraphrase through `--hint "TEXT"` on the first call. Build the hint entirely from the desired target surface, object, operation, and state—for example, `control existing logged-in Chrome tabs` or `analyze standalone spreadsheet file workbook data`. Use terms implied by the task rather than a guessed Skill name. With hints, require `ranking_strategy: task_hint_reciprocal_rank_fusion`; use the numeric `task_channel_rank` and `augmented_channel_rank` fields to distinguish native task evidence from hint-expanded evidence. Retry once with a refined target description only when the result is empty or clearly about another domain. Explain the top matches and evidence. A `variant_count` above one is unresolved same-name content ambiguity: keep each returned variant's path and provider facts together, respect `variants_truncated`, and execute the read-only `variant_finding.argv`. When its state is `report_required`, materialize the current Report first; when `available`, inspect that exact Finding before choosing content. Otherwise read the selected `SKILL.md` directly from its returned path. Finding a Skill does not activate or install it.
-
-Treat `providers` with `governable: false` as locally discovered provider-managed Skills. They may come from explicit Codex configuration or a verified remote-plugin install marker. They are valid read-only search results, but must not be moved, updated, consolidated, or added to a governance Plan.
-
-Never parse styled terminal output, invent a health score, infer token savings, or claim files changed without a successful Receipt.
+Never parse styled terminal output, invent a health score, infer token savings,
+claim unobserved usage, or weaken ambiguity, drift, trust, and recovery checks.
+In the final response, state whether files changed; claim changes only from a
+verified Receipt or from task tools actually used after routing.

--- a/skill/skillroster/references/governance.md
+++ b/skill/skillroster/references/governance.md
@@ -1,0 +1,75 @@
+# Governance workflow
+
+## Inspect
+
+Run `skillroster scan --json`, then the bounded `skillroster report --json`.
+Use `finding_rollups` for complete group scale and the selected findings for the
+first decisions. Use `report --findings --limit 20 --json`, optionally narrowed
+by one category or severity, only when enumeration is needed. Follow
+`page.next_offset` while that decision remains open. Reserve `report --full`
+for deliberate exhaustive export.
+
+Usage evidence is five-stage and conservative. Read `session_coverage` before
+describing it. `sampled_agents` support bounded observed events;
+`complete_agents` alone support a complete observable-session denominator;
+`missing_root_agents` and `inaccessible_agents` are unknown, not unused.
+`Exposed` counts placements; later stages count events. Keep Agent, stage,
+quality, event count, and observation window together.
+
+Use stable Finding and Evidence IDs. For path or decision facts, call
+`report --finding ID --limit 20 --json`. Treat
+`planning.uncertainty.review_required` as review-required, not evidence-backed.
+
+Keep the same Report and Snapshot for follow-up pages and decisions; do not
+silently rescan between them. In `selection_evidence`, `target_agent` means the
+named Agent used that exact Skill identity. `cross_agent` means only the Agents
+listed in `evidence_agents` supplied evidence; describe it as “used elsewhere,”
+never as target-Agent usage. Similar names and paths do not transfer evidence.
+
+## Plan
+
+Make semantic choices in conversation, then submit them to
+`skillroster plan --stdin --json`. Every declarative request includes
+`schema_version: 1`:
+
+- `finding_roster_changes`: preferred for a large default Roster. Supply the
+  Finding ID, per-Agent `core_budget` from 1 through 50, and optional protected
+  Skill IDs. Protected, declared, and bootstrap Skills come first; target-Agent
+  usage outranks exact-identity cross-Agent usage, then stable fallback. Missing
+  usage never implies Explicit-only or Archived.
+- `finding_library_changes`: preferred for exact duplicates. Supply the Finding
+  ID, a listed canonical placement, and `managed` or `hosted`.
+- Raw `roster_changes`, `library_changes`, and `source_updates` are advanced
+  forms. Bind them to the latest Snapshot, complete scope, current Evidence,
+  placement/source facts, revision, and fingerprint. For local source drift,
+  require the user's explicit `retain_local`, `adopt_upstream`, or
+  `preserve_both` choice.
+
+Keep Roster, source, and Library changes in separate Plans. A stale Snapshot,
+Evidence ID, fingerprint, incomplete scope, or revision requires rescan or user
+input, never weaker validation.
+
+If planning reports `trusted_canonical_sources_required`, use only the typed
+blocked Skills and observed `--source-root` suggestions. A truncated result
+points to a SkillRoster-owned JSON detail file; validate its schema before
+using the complete identities and argv. Do not inspect or trust targets
+independently, synthesize broader parents, or submit a partial Plan.
+
+For an escaping Skill link, show the observed target and obtain confirmation
+before rescanning with one explicit source root per trusted canonical source.
+Then prefer a reviewed Managed or Hosted Library Plan.
+
+## Present
+
+Show one bounded viewport with a one-sentence diagnosis and exactly these four
+core metrics: independent Skill count, placement count, default exposure, and
+observed-use count. Show the three highest-priority Findings plus compact
+rollups for the complete scale of every Finding group. Prioritize
+recommendations and state their expected measurable impact. Include
+uncertainties, evidence quality, safety risks, and whether confirmation is
+required. Name one primary next action. For a proposed change, include its
+measurable before/after impact, `change_summary`, operation groups, affected
+facts, uncertainty, reversibility, canonical deletion count, and Plan ID. Use
+`plan --show PLAN_ID --json` only when an exact operation, path, selection, or
+complete ID list is required. State explicitly that inspection and planning
+changed no Agent files.

--- a/skill/skillroster/references/mutation.md
+++ b/skill/skillroster/references/mutation.md
@@ -1,0 +1,34 @@
+# Mutation and recovery
+
+## Setup
+
+Run `skillroster setup --json` to install or upgrade this complete Bootstrap
+package. An exact official older package produces a recoverable Plan. When
+`state` is `modified_choice_required`, show affected Agent targets and ask for
+`retain-local` or `adopt-current`; never choose for the user. Unsupported links
+or non-files remain blocked.
+
+## Apply
+
+Before `skillroster apply PLAN_ID --json`, show the complete bounded Plan impact
+and obtain one explicit confirmation. Do not replace the Plan with filesystem
+commands or bypass drift checks. Report verification, changed-path count,
+Receipt ID, and canonical deletion count.
+
+“Complete” means every affected Agent, Skill, placement, operation group,
+exclusion, risk, and before/after delta is accounted for by count. It does not
+mean dumping every internal operation. Load stored Plan detail only for exact
+questions.
+
+## Undo and recovery
+
+Explain the bounded Receipt impact and obtain one explicit confirmation before
+`skillroster undo RECEIPT_ID --json`.
+
+Stop mutating on ambiguity, drift, unsupported scope, or recovery required.
+Recovery becomes the only mutating next action. Use `skillroster status --json`
+for pending Plans, the last Receipt, retention, and recovery state, and
+`skillroster lifecycle recovery --json` for an unresolved Receipt.
+
+Export or purge local lifecycle data only when requested. Purge changes
+controlled SQLite history, not Agent files.

--- a/skill/skillroster/references/routing.md
+++ b/skill/skillroster/references/routing.md
@@ -1,0 +1,27 @@
+# Routing details
+
+The root Route gate is authoritative. Read this file for an empty or
+wrong-domain result, `variant_count > 1`, `variants_truncated`, or
+`report_required`. Keep `TASK` verbatim. A non-English or mixed task receives
+exactly one faithful English `--hint` on the first call.
+Build the hint from the desired surface, object, operation, and state; never
+guess a Skill name.
+
+With a hint, require
+`ranking_strategy: task_hint_reciprocal_rank_fusion`. Use `task_channel_rank`
+and `augmented_channel_rank` to distinguish native task evidence from
+hint-expanded evidence. Retry at most once, only for an empty or wrong-domain
+result. Change only the hint; an English task may add one on its retry.
+
+When `variant_count` is above one, keep each path and provider together. Respect
+`variants_truncated` and run the returned read-only `variant_finding.argv`.
+Materialize the current Report first only when the result says
+`report_required`; inspect that exact Finding before choosing content.
+
+Only after ambiguity is resolved, or when `variant_count == 1`, read the
+selected result's exact `SKILL.md` path directly. Finding a Skill does not
+activate, install, or authorize it, and SkillRoster has no load or activate
+step.
+
+Provider-managed results with `governable: false` are valid read-only matches.
+Do not move, update, consolidate, or add them to a governance Plan.

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
+use crate::bootstrap::PACKAGE_FILES as BOOTSTRAP_PACKAGE_FILES;
 use crate::change::{
     self, ChangeReceipt, Operation, OperationPolicy, PrepareContext, PreparedPlan,
 };
@@ -6092,7 +6093,7 @@ fn undo_command(store: &StateStore, id: &str) -> Result<Value> {
     Ok(mutation_result(&outcome, &receipt, Some(id)))
 }
 
-const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
+const LEGACY_SINGLE_FILE_BOOTSTRAPS: &[(&str, &str)] = &[
     (
         "1.0.0",
         "08440a4a3e10489eae2484d0a5bf8f4b0451d22c43edaa90c75fcd0b66fd4a74",
@@ -6229,6 +6230,10 @@ const LEGACY_BOOTSTRAPS: &[(&str, &str)] = &[
         "1.8.19",
         "78aa0dbdf53c3f9f08fb5bf9805e33b2d5b8ffe4c63bac05d88391f608fab16c",
     ),
+    (
+        "1.8.20",
+        "fc1318f0a8587ce193ab1f54462374508026cf8c50a382b613dc18b48f9d09f2",
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -6238,28 +6243,10 @@ enum BootstrapContentStatus {
     Modified,
 }
 
-impl BootstrapContentStatus {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Current => "current",
-            Self::OfficialOutdated(_) => "official_outdated",
-            Self::Modified => "modified",
-        }
-    }
-
-    fn installed_version(self) -> Option<&'static str> {
-        match self {
-            Self::Current => Some(env!("CARGO_PKG_VERSION")),
-            Self::OfficialOutdated(version) => Some(version),
-            Self::Modified => None,
-        }
-    }
-}
-
 fn bootstrap_content_status(digest: &str, current_digest: &str) -> BootstrapContentStatus {
     if digest == current_digest {
         BootstrapContentStatus::Current
-    } else if let Some((version, _)) = LEGACY_BOOTSTRAPS
+    } else if let Some((version, _)) = LEGACY_SINGLE_FILE_BOOTSTRAPS
         .iter()
         .find(|(_, official_digest)| *official_digest == digest)
     {
@@ -6271,6 +6258,120 @@ fn bootstrap_content_status(digest: &str, current_digest: &str) -> BootstrapCont
 
 fn normalized_bootstrap_content(content: &str) -> String {
     content.replace("\r\n", "\n")
+}
+
+/// Exact manifests for released Bootstrap packages that already contained all
+/// managed files. Add one entry when a package release is superseded; setup
+/// never infers an official package by mixing file digests from different
+/// releases.
+#[derive(Clone, Debug)]
+struct BootstrapPackageManifest<'a> {
+    version: &'a str,
+    file_digests: &'a [(&'a str, &'a str)],
+}
+
+const LEGACY_COMPLETE_BOOTSTRAP_PACKAGES: &[BootstrapPackageManifest<'static>] = &[];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BootstrapFileStatus {
+    Current,
+    OfficialOutdated(&'static str),
+    Missing,
+    Modified,
+    Unsupported,
+}
+
+impl BootstrapFileStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::OfficialOutdated(_) => "official_outdated",
+            Self::Missing => "missing",
+            Self::Modified => "modified",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+fn current_bootstrap_package() -> Vec<(&'static str, String, String)> {
+    BOOTSTRAP_PACKAGE_FILES
+        .iter()
+        .map(|file| {
+            let content = normalized_bootstrap_content(file.content);
+            (
+                file.relative_path,
+                content_digest(content.as_bytes()),
+                content,
+            )
+        })
+        .collect()
+}
+
+fn legacy_bootstrap_package_version<'a>(
+    observed_digests: &[Option<String>],
+    complete_packages: &'a [BootstrapPackageManifest<'a>],
+) -> Option<&'a str> {
+    if observed_digests.len() != BOOTSTRAP_PACKAGE_FILES.len() {
+        return None;
+    }
+    if let Some(package) = complete_packages.iter().find(|package| {
+        package.file_digests.len() == BOOTSTRAP_PACKAGE_FILES.len()
+            && BOOTSTRAP_PACKAGE_FILES
+                .iter()
+                .zip(observed_digests)
+                .all(|(file, observed)| {
+                    package
+                        .file_digests
+                        .iter()
+                        .find(|(relative_path, _)| *relative_path == file.relative_path)
+                        .is_some_and(|(_, expected)| observed.as_deref() == Some(*expected))
+                })
+    }) {
+        return Some(package.version);
+    }
+    if observed_digests[1..].iter().all(Option::is_none) {
+        let skill_digest = observed_digests[0].as_deref()?;
+        return LEGACY_SINGLE_FILE_BOOTSTRAPS
+            .iter()
+            .find_map(|(version, digest)| (*digest == skill_digest).then_some(*version));
+    }
+    None
+}
+
+fn bootstrap_file_status(
+    relative_path: &str,
+    path: &Path,
+    current_digest: &str,
+) -> (BootstrapFileStatus, Option<String>) {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.file_type().is_file() => {
+            (BootstrapFileStatus::Unsupported, None)
+        }
+        Ok(_) => match std::fs::read(path) {
+            Ok(content) => {
+                let digest = bootstrap_content_digest(&content);
+                let status = if digest == current_digest {
+                    BootstrapFileStatus::Current
+                } else if relative_path == "SKILL.md" {
+                    match bootstrap_content_status(&digest, current_digest) {
+                        BootstrapContentStatus::OfficialOutdated(version) => {
+                            BootstrapFileStatus::OfficialOutdated(version)
+                        }
+                        BootstrapContentStatus::Current => BootstrapFileStatus::Current,
+                        BootstrapContentStatus::Modified => BootstrapFileStatus::Modified,
+                    }
+                } else {
+                    BootstrapFileStatus::Modified
+                };
+                (status, Some(digest))
+            }
+            Err(_) => (BootstrapFileStatus::Unsupported, None),
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            (BootstrapFileStatus::Missing, None)
+        }
+        Err(_) => (BootstrapFileStatus::Unsupported, None),
+    }
 }
 
 fn bootstrap_content_digest(content: &[u8]) -> String {
@@ -6285,6 +6386,22 @@ fn setup_command(
     home: &Path,
     state_dir: &Path,
     modified_choice: Option<ModifiedBootstrapChoice>,
+) -> Result<Value> {
+    setup_command_with_manifests(
+        store,
+        home,
+        state_dir,
+        modified_choice,
+        LEGACY_COMPLETE_BOOTSTRAP_PACKAGES,
+    )
+}
+
+fn setup_command_with_manifests<'a>(
+    store: &StateStore,
+    home: &Path,
+    state_dir: &Path,
+    modified_choice: Option<ModifiedBootstrapChoice>,
+    legacy_complete_packages: &'a [BootstrapPackageManifest<'a>],
 ) -> Result<Value> {
     let Some(snapshot) = store.latest_completed_scan()? else {
         return Ok(json!({
@@ -6306,9 +6423,7 @@ fn setup_command(
             "next": "skillroster scan --json"
         }));
     };
-    let current_content =
-        normalized_bootstrap_content(include_str!("../skill/skillroster/SKILL.md"));
-    let current_digest = content_digest(current_content.as_bytes());
+    let current_package = current_bootstrap_package();
     let mut detected = Vec::new();
     let mut targets = Vec::new();
     let mut operations = Vec::new();
@@ -6320,7 +6435,7 @@ fn setup_command(
     let mut replace_count = 0_usize;
     let mut physical_targets = BTreeSet::new();
     let mut planned_directories = BTreeSet::new();
-    let mut planned_entrypoints = BTreeSet::new();
+    let mut planned_files = BTreeSet::new();
     for roots in harness::known_agent_roots(home) {
         for root in roots.skill_roots.into_iter().filter(|path| path.is_dir()) {
             let directory = root.join("skillroster");
@@ -6330,99 +6445,139 @@ fn setup_command(
             })?;
             let physical_directory = physical_root.join("skillroster");
             let physical_entrypoint = physical_directory.join("SKILL.md");
-            physical_targets.insert(physical_entrypoint.clone());
+            physical_targets.insert(physical_directory.clone());
             detected.push(json!({"agent": roots.agent.id(), "target": entrypoint}));
             let directory_is_unsupported = match std::fs::symlink_metadata(&directory) {
                 Ok(metadata) => metadata.file_type().is_symlink() || !metadata.file_type().is_dir(),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
                 Err(_) => true,
             };
-            let (status, installed_version) = match std::fs::symlink_metadata(&entrypoint) {
-                Ok(metadata)
-                    if directory_is_unsupported
-                        || metadata.file_type().is_symlink()
-                        || !metadata.file_type().is_file() =>
-                {
-                    unsupported_count += 1;
-                    ("unsupported", None)
-                }
-                Ok(_) => match std::fs::read(&entrypoint) {
-                    Ok(content) => {
-                        let digest = bootstrap_content_digest(&content);
-                        let content_status = bootstrap_content_status(&digest, &current_digest);
-                        match content_status {
-                            BootstrapContentStatus::Current => current_count += 1,
-                            BootstrapContentStatus::OfficialOutdated(_) => {
-                                outdated_count += 1;
-                                replace_count += 1;
-                                if planned_entrypoints.insert(physical_entrypoint.clone()) {
-                                    operations.push(json!({
-                                        "kind": "replace_file",
-                                        "target": entrypoint,
-                                        "content": &current_content,
-                                        "expected_fingerprint": change::fingerprint(&entrypoint)?
-                                    }));
-                                }
-                            }
-                            BootstrapContentStatus::Modified => {
-                                modified_count += 1;
-                                if matches!(
-                                    modified_choice,
-                                    Some(ModifiedBootstrapChoice::AdoptCurrent)
-                                ) {
-                                    replace_count += 1;
-                                    if planned_entrypoints.insert(physical_entrypoint.clone()) {
-                                        operations.push(json!({
-                                            "kind": "replace_file",
-                                            "target": entrypoint,
-                                            "content": &current_content,
-                                            "expected_fingerprint": change::fingerprint(&entrypoint)?
-                                        }));
-                                    }
-                                }
-                            }
-                        }
-                        (content_status.as_str(), content_status.installed_version())
-                    }
-                    Err(_) => {
-                        unsupported_count += 1;
-                        ("unsupported", None)
-                    }
-                },
-                Err(error)
-                    if error.kind() == std::io::ErrorKind::NotFound
-                        && !directory_is_unsupported =>
-                {
-                    missing_count += 1;
-                    if !directory.exists() && planned_directories.insert(physical_directory.clone())
-                    {
-                        operations.push(json!({
-                            "kind": "create_directory",
-                            "target": directory,
-                            "expected_fingerprint": "missing"
-                        }));
-                    }
-                    if planned_entrypoints.insert(physical_entrypoint.clone()) {
-                        operations.push(json!({
-                            "kind": "write_file",
-                            "target": entrypoint,
-                            "content": &current_content,
-                            "expected_fingerprint": "missing"
-                        }));
-                    }
-                    ("missing", None)
-                }
-                Err(_) => {
-                    unsupported_count += 1;
-                    ("unsupported", None)
-                }
+            let references = directory.join("references");
+            let references_are_unsupported = match std::fs::symlink_metadata(&references) {
+                Ok(metadata) => metadata.file_type().is_symlink() || !metadata.file_type().is_dir(),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+                Err(_) => true,
             };
+            let package_missing = !directory.exists() && !directory_is_unsupported;
+            let observed_files = current_package
+                .iter()
+                .map(|(relative_path, current_digest, _)| {
+                    let (status, digest) = bootstrap_file_status(
+                        relative_path,
+                        &directory.join(relative_path),
+                        current_digest,
+                    );
+                    (*relative_path, status, digest)
+                })
+                .collect::<Vec<_>>();
+            let observed_digests = observed_files
+                .iter()
+                .map(|(_, _, digest)| digest.clone())
+                .collect::<Vec<_>>();
+            let legacy_version =
+                legacy_bootstrap_package_version(&observed_digests, legacy_complete_packages);
+            let all_managed_files_missing = observed_files
+                .iter()
+                .all(|(_, status, _)| matches!(status, BootstrapFileStatus::Missing));
+            let package_status = if directory_is_unsupported
+                || references_are_unsupported
+                || observed_files
+                    .iter()
+                    .any(|(_, status, _)| matches!(status, BootstrapFileStatus::Unsupported))
+            {
+                "unsupported"
+            } else if package_missing || all_managed_files_missing {
+                "missing"
+            } else if observed_files
+                .iter()
+                .all(|(_, status, _)| matches!(status, BootstrapFileStatus::Current))
+            {
+                "current"
+            } else if legacy_version.is_some() {
+                "official_outdated"
+            } else {
+                "modified"
+            };
+            match package_status {
+                "unsupported" => unsupported_count += 1,
+                "missing" => missing_count += 1,
+                "current" => current_count += 1,
+                "official_outdated" => {
+                    outdated_count += 1;
+                    replace_count += 1;
+                }
+                "modified" => {
+                    modified_count += 1;
+                    if matches!(modified_choice, Some(ModifiedBootstrapChoice::AdoptCurrent)) {
+                        replace_count += 1;
+                    }
+                }
+                _ => unreachable!("package status is exhaustive"),
+            }
+            let should_install = package_status == "missing"
+                || package_status == "official_outdated"
+                || (package_status == "modified"
+                    && matches!(modified_choice, Some(ModifiedBootstrapChoice::AdoptCurrent)));
+            if should_install {
+                if package_missing && planned_directories.insert(physical_directory.clone()) {
+                    operations.push(json!({
+                        "kind": "create_directory",
+                        "target": directory,
+                        "expected_fingerprint": "missing"
+                    }));
+                }
+                let physical_references = physical_directory.join("references");
+                if !references.exists() && planned_directories.insert(physical_references) {
+                    operations.push(json!({
+                        "kind": "create_directory",
+                        "target": references,
+                        "expected_fingerprint": "missing"
+                    }));
+                }
+                for ((relative_path, _, content), (_, status, _)) in
+                    current_package.iter().zip(&observed_files)
+                {
+                    if matches!(status, BootstrapFileStatus::Current) {
+                        continue;
+                    }
+                    let target = directory.join(relative_path);
+                    let physical_target = physical_directory.join(relative_path);
+                    if !planned_files.insert(physical_target) {
+                        continue;
+                    }
+                    let kind = match status {
+                        BootstrapFileStatus::Missing => "write_file",
+                        BootstrapFileStatus::Modified
+                        | BootstrapFileStatus::OfficialOutdated(_) => "replace_file",
+                        BootstrapFileStatus::Current | BootstrapFileStatus::Unsupported => {
+                            unreachable!("install only receives supported non-current files")
+                        }
+                    };
+                    operations.push(json!({
+                        "kind": kind,
+                        "target": target,
+                        "content": content,
+                        "expected_fingerprint": change::fingerprint(&target)?
+                    }));
+                }
+            }
             targets.push(json!({
                 "agent": roots.agent.id(),
                 "target": entrypoint,
                 "physical_target": physical_entrypoint,
-                "status": status,
-                "installed_version": installed_version
+                "status": package_status,
+                "installed_version": if package_status == "current" {
+                    Some(env!("CARGO_PKG_VERSION"))
+                } else if package_status == "official_outdated" {
+                    legacy_version
+                } else {
+                    None
+                },
+                "managed_file_count": current_package.len(),
+                "managed_files": observed_files.iter().map(|(relative_path, status, _)| json!({
+                    "relative_path": relative_path,
+                    "status": status.as_str()
+                })).collect::<Vec<_>>()
             }));
         }
     }
@@ -8316,11 +8471,11 @@ mod recovery_tests {
             BootstrapContentStatus::Current
         );
         assert!(
-            !LEGACY_BOOTSTRAPS
+            !LEGACY_SINGLE_FILE_BOOTSTRAPS
                 .iter()
                 .any(|(_, digest)| *digest == current)
         );
-        for (version, digest) in LEGACY_BOOTSTRAPS {
+        for (version, digest) in LEGACY_SINGLE_FILE_BOOTSTRAPS {
             assert_eq!(
                 bootstrap_content_status(digest, &current),
                 BootstrapContentStatus::OfficialOutdated(version)
@@ -8339,6 +8494,95 @@ mod recovery_tests {
             ),
             BootstrapContentStatus::OfficialOutdated("1.4.0")
         );
+    }
+
+    #[test]
+    fn exact_complete_bootstrap_manifest_upgrades_and_undoes_without_accepting_a_mix() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let state = temp.path().join("state");
+        let root = home.join(".codex/skills");
+        let package = root.join("skillroster");
+        std::fs::create_dir_all(package.join("references")).unwrap();
+        std::fs::create_dir_all(&state).unwrap();
+        let current = current_bootstrap_package();
+        let previous = current
+            .iter()
+            .map(|(_, _, content)| format!("{content}\n<!-- previous official package -->\n"))
+            .collect::<Vec<_>>();
+        let previous_digests = previous
+            .iter()
+            .map(|content| content_digest(content.as_bytes()))
+            .collect::<Vec<_>>();
+        let previous_files = current
+            .iter()
+            .zip(&previous_digests)
+            .map(|((relative_path, _, _), digest)| (*relative_path, digest.as_str()))
+            .collect::<Vec<_>>();
+        let manifests = [BootstrapPackageManifest {
+            version: "previous-complete-fixture",
+            file_digests: &previous_files,
+        }];
+        for ((relative_path, _, _), content) in current.iter().zip(&previous) {
+            std::fs::write(package.join(relative_path), content).unwrap();
+        }
+        let store = StateStore::open(state.join("skillroster.db")).unwrap();
+        scan_command(&store, &home, &state, Vec::new(), Vec::new()).unwrap();
+
+        std::fs::write(package.join(current[1].0), &current[1].2).unwrap();
+        let mixed = setup_command_with_manifests(&store, &home, &state, None, &manifests).unwrap();
+        assert_eq!(mixed["state"], "modified_choice_required");
+        assert_eq!(mixed["outdated_count"], 0);
+        std::fs::write(package.join(current[1].0), &previous[1]).unwrap();
+
+        let incomplete_manifests = [BootstrapPackageManifest {
+            version: "incomplete-fixture",
+            file_digests: &previous_files[..3],
+        }];
+        let incomplete =
+            setup_command_with_manifests(&store, &home, &state, None, &incomplete_manifests)
+                .unwrap();
+        assert_eq!(incomplete["state"], "modified_choice_required");
+
+        let duplicate_path_files = [
+            previous_files[0],
+            previous_files[1],
+            previous_files[2],
+            previous_files[2],
+        ];
+        let duplicate_path_manifests = [BootstrapPackageManifest {
+            version: "duplicate-path-fixture",
+            file_digests: &duplicate_path_files,
+        }];
+        let duplicate_path =
+            setup_command_with_manifests(&store, &home, &state, None, &duplicate_path_manifests)
+                .unwrap();
+        assert_eq!(duplicate_path["state"], "modified_choice_required");
+
+        let upgrade =
+            setup_command_with_manifests(&store, &home, &state, None, &manifests).unwrap();
+        assert_eq!(upgrade["state"], "preview_ready");
+        assert_eq!(upgrade["outdated_count"], 1);
+        assert_eq!(upgrade["operation_count"], 4);
+        assert_eq!(
+            upgrade["targets"][0]["installed_version"],
+            "previous-complete-fixture"
+        );
+        let applied = apply_command(&store, upgrade["plan_id"].as_str().unwrap()).unwrap();
+        for (relative_path, _, content) in &current {
+            assert_eq!(
+                std::fs::read_to_string(package.join(relative_path)).unwrap(),
+                *content
+            );
+        }
+        let undone = undo_command(&store, applied["receipt_id"].as_str().unwrap()).unwrap();
+        assert_eq!(undone["verification"], "passed");
+        for ((relative_path, _, _), content) in current.iter().zip(&previous) {
+            assert_eq!(
+                std::fs::read_to_string(package.join(relative_path)).unwrap(),
+                *content
+            );
+        }
     }
 
     #[test]

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+#[derive(Clone, Copy)]
+pub(crate) struct PackageFile {
+    pub(crate) relative_path: &'static str,
+    pub(crate) content: &'static str,
+}
+
+pub(crate) const PACKAGE_FILES: [PackageFile; 4] = [
+    PackageFile {
+        relative_path: "SKILL.md",
+        content: include_str!("../skill/skillroster/SKILL.md"),
+    },
+    PackageFile {
+        relative_path: "references/routing.md",
+        content: include_str!("../skill/skillroster/references/routing.md"),
+    },
+    PackageFile {
+        relative_path: "references/governance.md",
+        content: include_str!("../skill/skillroster/references/governance.md"),
+    },
+    PackageFile {
+        relative_path: "references/mutation.md",
+        content: include_str!("../skill/skillroster/references/mutation.md"),
+    },
+];
+
+pub(crate) fn is_managed_target(relative_to_skill_root: &Path) -> bool {
+    let Ok(relative_to_package) = relative_to_skill_root.strip_prefix("skillroster") else {
+        return false;
+    };
+    PACKAGE_FILES
+        .iter()
+        .any(|file| relative_to_package == Path::new(file.relative_path))
+}

--- a/src/change.rs
+++ b/src/change.rs
@@ -359,7 +359,7 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
         {
             return Err(ChangeError::new(
                 "invalid_setup_operation",
-                "bootstrap setup may only create or replace its package directory and SKILL.md",
+                "bootstrap setup may only create directories and write or replace files in its fixed package",
             ));
         }
         OperationPolicy::SourceUpdate
@@ -406,6 +406,23 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
     }
 
     let state_dir = canonical_directory(&ctx.state_dir, "state_dir")?;
+    let bootstrap_roots = if matches!(ctx.operation_policy, OperationPolicy::BootstrapSetup) {
+        let roots = ctx
+            .approved_roots
+            .iter()
+            .filter(|root| {
+                !is_controlled_state_root(root, &ctx.state_dir)
+                    && !is_controlled_state_root(root, &state_dir)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        normalize_roots(&roots, &state_dir)?
+            .into_iter()
+            .filter(|root| !is_controlled_state_root(root, &state_dir))
+            .collect()
+    } else {
+        Vec::new()
+    };
     let roots = normalize_roots(&ctx.approved_roots, &state_dir)?;
     if roots.iter().any(|root| {
         (state_dir.starts_with(root) || root.starts_with(&state_dir))
@@ -424,6 +441,9 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
     let mut projected_fingerprints = HashMap::new();
     for raw in input.operations {
         let operation = normalize_operation(raw, &roots, &projected_present)?;
+        if matches!(ctx.operation_policy, OperationPolicy::BootstrapSetup) {
+            validate_bootstrap_operation_target(&operation, &bootstrap_roots)?;
+        }
         let target = operation.target().to_path_buf();
         if !targets.insert(target.clone()) {
             return Err(ChangeError::new(
@@ -866,6 +886,34 @@ fn normalize_operation(
         },
     };
     Ok(normalized)
+}
+
+fn validate_bootstrap_operation_target(operation: &Operation, roots: &[PathBuf]) -> Result<()> {
+    let allowed = roots.iter().any(|root| {
+        let Ok(relative) = operation.target().strip_prefix(root) else {
+            return false;
+        };
+        match operation {
+            Operation::CreateDirectory { .. } => {
+                relative == Path::new("skillroster")
+                    || relative == Path::new("skillroster/references")
+            }
+            Operation::WriteFile { .. } | Operation::ReplaceFile { .. } => {
+                crate::bootstrap::is_managed_target(relative)
+            }
+            _ => false,
+        }
+    });
+    if !allowed {
+        return Err(ChangeError::new(
+            "invalid_setup_target",
+            format!(
+                "bootstrap setup target {} is outside the fixed managed package",
+                operation.target().display()
+            ),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_current_state(operation: &Operation, roots: &[PathBuf]) -> Result<()> {
@@ -1966,6 +2014,97 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(error.code, "operations_not_declarative");
+    }
+
+    #[test]
+    fn bootstrap_setup_accepts_only_fixed_package_targets() {
+        let (_temp, root, state) = fixture();
+        let library = state.join("library");
+        let plan_backups = state.join("plan-backups");
+        fs::create_dir(&library).unwrap();
+        fs::create_dir(&plan_backups).unwrap();
+        let context = PrepareContext {
+            approved_roots: vec![root.clone(), library.clone(), plan_backups.clone()],
+            state_dir: state,
+            operation_policy: OperationPolicy::BootstrapSetup,
+        };
+        let allowed = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "write_file",
+                "target": root.join("skillroster/references/../references/routing.md"),
+                "content": "routing",
+                "expected_fingerprint": "missing"
+            }]
+        })
+        .to_string();
+        assert!(prepare(&allowed, &context).is_ok());
+
+        for target in [
+            root.join("skillroster/notes.md"),
+            root.join("other/SKILL.md"),
+            library.join("skillroster/SKILL.md"),
+            plan_backups.join("skillroster/SKILL.md"),
+        ] {
+            let refused = serde_json::json!({
+                "schema_version": 1,
+                "scan_id": "scan_1",
+                "operations": [{
+                    "kind": "write_file",
+                    "target": target,
+                    "content": "unexpected",
+                    "expected_fingerprint": "missing"
+                }]
+            })
+            .to_string();
+            assert_eq!(
+                prepare(&refused, &context).unwrap_err().code,
+                "invalid_setup_target"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bootstrap_setup_rejects_agent_root_aliases_to_controlled_state_roots() {
+        use std::os::unix::fs::symlink;
+
+        let (_temp, root, state) = fixture();
+        let library = state.join("library");
+        let plan_backups = state.join("plan-backups");
+        fs::create_dir(&library).unwrap();
+        fs::create_dir(&plan_backups).unwrap();
+        let library_alias = root.join("library-alias");
+        let backups_alias = root.join("backups-alias");
+        symlink(&library, &library_alias).unwrap();
+        symlink(&plan_backups, &backups_alias).unwrap();
+        let context = PrepareContext {
+            approved_roots: vec![library_alias.clone(), backups_alias.clone()],
+            state_dir: state,
+            operation_policy: OperationPolicy::BootstrapSetup,
+        };
+
+        for target in [
+            library_alias.join("skillroster/SKILL.md"),
+            backups_alias.join("skillroster/SKILL.md"),
+        ] {
+            let input = serde_json::json!({
+                "schema_version": 1,
+                "scan_id": "scan_1",
+                "operations": [{
+                    "kind": "write_file",
+                    "target": target,
+                    "content": "unexpected",
+                    "expected_fingerprint": "missing"
+                }]
+            })
+            .to_string();
+            assert_eq!(
+                prepare(&input, &context).unwrap_err().code,
+                "invalid_setup_target"
+            );
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+mod bootstrap;
 pub mod change;
 pub mod cli;
 pub mod harness;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2174,19 +2174,35 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
         &[&common[..], &["plan", "--show", plan_id]].concat(),
         None,
     ));
-    assert_eq!(detail["result"]["operations"][0]["kind"], "replace_file");
+    assert!(
+        detail["result"]["operations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|operation| operation["kind"] == "replace_file")
+    );
 
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
     assert_eq!(
         fs::read_to_string(&bootstrap).unwrap(),
         include_str!("../skill/skillroster/SKILL.md").replace("\r\n", "\n")
     );
+    for reference in ["routing.md", "governance.md", "mutation.md"] {
+        assert!(
+            bootstrap
+                .parent()
+                .unwrap()
+                .join("references")
+                .join(reference)
+                .is_file()
+        );
+    }
     let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_eq!(current["result"]["state"], "up_to_date");
     assert!(current["result"]["plan_id"].is_null());
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.20"
+        env!("CARGO_PKG_VERSION")
     );
 
     let undone = json_output(&run(
@@ -2270,7 +2286,268 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
         let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
         assert_eq!(undone["result"]["verification"], "passed");
         assert_eq!(fs::read_to_string(&bootstrap).unwrap(), legacy);
+        assert!(!bootstrap.parent().unwrap().join("references").exists());
     }
+}
+
+#[test]
+fn setup_manages_the_fixed_bootstrap_package_and_preserves_unmanaged_files() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    fs::create_dir_all(&root).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    json_output(&run(
+        &[
+            &common[..],
+            &["apply", setup["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    let package = root.join("skillroster");
+    let routing = package.join("references/routing.md");
+    let unmanaged = package.join("notes.local.md");
+    fs::write(&unmanaged, "keep me\n").unwrap();
+    fs::write(&routing, "local routing instructions\n").unwrap();
+
+    let blocked = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(blocked["result"]["state"], "modified_choice_required");
+    assert_eq!(blocked["result"]["modified_count"], 1);
+    assert!(blocked["result"]["plan_id"].is_null());
+
+    let retained = json_output(&run(
+        &[&common[..], &["setup", "--modified-choice", "retain-local"]].concat(),
+        None,
+    ));
+    assert_eq!(retained["result"]["state"], "local_modifications_retained");
+    assert_eq!(
+        fs::read_to_string(&routing).unwrap(),
+        "local routing instructions\n"
+    );
+
+    let adopt = json_output(&run(
+        &[
+            &common[..],
+            &["setup", "--modified-choice", "adopt-current"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(adopt["result"]["operation_count"], 1);
+    let adopted = json_output(&run(
+        &[
+            &common[..],
+            &["apply", adopt["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(
+        fs::read_to_string(&routing).unwrap(),
+        include_str!("../skill/skillroster/references/routing.md").replace("\r\n", "\n")
+    );
+    assert_eq!(fs::read_to_string(&unmanaged).unwrap(), "keep me\n");
+    let healthy = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(healthy["result"]["state"], "up_to_date");
+    assert_eq!(healthy["result"]["targets"][0]["managed_file_count"], 4);
+
+    let undone = json_output(&run(
+        &[
+            &common[..],
+            &["undo", adopted["result"]["receipt_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert_eq!(
+        fs::read_to_string(&routing).unwrap(),
+        "local routing instructions\n"
+    );
+    assert_eq!(fs::read_to_string(&unmanaged).unwrap(), "keep me\n");
+}
+
+#[test]
+fn setup_does_not_report_a_package_with_a_missing_reference_as_current() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    fs::create_dir_all(&root).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    json_output(&run(
+        &[
+            &common[..],
+            &["apply", setup["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    fs::remove_file(root.join("skillroster/references/governance.md")).unwrap();
+
+    let result = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(result["result"]["state"], "modified_choice_required");
+    assert_eq!(result["result"]["current_count"], 0);
+    assert_eq!(result["result"]["modified_count"], 1);
+    assert!(result["result"]["plan_id"].is_null());
+    assert!(
+        result["result"]["targets"][0]["managed_files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|file| {
+                file["relative_path"] == "references/governance.md" && file["status"] == "missing"
+            })
+    );
+
+    let adopt = json_output(&run(
+        &[
+            &common[..],
+            &["setup", "--modified-choice", "adopt-current"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(adopt["result"]["operation_count"], 1);
+    let plan_id = adopt["result"]["plan_id"].as_str().unwrap();
+    let detail = json_output(&run(
+        &[&common[..], &["plan", "--show", plan_id]].concat(),
+        None,
+    ));
+    assert_eq!(detail["result"]["operations"].as_array().unwrap().len(), 1);
+    assert_eq!(detail["result"]["operations"][0]["kind"], "write_file");
+    let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+    assert!(root.join("skillroster/references/governance.md").is_file());
+    let undone = json_output(&run(
+        &[
+            &common[..],
+            &["undo", applied["result"]["receipt_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert!(!root.join("skillroster/references/governance.md").exists());
+}
+
+#[test]
+fn setup_treats_a_package_with_no_managed_files_as_missing_and_preserves_extra_files() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    let package = root.join("skillroster");
+    fs::create_dir_all(&package).unwrap();
+    let extra = package.join("notes.local.md");
+    fs::write(&extra, "keep me\n").unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(setup["result"]["state"], "preview_ready");
+    assert_eq!(setup["result"]["missing_count"], 1);
+    assert_eq!(setup["result"]["modified_count"], 0);
+    assert_eq!(setup["result"]["targets"][0]["status"], "missing");
+    assert_eq!(setup["result"]["operation_count"], 5);
+    let applied = json_output(&run(
+        &[
+            &common[..],
+            &["apply", setup["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(fs::read_to_string(&extra).unwrap(), "keep me\n");
+    assert!(package.join("SKILL.md").is_file());
+    assert!(package.join("references/mutation.md").is_file());
+
+    let undone = json_output(&run(
+        &[
+            &common[..],
+            &["undo", applied["result"]["receipt_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert_eq!(fs::read_to_string(&extra).unwrap(), "keep me\n");
+    assert!(!package.join("SKILL.md").exists());
+    assert!(!package.join("references").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_rejects_a_symlinked_managed_reference() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    fs::create_dir_all(&root).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    json_output(&run(
+        &[
+            &common[..],
+            &["apply", setup["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    let routing = root.join("skillroster/references/routing.md");
+    fs::remove_file(&routing).unwrap();
+    symlink(root.join("skillroster/SKILL.md"), &routing).unwrap();
+
+    let result = json_output(&run(
+        &[
+            &common[..],
+            &["setup", "--modified-choice", "adopt-current"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(result["result"]["state"], "unsupported_targets");
+    assert_eq!(result["result"]["unsupported_count"], 1);
+    assert!(result["result"]["plan_id"].is_null());
+    assert!(
+        fs::symlink_metadata(routing)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
 }
 
 #[cfg(unix)]
@@ -2313,7 +2590,7 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
     assert_eq!(setup["result"]["targets"].as_array().unwrap().len(), 5);
     assert_eq!(setup["result"]["missing_count"], 5);
     assert_eq!(setup["result"]["physical_target_count"], 3);
-    assert_eq!(setup["result"]["operation_count"], 6);
+    assert_eq!(setup["result"]["operation_count"], 18);
 
     let plan_id = setup["result"]["plan_id"].as_str().unwrap();
     let detail = json_output(&run(
@@ -2321,16 +2598,19 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
         None,
     ));
     let operations = detail["result"]["operations"].as_array().unwrap();
-    assert_eq!(operations.len(), 6);
+    assert_eq!(operations.len(), 18);
     let unique_targets = operations
         .iter()
         .map(|operation| operation["target"].as_str().unwrap())
         .collect::<std::collections::BTreeSet<_>>();
-    assert_eq!(unique_targets.len(), 6);
+    assert_eq!(unique_targets.len(), 18);
 
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
     for root in [&shared, &opencode, &hermes] {
         assert!(root.join("skillroster/SKILL.md").is_file());
+        assert!(root.join("skillroster/references/routing.md").is_file());
+        assert!(root.join("skillroster/references/governance.md").is_file());
+        assert!(root.join("skillroster/references/mutation.md").is_file());
     }
     let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
     let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
@@ -2521,7 +2801,10 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.20");
+    assert_eq!(
+        output["result"]["bootstrap_version"],
+        env!("CARGO_PKG_VERSION")
+    );
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],


### PR DESCRIPTION
## Problem

The Bootstrap had grown into one dense file, while setup only managed SKILL.md. Splitting instructions without package-aware setup would leave Agents with incomplete or stale references.

## Solution

- Keep one SkillRoster Skill and move routing, governance, and mutation detail behind progressive-disclosure references.
- Manage SKILL.md plus three fixed references as one setup package.
- Preserve explicit confirmation, Plan, Receipt, and Undo semantics for install and upgrade.
- Fail closed on modified, incomplete, symlinked, non-file, controlled-state, or non-exact legacy packages.
- Preserve unmanaged extras and deduplicate shared physical Agent roots.
- Prepare version 1.8.21 and recognize the exact official 1.8.20 single-file Bootstrap.

Supports the Bootstrap and harness seam needed by #129. This PR does not close the paired-pilot issue.

## Verification

- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features: 192 unit, 7 acceptance, 57 CLI
- Skill package validation
- Independent Standards and Spec reviews: 0 blocker, 0 should-fix