### PR TITLE
feat: remember source root read permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "ulid",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,8 @@ serde_json = "1.0"
 sha2 = "0.10"
 ulid = { version = "1.2", features = ["serde"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile = "3.20"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The agent then calls the `skillroster` CLI and returns an evidence-backed plan f
 
 ```bash
 skillroster scan --json
-skillroster --source-root /absolute/trusted/source scan --json
+skillroster --source-root /absolute/confirmed/source scan --json
 skillroster report --json
 skillroster report --findings --limit 20 --json
 skillroster report --findings --category usage --json
@@ -42,6 +42,9 @@ skillroster apply <plan-id> --json
 skillroster undo <receipt-id> --json
 skillroster setup --json
 skillroster status --json
+skillroster source-root confirm --finding <finding-id> --path /absolute/observed/source --json
+skillroster source-root inspect --json
+skillroster source-root revoke <permission-id> --json
 skillroster lifecycle inspect --json
 skillroster lifecycle export --output ./skillroster-export.json --json
 skillroster lifecycle exclude codex --json
@@ -68,6 +71,15 @@ preserved and reported as blocked.
 that Agent's default exposure. `--source-root PATH` approves a non-exposed
 canonical source directory for the current Scan. Neither option crawls outside
 the exact supplied path.
+
+For a reusable decision, `source-root confirm` records one exact local read
+permission bound to the current escaping-link Finding and stable filesystem
+identity. It does not endorse the source, raise Evidence quality, or authorize
+Plan/Apply. Missing, replaced, or retargeted roots fail closed; inspect or
+revoke the local audit record explicitly. Scan checks the frozen identity and
+entrypoint binding before and after bounded discovery/consumption and discards
+facts when it observes drift. This detects accidental or persistent local
+drift; it is not a sandbox against a malicious same-user ABA race.
 
 Agent-authored Plans are declarative: they reference the latest Snapshot and
 Evidence IDs, then request Roster states, managed/hosted Library placement, or a

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -209,8 +209,9 @@ Summary order and bind each stable Finding ID without implying Plan or Apply.
 
 Suggested action argv retains any effective `--state-dir`, `--home`, `--root`,
 and `--source-root` overrides so an Agent can execute the transition against
-the same local Snapshot and discovery trust boundary. It never broadens source
-trust or treats a suggested mutation as authorization.
+the same local Snapshot and explicit read boundary. It never broadens read
+permission, endorses source content, or treats a suggested mutation as
+authorization.
 
 Suggested actions must represent a required or evidence-backed transition.
 Healthy `status` output with a completed Snapshot does not prescribe another
@@ -253,9 +254,14 @@ The Agent distinguishes “not observed” from “unused,” names missing cove
 ### External canonical source
 
 The Agent leaves an escaping link unread, shows its target, and asks whether
-the source is intentional. A confirmed source is rescanned through
-`--source-root` without increasing any Agent's default exposure; unconfirmed
-sources remain excluded.
+the source is intentional. After confirmation it records an exact local read
+permission with `source-root confirm`, then rescans without increasing any
+Agent's default exposure. The decision does not endorse content or authorize a
+Plan; unconfirmed, revoked, or identity-drifted sources remain excluded. The
+temporary `--source-root` flag remains available for one Scan. Drift detection
+uses bounded identity and entrypoint-binding checks around discovery and
+content consumption; it detects accidental or persistent changes, not a
+malicious same-user ABA race completed entirely between checkpoints.
 
 ### One-confirmation Apply
 

--- a/docs/local-data-lifecycle.md
+++ b/docs/local-data-lifecycle.md
@@ -4,6 +4,16 @@ SkillRoster keeps governance state in `~/.skillroster/skillroster.db`. It reads
 supported Agent sessions in place and stores only derived evidence summaries;
 exports do not contain raw prompts or responses.
 
+Exact source-root read permissions are also local SQLite policy. Each record
+keeps the confirmed canonical directory, bound Finding/Snapshot, approval and
+optional revocation time, and stable filesystem identity. Use
+`skillroster source-root inspect --json` to see active, revoked, missing,
+replaced, or retargeted permissions. A permission survives ordinary evidence
+and Plan/Receipt purges; revoke it explicitly with
+`skillroster source-root revoke ID --json`, or remove it with the complete local
+state. These records authorize factual reads only and never endorse content or
+authorize governance.
+
 When a bounded planning error omits source-confirmation blockers, SkillRoster
 writes one versioned JSON detail artifact under
 `~/.skillroster/source-confirmation/`. These derived artifacts contain Skill
@@ -25,7 +35,8 @@ and a source-path digest; it does not store the sampled conversation text.
 
 Use `skillroster lifecycle inspect --json` to see row counts, retained
 source-confirmation detail counts, evidence-source exclusions, and recovery
-state. Export derived evidence and retained source-confirmation details to a
+state. It also reports source-root permission counts and drift state. Export
+derived evidence, the complete permission audit, and retained source-confirmation details to a
 new local file:
 
 ```sh

--- a/docs/local-data-lifecycle.md
+++ b/docs/local-data-lifecycle.md
@@ -12,7 +12,9 @@ replaced, or retargeted permissions. A permission survives ordinary evidence
 and Plan/Receipt purges; revoke it explicitly with
 `skillroster source-root revoke ID --json`, or remove it with the complete local
 state. These records authorize factual reads only and never endorse content or
-authorize governance.
+authorize governance. Filesystem identity includes a conservative object-epoch
+guard; metadata changes that could be object reuse may require revoke and
+reconfirm instead of silently continuing.
 
 When a bounded planning error omits source-confirmation blockers, SkillRoster
 writes one versioned JSON detail artifact under

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -144,8 +144,28 @@ skillroster plan --show <plan-id> [--json]
 skillroster apply <plan-id> [--json]
 skillroster undo <receipt-id> [--json]
 skillroster status [--json]
+skillroster source-root confirm --finding <finding-id> --path <absolute-path> [--json]
+skillroster source-root inspect [--json]
+skillroster source-root revoke <permission-id> [--json]
 skillroster setup [--modified-choice retain-local|adopt-current] [--json]
 ```
+
+`source-root confirm` persists one exact local read permission bound to a
+current completed escaping-link Finding, its observed canonical directory, and
+the directory's stable filesystem identity. Scan freezes active permissions
+before discovery; missing, inaccessible, replaced, or retargeted roots fail
+closed independently and remain typed audit facts. Confirming read access does
+not endorse content, raise Evidence quality, authorize governance or Plan/Apply,
+or change Agent/Skill files. `inspect` includes active, revoked, and drifted
+records; `revoke` retains the approval and revocation times. No parent, sibling,
+descendant, alias, wildcard, or Agent-specific permission is inferred.
+Discovery and content consumption recheck the frozen directory identity and
+exact entrypoint binding at bounded pre/post checkpoints, discard derived facts
+when they observe drift, and preserve the drift in the Snapshot. This protects
+against accidental or persistent local replacement and retargeting. It is not
+an adversarial sandbox against a same-user process completing an ABA swap
+entirely between checkpoints; descriptor/handle-bound traversal is tracked as
+separate security hardening.
 
 `setup` detects supported Agents and returns a preview for installing or
 upgrading the single bootstrap Skill. Exact official older copies are eligible

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -165,7 +165,9 @@ when they observe drift, and preserve the drift in the Snapshot. This protects
 against accidental or persistent local replacement and retargeting. It is not
 an adversarial sandbox against a same-user process completing an ABA swap
 entirely between checkpoints; descriptor/handle-bound traversal is tracked as
-separate security hardening.
+separate security hardening. The persisted object epoch is conservative:
+platform metadata changes that could indicate object reuse may require an
+explicit revoke and reconfirm rather than silently retaining read access.
 
 `setup` detects supported Agents and returns a preview for installing or
 upgrading the single bootstrap Skill. Exact official older copies are eligible

--- a/skill/skillroster/references/governance.md
+++ b/skill/skillroster/references/governance.md
@@ -49,15 +49,25 @@ Keep Roster, source, and Library changes in separate Plans. A stale Snapshot,
 Evidence ID, fingerprint, incomplete scope, or revision requires rescan or user
 input, never weaker validation.
 
-If planning reports `trusted_canonical_sources_required`, use only the typed
-blocked Skills and observed `--source-root` suggestions. A truncated result
+If planning reports `trusted_canonical_sources_required`, treat that stable ID
+only as a request for an exact local read permission, never as a claim that the
+directory or its content is trustworthy. Use only the typed blocked Skills and
+observed source targets. A truncated result
 points to a SkillRoster-owned JSON detail file; validate its schema before
 using the complete identities and argv. Do not inspect or trust targets
 independently, synthesize broader parents, or submit a partial Plan.
 
 For an escaping Skill link, show the observed target and obtain confirmation
-before rescanning with one explicit source root per trusted canonical source.
-Then prefer a reviewed Managed or Hosted Library Plan.
+before running
+`skillroster source-root confirm --finding FINDING_ID --path ABSOLUTE_PATH --json`.
+This records factual read access for that exact canonical directory and stable
+filesystem identity only. It does not endorse content, raise Evidence quality,
+or authorize Plan/Apply. Then rescan. Use `source-root inspect --json` to audit
+active, revoked, or drifted permissions and `source-root revoke ID --json` to
+revoke one. The temporary repeatable `--source-root` option remains a one-scan
+alternative. Treat its drift facts as bounded accidental/persistent-drift
+evidence, not proof against a malicious same-user ABA race. Never infer a
+parent, sibling, descendant, alias, or wildcard.
 
 ## Present
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2061,11 +2061,12 @@ fn conservative_source_policy_facts(
         .map(|root| {
             let id = root.permission.id.as_str();
             let mut fact = crate::source_policy::fact_from_frozen(root);
-            if let Some(previous) = before_by_id.get(id)
-                && previous.state != crate::source_policy::SourceRootState::Active
-                && fact.state == crate::source_policy::SourceRootState::Active
-            {
-                fact = crate::source_policy::fact_from_frozen(previous);
+            if let Some(previous) = before_by_id.get(id) {
+                if previous.state != crate::source_policy::SourceRootState::Active
+                    && fact.state == crate::source_policy::SourceRootState::Active
+                {
+                    fact = crate::source_policy::fact_from_frozen(previous);
+                }
             }
             if scan_drifted_permission_ids.contains(id) {
                 fact.state = crate::source_policy::SourceRootState::Inaccessible;

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,7 @@ use crate::change::{
 };
 use crate::cli::{
     Cli, Command, LifecycleCommand, ModifiedBootstrapChoice, ReportCategory, ReportSeverity,
+    SourceRootCommand,
 };
 use crate::harness::{self, AgentKind};
 use crate::model::{
@@ -209,6 +210,128 @@ pub fn run(cli: Cli) -> Result<Output> {
             };
             ("status", result, vec![], actions)
         }
+        Some(Command::SourceRoot(args)) => match args.command {
+            SourceRootCommand::Confirm(args) => {
+                if !args.path.is_absolute() {
+                    bail!("source root must be absolute: {}", args.path.display());
+                }
+                if !cli.json
+                    && !require_human_confirmation(
+                        &format!("Permit local reads of exactly {}?", args.path.display()),
+                        "This records one local read permission only. It does not endorse the content, raise Evidence quality, authorize a Plan, or change Agent/Skill files.",
+                    )?
+                {
+                    return cancelled_output("source-root");
+                }
+                let finding_id = FindingId::parse(args.finding)?;
+                let finding = store.get_finding(&finding_id)?.ok_or_else(|| {
+                    crate::source_policy::SourceRootPolicyError::FindingNotFound {
+                        finding_id: finding_id.to_string(),
+                    }
+                })?;
+                let (_, snapshot) = latest_scan(&store)?;
+                let outcome = crate::source_policy::confirm_source_root(
+                    &store, &finding, &snapshot, &args.path,
+                )?;
+                let result = json!({
+                    "operation": "confirm",
+                    "permission": crate::source_policy::permission_json(&outcome.permission, None),
+                    "already_permitted": outcome.already_permitted,
+                    "permission_scope": "exact_local_read_only",
+                    "content_endorsed": false,
+                    "evidence_quality_changed": false,
+                    "governance_authorized": false,
+                    "plan_apply_authorized": false,
+                    "local_state_changed": !outcome.already_permitted,
+                    "state_files_changed": !outcome.already_permitted,
+                    "agent_files_changed": false,
+                    "skill_files_changed": false,
+                    "files_changed": false,
+                });
+                (
+                    "source-root",
+                    result,
+                    vec![],
+                    vec![action(
+                        "scan",
+                        &["scan", "--json"],
+                        false,
+                        false,
+                        "source_root_permission_recorded",
+                    )],
+                )
+            }
+            SourceRootCommand::Inspect(args) => {
+                let mut result = crate::source_policy::policy_value(
+                    &store,
+                    true,
+                    usize::from(args.limit),
+                    usize::try_from(args.offset)?,
+                )?;
+                result["operation"] = json!("inspect");
+                result["permission_scope"] = json!("exact_local_read_only");
+                result["content_endorsed"] = json!(false);
+                result["evidence_quality_changed"] = json!(false);
+                result["governance_authorized"] = json!(false);
+                result["files_changed"] = json!(false);
+                result["state_files_changed"] = json!(false);
+                let actions = result["next_offset"]
+                    .as_u64()
+                    .map(|offset| {
+                        action(
+                            "inspect_more_source_root_permissions",
+                            &[
+                                "source-root",
+                                "inspect",
+                                "--limit",
+                                &args.limit.to_string(),
+                                "--offset",
+                                &offset.to_string(),
+                                "--json",
+                            ],
+                            false,
+                            false,
+                            "more_source_root_permissions_available",
+                        )
+                    })
+                    .into_iter()
+                    .collect();
+                ("source-root", result, vec![], actions)
+            }
+            SourceRootCommand::Revoke(args) => {
+                if !cli.json
+                    && !require_human_confirmation(
+                        &format!("Revoke source-root read permission {}?", args.id),
+                        "Future Scans will fail closed for this exact root unless separately permitted. Agent and Skill files are not changed.",
+                    )?
+                {
+                    return cancelled_output("source-root");
+                }
+                let permission = crate::source_policy::revoke_permission(&store, &args.id)?;
+                let result = json!({
+                    "operation": "revoke",
+                    "permission": crate::source_policy::permission_json(&permission, None),
+                    "permission_scope": "exact_local_read_only",
+                    "local_state_changed": true,
+                    "state_files_changed": true,
+                    "agent_files_changed": false,
+                    "skill_files_changed": false,
+                    "files_changed": false,
+                });
+                (
+                    "source-root",
+                    result,
+                    vec![],
+                    vec![action(
+                        "scan",
+                        &["scan", "--json"],
+                        false,
+                        false,
+                        "source_root_permission_revoked",
+                    )],
+                )
+            }
+        },
         Some(Command::Scan) => {
             let (result, warnings) = scan_command(
                 &store,
@@ -457,6 +580,9 @@ fn command_requires_exclusive_state_lock(command: Option<&Command>) -> bool {
     matches!(
         command,
         Some(Command::Apply(_) | Command::Undo(_) | Command::Setup(_))
+            | Some(Command::SourceRoot(crate::cli::SourceRootArgs {
+                command: SourceRootCommand::Confirm(_) | SourceRootCommand::Revoke(_),
+            }))
             | Some(Command::Lifecycle(crate::cli::LifecycleArgs {
                 command: LifecycleCommand::Purge(_),
             }))
@@ -652,6 +778,60 @@ fn fingerprint_remediation(completeness: scan::FingerprintCompleteness) -> Value
 }
 
 fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError {
+    if let Some(policy) = error.downcast_ref::<crate::source_policy::SourceRootPolicyError>() {
+        use crate::source_policy::SourceRootPolicyError as PolicyError;
+        let facts = match policy {
+            PolicyError::FindingNotFound { finding_id }
+            | PolicyError::NotEscapingLinkFinding { finding_id } => {
+                json!({"finding_id": finding_id})
+            }
+            PolicyError::FindingSnapshotNotCurrent {
+                finding_id,
+                finding_snapshot,
+                current_snapshot,
+            } => json!({
+                "finding_id": finding_id,
+                "finding_snapshot_id": finding_snapshot,
+                "current_snapshot_id": current_snapshot,
+            }),
+            PolicyError::PathNotResolvable { path, reason } => {
+                json!({"path": path, "reason": reason})
+            }
+            PolicyError::PathNotObservedTarget { path }
+            | PolicyError::PathNotDirectory { path } => json!({"path": path}),
+            PolicyError::PermissionNotFound { permission_id }
+            | PolicyError::PermissionAlreadyRevoked { permission_id } => {
+                json!({"permission_id": permission_id})
+            }
+            PolicyError::ActivePermissionIdentityDrift {
+                permission_id,
+                path,
+            } => json!({"permission_id": permission_id, "path": path}),
+        };
+        let mut details = json!({
+            "permission_scope": "exact_local_read_only",
+            "content_endorsed": false,
+            "evidence_quality_changed": false,
+            "governance_authorized": false,
+            "plan_apply_authorized": false,
+            "files_changed": false,
+            "state_files_changed": false,
+            "next_action": match policy {
+                PolicyError::FindingSnapshotNotCurrent { .. } => "scan_then_open_current_finding",
+                PolicyError::PermissionAlreadyRevoked { .. } => "inspect_source_root_permissions",
+                PolicyError::ActivePermissionIdentityDrift { .. } => "revoke_then_confirm_current_observed_target",
+                _ => "inspect_exact_source_root_facts",
+            }
+        });
+        if let (Some(details), Some(facts)) = (details.as_object_mut(), facts.as_object()) {
+            details.extend(facts.clone());
+        }
+        return ClassifiedError {
+            code: policy.code(),
+            retryable: false,
+            details: Some(details),
+        };
+    }
     if let Some(blocker) = error.downcast_ref::<IncompleteFingerprintBlocker>() {
         return ClassifiedError {
             code: "incomplete_package_fingerprint",
@@ -1095,6 +1275,7 @@ fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> 
             "source_confirmation_details": source_confirmation_detail_summary(state_dir)?,
             "current": lifecycle,
         },
+        "source_root_permissions": crate::source_policy::policy_value(store, true, 100, 0)?,
         "files_changed": false
     }))
 }
@@ -1122,6 +1303,7 @@ fn lifecycle_export_command(store: &StateStore, state_dir: &Path, output: &Path)
         "data": store.export_lifecycle()?,
         "evidence_exclusions": store.evidence_exclusions()?,
         "source_confirmation_details": source_confirmation_details,
+        "source_root_permissions": crate::source_policy::policy_export_value(store)?,
         "privacy": "derived summaries only; no raw conversation text",
     });
     let parent = output
@@ -1152,6 +1334,7 @@ fn lifecycle_export_command(store: &StateStore, state_dir: &Path, output: &Path)
         "output_path": output,
         "counts": store.lifecycle_counts()?,
         "source_confirmation_detail_count": source_confirmation_details.len(),
+        "source_root_permission_count": store.list_source_root_permissions()?.len(),
         "files_changed": true,
     }))
 }
@@ -1169,6 +1352,7 @@ fn lifecycle_inspect_command(
         "database_path": database_path,
         "counts": counts,
         "source_confirmation_details": source_confirmation_details,
+        "source_root_permissions": crate::source_policy::policy_value(store, true, 100, 0)?,
         "evidence_exclusions": store.evidence_exclusions()?,
         "recovery_state": recovery_text(store, state_dir)?,
         "privacy": "derived summaries only; no raw conversation text",
@@ -1706,6 +1890,23 @@ fn scan_command(
 ) -> Result<(Value, Vec<String>)> {
     let started = Utc::now().timestamp();
     let id = ScanId::new();
+    // Freeze durable read permissions once before discovery. Only exact roots
+    // whose path and stable filesystem identity still match enter the Scan;
+    // drift is local to that permission and persists as typed Snapshot facts.
+    let frozen_permissions = crate::source_policy::freeze_active_roots(store)?;
+    let durable_read_roots = frozen_permissions
+        .iter()
+        .filter(|root| root.state == crate::source_policy::SourceRootState::Active)
+        .filter_map(|root| {
+            root.resolved_path
+                .clone()
+                .map(|path| crate::scan::DurableReadRoot {
+                    permission_id: root.permission.id.as_str().to_owned(),
+                    path,
+                    identity: root.permission.identity.clone(),
+                })
+        })
+        .collect::<Vec<_>>();
     store.save_scan(&ScanRun {
         id: id.clone(),
         started_at: started,
@@ -1716,13 +1917,14 @@ fn scan_command(
     let mut options = ScanOptions::for_home(home);
     options.explicit_skill_roots = explicit;
     options.explicit_source_roots = source_roots;
+    options.durable_read_roots = durable_read_roots;
     options.managed_source_roots = vec![state_dir.join("library")];
     options.excluded_session_agents = store
         .evidence_exclusions()?
         .iter()
         .map(|agent| parse_agent_kind(agent))
         .collect::<Result<_>>()?;
-    let result = match scan::scan(&options) {
+    let mut result = match scan::scan(&options) {
         Ok(result) => result,
         Err(error) => {
             store.save_scan(&ScanRun {
@@ -1735,6 +1937,38 @@ fn scan_command(
             return Err(error.into());
         }
     };
+    let post_scan_permissions = match crate::source_policy::freeze_active_roots(store) {
+        Ok(permissions) => permissions,
+        Err(error) => {
+            store.save_scan(&ScanRun {
+                id,
+                started_at: started,
+                completed_at: Some(Utc::now().timestamp()),
+                status: ScanStatus::Failed,
+                coverage_notes: vec![error.to_string()],
+            })?;
+            return Err(error.into());
+        }
+    };
+    let policy_facts = conservative_source_policy_facts(
+        &frozen_permissions,
+        &post_scan_permissions,
+        &result.durable_read_drifted_permission_ids,
+    );
+    for fact in policy_facts
+        .iter()
+        .filter(|fact| fact.state != crate::source_policy::SourceRootState::Active)
+    {
+        result.warnings.push(format!(
+            "source-root permission {} is {} and was excluded: {}",
+            fact.permission_id,
+            serde_json::to_value(fact.state)?
+                .as_str()
+                .unwrap_or("drifted"),
+            fact.drift_reason.as_deref().unwrap_or("identity drift")
+        ));
+    }
+    result.source_root_policy = policy_facts;
     store.begin_scan_snapshot()?;
     let persistence = (|| -> Result<()> {
         persist_index(store, &id, &result)?;
@@ -1796,10 +2030,53 @@ fn scan_command(
             "placement_count": result.placements.len(),
             "roots": roots,
             "coverage": coverage,
+            "source_root_policy": {
+                "scope": "exact_local_read_only",
+                "content_endorsed": false,
+                "evidence_quality_changed": false,
+                "governance_authorized": false,
+                "permissions": result.source_root_policy,
+            },
             "files_changed": false
         }),
         warnings,
     ))
+}
+
+/// Merge policy observations conservatively across a Scan. Once a permission
+/// is observed drifted at any bounded checkpoint, a later path check cannot
+/// promote it back to Active. This also carries drift detected inside Scan
+/// discovery/consumption into the persisted Snapshot fact.
+fn conservative_source_policy_facts(
+    before: &[crate::source_policy::FrozenSourceRoot],
+    after: &[crate::source_policy::FrozenSourceRoot],
+    scan_drifted_permission_ids: &BTreeSet<String>,
+) -> Vec<crate::source_policy::SourceRootPolicyFact> {
+    let before_by_id = before
+        .iter()
+        .map(|root| (root.permission.id.as_str(), root))
+        .collect::<BTreeMap<_, _>>();
+    after
+        .iter()
+        .map(|root| {
+            let id = root.permission.id.as_str();
+            let mut fact = crate::source_policy::fact_from_frozen(root);
+            if let Some(previous) = before_by_id.get(id)
+                && previous.state != crate::source_policy::SourceRootState::Active
+                && fact.state == crate::source_policy::SourceRootState::Active
+            {
+                fact = crate::source_policy::fact_from_frozen(previous);
+            }
+            if scan_drifted_permission_ids.contains(id) {
+                fact.state = crate::source_policy::SourceRootState::Inaccessible;
+                fact.resolved_path = None;
+                fact.drift_reason = Some(
+                    "drift detected during bounded Scan checks; source root was excluded".into(),
+                );
+            }
+            fact
+        })
+        .collect()
 }
 
 fn compact_scan_warnings(warnings: Vec<String>) -> Vec<String> {
@@ -2194,6 +2471,12 @@ fn add_finding_resolution(object: &mut serde_json::Map<String, Value>) {
         "resolution".into(),
         json!({
             "decision": "confirm_trusted_source_roots",
+            "decision_semantics": "confirm_exact_local_read_permission",
+            "permission_scope": "exact_local_read_only",
+            "content_endorsed": false,
+            "evidence_quality_changed": false,
+            "governance_authorized": false,
+            "plan_apply_authorized": false,
             "automatic_change_supported": false,
             "observed_link_targets": observed_link_targets,
             "after_confirmation": {
@@ -2664,6 +2947,31 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
                     "finding_action_available",
                 ));
             }
+            if requires_trust_decision {
+                for path in result["resolution"]["observed_link_targets"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(Value::as_str)
+                    .take(10)
+                {
+                    actions.push(action(
+                        "confirm_source_root_read_permission",
+                        &[
+                            "source-root",
+                            "confirm",
+                            "--finding",
+                            id,
+                            "--path",
+                            path,
+                            "--json",
+                        ],
+                        true,
+                        true,
+                        "exact_local_source_read_permission_required",
+                    ));
+                }
+            }
             if !full {
                 let limit = limit.to_string();
                 let offset = offset.to_string();
@@ -3111,6 +3419,12 @@ fn finding_roster_planning(
             "supported": false,
             "reason": "trusted_canonical_sources_required",
             "decision": "confirm_trusted_source_roots",
+            "decision_semantics": "confirm_exact_local_read_permission",
+            "permission_scope": "exact_local_read_only",
+            "content_endorsed": false,
+            "evidence_quality_changed": false,
+            "governance_authorized": false,
+            "plan_apply_authorized": false,
             "automatic_change_supported": false,
             "snapshot_id": scan_id,
             "request_field": "finding_roster_changes",
@@ -7615,6 +7929,42 @@ fn action(
 mod recovery_tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn scan_detected_source_root_drift_cannot_be_promoted_back_to_active() {
+        let permission = crate::source_policy::SourceRootPermission {
+            id: crate::source_policy::SourcePermissionId::parse("sroot_fixture").unwrap(),
+            path: PathBuf::from("/fixture/source"),
+            finding_id: "finding_fixture".into(),
+            snapshot_id: "scan_fixture".into(),
+            identity: crate::source_policy::RootIdentity::Unavailable,
+            granted_at: 1,
+            revoked_at: None,
+        };
+        let active = crate::source_policy::FrozenSourceRoot {
+            permission,
+            state: crate::source_policy::SourceRootState::Active,
+            resolved_path: Some(PathBuf::from("/fixture/source")),
+            drift_reason: None,
+        };
+        let facts = conservative_source_policy_facts(
+            std::slice::from_ref(&active),
+            std::slice::from_ref(&active),
+            &BTreeSet::from(["sroot_fixture".into()]),
+        );
+
+        assert_eq!(
+            facts[0].state,
+            crate::source_policy::SourceRootState::Inaccessible
+        );
+        assert!(facts[0].resolved_path.is_none());
+        assert!(
+            facts[0]
+                .drift_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("during bounded Scan"))
+        );
+    }
 
     fn coverage_finding(basis: crate::query::FindingCoverageBasis) -> crate::query::Finding {
         crate::query::Finding {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,7 @@ impl Cli {
             Some(Command::Status) => "status",
             Some(Command::Lifecycle(_)) => "lifecycle",
             Some(Command::Setup(_)) => "setup",
+            Some(Command::SourceRoot(_)) => "source-root",
             None => "home",
         }
     }
@@ -71,6 +72,46 @@ pub enum Command {
     Lifecycle(LifecycleArgs),
     /// Preview bootstrap Skill installation or upgrade for detected Agents.
     Setup(SetupArgs),
+    /// Confirm, inspect, or revoke exact local source-root read permissions.
+    SourceRoot(SourceRootArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct SourceRootArgs {
+    #[command(subcommand)]
+    pub command: SourceRootCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SourceRootCommand {
+    /// Permit factual reads of one exact target observed by an escaping-link Finding.
+    Confirm(SourceRootConfirmArgs),
+    /// Inspect active, revoked, and drifted local read permissions.
+    Inspect(SourceRootInspectArgs),
+    /// Revoke one exact local read permission by opaque ID.
+    Revoke(IdArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct SourceRootInspectArgs {
+    /// Maximum permission records returned in this page.
+    #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u16).range(1..=100))]
+    pub limit: u16,
+
+    /// Zero-based permission-record offset.
+    #[arg(long, default_value_t = 0)]
+    pub offset: u32,
+}
+
+#[derive(Debug, Args)]
+pub struct SourceRootConfirmArgs {
+    /// Current escaping-link Finding that observed the exact target.
+    #[arg(long)]
+    pub finding: String,
+
+    /// Exact absolute observed canonical directory.
+    #[arg(long)]
+    pub path: PathBuf,
 }
 
 #[derive(Debug, Args)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,5 @@ pub mod query;
 pub mod roster_plan;
 pub mod roster_recommendation;
 pub mod scan;
+pub mod source_policy;
 pub mod sqlite;

--- a/src/model.rs
+++ b/src/model.rs
@@ -74,6 +74,15 @@ pub struct InvalidId {
     value: String,
 }
 
+impl InvalidId {
+    pub(crate) fn new(expected_prefix: &'static str, value: impl Into<String>) -> Self {
+        Self {
+            expected_prefix,
+            value: value.into(),
+        }
+    }
+}
+
 impl fmt::Display for InvalidId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(

--- a/src/present.rs
+++ b/src/present.rs
@@ -167,6 +167,7 @@ fn render(command: &str, result: &Value, options: RenderOptions) -> String {
         "plan" => plan(result, &mut lines, options.width),
         "apply" | "undo" => mutation(result, &mut lines),
         "lifecycle" => lifecycle(result, &mut lines),
+        "source-root" => source_root(result, &mut lines),
         "setup" => setup(result, &mut lines, options.width),
         _ => home(result, &mut lines),
     }
@@ -194,11 +195,11 @@ pub fn blocked_roster_plan(details: &Value) -> String {
 
 fn blocked_roster_plan_lines(details: &Value, lines: &mut Vec<String>, width: usize) {
     fact(lines, "Status", "blocked");
-    fact(
-        lines,
-        "Decision",
-        text(details, "decision").replace('_', " "),
-    );
+    let decision = match text(details, "decision").as_str() {
+        "confirm_trusted_source_roots" => "confirm exact local reads".to_owned(),
+        other => other.replace('_', " "),
+    };
+    fact(lines, "Decision", decision);
     fact(lines, "Core budget", text(details, "requested_core_budget"));
     fact(
         lines,
@@ -281,7 +282,7 @@ fn blocked_roster_plan_lines(details: &Value, lines: &mut Vec<String>, width: us
     }
     lines.extend(summary(
         "Blocked · no automatic change is supported",
-        "Confirm the reported source directories before rescanning",
+        "Permit exact local reads, then rescan",
     ));
 }
 
@@ -642,7 +643,7 @@ fn finding_report(value: &Value, lines: &mut Vec<String>, width: usize) {
         }
         lines.extend(summary(
             "Blocked · no automatic change is supported",
-            "Confirm trusted source directories before rescanning",
+            "Permit exact local reads before rescanning",
         ));
     } else if value["resolution"]["decision"].as_str() == Some("choose_same_name_variant") {
         lines.push(String::new());
@@ -1673,6 +1674,48 @@ fn lifecycle(value: &Value, lines: &mut Vec<String>) {
             "Inspect JSON for details",
         )),
     }
+}
+
+fn source_root(value: &Value, lines: &mut Vec<String>) {
+    let operation = text(value, "operation");
+    fact(lines, "Operation", &operation);
+    fact(lines, "Scope", "exact local reads only");
+    match operation.as_str() {
+        "confirm" | "revoke" => {
+            fact(
+                lines,
+                "Permission",
+                text(&value["permission"], "permission_id"),
+            );
+            fact(lines, "Path", text(&value["permission"], "path"));
+            fact(lines, "State", text(&value["permission"], "state"));
+        }
+        "inspect" => {
+            fact(lines, "Active", text(value, "active_count"));
+            fact(lines, "Revoked", text(value, "revoked_count"));
+            for permission in value["permissions"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .take(5)
+            {
+                fact(
+                    lines,
+                    &text(permission, "state"),
+                    format!(
+                        "{} · {}",
+                        text(permission, "permission_id"),
+                        text(permission, "path")
+                    ),
+                );
+            }
+        }
+        _ => {}
+    }
+    lines.extend(summary(
+        "Local policy only · no Agent or Skill files changed",
+        "Read permission does not endorse content, raise Evidence quality, or authorize governance",
+    ));
 }
 
 fn home(value: &Value, lines: &mut Vec<String>) {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -25,11 +25,22 @@ pub struct ScanOptions {
     pub home: PathBuf,
     pub explicit_skill_roots: Vec<ExplicitSkillRoot>,
     pub explicit_source_roots: Vec<PathBuf>,
+    /// Durable permissions restore factual reads only. Unlike temporary
+    /// `explicit_source_roots`, they never make a placement governable.
+    #[serde(default)]
+    pub durable_read_roots: Vec<DurableReadRoot>,
     #[serde(default)]
     pub managed_source_roots: Vec<PathBuf>,
     pub excluded_session_agents: BTreeSet<AgentKind>,
     pub include_session_evidence: bool,
     pub max_depth: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DurableReadRoot {
+    pub permission_id: String,
+    pub path: PathBuf,
+    pub identity: crate::source_policy::RootIdentity,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -44,6 +55,7 @@ impl ScanOptions {
             home: home.into(),
             explicit_skill_roots: Vec::new(),
             explicit_source_roots: Vec::new(),
+            durable_read_roots: Vec::new(),
             managed_source_roots: Vec::new(),
             excluded_session_agents: BTreeSet::new(),
             include_session_evidence: true,
@@ -304,6 +316,14 @@ pub struct ScanResult {
     pub usage: Vec<UsageEvidence>,
     pub coverage: Vec<SessionCoverage>,
     pub warnings: Vec<String>,
+    /// Durable source-root read permissions frozen before this Scan. Drifted
+    /// permissions remain typed facts but are excluded from approved roots.
+    #[serde(default)]
+    pub source_root_policy: Vec<crate::source_policy::SourceRootPolicyFact>,
+    /// Permission IDs whose bounded discovery or consumption checks observed
+    /// drift, even if a later path check appears active again.
+    #[serde(default)]
+    pub durable_read_drifted_permission_ids: BTreeSet<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -313,6 +333,9 @@ struct EntryCandidate {
     governable: bool,
     provider: Option<String>,
     entrypoint: PathBuf,
+    /// Canonical physical Skill directory resolved during discovery. Durable
+    /// reads must remain bound to this exact directory at consumption time.
+    expected_physical_directory: Option<PathBuf>,
     link_target: Option<PathBuf>,
     link_status: LinkStatus,
 }
@@ -716,6 +739,19 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
         .chain(options.explicit_source_roots.iter().cloned())
         .chain(confirmed_source_roots.iter().cloned())
         .collect::<Vec<_>>();
+    let approved_roots = normalized_confirmed_source_roots(&approved_roots);
+    // Durable paths were already canonicalized and identity-frozen by the
+    // caller. Never canonicalize them again here: a post-freeze retarget must
+    // not become an approved root.
+    let mut approved_roots = approved_roots;
+    approved_roots.extend(
+        options
+            .durable_read_roots
+            .iter()
+            .map(|root| root.path.clone()),
+    );
+    approved_roots.sort();
+    approved_roots.dedup();
     let mut candidates = Vec::new();
 
     for roots in &known {
@@ -768,6 +804,22 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
             &mut candidates,
         );
     }
+    for root in &options.durable_read_roots {
+        observe_durable_skill_root(
+            root,
+            SkillRootPolicy {
+                agent: None,
+                explicit: true,
+                governable: false,
+                detail: Some("durable exact local read permission; not governable".into()),
+                provider: None,
+            },
+            &approved_roots,
+            options.max_depth,
+            &mut result,
+            &mut candidates,
+        );
+    }
     for root in &options.explicit_skill_roots {
         observe_skill_root(
             &root.path,
@@ -801,7 +853,12 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
         );
     }
 
-    materialize_candidates(candidates, &mut result);
+    materialize_candidates(
+        candidates,
+        &options.durable_read_roots,
+        &confirmed_source_roots,
+        &mut result,
+    );
 
     if options.include_session_evidence {
         for roots in &known {
@@ -925,6 +982,89 @@ fn observe_skill_root(
     }
 }
 
+fn observe_durable_skill_root(
+    root: &DurableReadRoot,
+    policy: SkillRootPolicy,
+    approved_roots: &[PathBuf],
+    max_depth: usize,
+    result: &mut ScanResult,
+    candidates: &mut Vec<EntryCandidate>,
+) {
+    observe_durable_skill_root_with_hook(
+        root,
+        policy,
+        approved_roots,
+        max_depth,
+        result,
+        candidates,
+        |_| {},
+    );
+}
+
+fn observe_durable_skill_root_with_hook(
+    root: &DurableReadRoot,
+    policy: SkillRootPolicy,
+    approved_roots: &[PathBuf],
+    max_depth: usize,
+    result: &mut ScanResult,
+    candidates: &mut Vec<EntryCandidate>,
+    mut before_enumerate: impl FnMut(&Path),
+) {
+    let reject = |detail: &str, result: &mut ScanResult| {
+        result
+            .durable_read_drifted_permission_ids
+            .insert(root.permission_id.clone());
+        result.roots.push(RootObservation {
+            agent: policy.agent,
+            kind: RootKind::Skills,
+            path: root.path.clone(),
+            status: RootStatus::Inaccessible,
+            explicit: policy.explicit,
+            detail: Some(detail.into()),
+            discovery_complete: false,
+        });
+        result.warnings.push(format!(
+            "excluded durable source root {}: {detail}",
+            root.path.display()
+        ));
+    };
+    if !crate::source_policy::identity_matches_exact(&root.path, &root.identity) {
+        reject("identity drift before enumeration", result);
+        return;
+    }
+    before_enumerate(&root.path);
+    if !crate::source_policy::identity_matches_exact(&root.path, &root.identity) {
+        reject("identity drift immediately before enumeration", result);
+        return;
+    }
+    let root_index = result.roots.len();
+    let candidate_start = candidates.len();
+    observe_skill_root(
+        &root.path,
+        policy,
+        approved_roots,
+        max_depth,
+        result,
+        candidates,
+    );
+    if !crate::source_policy::identity_matches_exact(&root.path, &root.identity) {
+        result
+            .durable_read_drifted_permission_ids
+            .insert(root.permission_id.clone());
+        candidates.truncate(candidate_start);
+        if let Some(observation) = result.roots.get_mut(root_index) {
+            observation.status = RootStatus::Inaccessible;
+            observation.discovery_complete = false;
+            observation.detail =
+                Some("identity drift during enumeration; candidates discarded".into());
+        }
+        result.warnings.push(format!(
+            "discarded durable source-root candidates after identity drift: {}",
+            root.path.display()
+        ));
+    }
+}
+
 fn discover_entrypoints(
     policy: &SkillRootPolicy,
     placement_root: &Path,
@@ -951,6 +1091,7 @@ fn discover_entrypoints(
                 root: placement_root.to_path_buf(),
                 governable: policy.governable,
                 provider: policy.provider.clone(),
+                expected_physical_directory: canonical_entrypoint_directory(&path),
                 entrypoint: path,
                 link_target: target,
                 link_status,
@@ -976,6 +1117,7 @@ fn discover_entrypoints(
                     root: placement_root.to_path_buf(),
                     governable: policy.governable,
                     provider: policy.provider.clone(),
+                    expected_physical_directory: canonical_entrypoint_directory(&linked_entrypoint),
                     entrypoint: linked_entrypoint,
                     link_target: target,
                     link_status: status,
@@ -1033,11 +1175,7 @@ fn canonical_existing_ancestor(path: &Path) -> Option<PathBuf> {
 }
 
 fn is_within_resolved_root(path: &Path, approved_roots: &[PathBuf]) -> bool {
-    approved_roots.iter().any(|root| {
-        fs::canonicalize(root)
-            .map(|root| path.starts_with(root))
-            .unwrap_or(false)
-    })
+    approved_roots.iter().any(|root| path.starts_with(root))
 }
 
 fn lexical_normalize(path: &Path) -> PathBuf {
@@ -1054,7 +1192,46 @@ fn lexical_normalize(path: &Path) -> PathBuf {
     normalized
 }
 
-fn materialize_candidates(candidates: Vec<EntryCandidate>, result: &mut ScanResult) {
+fn canonical_entrypoint_directory(entrypoint: &Path) -> Option<PathBuf> {
+    fs::canonicalize(entrypoint)
+        .ok()
+        .and_then(|entrypoint| entrypoint.parent().map(Path::to_path_buf))
+}
+
+fn durable_candidate_binding_is_current(
+    candidate: &EntryCandidate,
+    anchor: &DurableReadRoot,
+) -> bool {
+    let Some(expected) = candidate.expected_physical_directory.as_ref() else {
+        return false;
+    };
+    expected.starts_with(&anchor.path)
+        && crate::source_policy::identity_matches_exact(&anchor.path, &anchor.identity)
+        && canonical_entrypoint_directory(&candidate.entrypoint).as_ref() == Some(expected)
+}
+
+fn materialize_candidates(
+    candidates: Vec<EntryCandidate>,
+    durable_read_roots: &[DurableReadRoot],
+    temporary_source_roots: &[PathBuf],
+    result: &mut ScanResult,
+) {
+    materialize_candidates_with_hook(
+        candidates,
+        durable_read_roots,
+        temporary_source_roots,
+        result,
+        |_| {},
+    );
+}
+
+fn materialize_candidates_with_hook(
+    candidates: Vec<EntryCandidate>,
+    durable_read_roots: &[DurableReadRoot],
+    temporary_source_roots: &[PathBuf],
+    result: &mut ScanResult,
+    mut before_read: impl FnMut(&Path),
+) {
     let mut skills = BTreeMap::<String, ScannedSkill>::new();
     for candidate in candidates {
         let directory = candidate
@@ -1062,11 +1239,29 @@ fn materialize_candidates(candidates: Vec<EntryCandidate>, result: &mut ScanResu
             .parent()
             .unwrap_or(&candidate.root)
             .to_path_buf();
-        let safe_to_read = !matches!(
+        let expected_directory = candidate.expected_physical_directory.as_ref();
+        let temporary_override = expected_directory.is_some_and(|resolved| {
+            temporary_source_roots
+                .iter()
+                .any(|root| resolved.starts_with(root))
+        });
+        let durable_anchor = (!temporary_override)
+            .then(|| {
+                durable_read_roots.iter().find(|root| {
+                    candidate.entrypoint.starts_with(&root.path)
+                        || expected_directory
+                            .is_some_and(|resolved| resolved.starts_with(&root.path))
+                })
+            })
+            .flatten();
+        before_read(&candidate.entrypoint);
+        let binding_valid_before_read = durable_anchor
+            .is_none_or(|root| durable_candidate_binding_is_current(&candidate, root));
+        let initially_safe = !matches!(
             candidate.link_status,
             LinkStatus::Broken | LinkStatus::EscapesRoot
-        );
-        let (content, modified_at) = if safe_to_read {
+        ) && binding_valid_before_read;
+        let (mut content, mut modified_at) = if initially_safe {
             match read_bounded(&candidate.entrypoint, MAX_SKILL_FILE_BYTES) {
                 Ok(value) => value,
                 Err(error) => {
@@ -1084,8 +1279,8 @@ fn materialize_candidates(candidates: Vec<EntryCandidate>, result: &mut ScanResu
             ));
             (String::new(), None)
         };
-        let metadata = parse_skill_markdown(&content);
-        let (digest, fingerprint_completeness, fingerprint_detail) = if safe_to_read {
+        let mut metadata = parse_skill_markdown(&content);
+        let (mut digest, mut fingerprint_completeness, mut fingerprint_detail) = if initially_safe {
             match digest_skill_directory(&directory) {
                 Ok(fingerprint) => (
                     fingerprint.digest,
@@ -1116,6 +1311,38 @@ fn materialize_candidates(candidates: Vec<EntryCandidate>, result: &mut ScanResu
                 Some("Skill package was not read because its link is unsafe".into()),
             )
         };
+        let mut executable_files = if initially_safe {
+            executable_files(&directory).unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let binding_valid_after = durable_anchor
+            .is_none_or(|root| durable_candidate_binding_is_current(&candidate, root));
+        let safe_to_read = initially_safe && binding_valid_after;
+        if durable_anchor.is_some() && (!binding_valid_before_read || !binding_valid_after) {
+            if let Some(root) = durable_anchor {
+                result
+                    .durable_read_drifted_permission_ids
+                    .insert(root.permission_id.clone());
+            }
+            // The root or candidate binding changed at a bounded pre/post
+            // checkpoint. Discard every byte and derived fact; replacement
+            // content must not enter identity, search, Evidence, or governance.
+            result.warnings.push(format!(
+                "discarded Skill data after durable source-root binding drift: {}",
+                candidate.entrypoint.display()
+            ));
+            content.clear();
+            modified_at = None;
+            metadata = SkillMetadata::default();
+            digest = stable_digest(candidate.entrypoint.to_string_lossy().as_bytes());
+            fingerprint_completeness = FingerprintCompleteness::Unreadable;
+            fingerprint_detail = Some(
+                "Skill package data was discarded because its durable read permission drifted"
+                    .into(),
+            );
+            executable_files.clear();
+        }
         let identity_basis = match (&metadata.source, &metadata.version, &metadata.revision) {
             (Some(source), Some(version), _) => format!("source:{source}@{version}"),
             (Some(source), _, Some(revision)) => format!("source:{source}@{revision}"),
@@ -1133,11 +1360,6 @@ fn materialize_candidates(candidates: Vec<EntryCandidate>, result: &mut ScanResu
             })
             .unwrap_or_else(|| "unnamed".into());
         let normalized_text = normalize_search_text(&content);
-        let executable_files = if safe_to_read {
-            executable_files(&directory).unwrap_or_default()
-        } else {
-            Vec::new()
-        };
         let physical_directory = safe_to_read.then(|| {
             fs::canonicalize(&candidate.entrypoint)
                 .ok()
@@ -1182,7 +1404,7 @@ fn materialize_candidates(candidates: Vec<EntryCandidate>, result: &mut ScanResu
             link_target: candidate.link_target,
             link_status: candidate.link_status,
             default_exposed: candidate.agent.is_some(),
-            governable: candidate.governable,
+            governable: candidate.governable && durable_anchor.is_none(),
             provider: candidate.provider,
             executable_files,
             declared_name_matches_directory,
@@ -2791,6 +3013,184 @@ enabled = true
             fs::canonicalize(source_root).unwrap()
         );
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_read_discards_content_replaced_after_the_pre_read_identity_check() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_input = temp.path().join("source");
+        fs::create_dir(&source_input).unwrap();
+        fs::write(
+            source_input.join("SKILL.md"),
+            "---\nname: before\n---\noriginal body\n",
+        )
+        .unwrap();
+        let source = fs::canonicalize(&source_input).unwrap();
+        let agent_root = temp.path().join("agent");
+        fs::create_dir(&agent_root).unwrap();
+        let linked = agent_root.join("external");
+        std::os::unix::fs::symlink(&source, &linked).unwrap();
+        let anchor = DurableReadRoot {
+            permission_id: "sroot_replaced_during_read".into(),
+            path: source.clone(),
+            identity: crate::source_policy::capture_identity(&source).unwrap(),
+        };
+        let candidate = EntryCandidate {
+            agent: Some(AgentKind::Codex),
+            root: agent_root,
+            governable: true,
+            provider: None,
+            expected_physical_directory: Some(source.clone()),
+            entrypoint: linked.join("SKILL.md"),
+            link_target: Some(source.clone()),
+            link_status: LinkStatus::Valid,
+        };
+        let mut result = ScanResult::default();
+        let mut replaced = false;
+        materialize_candidates_with_hook(vec![candidate], &[anchor], &[], &mut result, |_| {
+            if replaced {
+                return;
+            }
+            fs::remove_dir_all(&source).unwrap();
+            fs::create_dir(&source).unwrap();
+            fs::write(
+                source.join("SKILL.md"),
+                "---\nname: replacement-secret\n---\nDO-NOT-ADOPT-SECRET\n",
+            )
+            .unwrap();
+            replaced = true;
+        });
+
+        assert_eq!(result.placements.len(), 1);
+        assert_eq!(
+            result.placements[0].fingerprint_completeness,
+            FingerprintCompleteness::Unreadable
+        );
+        assert!(!result.placements[0].governable);
+        assert!(result.placements[0].physical_directory.is_none());
+        let encoded = serde_json::to_string(&result).unwrap();
+        assert!(!encoded.contains("replacement-secret"));
+        assert!(!encoded.contains("DO-NOT-ADOPT-SECRET"));
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("binding drift"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_read_rejects_an_agent_symlink_retargeted_before_read() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_input = temp.path().join("source");
+        fs::create_dir(&source_input).unwrap();
+        fs::write(
+            source_input.join("SKILL.md"),
+            "---\nname: permitted\n---\npermitted body\n",
+        )
+        .unwrap();
+        let source = fs::canonicalize(&source_input).unwrap();
+        let external = temp.path().join("external");
+        fs::create_dir(&external).unwrap();
+        fs::write(
+            external.join("SKILL.md"),
+            "---\nname: external-marker\n---\nEXTERNAL-SECRET-MARKER\n",
+        )
+        .unwrap();
+        let agent_root = temp.path().join("agent");
+        fs::create_dir(&agent_root).unwrap();
+        let linked = agent_root.join("external");
+        std::os::unix::fs::symlink(&source, &linked).unwrap();
+        let anchor = DurableReadRoot {
+            permission_id: "sroot_retargeted_entrypoint".into(),
+            path: source.clone(),
+            identity: crate::source_policy::capture_identity(&source).unwrap(),
+        };
+        let candidate = EntryCandidate {
+            agent: Some(AgentKind::Codex),
+            root: agent_root,
+            governable: true,
+            provider: None,
+            entrypoint: linked.join("SKILL.md"),
+            expected_physical_directory: Some(source.clone()),
+            link_target: Some(source),
+            link_status: LinkStatus::Valid,
+        };
+        let mut result = ScanResult::default();
+        materialize_candidates_with_hook(vec![candidate], &[anchor], &[], &mut result, |_| {
+            fs::remove_file(&linked).unwrap();
+            std::os::unix::fs::symlink(&external, &linked).unwrap();
+        });
+
+        assert_eq!(result.placements.len(), 1);
+        assert_eq!(
+            result.placements[0].fingerprint_completeness,
+            FingerprintCompleteness::Unreadable
+        );
+        assert!(!result.placements[0].governable);
+        assert!(result.placements[0].physical_directory.is_none());
+        let encoded = serde_json::to_string(&result).unwrap();
+        assert!(!encoded.contains("external-marker"));
+        assert!(!encoded.contains("EXTERNAL-SECRET-MARKER"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_root_replacement_before_enumeration_discards_all_candidates() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_input = temp.path().join("source");
+        fs::create_dir_all(source_input.join("permitted-name")).unwrap();
+        fs::write(
+            source_input.join("permitted-name/SKILL.md"),
+            "---\nname: permitted-name\n---\n",
+        )
+        .unwrap();
+        let source = fs::canonicalize(&source_input).unwrap();
+        let anchor = DurableReadRoot {
+            permission_id: "sroot_replaced_before_enumeration".into(),
+            path: source.clone(),
+            identity: crate::source_policy::capture_identity(&source).unwrap(),
+        };
+        let mut result = ScanResult::default();
+        let mut candidates = Vec::new();
+        observe_durable_skill_root_with_hook(
+            &anchor,
+            SkillRootPolicy {
+                agent: None,
+                explicit: true,
+                governable: false,
+                detail: Some("durable read-only fixture".into()),
+                provider: None,
+            },
+            std::slice::from_ref(&source),
+            5,
+            &mut result,
+            &mut candidates,
+            |_| {
+                fs::remove_dir_all(&source).unwrap();
+                fs::create_dir_all(source.join("substitute-secret-name")).unwrap();
+                fs::write(
+                    source.join("substitute-secret-name/SKILL.md"),
+                    "---\nname: SUBSTITUTE-SECRET-NAME\n---\n",
+                )
+                .unwrap();
+            },
+        );
+
+        assert!(candidates.is_empty());
+        assert_eq!(result.roots.len(), 1);
+        assert_eq!(result.roots[0].status, RootStatus::Inaccessible);
+        assert!(!result.roots[0].discovery_complete);
+        assert!(
+            result
+                .durable_read_drifted_permission_ids
+                .contains("sroot_replaced_before_enumeration")
+        );
+        let encoded = serde_json::to_string(&result).unwrap();
+        assert!(!encoded.contains("substitute-secret-name"));
+        assert!(!encoded.contains("SUBSTITUTE-SECRET-NAME"));
     }
 
     #[test]

--- a/src/source_policy.rs
+++ b/src/source_policy.rs
@@ -129,7 +129,7 @@ pub(crate) fn capture_identity(path: &Path) -> io::Result<RootIdentity> {
             std::ptr::null(),
             OPEN_EXISTING,
             FILE_FLAG_BACKUP_SEMANTICS,
-            0,
+            std::ptr::null_mut(),
         )
     };
     if handle == INVALID_HANDLE_VALUE || handle.is_null() {

--- a/src/source_policy.rs
+++ b/src/source_policy.rs
@@ -79,20 +79,25 @@ impl fmt::Display for SourcePermissionId {
 
 /// Stable filesystem identity captured when a permission is granted.
 ///
-/// POSIX uses device + inode; Windows uses the volume serial paired with the
-/// 64-bit file index reported by `GetFileInformationByHandle`. A volume whose
-/// filesystem exposes no stable index reports `Unavailable`, and drift
-/// detection then degrades to exact resolved-path equality.
+/// POSIX uses device + inode plus the inode change-time epoch so immediate
+/// inode reuse cannot make a replacement look like the approved object.
+/// Windows pairs volume + file index with the object's creation time for the
+/// same reason. A platform without these facts reports `Unavailable`, and
+/// drift detection then degrades to exact resolved-path equality.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RootIdentity {
     Posix {
         dev: u64,
         ino: u64,
+        ctime: i64,
+        ctime_nsec: i64,
     },
     Windows {
         volume_serial: u32,
         file_index_high: u32,
         file_index_low: u32,
+        creation_time_high: u32,
+        creation_time_low: u32,
     },
     Unavailable,
 }
@@ -104,6 +109,8 @@ pub(crate) fn capture_identity(path: &Path) -> io::Result<RootIdentity> {
     Ok(RootIdentity::Posix {
         dev: metadata.dev(),
         ino: metadata.ino(),
+        ctime: metadata.ctime(),
+        ctime_nsec: metadata.ctime_nsec(),
     })
 }
 
@@ -145,6 +152,8 @@ pub(crate) fn capture_identity(path: &Path) -> io::Result<RootIdentity> {
         volume_serial: information.dwVolumeSerialNumber,
         file_index_high: information.nFileIndexHigh,
         file_index_low: information.nFileIndexLow,
+        creation_time_high: information.ftCreationTime.dwHighDateTime,
+        creation_time_low: information.ftCreationTime.dwLowDateTime,
     })
 }
 
@@ -589,16 +598,31 @@ fn lexical_normalize(path: &Path) -> PathBuf {
 
 pub fn identity_json(identity: &RootIdentity) -> Value {
     match identity {
-        RootIdentity::Posix { dev, ino } => json!({ "kind": "posix", "dev": dev, "ino": ino }),
+        RootIdentity::Posix {
+            dev,
+            ino,
+            ctime,
+            ctime_nsec,
+        } => json!({
+            "kind": "posix",
+            "dev": dev,
+            "ino": ino,
+            "ctime": ctime,
+            "ctime_nsec": ctime_nsec
+        }),
         RootIdentity::Windows {
             volume_serial,
             file_index_high,
             file_index_low,
+            creation_time_high,
+            creation_time_low,
         } => json!({
             "kind": "windows",
             "volume_serial": volume_serial,
             "file_index_high": file_index_high,
-            "file_index_low": file_index_low
+            "file_index_low": file_index_low,
+            "creation_time_high": creation_time_high,
+            "creation_time_low": creation_time_low
         }),
         RootIdentity::Unavailable => json!({ "kind": "unavailable" }),
     }

--- a/src/source_policy.rs
+++ b/src/source_policy.rs
@@ -1,0 +1,873 @@
+//! Deep local policy for durable, exact source-root read permissions.
+//!
+//! This module owns `source-root confirm`, `source-root inspect`,
+//! `source-root revoke`, and scan-time freezing. SQLite persistence and
+//! platform-specific filesystem identity stay internal and locally
+//! substitutable; the rest of the crate sees only typed local-policy facts.
+//!
+//! A permission binds one exact observed canonical source directory to one
+//! current completed Snapshot/Finding. It restores factual scanning only: it
+//! never adds Agent exposure, marks a source safe, authorizes governance,
+//! or enters Plan/Apply/Receipt semantics.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::model::FindingRecord;
+use crate::scan::{LinkStatus, ScanResult};
+use crate::sqlite::{StateStore, StorageResult};
+
+/// Stable Finding title a confirmation may be bound to.
+pub const ESCAPING_LINK_FINDING_TITLE: &str = "Skill links escape an approved root";
+
+static NEXT_PERMISSION_ID: AtomicU64 = AtomicU64::new(0);
+
+fn opaque_permission_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let sequence = NEXT_PERMISSION_ID.fetch_add(1, Ordering::Relaxed) as u128;
+    let process = std::process::id() as u128;
+    format!("sroot_{:032x}", nanos ^ (process << 64) ^ sequence)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SourcePermissionId(String);
+
+impl SourcePermissionId {
+    pub fn new() -> Self {
+        Self(opaque_permission_id())
+    }
+
+    pub fn parse(value: impl Into<String>) -> Result<Self, crate::model::InvalidId> {
+        let value = value.into();
+        if value.starts_with("sroot_") && value.len() > "sroot_".len() {
+            Ok(Self(value))
+        } else {
+            Err(crate::model::InvalidId::new("sroot", value))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for SourcePermissionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for SourcePermissionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Stable filesystem identity captured when a permission is granted.
+///
+/// POSIX uses device + inode; Windows uses the volume serial paired with the
+/// 64-bit file index reported by `GetFileInformationByHandle`. A volume whose
+/// filesystem exposes no stable index reports `Unavailable`, and drift
+/// detection then degrades to exact resolved-path equality.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RootIdentity {
+    Posix {
+        dev: u64,
+        ino: u64,
+    },
+    Windows {
+        volume_serial: u32,
+        file_index_high: u32,
+        file_index_low: u32,
+    },
+    Unavailable,
+}
+
+#[cfg(unix)]
+pub(crate) fn capture_identity(path: &Path) -> io::Result<RootIdentity> {
+    use std::os::unix::fs::MetadataExt;
+    let metadata = fs::metadata(path)?;
+    Ok(RootIdentity::Posix {
+        dev: metadata.dev(),
+        ino: metadata.ino(),
+    })
+}
+
+#[cfg(windows)]
+pub(crate) fn capture_identity(path: &Path) -> io::Result<RootIdentity> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, GetFileInformationByHandle,
+        OPEN_EXISTING,
+    };
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            0,
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE || handle.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let mut information = unsafe { std::mem::zeroed::<BY_HANDLE_FILE_INFORMATION>() };
+    let ok = unsafe { GetFileInformationByHandle(handle, &mut information) };
+    unsafe { CloseHandle(handle) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(RootIdentity::Windows {
+        volume_serial: information.dwVolumeSerialNumber,
+        file_index_high: information.nFileIndexHigh,
+        file_index_low: information.nFileIndexLow,
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn capture_identity(_path: &Path) -> io::Result<RootIdentity> {
+    Ok(RootIdentity::Unavailable)
+}
+
+pub(crate) fn identity_matches_exact(path: &Path, identity: &RootIdentity) -> bool {
+    fs::canonicalize(path).ok().as_deref() == Some(path)
+        && capture_identity(path).is_ok_and(|current| &current == identity)
+}
+
+/// One durable local read permission for one exact canonical source directory.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SourceRootPermission {
+    pub id: SourcePermissionId,
+    /// Exact canonical source directory the user confirmed, as observed.
+    pub path: PathBuf,
+    /// Escaping-link Finding the confirmation was bound to.
+    pub finding_id: String,
+    /// Completed Snapshot that Finding belonged to.
+    pub snapshot_id: String,
+    pub identity: RootIdentity,
+    pub granted_at: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<i64>,
+}
+
+/// Typed freeze state of one granted root at scan time.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceRootState {
+    /// Resolved to the granted canonical path with the granted identity.
+    Active,
+    /// The granted path no longer exists.
+    Missing,
+    /// The granted path exists but could not be resolved or identified.
+    Inaccessible,
+    /// The granted canonical path resolves to the same path but the
+    /// filesystem object at it has a different identity.
+    Replaced,
+    /// The granted canonical path now resolves to a different path.
+    Retargeted,
+}
+
+/// Persisted typed drift/policy fact carried by one Snapshot payload.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SourceRootPolicyFact {
+    pub permission_id: String,
+    pub granted_path: PathBuf,
+    pub granted_at: i64,
+    pub state: SourceRootState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drift_reason: Option<String>,
+}
+
+/// One frozen (resolved) view of a persisted active permission.
+#[derive(Clone, Debug)]
+pub struct FrozenSourceRoot {
+    pub permission: SourceRootPermission,
+    pub state: SourceRootState,
+    pub resolved_path: Option<PathBuf>,
+    pub drift_reason: Option<String>,
+}
+
+/// Typed `source-root` policy errors with stable codes for JSON envelopes.
+#[derive(Debug)]
+pub enum SourceRootPolicyError {
+    FindingNotFound {
+        finding_id: String,
+    },
+    NotEscapingLinkFinding {
+        finding_id: String,
+    },
+    FindingSnapshotNotCurrent {
+        finding_id: String,
+        finding_snapshot: String,
+        current_snapshot: String,
+    },
+    PathNotResolvable {
+        path: PathBuf,
+        reason: String,
+    },
+    PathNotObservedTarget {
+        path: PathBuf,
+    },
+    PathNotDirectory {
+        path: PathBuf,
+    },
+    PermissionNotFound {
+        permission_id: String,
+    },
+    PermissionAlreadyRevoked {
+        permission_id: String,
+    },
+    ActivePermissionIdentityDrift {
+        permission_id: String,
+        path: PathBuf,
+    },
+}
+
+impl SourceRootPolicyError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::FindingNotFound { .. } => "source_root_finding_not_found",
+            Self::FindingSnapshotNotCurrent { .. } => "source_root_finding_stale",
+            Self::NotEscapingLinkFinding { .. } => "source_root_finding_not_escaping",
+            Self::PathNotResolvable { .. } => "source_root_path_not_resolvable",
+            Self::PathNotObservedTarget { .. } => "source_root_path_not_observed",
+            Self::PathNotDirectory { .. } => "source_root_path_not_directory",
+            Self::PermissionNotFound { .. } => "source_root_permission_not_found",
+            Self::PermissionAlreadyRevoked { .. } => "source_root_permission_already_revoked",
+            Self::ActivePermissionIdentityDrift { .. } => "source_root_permission_identity_drift",
+        }
+    }
+}
+
+impl fmt::Display for SourceRootPolicyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FindingNotFound { finding_id } => {
+                write!(formatter, "Finding {finding_id} does not exist")
+            }
+            Self::FindingSnapshotNotCurrent {
+                finding_id,
+                finding_snapshot,
+                current_snapshot,
+            } => write!(
+                formatter,
+                "Finding {finding_id} belongs to Snapshot {finding_snapshot}, but the current completed Snapshot is {current_snapshot}; rescan and confirm against the current Finding"
+            ),
+            Self::NotEscapingLinkFinding { finding_id } => write!(
+                formatter,
+                "Finding {finding_id} is not a '{ESCAPING_LINK_FINDING_TITLE}' Finding and cannot confirm a source root"
+            ),
+            Self::PathNotResolvable { path, reason } => write!(
+                formatter,
+                "cannot resolve source root {}: {reason}",
+                path.display()
+            ),
+            Self::PathNotObservedTarget { path } => write!(
+                formatter,
+                "{} was not observed as an exact escaping link target in the bound Snapshot; confirm only an exact observed target",
+                path.display()
+            ),
+            Self::PathNotDirectory { path } => write!(
+                formatter,
+                "confirmed source root {} is not a directory",
+                path.display()
+            ),
+            Self::PermissionNotFound { permission_id } => {
+                write!(
+                    formatter,
+                    "source-root permission {permission_id} does not exist"
+                )
+            }
+            Self::PermissionAlreadyRevoked { permission_id } => write!(
+                formatter,
+                "source-root permission {permission_id} is already revoked"
+            ),
+            Self::ActivePermissionIdentityDrift {
+                permission_id,
+                path,
+            } => write!(
+                formatter,
+                "source-root permission {permission_id} no longer identifies {}; revoke it before confirming the current observed directory",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SourceRootPolicyError {}
+
+/// Outcome of one confirmation request.
+pub struct ConfirmOutcome {
+    pub permission: SourceRootPermission,
+    /// True when an identical active durable permission already existed; the
+    /// request then changed nothing.
+    pub already_permitted: bool,
+}
+
+/// Confirmation binds to the current completed Snapshot, the titled
+/// escaping-link Finding, and one exact canonical target observed by that
+/// Snapshot. No parent, sibling, descendant, alias, wildcard, or
+/// Agent-specific exception is inferred.
+pub fn confirm_source_root(
+    store: &StateStore,
+    finding: &FindingRecord,
+    snapshot: &ScanResult,
+    requested: &Path,
+) -> anyhow::Result<ConfirmOutcome> {
+    if finding.title != ESCAPING_LINK_FINDING_TITLE {
+        return Err(SourceRootPolicyError::NotEscapingLinkFinding {
+            finding_id: finding.id.as_str().to_owned(),
+        }
+        .into());
+    }
+    let report = store.get_report(&finding.report_id)?.ok_or_else(|| {
+        SourceRootPolicyError::FindingNotFound {
+            finding_id: finding.id.as_str().to_owned(),
+        }
+    })?;
+    let current =
+        store
+            .latest_completed_scan()?
+            .ok_or_else(|| SourceRootPolicyError::FindingNotFound {
+                finding_id: finding.id.as_str().to_owned(),
+            })?;
+    if report.scan_id != current.id {
+        return Err(SourceRootPolicyError::FindingSnapshotNotCurrent {
+            finding_id: finding.id.as_str().to_owned(),
+            finding_snapshot: report.scan_id.as_str().to_owned(),
+            current_snapshot: current.id.as_str().to_owned(),
+        }
+        .into());
+    }
+    let requested_exact = lexical_normalize(requested);
+    let observed = observed_exact_targets(snapshot);
+    if !observed.contains(&requested_exact) {
+        return Err(SourceRootPolicyError::PathNotObservedTarget {
+            path: requested_exact,
+        }
+        .into());
+    }
+    let requested = fs::canonicalize(&requested_exact).map_err(|error| {
+        SourceRootPolicyError::PathNotResolvable {
+            path: requested_exact,
+            reason: error.to_string(),
+        }
+    })?;
+    let metadata =
+        fs::metadata(&requested).map_err(|error| SourceRootPolicyError::PathNotResolvable {
+            path: requested.clone(),
+            reason: error.to_string(),
+        })?;
+    if !metadata.is_dir() {
+        return Err(SourceRootPolicyError::PathNotDirectory { path: requested }.into());
+    }
+    let identity =
+        capture_identity(&requested).map_err(|error| SourceRootPolicyError::PathNotResolvable {
+            path: requested.clone(),
+            reason: error.to_string(),
+        })?;
+    let existing = store
+        .list_source_root_permissions()?
+        .into_iter()
+        .find(|permission| permission.revoked_at.is_none() && permission.path == requested);
+    if existing
+        .as_ref()
+        .is_some_and(|permission| permission.identity == identity)
+    {
+        return Ok(ConfirmOutcome {
+            permission: existing.expect("checked above"),
+            already_permitted: true,
+        });
+    }
+    if let Some(existing) = existing {
+        return Err(SourceRootPolicyError::ActivePermissionIdentityDrift {
+            permission_id: existing.id.to_string(),
+            path: requested,
+        }
+        .into());
+    }
+    let permission = SourceRootPermission {
+        id: SourcePermissionId::new(),
+        path: requested,
+        finding_id: finding.id.as_str().to_owned(),
+        snapshot_id: report.scan_id.as_str().to_owned(),
+        identity,
+        granted_at: Utc::now().timestamp(),
+        revoked_at: None,
+    };
+    store.save_source_root_permission(&permission)?;
+    Ok(ConfirmOutcome {
+        permission,
+        already_permitted: false,
+    })
+}
+
+/// Every persisted permission (active and revoked), newest first. Auditable
+/// approval/revocation record; the CLI never deletes rows for a revoke.
+pub fn inspect_permissions(store: &StateStore) -> StorageResult<Vec<SourceRootPermission>> {
+    let mut permissions = store.list_source_root_permissions()?;
+    permissions.sort_by(|left, right| {
+        right
+            .granted_at
+            .cmp(&left.granted_at)
+            .then_with(|| left.id.as_str().cmp(right.id.as_str()))
+    });
+    Ok(permissions)
+}
+
+/// Revoke one durable permission by exact ID. A revoked permission stays in
+/// the auditable record with its revocation time.
+pub fn revoke_permission(
+    store: &StateStore,
+    permission_id: &str,
+) -> anyhow::Result<SourceRootPermission> {
+    let id = SourcePermissionId::parse(permission_id.to_owned())?;
+    let Some(mut permission) = store.get_source_root_permission(&id)? else {
+        return Err(SourceRootPolicyError::PermissionNotFound {
+            permission_id: permission_id.to_owned(),
+        }
+        .into());
+    };
+    if permission.revoked_at.is_some() {
+        return Err(SourceRootPolicyError::PermissionAlreadyRevoked {
+            permission_id: permission_id.to_owned(),
+        }
+        .into());
+    }
+    permission.revoked_at = Some(Utc::now().timestamp());
+    store.save_source_root_permission(&permission)?;
+    Ok(permission)
+}
+
+/// Resolve and freeze every active permitted root exactly once, before any
+/// discovery. A drifted root fails closed on its own and never makes an
+/// unrelated valid root unreadable.
+pub fn freeze_active_roots(store: &StateStore) -> StorageResult<Vec<FrozenSourceRoot>> {
+    let mut frozen = store
+        .list_source_root_permissions()?
+        .into_iter()
+        .filter(|permission| permission.revoked_at.is_none())
+        .map(|permission| freeze_permission(&permission))
+        .collect::<Vec<_>>();
+    frozen.sort_by(|left, right| left.permission.path.cmp(&right.permission.path));
+    Ok(frozen)
+}
+
+/// Freeze one permission against the live filesystem.
+///
+/// Identity-blind roots (identity `Unavailable`) degrade to exact
+/// resolved-path equality: missing, inaccessible, and retargeted drift are
+/// still detected; silent replacement at the same canonical path is not.
+pub fn freeze_permission(permission: &SourceRootPermission) -> FrozenSourceRoot {
+    let granted = &permission.path;
+    let resolved = match fs::canonicalize(granted) {
+        Ok(resolved) => resolved,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return FrozenSourceRoot {
+                permission: permission.clone(),
+                state: SourceRootState::Missing,
+                resolved_path: None,
+                drift_reason: Some(format!("granted path no longer exists: {}", error)),
+            };
+        }
+        Err(error) => {
+            return FrozenSourceRoot {
+                permission: permission.clone(),
+                state: SourceRootState::Inaccessible,
+                resolved_path: None,
+                drift_reason: Some(format!("granted path cannot be resolved: {error}")),
+            };
+        }
+    };
+    let identity_matches = match capture_identity(&resolved) {
+        Ok(current) => current == permission.identity,
+        Err(error) => {
+            return FrozenSourceRoot {
+                permission: permission.clone(),
+                state: SourceRootState::Inaccessible,
+                resolved_path: Some(resolved),
+                drift_reason: Some(format!("filesystem identity cannot be read: {error}")),
+            };
+        }
+    };
+    let (state, drift_reason) = classify_resolution(&resolved, granted, identity_matches);
+    FrozenSourceRoot {
+        permission: permission.clone(),
+        state,
+        resolved_path: Some(resolved),
+        drift_reason,
+    }
+}
+
+/// Pure typed drift classification. `resolved` is the current canonical
+/// resolution of `granted`; `identity_matches` is the comparison against the
+/// granted identity (declared impossible when the platform cannot compare).
+fn classify_resolution(
+    resolved: &Path,
+    granted: &Path,
+    identity_matches: bool,
+) -> (SourceRootState, Option<String>) {
+    if resolved != granted {
+        (
+            SourceRootState::Retargeted,
+            Some("granted canonical path now resolves to a different directory".into()),
+        )
+    } else if !identity_matches {
+        (
+            SourceRootState::Replaced,
+            Some("the filesystem object at the granted path has a different identity".into()),
+        )
+    } else {
+        (SourceRootState::Active, None)
+    }
+}
+
+/// One persisted, frozen policy fact for the scan payload and terminal views.
+pub fn fact_from_frozen(frozen: &FrozenSourceRoot) -> SourceRootPolicyFact {
+    SourceRootPolicyFact {
+        permission_id: frozen.permission.id.as_str().to_owned(),
+        granted_path: frozen.permission.path.clone(),
+        granted_at: frozen.permission.granted_at,
+        state: frozen.state,
+        resolved_path: frozen.resolved_path.clone(),
+        drift_reason: frozen.drift_reason.clone(),
+    }
+}
+
+/// Exact lexical link targets observed by one Snapshot's escaping Finding.
+/// Confirmation compares this spelling before resolving the filesystem so an
+/// unobserved alias cannot borrow another target's confirmation.
+fn observed_exact_targets(snapshot: &ScanResult) -> BTreeSet<PathBuf> {
+    snapshot
+        .placements
+        .iter()
+        .filter(|placement| placement.link_status == LinkStatus::EscapesRoot)
+        .filter_map(|placement| placement.link_target.as_ref())
+        .map(|target| lexical_normalize(target))
+        .collect()
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+pub fn identity_json(identity: &RootIdentity) -> Value {
+    match identity {
+        RootIdentity::Posix { dev, ino } => json!({ "kind": "posix", "dev": dev, "ino": ino }),
+        RootIdentity::Windows {
+            volume_serial,
+            file_index_high,
+            file_index_low,
+        } => json!({
+            "kind": "windows",
+            "volume_serial": volume_serial,
+            "file_index_high": file_index_high,
+            "file_index_low": file_index_low
+        }),
+        RootIdentity::Unavailable => json!({ "kind": "unavailable" }),
+    }
+}
+
+/// One permission as a bounded JSON fact. `current_state` is the live freeze
+/// state when one was computed (inspect), otherwise the stored lifecycle
+/// state.
+pub fn permission_json(
+    permission: &SourceRootPermission,
+    current_state: Option<SourceRootState>,
+) -> Value {
+    let state = if permission.revoked_at.is_some() {
+        "revoked".to_owned()
+    } else {
+        current_state
+            .and_then(|state| {
+                serde_json::to_value(state)
+                    .ok()
+                    .and_then(|value| value.as_str().map(str::to_owned))
+            })
+            .unwrap_or_else(|| "active".to_owned())
+    };
+    json!({
+        "permission_id": permission.id,
+        "path": permission.path,
+        "finding_id": permission.finding_id,
+        "snapshot_id": permission.snapshot_id,
+        "granted_at": permission.granted_at,
+        "revoked_at": permission.revoked_at,
+        "state": state,
+        "identity": identity_json(&permission.identity),
+    })
+}
+
+/// Bounded local-policy view for `source-root inspect`, `status`, and
+/// lifecycle inspection. `with_current_state` additionally resolves active
+/// permissions against the live filesystem.
+pub fn policy_value(
+    store: &StateStore,
+    with_current_state: bool,
+    limit: usize,
+    offset: usize,
+) -> StorageResult<Value> {
+    policy_value_with_page(store, with_current_state, Some((limit, offset)))
+}
+
+/// Complete local export view. This is written to the user-selected lifecycle
+/// export file rather than returned inline in the Agent JSON envelope.
+pub fn policy_export_value(store: &StateStore) -> StorageResult<Value> {
+    policy_value_with_page(store, false, None)
+}
+
+fn policy_value_with_page(
+    store: &StateStore,
+    with_current_state: bool,
+    page: Option<(usize, usize)>,
+) -> StorageResult<Value> {
+    let permissions = inspect_permissions(store)?;
+    let frozen = if with_current_state {
+        Some(freeze_active_roots(store)?)
+    } else {
+        None
+    };
+    let frozen_by_id = frozen
+        .as_ref()
+        .map(|frozen| {
+            frozen
+                .iter()
+                .map(|fact| (fact.permission.id.as_str(), fact))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+    let items = permissions
+        .iter()
+        .skip(page.map_or(0, |(_, offset)| offset))
+        .take(page.map_or(usize::MAX, |(limit, _)| limit))
+        .map(|permission| {
+            let current_state = frozen_by_id
+                .get(permission.id.as_str())
+                .map(|frozen| frozen.state);
+            let mut value = permission_json(permission, current_state);
+            if let Some(frozen) = frozen_by_id.get(permission.id.as_str()) {
+                value["resolved_path"] = json!(frozen.resolved_path);
+                value["drift_reason"] = json!(frozen.drift_reason);
+            }
+            value
+        })
+        .collect::<Vec<_>>();
+    let revoked_count = permissions
+        .iter()
+        .filter(|permission| permission.revoked_at.is_some())
+        .count();
+    let drifted_count = frozen_by_id
+        .values()
+        .filter(|frozen| frozen.state != SourceRootState::Active)
+        .count();
+    let active_count = permissions.len() - revoked_count - drifted_count;
+    let offset = page.map_or(0, |(_, offset)| offset);
+    let next_offset = (offset + items.len() < permissions.len()).then_some(offset + items.len());
+    Ok(json!({
+        "permission_count": permissions.len(),
+        "permissions_returned": items.len(),
+        "permissions_truncated": items.len() < permissions.len(),
+        "offset": offset,
+        "next_offset": next_offset,
+        "active_count": active_count,
+        "drifted_count": drifted_count,
+        "revoked_count": revoked_count,
+        "permissions": items,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn permission(path: PathBuf, identity: RootIdentity) -> SourceRootPermission {
+        SourceRootPermission {
+            id: SourcePermissionId::new(),
+            path,
+            finding_id: "finding_x".into(),
+            snapshot_id: "scan_x".into(),
+            identity,
+            granted_at: 1,
+            revoked_at: None,
+        }
+    }
+
+    #[test]
+    fn permission_ids_are_prefixed_and_parse_round_trips() {
+        let id = SourcePermissionId::new();
+        assert!(id.as_str().starts_with("sroot_"));
+        assert_eq!(SourcePermissionId::parse(id.to_string()).unwrap(), id);
+        assert!(SourcePermissionId::parse("finding_x").is_err());
+    }
+
+    #[test]
+    fn classification_of_resolution_states_is_exact() {
+        let granted = Path::new("/sources/shared");
+        assert_eq!(
+            classify_resolution(granted, granted, true),
+            (SourceRootState::Active, None)
+        );
+        let (state, reason) = classify_resolution(granted, granted, false);
+        assert_eq!(state, SourceRootState::Replaced);
+        assert!(reason.is_some());
+        let moved = Path::new("/sources/elsewhere");
+        let (state, reason) = classify_resolution(moved, granted, true);
+        assert_eq!(state, SourceRootState::Retargeted);
+        assert!(reason.is_some());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn freeze_reports_missing_and_retargeted_roots_without_touching_other_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let granted_input = temp.path().join("shared");
+        fs::create_dir(&granted_input).unwrap();
+        let granted = fs::canonicalize(&granted_input).unwrap();
+        let identity = capture_identity(&granted).unwrap();
+        let active = permission(granted.clone(), identity.clone());
+
+        let frozen = freeze_permission(&active);
+        assert_eq!(frozen.state, SourceRootState::Active);
+        assert_eq!(frozen.resolved_path.as_deref(), Some(granted.as_path()));
+
+        let retargeted = permission(granted.clone(), identity.clone());
+        fs::remove_dir(&granted).unwrap();
+        let replacement = temp.path().join("replacement");
+        fs::create_dir(&replacement).unwrap();
+        std::os::unix::fs::symlink(&replacement, &granted).unwrap();
+        let frozen = freeze_permission(&retargeted);
+        assert_eq!(frozen.state, SourceRootState::Retargeted);
+        assert_eq!(
+            frozen.resolved_path.as_deref(),
+            Some(fs::canonicalize(&replacement).unwrap().as_path())
+        );
+
+        let missing = permission(temp.path().join("absent"), identity);
+        let frozen = freeze_permission(&missing);
+        assert_eq!(frozen.state, SourceRootState::Missing);
+    }
+
+    #[test]
+    fn policy_value_reports_active_revoked_and_drift_counts() {
+        let store = StateStore::open_in_memory().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let granted_input = temp.path().join("shared");
+        fs::create_dir(&granted_input).unwrap();
+        let granted = fs::canonicalize(&granted_input).unwrap();
+        let identity = capture_identity(&granted).unwrap();
+        let mut permission = permission(granted.clone(), identity);
+        store.save_source_root_permission(&permission).unwrap();
+        permission.revoked_at = Some(2);
+        store.save_source_root_permission(&permission).unwrap();
+
+        let value = policy_value(&store, true, 100, 0).unwrap();
+        assert_eq!(value["permission_count"], 1);
+        assert_eq!(value["active_count"], 0);
+        assert_eq!(value["revoked_count"], 1);
+        assert_eq!(value["permissions"][0]["state"], "revoked");
+    }
+
+    #[test]
+    fn policy_value_pages_bounded_permission_records() {
+        let store = StateStore::open_in_memory().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        for name in ["one", "two"] {
+            let input = temp.path().join(name);
+            fs::create_dir(&input).unwrap();
+            let path = fs::canonicalize(input).unwrap();
+            store
+                .save_source_root_permission(&permission(
+                    path.clone(),
+                    capture_identity(&path).unwrap(),
+                ))
+                .unwrap();
+        }
+
+        let first = policy_value(&store, true, 1, 0).unwrap();
+        assert_eq!(first["permission_count"], 2);
+        assert_eq!(first["permissions_returned"], 1);
+        assert_eq!(first["offset"], 0);
+        assert_eq!(first["next_offset"], 1);
+        let second = policy_value(&store, true, 1, 1).unwrap();
+        assert_eq!(second["permissions_returned"], 1);
+        assert_eq!(second["offset"], 1);
+        assert!(second["next_offset"].is_null());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn freeze_rejects_a_replaced_directory_at_the_same_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let input = temp.path().join("shared");
+        fs::create_dir(&input).unwrap();
+        let granted = fs::canonicalize(&input).unwrap();
+        let approved = permission(granted.clone(), capture_identity(&granted).unwrap());
+
+        fs::remove_dir(&granted).unwrap();
+        fs::create_dir(&granted).unwrap();
+
+        let frozen = freeze_permission(&approved);
+        assert_eq!(frozen.state, SourceRootState::Replaced);
+        assert_eq!(frozen.resolved_path.as_deref(), Some(granted.as_path()));
+
+        let store = StateStore::open_in_memory().unwrap();
+        store.save_source_root_permission(&approved).unwrap();
+        let value = policy_value(&store, true, 100, 0).unwrap();
+        assert_eq!(value["active_count"], 0);
+        assert_eq!(value["drifted_count"], 1);
+        assert_eq!(value["revoked_count"], 0);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_identity_capture_rejects_a_replaced_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let input = temp.path().join("shared");
+        fs::create_dir(&input).unwrap();
+        let granted = fs::canonicalize(&input).unwrap();
+        let approved = permission(granted.clone(), capture_identity(&granted).unwrap());
+
+        fs::remove_dir(&granted).unwrap();
+        fs::create_dir(&granted).unwrap();
+
+        let frozen = freeze_permission(&approved);
+        assert_eq!(frozen.state, SourceRootState::Replaced);
+        assert_eq!(frozen.resolved_path.as_deref(), Some(granted.as_path()));
+    }
+}

--- a/src/source_policy.rs
+++ b/src/source_policy.rs
@@ -79,11 +79,12 @@ impl fmt::Display for SourcePermissionId {
 
 /// Stable filesystem identity captured when a permission is granted.
 ///
-/// POSIX uses device + inode plus the inode change-time epoch so immediate
-/// inode reuse cannot make a replacement look like the approved object.
-/// Windows pairs volume + file index with the object's creation time for the
-/// same reason. A platform without these facts reports `Unavailable`, and
-/// drift detection then degrades to exact resolved-path equality.
+/// POSIX uses device + inode plus the inode change time as a conservative reuse
+/// guard. Windows pairs volume + file index with the object's creation time for
+/// the same purpose. These fields reduce common object-reuse false negatives;
+/// their precision and guarantees still depend on the filesystem. A platform
+/// without these facts reports `Unavailable`, and drift detection then degrades
+/// to exact resolved-path equality.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RootIdentity {
     Posix {

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -9,8 +9,9 @@ use crate::model::{
     PlanStatus, ReceiptId, ReceiptRecord, ReceiptStatus, ReportId, ReportRecord, RootRecord,
     RosterEntry, ScanId, ScanRun, SkillId, SkillRecord, UsageEvent,
 };
+use crate::source_policy::{RootIdentity, SourcePermissionId, SourceRootPermission};
 
-const SCHEMA_VERSION: i64 = 9;
+const SCHEMA_VERSION: i64 = 10;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct LifecycleCounts {
@@ -21,6 +22,7 @@ pub struct LifecycleCounts {
     pub plans: u64,
     pub receipts: u64,
     pub evidence_exclusions: u64,
+    pub source_root_permissions: u64,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -217,6 +219,13 @@ impl StateStore {
         if current == 8 {
             let transaction = self.connection.transaction()?;
             migration_v9(&transaction)?;
+            transaction.pragma_update(None, "user_version", 9_i64)?;
+            transaction.commit()?;
+            current = 9;
+        }
+        if current == 9 {
+            let transaction = self.connection.transaction()?;
+            migration_v10(&transaction)?;
             transaction.pragma_update(None, "user_version", SCHEMA_VERSION)?;
             transaction.commit()?;
         }
@@ -227,6 +236,125 @@ impl StateStore {
         Ok(self
             .connection
             .pragma_query_value(None, "user_version", |row| row.get(0))?)
+    }
+
+    /// Stores one exact local source-root read permission. Immutable approval
+    /// facts cannot be replaced; the only allowed update is setting revoked_at.
+    pub fn save_source_root_permission(
+        &self,
+        permission: &SourceRootPermission,
+    ) -> StorageResult<()> {
+        let path = permission.path.to_str().ok_or_else(|| {
+            StorageError::InvalidData("source-root permission path must be valid Unicode".into())
+        })?;
+        let identity = json(&permission.identity)?;
+        if let Some(existing) = self.get_source_root_permission(&permission.id)? {
+            if existing.path != permission.path
+                || existing.finding_id != permission.finding_id
+                || existing.snapshot_id != permission.snapshot_id
+                || existing.identity != permission.identity
+                || existing.granted_at != permission.granted_at
+                || existing.revoked_at.is_some()
+                || permission.revoked_at.is_none()
+            {
+                return Err(StorageError::InvalidData(format!(
+                    "source-root permission {} immutable approval facts changed",
+                    permission.id
+                )));
+            }
+            self.connection.execute(
+                "UPDATE source_root_permissions SET revoked_at = ?1
+                 WHERE id = ?2 AND revoked_at IS NULL",
+                params![permission.revoked_at, permission.id.as_str()],
+            )?;
+            return Ok(());
+        }
+        self.connection.execute(
+            "INSERT INTO source_root_permissions
+                (id, canonical_path, finding_id, snapshot_id, identity_json, granted_at, revoked_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                permission.id.as_str(),
+                path,
+                permission.finding_id,
+                permission.snapshot_id,
+                identity,
+                permission.granted_at,
+                permission.revoked_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_source_root_permission(
+        &self,
+        id: &SourcePermissionId,
+    ) -> StorageResult<Option<SourceRootPermission>> {
+        self.connection
+            .query_row(
+                "SELECT canonical_path, finding_id, snapshot_id, identity_json,
+                        granted_at, revoked_at
+                 FROM source_root_permissions WHERE id = ?1",
+                [id.as_str()],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, i64>(4)?,
+                        row.get::<_, Option<i64>>(5)?,
+                    ))
+                },
+            )
+            .optional()?
+            .map(
+                |(path, finding_id, snapshot_id, identity, granted_at, revoked_at)| {
+                    Ok(SourceRootPermission {
+                        id: id.clone(),
+                        path: path.into(),
+                        finding_id,
+                        snapshot_id,
+                        identity: from_json::<RootIdentity>(&identity)?,
+                        granted_at,
+                        revoked_at,
+                    })
+                },
+            )
+            .transpose()
+    }
+
+    pub fn list_source_root_permissions(&self) -> StorageResult<Vec<SourceRootPermission>> {
+        let mut statement = self.connection.prepare(
+            "SELECT id, canonical_path, finding_id, snapshot_id, identity_json,
+                    granted_at, revoked_at
+             FROM source_root_permissions ORDER BY granted_at DESC, id",
+        )?;
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, Option<i64>>(6)?,
+                ))
+            })?
+            .map(|row| {
+                let (id, path, finding_id, snapshot_id, identity, granted_at, revoked_at) = row?;
+                Ok(SourceRootPermission {
+                    id: SourcePermissionId::parse(id).map_err(invalid_id)?,
+                    path: path.into(),
+                    finding_id,
+                    snapshot_id,
+                    identity: from_json::<RootIdentity>(&identity)?,
+                    granted_at,
+                    revoked_at,
+                })
+            })
+            .collect()
     }
 
     pub fn save_scan(&self, scan: &ScanRun) -> StorageResult<()> {
@@ -1449,6 +1577,7 @@ impl StateStore {
             plans: table_count(&self.connection, "plans")?,
             receipts: table_count(&self.connection, "receipts")?,
             evidence_exclusions: table_count(&self.connection, "evidence_exclusions")?,
+            source_root_permissions: table_count(&self.connection, "source_root_permissions")?,
         })
     }
 
@@ -1975,6 +2104,23 @@ fn migration_v9(transaction: &Transaction<'_>) -> StorageResult<()> {
     Ok(())
 }
 
+fn migration_v10(transaction: &Transaction<'_>) -> StorageResult<()> {
+    transaction.execute_batch(
+        "CREATE TABLE source_root_permissions (
+            id TEXT PRIMARY KEY,
+            canonical_path TEXT NOT NULL,
+            finding_id TEXT NOT NULL,
+            snapshot_id TEXT NOT NULL,
+            identity_json TEXT NOT NULL,
+            granted_at INTEGER NOT NULL,
+            revoked_at INTEGER
+         );
+         CREATE UNIQUE INDEX one_active_source_root_permission
+            ON source_root_permissions(canonical_path) WHERE revoked_at IS NULL;",
+    )?;
+    Ok(())
+}
+
 fn table_count(connection: &Connection, table: &str) -> StorageResult<u64> {
     let query = format!("SELECT COUNT(*) FROM {table}");
     Ok(connection.query_row(&query, [], |row| row.get(0))?)
@@ -2199,7 +2345,7 @@ mod tests {
 
     #[test]
     fn migration_upgrades_prior_states_sequentially() {
-        for starting_version in [1_i64, 2, 3, 4, 5, 6, 7, 8] {
+        for starting_version in [1_i64, 2, 3, 4, 5, 6, 7, 8, 9] {
             let mut connection = Connection::open_in_memory().unwrap();
             let transaction = connection.transaction().unwrap();
             migration_v1(&transaction).unwrap();
@@ -2223,6 +2369,9 @@ mod tests {
             }
             if starting_version >= 8 {
                 migration_v8(&transaction).unwrap();
+            }
+            if starting_version >= 9 {
+                migration_v9(&transaction).unwrap();
             }
             transaction
                 .pragma_update(None, "user_version", starting_version)

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1701,7 +1701,7 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
     let plan_input = json!({
         "schema_version": 1,
         "scan_id": snapshot,
-        "evidence_ids": [evidence_id],
+        "evidence_ids": [evidence_id.clone()],
         "roster_changes": [{
             "agent": "codex",
             "skill_id": skill_id,
@@ -3343,7 +3343,7 @@ fn source_update_requires_conflict_choice_and_round_trips_adoption() {
     let request = json!({
         "schema_version": 1,
         "scan_id": snapshot,
-        "evidence_ids": [evidence_id],
+        "evidence_ids": [evidence_id.clone()],
         "source_updates": [{
             "skill_id": skill_id,
             "placement_id": placement_id,
@@ -6743,17 +6743,312 @@ fn escaping_link_finding_requests_trust_confirmation_instead_of_a_plan() {
         detail["result"]["resolution"]["automatic_change_supported"],
         false
     );
-    assert_eq!(detail["suggested_actions"].as_array().unwrap().len(), 1);
-    assert_eq!(
-        detail["suggested_actions"][0]["action"],
-        "show_full_finding"
+    let actions = detail["suggested_actions"].as_array().unwrap();
+    assert_eq!(actions.len(), 2);
+    assert!(
+        actions
+            .iter()
+            .any(|action| action["action"] == "show_full_finding")
     );
+    let confirm = actions
+        .iter()
+        .find(|action| action["action"] == "confirm_source_root_read_permission")
+        .unwrap();
+    assert_eq!(confirm["requires_confirmation"], true);
+    assert_eq!(confirm["mutates"], true);
     assert!(
         detail["result"]["items"]
             .as_array()
             .unwrap()
             .iter()
             .any(|item| item["facts"]["link_target"] == json!(source))
+    );
+
+    let sibling = temp.path().join("unobserved-sibling");
+    fs::create_dir(&sibling).unwrap();
+    let unobserved = run(
+        &[
+            &common[..],
+            &[
+                "source-root",
+                "confirm",
+                "--finding",
+                finding_id,
+                "--path",
+                sibling.to_str().unwrap(),
+            ],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!unobserved.status.success());
+    let unobserved: Value = serde_json::from_slice(&unobserved.stdout).unwrap();
+    assert_eq!(unobserved["error"]["code"], "source_root_path_not_observed");
+    assert_eq!(unobserved["error"]["details"]["path"], json!(sibling));
+
+    let unobserved_alias = temp.path().join("unobserved-alias");
+    std::os::unix::fs::symlink(&source, &unobserved_alias).unwrap();
+    let alias = run(
+        &[
+            &common[..],
+            &[
+                "source-root",
+                "confirm",
+                "--finding",
+                finding_id,
+                "--path",
+                unobserved_alias.to_str().unwrap(),
+            ],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!alias.status.success());
+    let alias: Value = serde_json::from_slice(&alias.stdout).unwrap();
+    assert_eq!(alias["error"]["code"], "source_root_path_not_observed");
+    assert_eq!(alias["error"]["details"]["path"], json!(unobserved_alias));
+
+    let confirmed = json_output(&run_suggested_action(confirm));
+    assert_eq!(
+        confirmed["result"]["permission_scope"],
+        "exact_local_read_only"
+    );
+    assert_eq!(confirmed["result"]["content_endorsed"], false);
+    assert_eq!(confirmed["result"]["evidence_quality_changed"], false);
+    assert_eq!(confirmed["result"]["plan_apply_authorized"], false);
+    assert_eq!(confirmed["result"]["files_changed"], false);
+    assert_eq!(confirmed["result"]["state_files_changed"], true);
+    let mut permission_id = confirmed["result"]["permission"]["permission_id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+
+    let rescanned = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    assert_eq!(
+        rescanned["result"]["source_root_policy"]["permissions"][0]["state"],
+        "active"
+    );
+    let found = json_output(&run(&[&common[..], &["find", "fixture"]].concat(), None));
+    assert_eq!(found["result"]["matches"][0]["name"], "external");
+
+    let snapshot = rescanned["result"]["snapshot_id"].as_str().unwrap();
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let payload: String = database
+        .query_row(
+            "SELECT payload_json FROM scan_payloads WHERE scan_id = ?1",
+            [snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let payload: Value = serde_json::from_str(&payload).unwrap();
+    let external_skill = payload["skills"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|skill| skill["name"] == "external")
+        .unwrap();
+    let skill_id = external_skill["id"].as_str().unwrap();
+    let placements = payload["placements"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|placement| placement["skill_id"] == skill_id)
+        .collect::<Vec<_>>();
+    assert!(!placements.is_empty());
+    assert!(
+        placements
+            .iter()
+            .all(|placement| placement["governable"] == false)
+    );
+    assert!(
+        placements
+            .iter()
+            .all(|placement| { placement["fingerprint_completeness"] == "complete" })
+    );
+    let evidence_id: String = database
+        .query_row(
+            "SELECT id FROM evidence WHERE scan_id = ?1 ORDER BY id LIMIT 1",
+            [snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let placement_ids = placements
+        .iter()
+        .map(|placement| placement["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    let current_fingerprint = placements[0]["content_digest"].as_str().unwrap();
+    let upstream = "---\nname: external\nsource: fixture\nversion: v2\n---\nchanged\n";
+    let upstream_digest = format!("{:x}", Sha256::digest(upstream.as_bytes()));
+    let source_update = json!({
+        "schema_version": 1,
+        "scan_id": snapshot,
+        "evidence_ids": [evidence_id.clone()],
+        "source_updates": [{
+            "skill_id": skill_id,
+            "placement_id": placement_ids[0],
+            "source": "fixture",
+            "current_revision": "v1",
+            "current_fingerprint": current_fingerprint,
+            "base_digest": null,
+            "upstream_revision": "v2",
+            "upstream_content": upstream,
+            "upstream_digest": upstream_digest
+        }]
+    });
+    let source_update = run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&source_update.to_string()),
+    );
+    assert!(!source_update.status.success());
+    assert!(
+        String::from_utf8_lossy(&source_update.stdout).contains("read-only"),
+        "{}",
+        String::from_utf8_lossy(&source_update.stdout)
+    );
+    let library_change = json!({
+        "schema_version": 1,
+        "scan_id": snapshot,
+        "evidence_ids": [evidence_id.clone()],
+        "library_changes": [{
+            "skill_id": skill_id,
+            "canonical_placement_id": placement_ids[0],
+            "placement_ids": placement_ids,
+            "requested_state": "managed"
+        }]
+    });
+    let library_change = run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&library_change.to_string()),
+    );
+    assert!(!library_change.status.success());
+    assert!(String::from_utf8_lossy(&library_change.stdout).contains("read-only"));
+    let roster_change = json!({
+        "schema_version": 1,
+        "scan_id": snapshot,
+        "evidence_ids": [evidence_id],
+        "roster_changes": [{
+            "agent": "codex",
+            "skill_id": skill_id,
+            "state": "core"
+        }]
+    });
+    let roster_change = run(
+        &[&common[..], &["plan", "--stdin"]].concat(),
+        Some(&roster_change.to_string()),
+    );
+    assert!(!roster_change.status.success());
+    assert!(String::from_utf8_lossy(&roster_change.stdout).contains("read-only"));
+    let plan_count: i64 = database
+        .query_row("SELECT COUNT(*) FROM plans", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(plan_count, 0);
+
+    let stale = run_suggested_action(confirm);
+    assert!(!stale.status.success());
+    let stale: Value = serde_json::from_slice(&stale.stdout).unwrap();
+    assert_eq!(stale["error"]["code"], "source_root_finding_stale");
+
+    fs::remove_dir_all(&source).unwrap();
+    fs::create_dir(&source).unwrap();
+    fs::write(
+        source.join("SKILL.md"),
+        "---\nname: external\ndescription: replacement fixture\n---\n",
+    )
+    .unwrap();
+    let drifted = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    assert_eq!(
+        drifted["result"]["source_root_policy"]["permissions"][0]["state"],
+        "replaced"
+    );
+    let persisted_payload: String = database
+        .query_row(
+            "SELECT p.payload_json FROM scan_payloads p JOIN scans s ON s.id = p.scan_id WHERE s.status = 'completed' ORDER BY s.completed_at DESC, s.started_at DESC, s.rowid DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let persisted_payload: Value = serde_json::from_str(&persisted_payload).unwrap();
+    assert_ne!(
+        persisted_payload["source_root_policy"][0]["state"],
+        "active"
+    );
+    let drift_report = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    let drift_finding_id = drift_report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Skill links escape an approved root")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let drift_detail = json_output(&run(
+        &[&common[..], &["report", "--finding", drift_finding_id]].concat(),
+        None,
+    ));
+    let drift_confirm = drift_detail["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|action| action["action"] == "confirm_source_root_read_permission")
+        .unwrap();
+    let identity_conflict = run_suggested_action(drift_confirm);
+    assert!(!identity_conflict.status.success());
+    let identity_conflict: Value = serde_json::from_slice(&identity_conflict.stdout).unwrap();
+    assert_eq!(
+        identity_conflict["error"]["code"],
+        "source_root_permission_identity_drift"
+    );
+    assert_eq!(
+        identity_conflict["error"]["details"]["permission_id"],
+        permission_id
+    );
+
+    json_output(&run(
+        &[
+            &common[..],
+            &["source-root", "revoke", permission_id.as_str()],
+        ]
+        .concat(),
+        None,
+    ));
+    let reconfirmed = json_output(&run_suggested_action(drift_confirm));
+    assert_eq!(reconfirmed["result"]["already_permitted"], false);
+    permission_id = reconfirmed["result"]["permission"]["permission_id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let inspect = json_output(&run(
+        &[&common[..], &["source-root", "inspect"]].concat(),
+        None,
+    ));
+    assert_eq!(inspect["result"]["permission_count"], 2);
+    assert_eq!(inspect["result"]["active_count"], 1);
+    assert_eq!(inspect["result"]["revoked_count"], 1);
+
+    let revoked = json_output(&run(
+        &[
+            &common[..],
+            &["source-root", "revoke", permission_id.as_str()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(revoked["result"]["permission"]["state"], "revoked");
+    assert_eq!(revoked["result"]["files_changed"], false);
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let blocked_again = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    assert!(
+        blocked_again["result"]["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|finding| finding["title"] == "Skill links escape an approved root")
     );
 }
 


### PR DESCRIPTION
## Summary

- add Agent-first `source-root confirm / inspect / revoke` for exact durable local read permissions
- bind approval to a current escaping-link Finding, exact observed canonical path, and stable filesystem identity
- keep durable roots searchable and fingerprintable but strictly non-governable
- fail closed on bounded accidental/persistent drift, preserve typed audit facts, and keep approval/revocation history in SQLite schema v10
- retain one-shot `--source-root` compatibility and add bounded inspect pagination
- document the exact read-only authority and threat boundary; adversarial same-user ABA hardening is tracked separately in #135

## Safety

A durable permission does not endorse content, raise Evidence quality, authorize Plan/Apply, or modify Agent/Skill files. Source update, Library consolidation, and Roster planning all reject durable-only placements without storing a partial Plan.

The scanner checks frozen root identity and exact entrypoint binding around discovery and content consumption. If it observes replacement or retargeting, it discards content and derived metadata/digest/search/executable facts, marks the placement unreadable/non-governable, and persists a non-active typed policy fact.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
  - 202 unit
  - 7 acceptance
  - 57 CLI
- `git diff --check`
- independent final Spec review: 0 blocker / 0 should-fix / 0 nit
- independent final Safety review: 0 blocker / 0 should-fix

Cross-platform CI and isolated Pi Agent-loop evidence will be attached before merge.

Closes #134