### PR TITLE
feat: clarify placement mutation authority

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,17 @@ _Avoid_: Proof, confidence
 The typed coverage of a Skill package digest: Complete, Bounded, Unreadable, or Unknown. Only Complete may authorize an exact-content governance decision; the other states remain inventory facts.
 _Avoid_: Best-effort exact hash
 
+**Placement Path Ownership**:
+Whether a placement path is structurally inside a supported Agent's Skill root.
+It does not claim ownership or endorsement of content reached through a link.
+_Avoid_: Source ownership, Trusted content
+
+**Mutation Scope**:
+A typed Snapshot fact describing whether a placement is Mutable,
+Provider-read-only, Durable-read-only, or Untrusted-external. Only Mutable may
+authorize placement mutation; a missing legacy fact remains unknown.
+_Avoid_: Governable reason, Trust level
+
 **Usage Observation**:
 A privacy-preserving bounded observation for one Skill, Agent, usage stage,
 quality, and session-source path. Unchanged observations deduplicate across

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -28,7 +28,7 @@ The first complete release directly supports:
 
 Supported platforms are macOS, Linux, and Windows. WSL is treated as Linux. A platform or Agent is not declared supported until its adapter passes fixtures and a real-environment acceptance run.
 
-SkillRoster scans only known directories for these eight Agents, the active SkillRoster-owned Library root, Skill roots from Codex plugins proven by either explicit local enablement or a valid local remote-plugin install marker, plus paths explicitly provided by the user. It never crawls the entire home directory or treats an arbitrary plugin cache as installed. Explicitly disabled plugins remain excluded. Discovered Codex plugin Skills are Observed, searchable, and provider-managed read-only: they cannot become mutation targets or canonical Library sources. Invalid install markers and ambiguous cached plugin versions fail closed. Every Scan reports included, excluded, missing, and inaccessible roots. `--root AGENT=PATH` is an Agent placement root and contributes to exposure; `--source-root PATH` is an approved canonical source with no Agent identity and no default exposure. Source trust is explicit and scoped to the resolved canonical directory; a path and a symlink alias to that same directory have identical trust semantics.
+SkillRoster scans only known directories for these eight Agents, the active SkillRoster-owned Library root, Skill roots from Codex plugins proven by either explicit local enablement or a valid local remote-plugin install marker, plus paths explicitly provided by the user. It never crawls the entire home directory or treats an arbitrary plugin cache as installed. Explicitly disabled plugins remain excluded. Discovered Codex plugin Skills are Observed, searchable, and provider-managed read-only: they cannot become mutation targets or canonical Library sources. Invalid install markers and ambiguous cached plugin versions fail closed. Every new Snapshot records two orthogonal placement facts: `owned_by_agent` describes only whether the placement path is structurally inside an Agent root, while `mutation_scope` is `mutable`, `provider_read_only`, `durable_read_only`, or `untrusted_external`. Placement-path ownership never endorses linked source content. Compatibility field `governable` is true exactly for `mutable`; missing authority fields in legacy Snapshots remain unknown and cannot authorize mutation. Every Scan reports included, excluded, missing, and inaccessible roots. `--root AGENT=PATH` is an Agent placement root and contributes to exposure; `--source-root PATH` is an approved canonical source with no Agent identity and no default exposure. Source trust is explicit and scoped to the resolved canonical directory; a path and a symlink alias to that same directory have identical trust semantics.
 
 ## 3. Primary interaction
 
@@ -120,7 +120,7 @@ sources or operation targets. Before deriving operations, planning revalidates
 each captured physical source against the current logical entrypoint and stores
 those logical-entrypoint-to-physical-source bindings in the immutable Plan.
 Apply revalidates the complete binding set before entering Applying. A
-physical object shared with any provider-managed placement remains read-only,
+physical object shared with any non-mutable placement remains read-only,
 and a non-Agent source link that would be broken blocks the Plan. These
 blockers expose stable reasons, IDs, paths, and next actions in `error.details`;
 Agent callers never need to parse the human message.
@@ -226,8 +226,14 @@ path, Agent, provider, root, and governability fact together. It offers no Plan
 until the caller has compared the variants and chosen canonical content.
 Variant details keep provider, governance, and path facts bound to one identity;
 the response preserves the total count and marks bounded detail truncation.
-Provider-managed results include their plugin identity and a non-governable
-marker so Agents can route to them without proposing filesystem governance.
+Find and Finding detail keep bounded `owned_by_agent`, `mutation_scope`, and
+compatibility `governable` facts together. Provider-managed results also include
+their plugin identity. Planning remains Finding-specific: `planning.supported`
+is never true when a proposed demotion, removal, or operation would touch a
+non-governable placement. Read-only placements that remain unchanged may stay in
+the wider Finding scope. Typed reasons distinguish provider read-only, durable
+read-only, untrusted external, and legacy-unknown authority without asking the
+Agent to reconstruct policy.
 
 All JSON responses use a versioned envelope:
 

--- a/skill/skillroster/references/routing.md
+++ b/skill/skillroster/references/routing.md
@@ -23,5 +23,10 @@ selected result's exact `SKILL.md` path directly. Finding a Skill does not
 activate, install, or authorize it, and SkillRoster has no load or activate
 step.
 
-Provider-managed results with `governable: false` are valid read-only matches.
-Do not move, update, consolidate, or add them to a governance Plan.
+Read `owned_by_agent` as placement-path structure only, never as ownership or
+endorsement of linked source content. Read `mutation_scopes` before governance:
+only `mutable` may participate in a mutating Plan. `provider_read_only`,
+`durable_read_only`, and `untrusted_external` remain valid routing results but
+must not be moved, updated, consolidated, or added to a governance Plan. Missing
+scope facts mean a legacy Snapshot is unknown; rescan instead of inferring
+authority. `governable` remains a compatibility projection of `mutable`.

--- a/src/app.rs
+++ b/src/app.rs
@@ -933,7 +933,17 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
         };
     }
     if let Some(blocker) = error.downcast_ref::<crate::roster_plan::RosterSafetyBlocker>() {
-        let (code, reason, skill_id, placement_ids, paths, providers, next_action) = match blocker {
+        let (
+            code,
+            reason,
+            skill_id,
+            placement_ids,
+            paths,
+            providers,
+            mutation_scopes,
+            owned_by_agent,
+            next_action,
+        ) = match blocker {
             crate::roster_plan::RosterSafetyBlocker::ProviderManaged {
                 skill_id,
                 placement_ids,
@@ -946,7 +956,26 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
                 placement_ids,
                 paths,
                 Some(providers),
+                None,
+                json!(false),
                 "exclude_provider_managed_placement",
+            ),
+            crate::roster_plan::RosterSafetyBlocker::MutationScopeReadOnly {
+                skill_id,
+                placement_ids,
+                paths,
+                owned_by_agent,
+                mutation_scopes,
+            } => (
+                "roster_mutation_scope_read_only",
+                "non_mutable_placement_blocks_mutation",
+                skill_id,
+                placement_ids,
+                paths,
+                None,
+                Some(mutation_scopes),
+                json!(owned_by_agent),
+                "rescan_or_choose_mutable_placement",
             ),
             crate::roster_plan::RosterSafetyBlocker::DependentSource {
                 skill_id,
@@ -959,6 +988,8 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
                 placement_ids,
                 paths,
                 None,
+                None,
+                Value::Null,
                 "preserve_or_retarget_dependent_source",
             ),
         };
@@ -971,6 +1002,8 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
                 "placement_ids": placement_ids,
                 "paths": paths,
                 "providers": providers,
+                "mutation_scopes": mutation_scopes,
+                "owned_by_agent": owned_by_agent,
                 "files_changed": false,
                 "next_action": next_action
             })),
@@ -1578,7 +1611,14 @@ fn recognized_source_confirmation_detail(detail: &Value) -> bool {
                 let skill_id = blocker["skill_id"].as_str()?;
                 SkillId::parse(skill_id.to_owned()).ok()?;
                 (!blocker["name"].as_str()?.trim().is_empty()).then_some(())?;
-                (blocker["reason"] == "no_owned_exact_content_to_preserve").then_some(())?;
+                match blocker["reason"].as_str()? {
+                    "no_owned_exact_content_to_preserve" => {}
+                    "untrusted_external_placement_blocks_mutation" => {
+                        let scopes = blocker["mutation_scopes"].as_array()?;
+                        (scopes.len() == 1 && scopes[0] == "untrusted_external").then_some(())?;
+                    }
+                    _ => return None,
+                }
                 (blocker["state"] == "unchanged").then_some(())?;
                 let observed_source_target =
                     if let Some(target) = blocker.get("observed_source_target") {
@@ -2272,7 +2312,9 @@ fn report_command(
                         "link_target": placement.link_target,
                         "link_status": placement.link_status,
                         "default_exposed": placement.default_exposed,
-                        "governable": placement.governable,
+                        "owned_by_agent": placement.owned_by_agent,
+                        "mutation_scope": placement.mutation_scope,
+                        "governable": placement.is_mutable(),
                         "provider": placement.provider,
                         "content_digest": placement.content_digest,
                         "fingerprint_completeness": placement.fingerprint_completeness,
@@ -2548,7 +2590,8 @@ fn add_same_name_resolution(object: &mut serde_json::Map<String, Value>, scan: &
                 .iter()
                 .map(|placement| placement.root.display().to_string())
                 .collect::<BTreeSet<_>>();
-            let governable = placements.iter().any(|placement| placement.governable);
+            let governable = placements.iter().any(|placement| placement.is_mutable());
+            let authority = placement_authority_summary(&placements);
             Some(json!({
                 "skill_id": skill_id,
                 "content_digests": content_digests,
@@ -2559,7 +2602,9 @@ fn add_same_name_resolution(object: &mut serde_json::Map<String, Value>, scan: &
                 "providers": providers,
                 "roots": roots,
                 "source": skill.metadata.source.clone(),
-                "governable": governable
+                "governable": governable,
+                "owned_by_agent": authority.owned_by_agent,
+                "mutation_scopes": authority.mutation_scopes
             }))
         })
         .collect::<Vec<_>>();
@@ -2574,6 +2619,73 @@ fn add_same_name_resolution(object: &mut serde_json::Map<String, Value>, scan: &
             "next_step": "compare_variant_content_and_choose_canonical"
         }),
     );
+}
+
+struct PlacementAuthoritySummary {
+    owned_by_agent: Option<bool>,
+    mutation_scopes: Vec<scan::MutationScope>,
+}
+
+fn placement_authority_summary(placements: &[&scan::SkillPlacement]) -> PlacementAuthoritySummary {
+    let owned_by_agent = (!placements.is_empty()
+        && placements
+            .iter()
+            .all(|placement| placement.owned_by_agent.is_some()))
+    .then(|| {
+        placements
+            .iter()
+            .any(|placement| placement.owned_by_agent == Some(true))
+    });
+    let mutation_scopes = placements
+        .iter()
+        .filter_map(|placement| placement.mutation_scope)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    PlacementAuthoritySummary {
+        owned_by_agent,
+        mutation_scopes,
+    }
+}
+
+fn read_only_placement_reason(
+    placements: &[&scan::SkillPlacement],
+) -> (&'static str, &'static str) {
+    let scopes = placements
+        .iter()
+        .filter_map(|placement| placement.mutation_scope)
+        .collect::<BTreeSet<_>>();
+    if placements
+        .iter()
+        .any(|placement| placement.mutation_scope.is_none())
+    {
+        return (
+            "mutation_scope_unknown",
+            "Rescan with the current SkillRoster before preparing a mutating Plan.",
+        );
+    }
+    if scopes == BTreeSet::from([scan::MutationScope::ProviderReadOnly]) {
+        return (
+            "provider_managed_read_only",
+            "Keep provider-managed placements read-only.",
+        );
+    }
+    if scopes == BTreeSet::from([scan::MutationScope::DurableReadOnly]) {
+        return (
+            "durable_source_read_only",
+            "The source-read permission permits inspection only; choose a mutable placement for governance.",
+        );
+    }
+    if scopes == BTreeSet::from([scan::MutationScope::UntrustedExternal]) {
+        return (
+            "untrusted_external_source",
+            "Confirm the exact source root for reading, then rescan; confirmation does not authorize mutation.",
+        );
+    }
+    (
+        "non_mutable_placements",
+        "Resolve each typed mutation scope before preparing a mutating Plan.",
+    )
 }
 
 const SEMANTIC_COMPARISON_NAME_LIMIT: usize = 160;
@@ -2670,7 +2782,8 @@ fn add_semantic_overlap_comparison(
                 .iter()
                 .filter_map(|placement| placement.provider.clone())
                 .collect::<BTreeSet<_>>();
-            let governable = placements.iter().any(|placement| placement.governable);
+            let governable = placements.iter().any(|placement| placement.is_mutable());
+            let authority = placement_authority_summary(&placements);
             let (name, name_truncated) =
                 bounded_semantic_text(&skill.name, SEMANTIC_COMPARISON_NAME_LIMIT);
             let (description, description_truncated) = bounded_semantic_optional_text(
@@ -2729,7 +2842,9 @@ fn add_semantic_overlap_comparison(
                         "agent": placement.agent.map(AgentKind::id),
                         "provider": provider,
                         "provider_truncated": provider_truncated,
-                        "governable": placement.governable,
+                        "owned_by_agent": placement.owned_by_agent,
+                        "mutation_scope": placement.mutation_scope,
+                        "governable": placement.is_mutable(),
                         "default_exposed": placement.default_exposed,
                         "link_status": placement.link_status,
                         "fingerprint_completeness": placement.fingerprint_completeness,
@@ -2766,6 +2881,8 @@ fn add_semantic_overlap_comparison(
                 "provider_count": provider_count,
                 "providers_truncated": providers_truncated,
                 "governable": governable,
+                "owned_by_agent": authority.owned_by_agent,
+                "mutation_scopes": authority.mutation_scopes,
                 "placement_count": placements.len(),
                 "readable_path_count": readable_path_count,
                 "readable_paths_truncated": readable_path_count > current_paths.paths.len(),
@@ -2807,6 +2924,7 @@ fn compact_finding_detail(mut details: Value) -> Value {
                 .unwrap_or_else(|| json!({}));
             if let Some(facts) = facts.as_object_mut() {
                 facts.remove("root_id");
+                facts.retain(|_, value| !value.is_null());
             }
             json!({
                 "evidence_id": evidence["id"],
@@ -3044,18 +3162,37 @@ fn finding_library_planning(
         .iter()
         .map(String::as_str)
         .collect::<std::collections::BTreeSet<_>>();
-    let protected_count = scan
+    let protected = scan
         .placements
         .iter()
-        .filter(|placement| affected.contains(placement.id.as_str()) && !placement.governable)
-        .count();
-    if protected_count > 0 {
+        .filter(|placement| affected.contains(placement.id.as_str()) && !placement.is_mutable())
+        .collect::<Vec<_>>();
+    let protected_count = protected.len();
+    if !protected.is_empty() {
+        let (reason, next_step) = read_only_placement_reason(&protected);
+        let authority = placement_authority_summary(&protected);
+        let blocked_placements = protected
+            .iter()
+            .take(5)
+            .map(|placement| {
+                json!({
+                    "placement_id": placement.id,
+                    "owned_by_agent": placement.owned_by_agent,
+                    "mutation_scope": placement.mutation_scope,
+                    "provider": placement.provider
+                })
+            })
+            .collect::<Vec<_>>();
         return Some(json!({
             "supported": false,
-            "reason": "external_observed_placements",
+            "reason": reason,
             "snapshot_id": scan_id,
             "protected_placement_count": protected_count,
-            "next_step": "Keep provider-managed plugin Skills read-only; govern only Agent-owned placements."
+            "blocked_placements": blocked_placements,
+            "blocked_placements_truncated": protected_count > 5,
+            "owned_by_agent": authority.owned_by_agent,
+            "mutation_scopes": authority.mutation_scopes,
+            "next_step": next_step
         }));
     }
     let mut physical_groups =
@@ -3063,7 +3200,7 @@ fn finding_library_planning(
     for placement in scan
         .placements
         .iter()
-        .filter(|placement| affected.contains(placement.id.as_str()) && placement.governable)
+        .filter(|placement| affected.contains(placement.id.as_str()) && placement.is_mutable())
     {
         physical_groups
             .entry(placement.physical_directory_or_logical().to_path_buf())
@@ -3091,7 +3228,9 @@ fn finding_library_planning(
                     "path": placement.entrypoint,
                     "agent": placement.agent.map(AgentKind::id),
                     "default_exposed": placement.default_exposed,
-                    "governable": placement.governable,
+                    "governable": placement.is_mutable(),
+                    "owned_by_agent": placement.owned_by_agent,
+                    "mutation_scope": placement.mutation_scope,
                     "reason": reason
                 }),
             ))
@@ -3297,16 +3436,7 @@ fn finding_roster_planning(
         .exclusions
         .iter()
         .take(5)
-        .map(|exclusion| {
-            json!({
-                "agent": exclusion.agent,
-                "skill_id": exclusion.skill_id,
-                "name": exclusion.name,
-                "reason": exclusion.reason,
-                "state": "unchanged",
-                "observed_source_target": exclusion.observed_source_target
-            })
-        })
+        .map(crate::roster_plan::blocked_change_json)
         .collect::<Vec<_>>();
     if blocked_change_count > 0 {
         let blocked_skills = blocked_skill_planning(&supported.exclusions, full);
@@ -3414,6 +3544,39 @@ fn finding_roster_planning(
                         "use user-approved source-link preservation, then retry from fresh evidence; another independent blocker may still fail closed"
                     }
                 }
+            })));
+        }
+        let mutation_scopes = supported
+            .exclusions
+            .iter()
+            .flat_map(|exclusion| match exclusion.safety_blocker.as_ref() {
+                Some(crate::roster_plan::RosterSafetyBlocker::ProviderManaged { .. }) => {
+                    vec!["provider_read_only".to_owned()]
+                }
+                Some(crate::roster_plan::RosterSafetyBlocker::MutationScopeReadOnly {
+                    mutation_scopes,
+                    ..
+                }) => mutation_scopes.clone(),
+                _ => Vec::new(),
+            })
+            .collect::<BTreeSet<_>>();
+        let requires_more_than_read_confirmation = mutation_scopes.is_empty()
+            || mutation_scopes
+                .iter()
+                .any(|scope| scope != "untrusted_external");
+        if requires_more_than_read_confirmation {
+            return Ok(Some(json!({
+                "supported": false,
+                "reason": "mutation_scope_blocks_roster_change",
+                "decision": "choose_mutable_placements_or_keep_unchanged",
+                "automatic_change_supported": false,
+                "snapshot_id": scan_id,
+                "request_field": "finding_roster_changes",
+                "mutation_scopes": mutation_scopes,
+                "blocked_change_count": blocked_change_count,
+                "blocked_changes": blocked_changes,
+                "blocked_changes_truncated": blocked_change_count > 5,
+                "next": "Provider and durable read permissions authorize inspection only; keep these placements unchanged or choose current mutable placements. Rescan when scope facts are missing."
             })));
         }
         return Ok(Some(json!({
@@ -5206,7 +5369,14 @@ fn finding_roster_safety_blocker(
 ) -> Option<crate::roster_plan::RosterSafetyBlocker> {
     exclusions
         .iter()
-        .find_map(|exclusion| exclusion.safety_blocker.clone())
+        .filter_map(|exclusion| exclusion.safety_blocker.clone())
+        .find(|blocker| match blocker {
+            crate::roster_plan::RosterSafetyBlocker::MutationScopeReadOnly {
+                mutation_scopes,
+                ..
+            } => mutation_scopes.len() != 1 || mutation_scopes[0].as_str() != "untrusted_external",
+            _ => true,
+        })
 }
 
 fn exact_duplicate_finding_scope(
@@ -5449,10 +5619,14 @@ fn normalize_agent_plan(
                 request.skill_id
             );
         }
-        if !placement.governable {
+        if !placement.is_mutable() {
             bail!(
-                "Placement {} is provider-managed and read-only; source updates are not allowed",
-                request.placement_id
+                "Placement {} has read-only mutation_scope {}; source updates require mutable",
+                request.placement_id,
+                placement
+                    .mutation_scope
+                    .map(scan::MutationScope::id)
+                    .unwrap_or("unknown")
             );
         }
         if placement.content_digest != request.current_fingerprint {
@@ -5725,10 +5899,24 @@ fn normalize_library_plan(
         {
             return Err(blocker.into());
         }
-        if all_placements.iter().any(|placement| !placement.governable) {
+        if all_placements
+            .iter()
+            .any(|placement| !placement.is_mutable())
+        {
+            let scopes = all_placements
+                .iter()
+                .filter(|placement| !placement.is_mutable())
+                .map(|placement| {
+                    placement
+                        .mutation_scope
+                        .map(scan::MutationScope::id)
+                        .unwrap_or("unknown")
+                })
+                .collect::<BTreeSet<_>>();
             bail!(
-                "Library change for {} includes provider-managed read-only placements",
-                request.skill_id
+                "Library change for {} includes read-only placements with mutation_scope {:?}",
+                request.skill_id,
+                scopes
             );
         }
         let expected_ids = all_placements
@@ -7151,7 +7339,9 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
                 "link_status": placement.link_status,
                 "link_target": placement.link_target,
                 "default_exposed": placement.default_exposed,
-                "governable": placement.governable,
+                "governable": placement.is_mutable(),
+                "owned_by_agent": placement.owned_by_agent,
+                "mutation_scope": placement.mutation_scope,
                 "provider": placement.provider,
                 "fingerprint_completeness": placement.fingerprint_completeness,
                 "fingerprint_detail": placement.fingerprint_detail,
@@ -7301,6 +7491,7 @@ fn validate_roster_changes(
     plan: &PreparedPlan,
     scan: &ScanResult,
 ) -> Result<()> {
+    validate_governance_operation_mutation_scopes(plan, scan)?;
     let mut requested = std::collections::HashSet::new();
     for change in &plan.roster_changes {
         let agent = harness_agent(&change.agent)?;
@@ -7317,12 +7508,29 @@ fn validate_roster_changes(
         if !store.skill_exists(&skill_id)? {
             bail!("Skill {skill_id} is not present in the Library index");
         }
-        if !scan
+        let has_mutable_placement = scan
             .placements
             .iter()
-            .any(|placement| placement.skill_id == change.skill_id && placement.governable)
-        {
-            bail!("Skill {skill_id} is provider-managed and read-only");
+            .any(|placement| placement.skill_id == change.skill_id && placement.is_mutable());
+        let read_only_placement_remains_unchanged = change.state == "core"
+            && scan.placements.iter().any(|placement| {
+                placement.skill_id == change.skill_id
+                    && placement.agent == Some(agent)
+                    && placement.default_exposed
+            });
+        if !has_mutable_placement && !read_only_placement_remains_unchanged {
+            let scopes = scan
+                .placements
+                .iter()
+                .filter(|placement| placement.skill_id == change.skill_id)
+                .map(|placement| {
+                    placement
+                        .mutation_scope
+                        .map(scan::MutationScope::id)
+                        .unwrap_or("unknown")
+                })
+                .collect::<BTreeSet<_>>();
+            bail!("Skill {skill_id} has no mutable placement; read-only mutation_scope {scopes:?}");
         }
         if !requested.insert((change.agent.as_str(), change.skill_id.as_str())) {
             bail!(
@@ -7333,6 +7541,56 @@ fn validate_roster_changes(
         roster_state(&change.state)?;
     }
     Ok(())
+}
+
+fn validate_governance_operation_mutation_scopes(
+    plan: &PreparedPlan,
+    scan: &ScanResult,
+) -> Result<()> {
+    let has_governance_changes = !plan.roster_changes.is_empty()
+        || !plan.source_updates.is_empty()
+        || !plan.library_changes.is_empty();
+    if !has_governance_changes || plan.operations.is_empty() {
+        return Ok(());
+    }
+    for operation in &plan.operations {
+        let mutation_paths = match operation {
+            Operation::MoveRecoverable { source, target, .. } => {
+                vec![source.as_path(), target.as_path()]
+            }
+            Operation::CreateSymlink { target, .. }
+            | Operation::WriteFile { target, .. }
+            | Operation::ReplaceFile { target, .. }
+            | Operation::RemoveSymlink { target, .. }
+            | Operation::Copy { target, .. } => vec![target.as_path()],
+            Operation::CreateDirectory { .. } => Vec::new(),
+        };
+        for mutation_path in mutation_paths {
+            let mut blocked_by_skill = BTreeMap::<&str, Vec<&scan::SkillPlacement>>::new();
+            for placement in scan.placements.iter().filter(|placement| {
+                !placement.is_mutable()
+                    && (paths_overlap(mutation_path, &placement.directory)
+                        || placement
+                            .physical_directory
+                            .as_ref()
+                            .is_some_and(|physical| paths_overlap(mutation_path, physical)))
+            }) {
+                blocked_by_skill
+                    .entry(&placement.skill_id)
+                    .or_default()
+                    .push(placement);
+            }
+            if let Some((skill_id, mut placements)) = blocked_by_skill.into_iter().next() {
+                placements.sort_by(|left, right| left.id.cmp(&right.id));
+                return Err(crate::roster_plan::read_only_blocker(skill_id, &placements).into());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn paths_overlap(left: &Path, right: &Path) -> bool {
+    left == right || left.starts_with(right) || right.starts_with(left)
 }
 
 fn validate_governance_fingerprint_completeness(
@@ -7930,6 +8188,36 @@ fn action(
 mod recovery_tests {
     use super::*;
     use tempfile::TempDir;
+
+    fn placement_with_scope(
+        id: &str,
+        skill_id: &str,
+        directory: &str,
+        mutation_scope: Option<scan::MutationScope>,
+    ) -> scan::SkillPlacement {
+        let directory = PathBuf::from(directory);
+        scan::SkillPlacement {
+            id: id.into(),
+            skill_id: skill_id.into(),
+            agent: Some(AgentKind::Codex),
+            root: PathBuf::from("/fixture/root"),
+            entrypoint: directory.join("SKILL.md"),
+            directory,
+            physical_directory: None,
+            content_digest: "legacy-digest".into(),
+            fingerprint_completeness: scan::FingerprintCompleteness::Complete,
+            fingerprint_detail: None,
+            link_target: None,
+            link_status: scan::LinkStatus::NotLink,
+            default_exposed: true,
+            owned_by_agent: mutation_scope.map(|_| true),
+            mutation_scope,
+            governable: mutation_scope == Some(scan::MutationScope::Mutable),
+            provider: None,
+            executable_files: vec![],
+            declared_name_matches_directory: Some(true),
+        }
+    }
 
     #[test]
     fn scan_detected_source_root_drift_cannot_be_promoted_back_to_active() {
@@ -8617,6 +8905,12 @@ mod recovery_tests {
             link_target: None,
             link_status: scan::LinkStatus::NotLink,
             default_exposed: governable,
+            owned_by_agent: Some(governable),
+            mutation_scope: Some(if governable {
+                scan::MutationScope::Mutable
+            } else {
+                scan::MutationScope::ProviderReadOnly
+            }),
             governable,
             provider: (!governable).then(|| "plugin@market".into()),
             executable_files: Vec::new(),
@@ -8647,7 +8941,8 @@ mod recovery_tests {
         let planning = finding_library_planning(&finding, &scan_id, &scan_id, &scan).unwrap();
 
         assert_eq!(planning["supported"], false);
-        assert_eq!(planning["reason"], "external_observed_placements");
+        assert_eq!(planning["reason"], "provider_managed_read_only");
+        assert_eq!(planning["mutation_scopes"], json!(["provider_read_only"]));
         assert_eq!(planning["protected_placement_count"], 1);
 
         let blocker = finding_roster_safety_blocker(&[crate::roster_plan::RosterChangeExclusion {
@@ -8699,6 +8994,8 @@ mod recovery_tests {
             link_target: None,
             link_status: scan::LinkStatus::NotLink,
             default_exposed: true,
+            owned_by_agent: Some(true),
+            mutation_scope: Some(scan::MutationScope::Mutable),
             governable: true,
             provider: None,
             executable_files: Vec::new(),
@@ -8793,6 +9090,8 @@ mod recovery_tests {
                 link_target: None,
                 link_status: scan::LinkStatus::NotLink,
                 default_exposed: true,
+                owned_by_agent: Some(true),
+                mutation_scope: Some(scan::MutationScope::Mutable),
                 governable: true,
                 provider: None,
                 executable_files: vec![],
@@ -8812,6 +9111,248 @@ mod recovery_tests {
             blocked["error"]["details"]["remediation"]["required_before_rescan"],
             false
         );
+    }
+
+    #[test]
+    fn apply_validation_rejects_legacy_roster_operations_on_unknown_scope() {
+        let placement_path = PathBuf::from("/fixture/root/legacy");
+        let prepared = PreparedPlan {
+            id: PlanId::new().to_string(),
+            scan_id: ScanId::new().to_string(),
+            evidence_ids: vec![],
+            digest: "sha256:test".into(),
+            operations: vec![Operation::MoveRecoverable {
+                source: placement_path.clone(),
+                target: PathBuf::from("/fixture/state/backup/legacy"),
+                expected_fingerprint: "sha256:legacy".into(),
+            }],
+            roster_changes: vec![change::RosterChange {
+                agent: "codex".into(),
+                skill_id: "skill_legacy".into(),
+                state: "core".into(),
+            }],
+            source_updates: vec![],
+            library_changes: vec![],
+            approved_roots: vec![PathBuf::from("/fixture")],
+            state_dir: PathBuf::from("/fixture/state"),
+        };
+        let scan = ScanResult {
+            placements: vec![scan::SkillPlacement {
+                id: "placement_legacy".into(),
+                skill_id: "skill_legacy".into(),
+                agent: Some(AgentKind::Codex),
+                root: PathBuf::from("/fixture/root"),
+                directory: placement_path,
+                entrypoint: PathBuf::from("/fixture/root/legacy/SKILL.md"),
+                physical_directory: None,
+                content_digest: "legacy-digest".into(),
+                fingerprint_completeness: scan::FingerprintCompleteness::Complete,
+                fingerprint_detail: None,
+                link_target: None,
+                link_status: scan::LinkStatus::NotLink,
+                default_exposed: true,
+                owned_by_agent: None,
+                mutation_scope: None,
+                governable: true,
+                provider: None,
+                executable_files: vec![],
+                declared_name_matches_directory: Some(true),
+            }],
+            ..ScanResult::default()
+        };
+
+        let error = validate_governance_operation_mutation_scopes(&prepared, &scan).unwrap_err();
+
+        let blocker = error
+            .downcast_ref::<crate::roster_plan::RosterSafetyBlocker>()
+            .unwrap();
+        assert!(matches!(
+            blocker,
+            crate::roster_plan::RosterSafetyBlocker::MutationScopeReadOnly {
+                mutation_scopes,
+                ..
+            } if mutation_scopes == &["unknown"]
+        ));
+    }
+
+    #[test]
+    fn apply_validation_rejects_legacy_library_operations_on_unknown_scope() {
+        let placement_path = PathBuf::from("/fixture/root/legacy");
+        let prepared = PreparedPlan {
+            id: PlanId::new().to_string(),
+            scan_id: ScanId::new().to_string(),
+            evidence_ids: vec![],
+            digest: "sha256:test".into(),
+            operations: vec![Operation::MoveRecoverable {
+                source: placement_path.clone(),
+                target: PathBuf::from("/fixture/state/backup/legacy"),
+                expected_fingerprint: "sha256:legacy".into(),
+            }],
+            roster_changes: vec![],
+            source_updates: vec![],
+            library_changes: vec![change::LibraryChangeAction {
+                skill_id: "skill_legacy".into(),
+                canonical_placement_id: "placement_legacy".into(),
+                placement_ids: vec!["placement_legacy".into()],
+                requested_state: "managed".into(),
+                canonical_path: placement_path.clone(),
+                library_path: None,
+            }],
+            approved_roots: vec![PathBuf::from("/fixture")],
+            state_dir: PathBuf::from("/fixture/state"),
+        };
+        let scan = ScanResult {
+            placements: vec![placement_with_scope(
+                "placement_legacy",
+                "skill_legacy",
+                placement_path.to_str().unwrap(),
+                None,
+            )],
+            ..ScanResult::default()
+        };
+
+        let error = validate_governance_operation_mutation_scopes(&prepared, &scan).unwrap_err();
+
+        let blocker = error
+            .downcast_ref::<crate::roster_plan::RosterSafetyBlocker>()
+            .unwrap();
+        assert!(matches!(
+            blocker,
+            crate::roster_plan::RosterSafetyBlocker::MutationScopeReadOnly {
+                skill_id,
+                placement_ids,
+                mutation_scopes,
+                ..
+            } if skill_id == "skill_legacy"
+                && placement_ids == &["placement_legacy"]
+                && mutation_scopes == &["unknown"]
+        ));
+    }
+
+    #[test]
+    fn apply_validation_rejects_legacy_source_updates_on_unknown_scope() {
+        let placement_path = PathBuf::from("/fixture/root/legacy");
+        let entrypoint = placement_path.join("SKILL.md");
+        let prepared = PreparedPlan {
+            id: PlanId::new().to_string(),
+            scan_id: ScanId::new().to_string(),
+            evidence_ids: vec![],
+            digest: "sha256:test".into(),
+            operations: vec![Operation::ReplaceFile {
+                target: entrypoint.clone(),
+                content: "replacement".into(),
+                expected_fingerprint: "sha256:legacy".into(),
+            }],
+            roster_changes: vec![],
+            source_updates: vec![change::SourceUpdateAction {
+                skill_id: "skill_legacy".into(),
+                placement_id: "placement_legacy".into(),
+                choice: "adopt".into(),
+                source: "fixture".into(),
+                from_revision: "old".into(),
+                to_revision: "new".into(),
+                current_digest: "legacy-digest".into(),
+                expected_file_fingerprint: "sha256:legacy".into(),
+                upstream_digest: "upstream-digest".into(),
+                baseline_trusted: true,
+                choice_reason: "fixture".into(),
+                target: entrypoint,
+            }],
+            library_changes: vec![],
+            approved_roots: vec![PathBuf::from("/fixture")],
+            state_dir: PathBuf::from("/fixture/state"),
+        };
+        let scan = ScanResult {
+            placements: vec![placement_with_scope(
+                "placement_legacy",
+                "skill_legacy",
+                placement_path.to_str().unwrap(),
+                None,
+            )],
+            ..ScanResult::default()
+        };
+
+        let error = validate_governance_operation_mutation_scopes(&prepared, &scan).unwrap_err();
+
+        let blocker = error
+            .downcast_ref::<crate::roster_plan::RosterSafetyBlocker>()
+            .unwrap();
+        assert!(matches!(
+            blocker,
+            crate::roster_plan::RosterSafetyBlocker::MutationScopeReadOnly {
+                skill_id,
+                placement_ids,
+                mutation_scopes,
+                ..
+            } if skill_id == "skill_legacy"
+                && placement_ids == &["placement_legacy"]
+                && mutation_scopes == &["unknown"]
+        ));
+    }
+
+    #[test]
+    fn operation_scope_blocker_groups_nested_matches_by_skill() {
+        let prepared = PreparedPlan {
+            id: PlanId::new().to_string(),
+            scan_id: ScanId::new().to_string(),
+            evidence_ids: vec![],
+            digest: "sha256:test".into(),
+            operations: vec![Operation::MoveRecoverable {
+                source: PathBuf::from("/fixture/root/shared"),
+                target: PathBuf::from("/fixture/state/backup/shared"),
+                expected_fingerprint: "sha256:legacy".into(),
+            }],
+            roster_changes: vec![],
+            source_updates: vec![],
+            library_changes: vec![change::LibraryChangeAction {
+                skill_id: "skill_a".into(),
+                canonical_placement_id: "placement_a2".into(),
+                placement_ids: vec!["placement_a2".into()],
+                requested_state: "managed".into(),
+                canonical_path: PathBuf::from("/fixture/root/shared/a2"),
+                library_path: None,
+            }],
+            approved_roots: vec![PathBuf::from("/fixture")],
+            state_dir: PathBuf::from("/fixture/state"),
+        };
+        let scan = ScanResult {
+            placements: vec![
+                placement_with_scope(
+                    "placement_z",
+                    "skill_z",
+                    "/fixture/root/shared/z",
+                    Some(scan::MutationScope::DurableReadOnly),
+                ),
+                placement_with_scope(
+                    "placement_a2",
+                    "skill_a",
+                    "/fixture/root/shared/a2",
+                    Some(scan::MutationScope::DurableReadOnly),
+                ),
+                placement_with_scope(
+                    "placement_a1",
+                    "skill_a",
+                    "/fixture/root/shared/a1",
+                    Some(scan::MutationScope::DurableReadOnly),
+                ),
+            ],
+            ..ScanResult::default()
+        };
+
+        let error = validate_governance_operation_mutation_scopes(&prepared, &scan).unwrap_err();
+
+        let blocker = error
+            .downcast_ref::<crate::roster_plan::RosterSafetyBlocker>()
+            .unwrap();
+        assert!(matches!(
+            blocker,
+            crate::roster_plan::RosterSafetyBlocker::MutationScopeReadOnly {
+                skill_id,
+                placement_ids,
+                ..
+            } if skill_id == "skill_a"
+                && placement_ids == &["placement_a1", "placement_a2"]
+        ));
     }
 
     #[test]
@@ -9358,15 +9899,26 @@ mod recovery_tests {
                 .to_string(),
         ];
         let exclusions = (0..11)
-            .map(|index| crate::roster_plan::RosterChangeExclusion {
-                agent: "codex".into(),
-                skill_id: format!("skill_{index:032}"),
-                name: format!("skill-{index:02}"),
-                reason: "no_owned_exact_content_to_preserve",
-                observed_source_target: Some(crate::roster_plan::test_absolute_path(&format!(
-                    "opt/root-{index:02}/pkg"
-                ))),
-                safety_blocker: None,
+            .map(|index| {
+                let skill_id = format!("skill_{index:032}");
+                let path =
+                    crate::roster_plan::test_absolute_path(&format!("opt/root-{index:02}/pkg"));
+                crate::roster_plan::RosterChangeExclusion {
+                    agent: "codex".into(),
+                    skill_id: skill_id.clone(),
+                    name: format!("skill-{index:02}"),
+                    reason: "untrusted_external_placement_blocks_mutation",
+                    observed_source_target: Some(path.clone()),
+                    safety_blocker: Some(
+                        crate::roster_plan::RosterSafetyBlocker::MutationScopeReadOnly {
+                            skill_id,
+                            placement_ids: vec![format!("placement_{index:032}")],
+                            paths: vec![path],
+                            owned_by_agent: Some(true),
+                            mutation_scopes: vec!["untrusted_external".into()],
+                        },
+                    ),
+                }
             })
             .collect::<Vec<_>>();
         let blocked = crate::roster_plan::source_confirmation_block(
@@ -9463,9 +10015,21 @@ mod recovery_tests {
             );
         }
         validate_source_confirmation_detail(Path::new(detail_path)).unwrap();
+        assert_eq!(
+            source_confirmation_detail_summary(state.path()).unwrap()["count"],
+            1
+        );
+        assert_eq!(
+            read_source_confirmation_details(state.path())
+                .unwrap()
+                .len(),
+            1
+        );
         let mut unrecognized = complete.clone();
         unrecognized["action_context_argv"] = json!(["--yes", "true"]);
         assert!(!recognized_source_confirmation_detail(&unrecognized));
+        assert_eq!(remove_source_confirmation_details(state.path()).unwrap(), 1);
+        assert!(!Path::new(detail_path).exists());
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -213,6 +213,14 @@ pub struct FindMatch {
     pub providers: Vec<String>,
     /// True when at least one placement may participate in a governance Plan.
     pub governable: bool,
+    /// Whether any placement path is structurally Agent-owned. `None` means a
+    /// legacy Snapshot did not record complete ownership facts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owned_by_agent: Option<bool>,
+    /// Distinct mutation scopes across the matched placements. An empty set on
+    /// a legacy Snapshot means unknown, not mutable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mutation_scopes: Vec<crate::scan::MutationScope>,
     pub match_reasons: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task_channel_rank: Option<usize>,
@@ -274,6 +282,31 @@ pub struct FindVariant {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub providers: Vec<String>,
     pub governable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owned_by_agent: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mutation_scopes: Vec<crate::scan::MutationScope>,
+}
+
+fn placement_authority_facts(
+    placements: &[&crate::scan::SkillPlacement],
+) -> (Option<bool>, Vec<crate::scan::MutationScope>) {
+    let owned_by_agent = (!placements.is_empty()
+        && placements
+            .iter()
+            .all(|placement| placement.owned_by_agent.is_some()))
+    .then(|| {
+        placements
+            .iter()
+            .any(|placement| placement.owned_by_agent == Some(true))
+    });
+    let mutation_scopes = placements
+        .iter()
+        .filter_map(|placement| placement.mutation_scope)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    (owned_by_agent, mutation_scopes)
 }
 
 #[derive(Clone, Debug)]
@@ -1820,7 +1853,8 @@ pub(crate) fn find_matching(
                 .collect::<Vec<_>>();
             providers.sort();
             providers.dedup();
-            let governable = placements.iter().any(|placement| placement.governable);
+            let governable = placements.iter().any(|placement| placement.is_mutable());
+            let (owned_by_agent, mutation_scopes) = placement_authority_facts(&placements);
             let variants = if variant_count > 1 {
                 variant_skill_ids
                     .iter()
@@ -1852,6 +1886,8 @@ pub(crate) fn find_matching(
                             .collect::<Vec<_>>();
                         providers.sort();
                         providers.dedup();
+                        let (owned_by_agent, mutation_scopes) =
+                            placement_authority_facts(&variant_placements);
                         Some(FindVariant {
                             skill_id: variant_id.clone(),
                             paths,
@@ -1861,7 +1897,9 @@ pub(crate) fn find_matching(
                             providers,
                             governable: variant_placements
                                 .iter()
-                                .any(|placement| placement.governable),
+                                .any(|placement| placement.is_mutable()),
+                            owned_by_agent,
+                            mutation_scopes,
                         })
                     })
                     .collect()
@@ -1879,6 +1917,8 @@ pub(crate) fn find_matching(
                 source: skill.metadata.source.clone(),
                 providers,
                 governable,
+                owned_by_agent,
+                mutation_scopes,
                 match_reasons: reasons,
                 task_channel_rank: None,
                 augmented_channel_rank: None,
@@ -3052,6 +3092,8 @@ mod tests {
                 source: None,
                 providers: Vec::new(),
                 governable: true,
+                owned_by_agent: Some(true),
+                mutation_scopes: vec![crate::scan::MutationScope::Mutable],
                 match_reasons: reasons.iter().map(|reason| (*reason).into()).collect(),
                 task_channel_rank: None,
                 augmented_channel_rank: None,
@@ -3431,6 +3473,8 @@ mod tests {
                     link_target: None,
                     link_status: crate::scan::LinkStatus::NotLink,
                     default_exposed: true,
+                    owned_by_agent: Some(true),
+                    mutation_scope: Some(crate::scan::MutationScope::Mutable),
                     governable: true,
                     provider: None,
                     executable_files: Vec::new(),

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -89,6 +89,13 @@ pub enum RosterSafetyBlocker {
         paths: Vec<PathBuf>,
         providers: Vec<String>,
     },
+    MutationScopeReadOnly {
+        skill_id: String,
+        placement_ids: Vec<String>,
+        paths: Vec<PathBuf>,
+        owned_by_agent: Option<bool>,
+        mutation_scopes: Vec<String>,
+    },
     DependentSource {
         skill_id: String,
         placement_ids: Vec<String>,
@@ -103,11 +110,82 @@ impl std::fmt::Display for RosterSafetyBlocker {
                 formatter,
                 "Skill {skill_id} includes a provider-managed placement that is read-only"
             ),
+            Self::MutationScopeReadOnly {
+                skill_id,
+                mutation_scopes,
+                ..
+            } => write!(
+                formatter,
+                "Skill {skill_id} includes a read-only placement with mutation_scope {}",
+                mutation_scopes.join(", ")
+            ),
             Self::DependentSource { skill_id, .. } => write!(
                 formatter,
                 "Skill {skill_id} has a non-Agent source link that depends on a placement scheduled for removal"
             ),
         }
+    }
+}
+
+pub(crate) fn read_only_blocker(
+    skill_id: &str,
+    placements: &[&SkillPlacement],
+) -> RosterSafetyBlocker {
+    let providers = placements
+        .iter()
+        .filter_map(|placement| placement.provider.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if placements.iter().all(|placement| {
+        placement.mutation_scope == Some(crate::scan::MutationScope::ProviderReadOnly)
+    }) {
+        return RosterSafetyBlocker::ProviderManaged {
+            skill_id: skill_id.to_owned(),
+            placement_ids: placements
+                .iter()
+                .map(|placement| placement.id.clone())
+                .collect(),
+            paths: placements
+                .iter()
+                .map(|placement| placement.directory.clone())
+                .collect(),
+            providers,
+        };
+    }
+    let mutation_scopes = placements
+        .iter()
+        .map(|placement| {
+            placement
+                .mutation_scope
+                .map(crate::scan::MutationScope::id)
+                .unwrap_or("unknown")
+                .to_owned()
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let owned_by_agent = (!placements.is_empty()
+        && placements
+            .iter()
+            .all(|placement| placement.owned_by_agent.is_some()))
+    .then(|| {
+        placements
+            .iter()
+            .any(|placement| placement.owned_by_agent == Some(true))
+    });
+    RosterSafetyBlocker::MutationScopeReadOnly {
+        skill_id: skill_id.to_owned(),
+        placement_ids: placements
+            .iter()
+            .map(|placement| placement.id.clone())
+            .collect(),
+        paths: placements
+            .iter()
+            .map(|placement| placement.directory.clone())
+            .collect(),
+        owned_by_agent,
+        mutation_scopes,
     }
 }
 
@@ -255,7 +333,7 @@ pub fn source_confirmation_block(
     })
 }
 
-fn blocked_change_json(exclusion: &RosterChangeExclusion) -> Value {
+pub(crate) fn blocked_change_json(exclusion: &RosterChangeExclusion) -> Value {
     let mut item = json!({
         "agent": exclusion.agent,
         "skill_id": exclusion.skill_id,
@@ -265,6 +343,27 @@ fn blocked_change_json(exclusion: &RosterChangeExclusion) -> Value {
     });
     if let Some(target) = &exclusion.observed_source_target {
         item["observed_source_target"] = json!(target);
+    }
+    if let Some(blocker) = &exclusion.safety_blocker {
+        let mutation_scopes = match blocker {
+            RosterSafetyBlocker::ProviderManaged { .. } => {
+                item["owned_by_agent"] = json!(false);
+                item["mutation_scope"] = json!("provider_read_only");
+                json!(["provider_read_only"])
+            }
+            RosterSafetyBlocker::MutationScopeReadOnly {
+                owned_by_agent,
+                mutation_scopes,
+                ..
+            } => {
+                item["owned_by_agent"] = json!(owned_by_agent);
+                item["mutation_scope"] =
+                    json!((mutation_scopes.len() == 1).then(|| mutation_scopes[0].as_str()));
+                json!(mutation_scopes)
+            }
+            RosterSafetyBlocker::DependentSource { .. } => json!([]),
+        };
+        item["mutation_scopes"] = mutation_scopes;
     }
     item
 }
@@ -418,8 +517,8 @@ pub fn exclude_unpreservable_demotions(
                     .is_some_and(|agent| demoted_agents.contains(&agent))
             })
             .collect::<Vec<_>>();
-        let provider_managed_removals =
-            provider_placements_on_physical_removal(&placements, &removable).collect::<Vec<_>>();
+        let read_only_removals =
+            read_only_placements_on_physical_removal(&placements, &removable).collect::<Vec<_>>();
         let skill = scan
             .skills
             .iter()
@@ -442,27 +541,28 @@ pub fn exclude_unpreservable_demotions(
             .filter(|placement| placement.agent.is_none())
             .filter(|placement| depends_on_physical_removal(placement, &removable))
             .collect::<Vec<_>>();
-        let (reason, safety_blocker) = if !provider_managed_removals.is_empty() {
-            (
-                "provider_managed_placement_is_read_only",
-                Some(RosterSafetyBlocker::ProviderManaged {
-                    skill_id: skill_id.to_owned(),
-                    placement_ids: provider_managed_removals
-                        .iter()
-                        .map(|placement| placement.id.clone())
-                        .collect(),
-                    paths: provider_managed_removals
-                        .iter()
-                        .map(|placement| placement.directory.clone())
-                        .collect(),
-                    providers: provider_managed_removals
-                        .iter()
-                        .filter_map(|placement| placement.provider.clone())
-                        .collect::<BTreeSet<_>>()
-                        .into_iter()
-                        .collect(),
-                }),
-            )
+        let (reason, safety_blocker) = if !read_only_removals.is_empty() {
+            let blocker = read_only_blocker(skill_id, &read_only_removals);
+            let reason = match &blocker {
+                RosterSafetyBlocker::ProviderManaged { .. } => {
+                    "provider_managed_placement_is_read_only"
+                }
+                RosterSafetyBlocker::MutationScopeReadOnly {
+                    mutation_scopes, ..
+                } if mutation_scopes == &["durable_read_only"] => {
+                    "durable_read_only_placement_blocks_mutation"
+                }
+                RosterSafetyBlocker::MutationScopeReadOnly {
+                    mutation_scopes, ..
+                } if mutation_scopes == &["untrusted_external"] => {
+                    "untrusted_external_placement_blocks_mutation"
+                }
+                RosterSafetyBlocker::MutationScopeReadOnly { .. } => {
+                    "non_mutable_placement_blocks_mutation"
+                }
+                RosterSafetyBlocker::DependentSource { .. } => unreachable!(),
+            };
+            (reason, Some(blocker))
         } else if !non_agent_source_dependencies.is_empty() {
             (
                 "non_agent_source_link_depends_on_removal",
@@ -558,25 +658,23 @@ pub fn derive(
         if placements.is_empty() {
             bail!("Skill {skill_id} has no verified placement");
         }
-        if !placements.iter().any(|placement| placement.governable) {
-            return Err(RosterSafetyBlocker::ProviderManaged {
-                skill_id: skill_id.to_owned(),
-                placement_ids: placements
-                    .iter()
-                    .map(|placement| placement.id.clone())
-                    .collect(),
-                paths: placements
-                    .iter()
-                    .map(|placement| placement.directory.clone())
-                    .collect(),
-                providers: placements
-                    .iter()
-                    .filter_map(|placement| placement.provider.clone())
-                    .collect::<BTreeSet<_>>()
-                    .into_iter()
-                    .collect(),
-            }
-            .into());
+        let desired = requests
+            .iter()
+            .map(|request| Ok((agent(&request.agent)?, roster_state(&request.state)?)))
+            .collect::<Result<BTreeMap<_, _>>>()?;
+        let read_only_placements_remain_unchanged = requests.iter().all(|request| {
+            matches!(roster_state(&request.state), Ok(RosterState::Core))
+                && agent(&request.agent).is_ok_and(|requested_agent| {
+                    placements.iter().any(|placement| {
+                        placement.agent == Some(requested_agent)
+                            && unchanged_core_exposure(placement, &skill.content_digest)
+                    })
+                })
+        });
+        if !placements.iter().any(|placement| placement.is_mutable())
+            && !read_only_placements_remain_unchanged
+        {
+            return Err(read_only_blocker(skill_id, &placements).into());
         }
         for placement in placements
             .iter()
@@ -584,10 +682,6 @@ pub fn derive(
         {
             placement.validated_physical_directory()?;
         }
-        let desired = requests
-            .iter()
-            .map(|request| Ok((agent(&request.agent)?, roster_state(&request.state)?)))
-            .collect::<Result<BTreeMap<_, _>>>()?;
         ensure_physical_exposure_compatible(skill_id, &placements, &desired)?;
         let removal = placements
             .iter()
@@ -602,27 +696,17 @@ pub fn derive(
         for placement in &removal {
             placement.validated_physical_directory()?;
         }
-        let provider_placement_ids = provider_placements_on_physical_removal(&placements, &removal)
-            .map(|placement| placement.id.clone())
-            .collect::<Vec<_>>();
-        if !provider_placement_ids.is_empty() {
-            return Err(RosterSafetyBlocker::ProviderManaged {
-                skill_id: skill_id.to_owned(),
-                placement_ids: provider_placement_ids.clone(),
-                paths: placements
-                    .iter()
-                    .filter(|placement| provider_placement_ids.contains(&placement.id))
-                    .map(|placement| placement.directory.clone())
-                    .collect(),
-                providers: placements
-                    .iter()
-                    .filter(|placement| provider_placement_ids.contains(&placement.id))
-                    .filter_map(|placement| placement.provider.clone())
-                    .collect::<BTreeSet<_>>()
-                    .into_iter()
-                    .collect(),
-            }
-            .into());
+        let read_only_placement_ids =
+            read_only_placements_on_physical_removal(&placements, &removal)
+                .map(|placement| placement.id.clone())
+                .collect::<Vec<_>>();
+        if !read_only_placement_ids.is_empty() {
+            let blocked = placements
+                .iter()
+                .copied()
+                .filter(|placement| read_only_placement_ids.contains(&placement.id))
+                .collect::<Vec<_>>();
+            return Err(read_only_blocker(skill_id, &blocked).into());
         }
         let mut source = verified_real_source(&placements, &removal, &skill.content_digest);
         let mut source_fingerprint = source
@@ -697,6 +781,14 @@ pub fn derive(
             .into());
         }
         if !dependent_links.is_empty() {
+            let read_only = dependent_links
+                .iter()
+                .copied()
+                .filter(|placement| !placement.is_mutable())
+                .collect::<Vec<_>>();
+            if !read_only.is_empty() {
+                return Err(read_only_blocker(skill_id, &read_only).into());
+            }
             let source = source
                 .clone()
                 .ok_or_else(|| anyhow!("Skill {skill_id} has no verified canonical source"))?;
@@ -782,9 +874,7 @@ pub fn derive(
                 continue;
             }
             if existing.iter().any(|placement| {
-                placement.default_exposed
-                    && placement.link_status != LinkStatus::Broken
-                    && placement.content_digest == skill.content_digest
+                unchanged_core_exposure(placement, &skill.content_digest)
                     && !placement.link_target.as_ref().is_some_and(|target| {
                         removal.iter().any(|removed| target == &removed.directory)
                     })
@@ -796,6 +886,14 @@ pub fn derive(
                     "reason": "already_exposed_exact_content"
                 }));
                 continue;
+            }
+            let read_only = existing
+                .iter()
+                .copied()
+                .filter(|placement| !placement.is_mutable())
+                .collect::<Vec<_>>();
+            if !read_only.is_empty() {
+                return Err(read_only_blocker(skill_id, &read_only).into());
             }
             let source = source
                 .clone()
@@ -962,7 +1060,7 @@ fn depends_on_physical_removal(placement: &SkillPlacement, removal: &[&SkillPlac
         })
 }
 
-fn provider_placements_on_physical_removal<'a>(
+fn read_only_placements_on_physical_removal<'a>(
     placements: &'a [&SkillPlacement],
     removal: &[&SkillPlacement],
 ) -> impl Iterator<Item = &'a SkillPlacement> {
@@ -971,7 +1069,7 @@ fn provider_placements_on_physical_removal<'a>(
         .map(|placement| physical_mutation_path(placement))
         .collect::<BTreeSet<_>>();
     placements.iter().copied().filter(move |placement| {
-        !placement.governable && removal_paths.contains(&physical_mutation_path(placement))
+        !placement.is_mutable() && removal_paths.contains(&physical_mutation_path(placement))
     })
 }
 
@@ -1054,12 +1152,18 @@ fn verified_real_source(
 }
 
 fn is_real_exact(placement: &SkillPlacement, digest: &str) -> bool {
-    placement.governable
+    placement.is_mutable()
         && placement.fingerprint_completeness == FingerprintCompleteness::Complete
         && placement.content_digest == digest
         && placement.link_target.is_none()
         && std::fs::symlink_metadata(&placement.directory)
             .is_ok_and(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink())
+}
+
+fn unchanged_core_exposure(placement: &SkillPlacement, digest: &str) -> bool {
+    placement.default_exposed
+        && placement.link_status != LinkStatus::Broken
+        && placement.content_digest == digest
 }
 
 fn agent_root(scan: &ScanResult, agent: AgentKind) -> Result<PathBuf> {
@@ -1424,6 +1528,8 @@ mod tests {
             .clone();
         provider.id = "placement_provider_fixture".into();
         provider.agent = None;
+        provider.owned_by_agent = Some(false);
+        provider.mutation_scope = Some(crate::scan::MutationScope::ProviderReadOnly);
         provider.governable = false;
         provider.provider = Some("fixture-provider".into());
         let provider_directory = provider.directory.clone();
@@ -1590,7 +1696,7 @@ mod tests {
         assert_eq!(supported.exclusions[0].name, "external");
         assert_eq!(
             supported.exclusions[0].reason,
-            "no_owned_exact_content_to_preserve"
+            "untrusted_external_placement_blocks_mutation"
         );
         assert_eq!(
             supported.exclusions[0].observed_source_target.as_deref(),
@@ -1632,6 +1738,46 @@ mod tests {
         assert!(plan.operations.is_empty());
         assert!(fs::read_dir(&state).unwrap().next().is_none());
         assert!(outside.join("SKILL.md").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mutable_sibling_cannot_authorize_replacing_a_read_only_core_placement() {
+        let (temp, mut snapshot, shared_skill) = shared_agent_root_fixture();
+        let codex = snapshot
+            .placements
+            .iter_mut()
+            .find(|placement| placement.agent == Some(AgentKind::Codex))
+            .unwrap();
+        codex.content_digest = "different-observed-digest".into();
+        codex.mutation_scope = Some(crate::scan::MutationScope::DurableReadOnly);
+        codex.governable = false;
+        let codex_path = codex.directory.clone();
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+
+        let error = derive(
+            &snapshot,
+            &state,
+            &[RosterChange {
+                agent: "codex".into(),
+                skill_id: snapshot.skills[0].id.clone(),
+                state: "core".into(),
+            }],
+        )
+        .unwrap_err();
+
+        let blocker = error.downcast_ref::<RosterSafetyBlocker>().unwrap();
+        assert!(matches!(
+            blocker,
+            RosterSafetyBlocker::MutationScopeReadOnly {
+                mutation_scopes,
+                ..
+            } if mutation_scopes == &["durable_read_only"]
+        ));
+        assert!(codex_path.join("SKILL.md").is_file());
+        assert!(shared_skill.join("SKILL.md").is_file());
+        assert!(fs::read_dir(&state).unwrap().next().is_none());
     }
 
     #[cfg(unix)]

--- a/src/roster_recommendation.rs
+++ b/src/roster_recommendation.rs
@@ -764,6 +764,8 @@ mod tests {
                 link_target: None,
                 link_status: LinkStatus::NotLink,
                 default_exposed: true,
+                owned_by_agent: Some(true),
+                mutation_scope: Some(crate::scan::MutationScope::Mutable),
                 governable: true,
                 provider: None,
                 executable_files: Vec::new(),

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -157,6 +157,14 @@ pub struct SkillPlacement {
     pub link_target: Option<PathBuf>,
     pub link_status: LinkStatus,
     pub default_exposed: bool,
+    /// Stable structural ownership of the placement path. This does not claim
+    /// ownership or endorsement of content reached through a link.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owned_by_agent: Option<bool>,
+    /// The bounded mutation authority observed for this placement. Missing on
+    /// legacy Snapshots means unknown and must never authorize mutation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mutation_scope: Option<MutationScope>,
     /// Whether SkillRoster may include this placement in a mutating governance Plan.
     /// External provider caches are observed and searchable, but never governable.
     #[serde(default = "default_true")]
@@ -168,6 +176,32 @@ pub struct SkillPlacement {
     pub executable_files: Vec<PathBuf>,
     #[serde(default)]
     pub declared_name_matches_directory: Option<bool>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationScope {
+    Mutable,
+    ProviderReadOnly,
+    DurableReadOnly,
+    UntrustedExternal,
+}
+
+impl MutationScope {
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Mutable => "mutable",
+            Self::ProviderReadOnly => "provider_read_only",
+            Self::DurableReadOnly => "durable_read_only",
+            Self::UntrustedExternal => "untrusted_external",
+        }
+    }
+}
+
+impl SkillPlacement {
+    pub fn is_mutable(&self) -> bool {
+        self.governable && self.mutation_scope == Some(MutationScope::Mutable)
+    }
 }
 
 #[derive(Debug)]
@@ -1390,6 +1424,18 @@ fn materialize_candidates_with_hook(
             candidate.root.display(),
             candidate.entrypoint.display()
         );
+        let mutation_scope = if candidate.provider.is_some() {
+            MutationScope::ProviderReadOnly
+        } else if durable_anchor.is_some() {
+            MutationScope::DurableReadOnly
+        } else if !candidate.governable
+            || candidate.link_status == LinkStatus::EscapesRoot
+            || !safe_to_read
+        {
+            MutationScope::UntrustedExternal
+        } else {
+            MutationScope::Mutable
+        };
         result.placements.push(SkillPlacement {
             id: format!("placement_{}", stable_digest(placement_basis.as_bytes())),
             skill_id,
@@ -1404,7 +1450,9 @@ fn materialize_candidates_with_hook(
             link_target: candidate.link_target,
             link_status: candidate.link_status,
             default_exposed: candidate.agent.is_some(),
-            governable: candidate.governable && durable_anchor.is_none(),
+            owned_by_agent: Some(candidate.agent.is_some()),
+            mutation_scope: Some(mutation_scope),
+            governable: mutation_scope == MutationScope::Mutable,
             provider: candidate.provider,
             executable_files,
             declared_name_matches_directory,
@@ -2479,6 +2527,11 @@ enabled = true
         assert_eq!(result.skills[0].name, "design-kpis");
         assert_eq!(result.placements.len(), 1);
         assert!(!result.placements[0].governable);
+        assert_eq!(result.placements[0].owned_by_agent, Some(false));
+        assert_eq!(
+            result.placements[0].mutation_scope,
+            Some(MutationScope::ProviderReadOnly)
+        );
         assert_eq!(
             result.placements[0].provider.as_deref(),
             Some("data-analytics@openai-curated-remote")
@@ -2808,6 +2861,11 @@ enabled = true
         let result = scan(&options).unwrap();
         assert_eq!(result.skills.len(), 1);
         assert_eq!(result.placements.len(), 2);
+        assert!(result.placements.iter().all(|placement| {
+            placement.owned_by_agent == Some(true)
+                && placement.mutation_scope == Some(MutationScope::Mutable)
+                && placement.governable
+        }));
         assert!(result.roots.iter().any(|seen| seen.explicit));
         fs::remove_dir_all(root).unwrap();
     }
@@ -3068,6 +3126,11 @@ enabled = true
             FingerprintCompleteness::Unreadable
         );
         assert!(!result.placements[0].governable);
+        assert_eq!(result.placements[0].owned_by_agent, Some(true));
+        assert_eq!(
+            result.placements[0].mutation_scope,
+            Some(MutationScope::DurableReadOnly)
+        );
         assert!(result.placements[0].physical_directory.is_none());
         let encoded = serde_json::to_string(&result).unwrap();
         assert!(!encoded.contains("replacement-secret"));
@@ -4040,6 +4103,12 @@ enabled = true
         let result = scan(&options).unwrap();
         assert_eq!(result.placements.len(), 1);
         assert_eq!(result.placements[0].link_status, LinkStatus::EscapesRoot);
+        assert_eq!(result.placements[0].owned_by_agent, Some(true));
+        assert_eq!(
+            result.placements[0].mutation_scope,
+            Some(MutationScope::UntrustedExternal)
+        );
+        assert!(!result.placements[0].governable);
         assert!(result.skills[0].summary.is_empty());
         assert!(
             result
@@ -4049,6 +4118,30 @@ enabled = true
         );
         fs::remove_dir_all(root).unwrap();
         fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[test]
+    fn legacy_placement_authority_is_unknown_and_cannot_authorize_mutation() {
+        let value = serde_json::json!({
+            "id": "placement_legacy",
+            "skill_id": "skill_legacy",
+            "agent": "codex",
+            "root": "/tmp/skills",
+            "directory": "/tmp/skills/example",
+            "entrypoint": "/tmp/skills/example/SKILL.md",
+            "content_digest": "sha256:legacy",
+            "link_target": null,
+            "link_status": "not_link",
+            "default_exposed": true,
+            "governable": true,
+            "executable_files": [],
+            "declared_name_matches_directory": true
+        });
+        let placement: SkillPlacement = serde_json::from_value(value).unwrap();
+
+        assert_eq!(placement.owned_by_agent, None);
+        assert_eq!(placement.mutation_scope, None);
+        assert!(!placement.is_mutable());
     }
 
     #[cfg(unix)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4822,7 +4822,10 @@ fn custom_budget_plan_reports_actionable_source_blockers() {
             .iter()
             .all(|item| {
                 item["agent"] == "codex"
-                    && item["reason"] == "no_owned_exact_content_to_preserve"
+                    && item["reason"] == "untrusted_external_placement_blocks_mutation"
+                    && item["owned_by_agent"] == true
+                    && item["mutation_scope"] == "untrusted_external"
+                    && item["mutation_scopes"] == json!(["untrusted_external"])
                     && item["observed_source_target"]
                         .as_str()
                         .is_some_and(|path| path.starts_with(reviewed.to_str().unwrap()))
@@ -6830,6 +6833,12 @@ fn escaping_link_finding_requests_trust_confirmation_instead_of_a_plan() {
     );
     let found = json_output(&run(&[&common[..], &["find", "fixture"]].concat(), None));
     assert_eq!(found["result"]["matches"][0]["name"], "external");
+    assert_eq!(found["result"]["matches"][0]["owned_by_agent"], true);
+    assert_eq!(
+        found["result"]["matches"][0]["mutation_scopes"],
+        json!(["durable_read_only"])
+    );
+    assert_eq!(found["result"]["matches"][0]["governable"], false);
 
     let snapshot = rescanned["result"]["snapshot_id"].as_str().unwrap();
     let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
@@ -6859,6 +6868,16 @@ fn escaping_link_finding_requests_trust_confirmation_instead_of_a_plan() {
         placements
             .iter()
             .all(|placement| placement["governable"] == false)
+    );
+    assert!(
+        placements
+            .iter()
+            .any(|placement| placement["owned_by_agent"] == true)
+    );
+    assert!(
+        placements
+            .iter()
+            .all(|placement| placement["mutation_scope"] == "durable_read_only")
     );
     assert!(
         placements
@@ -6936,12 +6955,17 @@ fn escaping_link_finding_requests_trust_confirmation_instead_of_a_plan() {
         &[&common[..], &["plan", "--stdin"]].concat(),
         Some(&roster_change.to_string()),
     );
-    assert!(!roster_change.status.success());
-    assert!(String::from_utf8_lossy(&roster_change.stdout).contains("read-only"));
+    assert!(roster_change.status.success());
+    let roster_change: Value = serde_json::from_slice(&roster_change.stdout).unwrap();
+    assert_eq!(roster_change["result"]["files_changed"], false);
+    assert_eq!(
+        roster_change["result"]["change_summary"]["operation_count"],
+        0
+    );
     let plan_count: i64 = database
         .query_row("SELECT COUNT(*) FROM plans", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(plan_count, 0);
+    assert_eq!(plan_count, 1);
 
     let stale = run_suggested_action(confirm);
     assert!(!stale.status.success());


### PR DESCRIPTION
Closes #137.

## What changed

- adds orthogonal `owned_by_agent` and typed `mutation_scope` facts while preserving `governable` as the mutable compatibility projection
- exposes authority facts in Report, Find, exact-duplicate and large-roster planning
- distinguishes provider, durable-read, untrusted-external, and legacy-unknown blockers
- keeps unchanged read-only Core placements valid only for true zero-operation plans
- validates actual operation source/target paths at Plan and Apply across Roster, Library, and Source Update; legacy authority-less governance plans fail closed
- keeps Scan/Report separation and Snapshot-scoped Finding IDs unchanged

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (208 unit + 7 acceptance + 57 CLI)
- `git diff --check`
- isolated Pi fixture: untrusted external -> confirmed exact local read -> durable read-only; Find returns `owned_by_agent=true`, `mutation_scopes=[durable_read_only]`, `governable=false`; no real Agent files or real SkillRoster state touched
- final independent Spec review: 0 blocker / 0 should-fix / 0 nit
- final independent Safety review: 0 blocker / 0 should-fix

## Boundaries

No new command, database subsystem, semantic model, generic readiness engine, TUI, MCP, stable cross-Snapshot Finding ID, or Scan/Report merge.