### PR TITLE
test: correct Codex transfer evidence scoring

### DIFF
--- a/tests/fixtures/codex-cold-routing-transfer.json
+++ b/tests/fixtures/codex-cold-routing-transfer.json
@@ -33,7 +33,7 @@
       "oracle": {
         "path": "outputs/order-architecture.html",
         "minimum_bytes": 20000,
-        "required_substrings": ["<svg", "<style", "<script", "data-theme", "btn-theme", "Web 客户端", "API Gateway", "Auth Service", "Order Service", "PostgreSQL", "Queue", "Worker", "Object Storage", "HTTPS", "SQL", "异步事件", "信任边界"],
+        "required_substrings": ["<svg", "<style", "<script", "data-theme", "btn-theme", "Web 客户端", "API Gateway", "Auth Service", "Order Service", "PostgreSQL", "Queue", "Worker", "Object Storage", "HTTPS", "SQL", "异步事件"],
         "required_regex": ["(btn-node-finder|data-node-finder-trigger|search)", "(data-intent-trace-active|data-route-probe-overlay|trace)"],
         "forbidden_regex": ["<script\\b[^>]*\\bsrc\\s*=", "<link\\b(?=[^>]*\\brel\\s*=\\s*['\"]?stylesheet)(?=[^>]*\\bhref\\s*=)[^>]*>"],
         "forbidden_substrings": [],
@@ -43,6 +43,33 @@
           "artifact_path": "outputs/order-architecture.html",
           "quality": "showcase",
           "validation_check_count": 9
+        },
+        "architecture_spec_contract": {
+          "spec_path": "scratch/order-architecture.spec.json",
+          "components": [
+            { "id": "web-client", "label": "Web 客户端" },
+            { "id": "api-gateway", "label": "API Gateway" },
+            { "id": "auth-service", "label": "Auth Service" },
+            { "id": "order-service", "label": "Order Service" },
+            { "id": "postgresql", "label": "PostgreSQL" },
+            { "id": "queue", "label": "Queue" },
+            { "id": "worker", "label": "Worker" },
+            { "id": "object-storage", "label": "Object Storage" }
+          ],
+          "boundaries": [
+            { "label": "用户端", "members": ["web-client"] },
+            { "label": "应用服务区", "members": ["api-gateway", "auth-service", "order-service"] },
+            { "label": "数据与异步基础设施区", "members": ["postgresql", "queue", "worker", "object-storage"] }
+          ],
+          "connections": [
+            { "id": "web-to-gateway", "from": "web-client", "to": "api-gateway", "label_regex": "^HTTPS$" },
+            { "id": "gateway-to-order", "from": "api-gateway", "to": "order-service", "label_regex": "^HTTPS$" },
+            { "id": "order-to-db", "from": "order-service", "to": "postgresql", "label_regex": "^SQL$" },
+            { "id": "gateway-to-auth", "from": "api-gateway", "to": "auth-service", "label_regex": "HTTPS.*(认证|Auth)|(?:认证|Auth).*HTTPS" },
+            { "id": "order-to-queue", "from": "order-service", "to": "queue", "label_regex": "(发布|publish).*(异步事件|event)|(异步事件|event).*(发布|publish)" },
+            { "id": "queue-to-worker", "from": "queue", "to": "worker", "label_regex": "(消费|consume).*(异步事件|event)|(异步事件|event).*(消费|consume)" },
+            { "id": "worker-to-storage", "from": "worker", "to": "object-storage", "label_regex": "(写入|write).*(订单文档|document)|(订单文档|document).*(写入|write)" }
+          ]
         }
       }
     }

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -39,12 +39,13 @@ export function parseArgs(argv) {
     codex: "codex", bootstrap: join(REPO, "skill/skillroster/SKILL.md"),
     skillsRoot: join(homedir(), ".agents_skills"), cli: join(REPO, "target/debug/skillroster"),
     runsDir: join(tmpdir(), "skillroster-codex-transfer"), authSource: null,
-    timeoutMs: 300_000, execute: false,
+    timeoutMs: 300_000, execute: false, reevaluateRoot: null, reevaluateOutput: null,
   };
   const values = new Map([
     ["--manifest", "manifest"], ["--task", "task"], ["--arm", "arm"], ["--model", "model"],
     ["--codex", "codex"], ["--bootstrap", "bootstrap"], ["--skills-root", "skillsRoot"],
     ["--cli", "cli"], ["--runs-dir", "runsDir"], ["--auth-source", "authSource"], ["--timeout-ms", "timeoutMs"],
+    ["--reevaluate-root", "reevaluateRoot"], ["--reevaluate-output", "reevaluateOutput"],
   ]);
   for (let index = 0; index < argv.length;) {
     if (argv[index] === "--execute") { options.execute = true; index += 1; continue; }
@@ -55,7 +56,9 @@ export function parseArgs(argv) {
   }
   if (!["core", "on_demand", "both"].includes(options.arm)) fail("--arm must be core, on_demand, or both");
   if (!Number.isSafeInteger(options.timeoutMs) || options.timeoutMs < 1_000 || options.timeoutMs > 900_000) fail("--timeout-ms must be between 1000 and 900000");
+  if (options.execute && options.reevaluateRoot) fail("--execute and --reevaluate-root are mutually exclusive");
   if (options.execute && !options.authSource) fail("--execute requires an explicit --auth-source");
+  if (options.reevaluateOutput && !options.reevaluateRoot) fail("--reevaluate-output requires --reevaluate-root");
   return options;
 }
 
@@ -75,6 +78,9 @@ export function validateManifest(manifest) {
     for (const pattern of [...(task.oracle.required_regex ?? []), ...(task.oracle.forbidden_regex ?? [])]) new RegExp(pattern, "u");
     const receipt = task.oracle.archify_receipt_contract;
     if (receipt && (receipt.type !== "architecture" || safeRelative(receipt.spec_path, `${task.id} receipt spec`) !== receipt.spec_path || safeRelative(receipt.artifact_path, `${task.id} receipt artifact`) !== task.oracle.path || receipt.quality !== "showcase" || receipt.validation_check_count !== 9)) fail(`${task.id} Archify receipt contract is invalid`);
+    const spec = task.oracle.architecture_spec_contract;
+    if (receipt && (!spec || spec.spec_path !== receipt.spec_path || spec.components?.length !== 8 || spec.boundaries?.length !== 3 || spec.connections?.length !== 7)) fail(`${task.id} architecture spec contract is invalid`);
+    for (const edge of spec?.connections ?? []) new RegExp(edge.label_regex, "u");
   }
   return manifest;
 }
@@ -168,8 +174,40 @@ export function evaluateOracle(workspace, oracle, evidence = {}) {
   for (const value of oracle.forbidden_substrings ?? []) if (text.includes(value)) failures.push(`forbidden_substring:${value}`);
   for (const value of oracle.required_regex ?? []) if (!new RegExp(value, "u").test(text)) failures.push(`missing_regex:${value}`);
   for (const value of oracle.forbidden_regex ?? []) if (new RegExp(value, "u").test(text)) failures.push(`forbidden_regex:${value}`);
-  failures.push(...evaluateArchifyReceipts(evidence.transcript ?? "", workspace, evidence.targetPackage, oracle.archify_receipt_contract));
-  return { passed: failures.length === 0, failures, output_sha256: sha(bytes), output_bytes: bytes.length, audit_scope: "offline_content_only" };
+  failures.push(...evaluateArchitectureSpec(workspace, oracle.architecture_spec_contract));
+  const archifyAttempts = evaluateArchifyReceipts(evidence.transcript ?? "", workspace, oracle.archify_receipt_contract); failures.push(...archifyAttempts);
+  const parentVerification = verifyArchifyParent(workspace, evidence.targetPackage, oracle.archify_receipt_contract, evidence.parentVerificationAuthority); if (parentVerification.passed === false) failures.push(...parentVerification.failures);
+  return { passed: failures.length === 0, failures, output_sha256: sha(bytes), output_bytes: bytes.length, audit_scope: "independent transcript-attempt and parent-owned frozen correctness evidence", archify_agent_attempts: { passed: archifyAttempts.length === 0, failures: archifyAttempts }, archify_parent_verification: parentVerification };
+}
+
+export function evaluateArchitectureSpec(workspace, contract) {
+  if (!contract) return [];
+  const path = noFollowWorkspaceFile(workspace, contract.spec_path); if (!path) return ["architecture_spec:missing_or_unsafe"];
+  let value; try { value = JSON.parse(readFileSync(path, "utf8")); } catch { return ["architecture_spec:invalid_json"]; }
+  const failures = []; const actualComponents = Array.isArray(value.components) ? value.components : []; const actualBoundaries = Array.isArray(value.boundaries) ? value.boundaries : []; const actualConnections = Array.isArray(value.connections) ? value.connections : [];
+  const expectedComponents = new Map(contract.components.map((component) => [component.id, component.label])); const actualIds = actualComponents.map((component) => component?.id);
+  if (new Set(actualIds).size !== actualIds.length) failures.push("architecture_spec:duplicate_component_id");
+  if (actualComponents.length !== expectedComponents.size || actualComponents.some((component) => expectedComponents.get(component?.id) !== component?.label)) failures.push("architecture_spec:component_set_mismatch");
+  const normalizeBoundary = (label) => typeof label === "string" ? label.replace(/^信任边界：/u, "") : null;
+  const expectedBoundaries = new Map(contract.boundaries.map((boundary) => [boundary.label, [...boundary.members].sort()])); const seenMembers = [];
+  if (actualBoundaries.length !== expectedBoundaries.size) failures.push("architecture_spec:boundary_count_mismatch");
+  const seenBoundaryLabels = new Set();
+  for (const boundary of actualBoundaries) {
+    const label = normalizeBoundary(boundary?.label); if (!expectedBoundaries.has(label) || seenBoundaryLabels.has(label)) { failures.push("architecture_spec:boundary_label_mismatch"); continue; }
+    seenBoundaryLabels.add(label); const members = Array.isArray(boundary.wraps) ? [...boundary.wraps].sort() : [];
+    if (JSON.stringify(members) !== JSON.stringify(expectedBoundaries.get(label))) failures.push(`architecture_spec:boundary_members_mismatch:${label}`);
+    seenMembers.push(...members);
+  }
+  if (seenMembers.length !== expectedComponents.size || new Set(seenMembers).size !== expectedComponents.size || seenMembers.some((id) => !expectedComponents.has(id))) failures.push("architecture_spec:boundary_partition_invalid");
+  const expectedEdges = new Map(contract.connections.map((edge) => [`${edge.from}\0${edge.to}`, edge.label_regex])); const seenEdges = new Set();
+  if (actualConnections.length !== expectedEdges.size) failures.push("architecture_spec:connection_count_mismatch");
+  for (const edge of actualConnections) {
+    const key = `${edge?.from}\0${edge?.to}`;
+    if (!expectedEdges.has(key) || seenEdges.has(key) || !expectedComponents.has(edge?.from) || !expectedComponents.has(edge?.to)) failures.push("architecture_spec:connection_identity_mismatch");
+    else if (!new RegExp(expectedEdges.get(key), "u").test(edge?.label ?? "")) failures.push(`architecture_spec:connection_label_mismatch:${edge.id}`);
+    seenEdges.add(key);
+  }
+  return [...new Set(failures)];
 }
 
 export function parseFindAudit(text, expected) {
@@ -236,14 +274,15 @@ export function assessTranscriptIntegrity(jsonl) {
     if (value?.type === "turn.failed") turnFailed += 1;
   }
   const commands = extractCommandEvents(jsonl).filter((event) => event.kind === "command");
-  const incompleteCommands = commands.filter((event) => event.status !== "completed" || !Number.isInteger(event.exit_code)).length;
+  const incompleteCommands = commands.filter((event) => !["completed", "failed"].includes(event.status) || !Number.isInteger(event.exit_code)).length;
   const successfulCommands = commands.filter((event) => event.status === "completed" && event.exit_code === 0).length;
+  const unsuccessfulCommands = commands.filter((event) => Number.isInteger(event.exit_code) && (event.status === "failed" || event.exit_code !== 0)).length;
   const violations = [];
   if (malformed) violations.push(`malformed_jsonl:${malformed}`);
   if (turnCompleted !== 1 || turnFailed) violations.push(`turn_completion:${turnCompleted}:${turnFailed}`);
   if (incompleteCommands) violations.push(`incomplete_command_events:${incompleteCommands}`);
   if (!successfulCommands) violations.push("successful_command_event_missing");
-  return { passed: violations.length === 0, violations, turn_completed_count: turnCompleted, successful_command_count: successfulCommands };
+  return { passed: violations.length === 0, violations, turn_completed_count: turnCompleted, successful_command_count: successfulCommands, unsuccessful_command_count: unsuccessfulCommands };
 }
 
 export function extractCommandTexts(jsonl) { return extractCommandEvents(jsonl).filter((event) => event.kind === "command").map((event) => event.command); }
@@ -271,42 +310,71 @@ function simpleCommandTokens(command) {
   return tokens;
 }
 
-export function evaluateArchifyReceipts(transcript, workspace, targetPackage, contract) {
-  if (!contract) return [];
-  if (!targetPackage) return ["archify_receipt:target_package_missing"];
-  const spec = noFollowWorkspaceFile(workspace, contract.spec_path); const artifact = noFollowWorkspaceFile(workspace, contract.artifact_path);
-  if (!spec || !artifact) return ["archify_receipt:bound_file_missing_or_unsafe"];
-  const script = join(targetPackage, "bin", "archify.mjs");
-  try { if (!lstatSync(script).isFile() || lstatSync(script).isSymbolicLink()) return ["archify_receipt:tool_missing_or_unsafe"]; } catch { return ["archify_receipt:tool_missing_or_unsafe"]; }
-  const canonicalScript = canonicalPath(script); const artifactBytes = readFileSync(artifact); const specBytes = readFileSync(spec);
+function parseArchifyTranscriptCommand(command, workspace, contract) {
+  const inner = unwrapSimpleShell(command); let nodePart = inner; let preparedArtifactParent = false;
+  if (inner.includes("&&")) {
+    const parts = inner.split(/\s+&&\s+/u); if (parts.length !== 2) return null;
+    const mkdir = simpleCommandTokens(parts[0]);
+    if (mkdir?.length !== 3 || basename(mkdir[0]) !== "mkdir" || mkdir[1] !== "-p" || canonicalPath(isAbsolute(mkdir[2]) ? mkdir[2] : join(workspace, mkdir[2])) !== canonicalPath(join(workspace, dirname(contract.artifact_path)))) return null;
+    nodePart = parts[1]; preparedArtifactParent = true;
+  }
+  const tokens = simpleCommandTokens(nodePart); if (!tokens || !["node", "node.exe"].includes(basename(tokens[0]).toLowerCase()) || tokens[1] !== "bin/archify.mjs") return null;
   const commandPath = (value) => canonicalPath(isAbsolute(value ?? "") ? value : join(workspace, value ?? ""));
-  const commandTokens = (command) => {
-    const tokens = simpleCommandTokens(command);
-    return tokens?.length > 1 && ["node", "node.exe"].includes(basename(tokens[0]).toLowerCase()) && commandPath(tokens[1]) === canonicalScript ? tokens : null;
-  };
-  const commonShape = (tokens) => tokens.at(-3) === "--quality" && tokens.at(-2) === contract.quality && tokens.at(-1) === "--json";
-  const isValidateCommand = (tokens) => tokens?.length === 8 && commonShape(tokens) && tokens[2] === "validate" && tokens[3] === contract.type && commandPath(tokens[4]) === spec;
-  const isDeliverCommand = (tokens) => tokens?.length === 9 && commonShape(tokens) && tokens[2] === "deliver" && tokens[3] === contract.type && commandPath(tokens[4]) === spec && commandPath(tokens[5]) === artifact;
-  const validValidateReceipt = (receipt) => receipt?.schemaVersion === 1 && receipt?.ok === true && receipt?.command === "validate" && receipt?.type === contract.type && canonicalPath(receipt.input ?? "") === spec && receipt?.checks?.length === contract.validation_check_count && receipt.checks.every((check) => check?.ok === true) && receipt?.composition?.status === "pass" && receipt?.composition?.summary?.errors === 0 && receipt?.composition?.summary?.warnings === 0;
-  const validDeliverReceipt = (receipt) => receipt?.schemaVersion === 1 && receipt?.ok === true && receipt?.command === "deliver" && receipt?.type === contract.type && canonicalPath(receipt.input ?? "") === spec && canonicalPath(receipt.output ?? "") === artifact && receipt?.specification?.sha256 === sha(specBytes) && receipt?.specification?.bytes === specBytes.length && receipt?.artifact?.sha256 === sha(artifactBytes) && receipt?.artifact?.bytes === artifactBytes.length && receipt?.validation?.checksPassed === contract.validation_check_count && receipt?.validation?.checkCount === contract.validation_check_count && receipt?.validation?.compositionProfile === contract.quality && receipt?.validation?.compositionStatus === "pass" && receipt?.validation?.errors === 0 && receipt?.validation?.warnings === 0;
-  const failures = []; const allowedDeliverIds = new Set(); let validateSucceeded = false; let deliverSucceeded = false;
+  const common = tokens.at(-3) === "--quality" && tokens.at(-2) === contract.quality && tokens.at(-1) === "--json";
+  const validate = tokens.length === 8 && tokens[2] === "validate" && tokens[3] === contract.type && commandPath(tokens[4]) === canonicalPath(join(workspace, contract.spec_path));
+  const deliver = tokens.length === 9 && tokens[2] === "deliver" && tokens[3] === contract.type && commandPath(tokens[4]) === canonicalPath(join(workspace, contract.spec_path)) && commandPath(tokens[5]) === canonicalPath(join(workspace, contract.artifact_path));
+  return common && ((validate && !preparedArtifactParent) || deliver) ? { command: validate ? "validate" : "deliver", argv: tokens.slice(1), argv_sha256: tokens.slice(1).map(sha) } : null;
+}
+
+export function evaluateArchifyReceipts(transcript, workspace, contract) {
+  if (!contract) return [];
+  const failures = []; let validateSucceeded = false; let deliverSucceeded = false;
   for (const event of extractRouteEvents(transcript)) {
     if (event.kind === "event_protocol_violation") { failures.push(`archify_receipt:event_protocol:${event.violation}`); continue; }
-    const tokens = event.kind === "command_start" || event.kind === "command_complete" ? commandTokens(event.command) : null;
-    if (event.kind === "command_start" && isDeliverCommand(tokens)) {
-      if (!validateSucceeded) failures.push("archify_receipt:deliver_started_before_validate_completed");
-      else allowedDeliverIds.add(event.id);
+    if (!event.command?.includes("archify.mjs")) continue;
+    const shape = parseArchifyTranscriptCommand(event.command, workspace, contract);
+    if (!shape) { failures.push("archify_receipt:command_shape_invalid"); continue; }
+    if (event.kind === "command_start") {
+      if (shape.command === "deliver" && !validateSucceeded) failures.push("archify_receipt:deliver_started_before_validate_completed");
       continue;
     }
     if (event.kind !== "command_complete" || event.exit_code !== 0 || event.status !== "completed" || typeof event.output !== "string") continue;
-    if (!tokens || !commonShape(tokens)) continue;
-    let receipt; try { receipt = JSON.parse(event.output); } catch { continue; }
-    if (isValidateCommand(tokens) && validValidateReceipt(receipt)) validateSucceeded = true;
-    if (isDeliverCommand(tokens) && allowedDeliverIds.has(event.id) && validDeliverReceipt(receipt)) deliverSucceeded = true;
+    if (shape.command === "validate") validateSucceeded = true;
+    if (shape.command === "deliver" && validateSucceeded) deliverSucceeded = true;
   }
-  if (!validateSucceeded) failures.push("archify_receipt:validate_missing_or_invalid");
-  if (!deliverSucceeded) failures.push("archify_receipt:deliver_missing_or_invalid");
+  if (!validateSucceeded) failures.push("archify_receipt:validate_attempt_missing_or_failed");
+  if (!deliverSucceeded) failures.push("archify_receipt:deliver_attempt_missing_or_failed");
   return [...new Set(failures)];
+}
+
+export function verifyArchifyParent(workspace, targetPackage, contract, authority = {}) {
+  if (!contract) return { passed: true, failures: [], audit_scope: "not_applicable" };
+  const failures = []; const spec = noFollowWorkspaceFile(workspace, contract.spec_path); const artifact = noFollowWorkspaceFile(workspace, contract.artifact_path);
+  if (!targetPackage || !spec || !artifact) return { passed: false, failures: ["archify_parent:bound_input_missing_or_unsafe"] };
+  if (authority.mode === "historical_untrusted") return { passed: null, performed: false, failures: ["archify_parent:historical_tool_identity_untrusted"], audit_scope: "not performed; no trustworthy external snapshot ledger" };
+  if (authority.protected_scopes_passed !== true || !authority.expected?.package_tree_sha256 || !authority.expected?.script_content_sha256) return { passed: false, performed: false, failures: ["archify_parent:fresh_tool_identity_untrusted"] };
+  const bin = join(targetPackage, "bin"); const script = join(bin, "archify.mjs"); let rootStat; let binStat; let scriptStat;
+  try { rootStat = lstatSync(targetPackage); binStat = lstatSync(bin); scriptStat = lstatSync(script); } catch { return { passed: false, performed: false, failures: ["archify_parent:frozen_tool_missing"] }; }
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink() || !binStat.isDirectory() || binStat.isSymbolicLink() || !scriptStat.isFile() || scriptStat.isSymbolicLink()) return { passed: false, performed: false, failures: ["archify_parent:frozen_tool_unsafe"] };
+  const canonicalPackage = realpathSync(targetPackage); const canonicalScript = realpathSync(script);
+  if (!inside(canonicalScript, canonicalPackage)) return { passed: false, performed: false, failures: ["archify_parent:frozen_tool_escape"] };
+  const actual = { package_tree_sha256: stateDigest(targetPackage), script_content_sha256: sha(readFileSync(canonicalScript)) };
+  if (actual.package_tree_sha256 !== authority.expected.package_tree_sha256 || actual.script_content_sha256 !== authority.expected.script_content_sha256) return { passed: false, performed: false, failures: ["archify_parent:frozen_tool_digest_mismatch"], expected_identity: authority.expected, actual_identity: actual };
+  const realNode = canonicalPath(process.execPath); const workspaceDigestBefore = stateDigest(workspace); const specificationSha256 = sha(readFileSync(spec)); const agentArtifactSha256 = sha(readFileSync(artifact)); const temp = mkdtempSync(join(tmpdir(), "skillroster-archify-parent-")); let independentBytes = null; let deliverReceipt = null; let validate = { status: null }; let validatePassed = false;
+  try {
+    if (inside(temp, dirname(workspace))) fail("parent verification temp must stay outside the source run root");
+    const copiedSpec = join(temp, "spec.json"); const independentArtifact = join(temp, "artifact.html"); copyFileSync(spec, copiedSpec);
+    const value = JSON.parse(readFileSync(copiedSpec, "utf8")); value.meta = { ...(value.meta ?? {}), output: independentArtifact }; writeFileSync(copiedSpec, JSON.stringify(value));
+    validate = run(realNode, [canonicalScript, "validate", contract.type, copiedSpec, "--quality", contract.quality, "--json"], { cwd: temp, timeout: 60_000 }); let validateReceipt = null; try { validateReceipt = JSON.parse(validate.stdout); } catch {}
+    validatePassed = validate.status === 0 && validateReceipt?.schemaVersion === 1 && validateReceipt?.ok === true && validateReceipt?.command === "validate" && validateReceipt?.type === contract.type && canonicalPath(validateReceipt.input ?? "") === canonicalPath(copiedSpec) && validateReceipt?.checks?.length === contract.validation_check_count && validateReceipt.checks.every((check) => check?.ok === true) && validateReceipt?.composition?.status === "pass" && validateReceipt?.composition?.summary?.errors === 0 && validateReceipt?.composition?.summary?.warnings === 0;
+    if (!validatePassed) failures.push("archify_parent:validate_failed");
+    const deliver = run(realNode, [canonicalScript, "deliver", contract.type, copiedSpec, independentArtifact, "--quality", contract.quality, "--json"], { cwd: temp, timeout: 60_000 });
+    try { deliverReceipt = JSON.parse(deliver.stdout); } catch {}
+    if (deliver.status !== 0 || deliverReceipt?.schemaVersion !== 1 || deliverReceipt?.ok !== true || deliverReceipt?.command !== "deliver" || canonicalPath(deliverReceipt.output ?? "") !== canonicalPath(independentArtifact) || !existsSync(independentArtifact)) failures.push("archify_parent:independent_deliver_failed");
+    else { independentBytes = readFileSync(independentArtifact); const agentBytes = readFileSync(artifact); if (independentBytes.length !== agentBytes.length || sha(independentBytes) !== sha(agentBytes)) failures.push("archify_parent:artifact_reproduction_mismatch"); }
+  } catch { failures.push("archify_parent:independent_verification_error"); } finally { rmSync(temp, { recursive: true, force: true }); }
+  const workspaceDigestAfter = stateDigest(workspace); if (workspaceDigestAfter !== workspaceDigestBefore) failures.push("archify_parent:source_workspace_changed");
+  return { passed: failures.length === 0, performed: true, failures, expected_identity: authority.expected, actual_identity: actual, real_node_sha256: sha(realNode), frozen_script_realpath_sha256: sha(canonicalScript), frozen_script_content_sha256: actual.script_content_sha256, specification_sha256: specificationSha256, agent_artifact_sha256: agentArtifactSha256, independent_artifact_sha256: independentBytes ? sha(independentBytes) : null, source_workspace_sha256_before: workspaceDigestBefore, source_workspace_sha256_after: workspaceDigestAfter, validate: { exit_code: validate.status, ok: validatePassed }, deliver: { ok: deliverReceipt?.ok === true }, audit_scope: "parent-owned frozen validate and independent deliver reproduction" };
 }
 
 function narrowRead(command, targetPath) {
@@ -344,7 +412,7 @@ function coveredThrough(ranges) {
 export function assessExactLoad(transcript, targetPath) {
   const canonical = canonicalPath(targetPath); const commands = extractCommandEvents(transcript); const lineCount = targetLineCount(canonical); const ranges = []; let loadEventIndex = null;
   if (lineCount !== null) for (const [index, event] of commands.entries()) {
-    if (event.kind !== "command" || event.exit_code !== 0) continue;
+    if (event.kind !== "command" || event.exit_code !== 0 || event.status !== "completed") continue;
     const read = verifiedRead(event.command, event.output, canonical); if (!read) continue;
     ranges.push(read); if (coveredThrough(ranges) >= lineCount) { loadEventIndex = index; break; }
   }
@@ -528,15 +596,18 @@ export function setupArm(root, task, arm, options) {
 function freezeSuite(manifest, options) {
   const root = mkdtempSync(join(options.runsDir, "suite-snapshot-")); const targets = join(root, "targets"); mkdirSync(targets);
   for (const name of new Set(manifest.tasks.map((task) => task.expected_skill))) cpSync(join(options.skillsRoot, name), join(targets, name), { recursive: true, dereference: true });
+  const targetPackages = Object.fromEntries([...new Set(manifest.tasks.map((task) => task.expected_skill))].map((name) => { const packageRoot = join(targets, name); const script = join(packageRoot, "bin", "archify.mjs"); return [name, { package_tree_sha256: stateDigest(packageRoot), script_content_sha256: existsSync(script) ? sha(readFileSync(script)) : null }]; }));
   const bootstrapRoot = join(root, "bootstrap"); cpSync(dirname(options.bootstrap), bootstrapRoot, { recursive: true, dereference: true });
   const cli = join(root, basename(options.cli)); copyFileSync(options.cli, cli); chmodSync(cli, statSync(options.cli).mode & 0o777);
   const manifestPath = join(root, "manifest.json"); copyFileSync(options.manifest, manifestPath);
   const version = run(options.codex, ["--version"], { encoding: "utf8", timeout: 30_000 });
   if (version.status !== 0 || !version.stdout.trim()) fail("unable to freeze Codex version identity");
-  const driverSha256 = sha(readFileSync(fileURLToPath(import.meta.url))); const frozenTreeDigest = stateDigest(root);
+  const driverSha256 = sha(readFileSync(fileURLToPath(import.meta.url))); const frozenTreeDigest = stateDigest(root); const realNode = canonicalPath(process.execPath); const parentVerifierIdentity = sha(`${realNode}\0${driverSha256}`);
   const facts = {
-    snapshot_digest: sha(`${frozenTreeDigest}\0${options.model}\0${driverSha256}`), manifest_sha256: sha(readFileSync(manifestPath)), cli_sha256: sha(readFileSync(cli)),
+    snapshot_digest: sha(`${frozenTreeDigest}\0${options.model}\0${driverSha256}\0${parentVerifierIdentity}`), manifest_sha256: sha(readFileSync(manifestPath)), cli_sha256: sha(readFileSync(cli)),
     bootstrap_sha256: stateDigest(bootstrapRoot), targets_sha256: stateDigest(targets), codex_version_sha256: sha(version.stdout.trim()), model: options.model, driver_sha256: driverSha256,
+    real_node_sha256: sha(realNode), parent_verifier_identity_sha256: parentVerifierIdentity,
+    target_packages: targetPackages,
   };
   return { options: { ...options, skillsRoot: targets, bootstrap: join(bootstrapRoot, basename(options.bootstrap)), cli }, facts };
 }
@@ -574,7 +645,7 @@ export function prepareOnDemand(paths, task, options, env) {
   const top = parseFindEnvelope(findResult.stdout); const status = invoke("status");
   if (top.skill !== task.expected_skill || !top.path || canonicalPath(top.path) !== canonicalTarget || top.roster_state !== "on_demand" || top.agents.length !== 0) fail("governed Find did not return one exact, non-exposed On-demand target");
   if (status.result.recovery_state !== "clear" || status.result.journal_issues?.length || status.result.last_receipt?.receipt_id !== applied.result.receipt_id) fail("SkillRoster recovery or Receipt state is not clear");
-  const bin = join(dirname(paths.audit), "bin"); mkdirSync(bin); const wrapper = join(bin, "skillroster"); writeFileSync(wrapper, findWrapperSource(), { mode: 0o755 }); chmodSync(wrapper, 0o755);
+  const bin = join(dirname(paths.audit), "bin"); mkdirSync(bin, { recursive: true }); const wrapper = join(bin, "skillroster"); writeFileSync(wrapper, findWrapperSource(), { mode: 0o755 }); chmodSync(wrapper, 0o755);
   return { bin, governance: { roster_state: top.roster_state, target_default_exposure: 0, receipt_id: applied.result.receipt_id, receipt_verification: applied.result.verification, recovery_state: status.result.recovery_state } };
 }
 
@@ -593,12 +664,13 @@ function executeArm(task, arm, options, suiteFacts) {
     let prepared = null;
     if (arm === "on_demand") prepared = prepareOnDemand(paths, task, options, env);
     const runEnv = { ...env };
-    if (prepared) Object.assign(runEnv, { PATH: `${prepared.bin}:${process.env.PATH ?? "/usr/bin:/bin"}`, SKILLROSTER_REAL_CLI: options.cli, SKILLROSTER_TEST_HOME: paths.home, SKILLROSTER_TEST_STATE: paths.state, SKILLROSTER_FIND_AUDIT: paths.audit });
+    if (prepared) Object.assign(runEnv, { SKILLROSTER_REAL_CLI: options.cli, SKILLROSTER_TEST_HOME: paths.home, SKILLROSTER_TEST_STATE: paths.state, SKILLROSTER_FIND_AUDIT: paths.audit });
+    if (prepared) runEnv.PATH = `${prepared.bin}:${process.env.PATH ?? "/usr/bin:/bin"}`;
     const result = run(options.codex, ["exec", "--ephemeral", "--ignore-user-config", "--sandbox", "workspace-write", "--skip-git-repo-check", "--json", "-m", options.model, "-C", paths.workspace, task.prompt], { cwd: paths.workspace, env: runEnv, timeout: options.timeoutMs });
     const protectedScopes = assessProtectedScopes(initialProtected, captureProtectedScopes(protectedPaths));
     writeFileSync(paths.transcript, result.stdout, { mode: 0o600 });
     const after = walk(paths.workspace); const workspace = assessWorkspaceChanges(initialWorkspace, after, Object.keys(task.workspace_files), task.allowed_changed_paths);
-    const oracle = result.status === 0 ? evaluateOracle(paths.workspace, task.oracle, { transcript: result.stdout, targetPackage: dirname(paths.targetPath) }) : { passed: false, failures: [`codex_exit:${result.status ?? "signal"}`] };
+    const oracle = result.status === 0 ? evaluateOracle(paths.workspace, task.oracle, { transcript: result.stdout, targetPackage: dirname(paths.targetPath), parentVerificationAuthority: { protected_scopes_passed: protectedScopes.passed, expected: suiteFacts.target_packages?.[task.expected_skill] } }) : { passed: false, failures: [`codex_exit:${result.status ?? "signal"}`] };
     const retrieval = arm === "on_demand" ? parseFindAudit(existsSync(paths.audit) ? readFileSync(paths.audit, "utf8") : "", { task: task.prompt, skill: task.expected_skill, path: paths.targetPath }) : { count: 0, contract_violation: false };
     const load = assessExactLoad(result.stdout, paths.targetPath);
     const routeOrder = arm === "on_demand" ? assessRouteOrder(result.stdout, { bootstrapPath: join(paths.codexHome, "skills", "skillroster", "SKILL.md"), targetPath: paths.targetPath, findAudit: retrieval, expectedTask: task.prompt, expectedSkill: task.expected_skill }) : { passed: true, audit_scope: "not_applicable" };
@@ -618,13 +690,40 @@ function dryRun(manifest, options) {
   return { status: "planned", execute: false, suite_id: manifest.suite_id, model: options.model, task_count: tasks.length, arms, run_count: tasks.length * arms.length, note: "Pass --execute and an explicit --auth-source to invoke Codex." };
 }
 
+export function reevaluateExistingRuns(suiteRoot, manifest) {
+  const sourceDigestBefore = stateDigest(suiteRoot); const results = [];
+  for (const task of manifest.tasks) for (const arm of ["core", "on_demand"]) {
+    const matches = readdirSync(suiteRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory() && entry.name.startsWith(`${task.id}-${arm}-`));
+    if (matches.length !== 1) { results.push({ task: task.id, arm, root: null, recomputed: false, formal_evidence_accepted: null, post_hoc_only: true, failures: [`run_root_count:${matches.length}`] }); continue; }
+    const root = join(suiteRoot, matches[0].name); const workspacePath = join(root, "workspace"); const transcriptPath = join(root, "codex-events.jsonl");
+    if (!existsSync(workspacePath) || !existsSync(transcriptPath)) { results.push({ task: task.id, arm, root, recomputed: false, formal_evidence_accepted: null, post_hoc_only: true, failures: ["workspace_or_transcript_missing"] }); continue; }
+    const transcriptText = readFileSync(transcriptPath, "utf8"); const targetPath = arm === "core" ? join(root, "home", ".codex", "skills", task.expected_skill, "SKILL.md") : join(root, "source", task.expected_skill, "SKILL.md");
+    const initial = new Map(Object.entries(task.workspace_files).map(([path, content]) => [path, sha(content)])); const workspace = assessWorkspaceChanges(initial, walk(workspacePath), Object.keys(task.workspace_files), task.allowed_changed_paths);
+    const retrieval = arm === "on_demand" ? parseFindAudit(existsSync(join(root, "find-audit.jsonl")) ? readFileSync(join(root, "find-audit.jsonl"), "utf8") : "", { task: task.prompt, skill: task.expected_skill, path: targetPath }) : { count: 0, contract_violation: false };
+    const load = assessExactLoad(transcriptText, targetPath); const transcript = assessTranscriptIntegrity(transcriptText);
+    const routeOrder = arm === "on_demand" ? assessRouteOrder(transcriptText, { bootstrapPath: join(root, "home", ".codex", "skills", "skillroster", "SKILL.md"), targetPath, findAudit: retrieval, expectedTask: task.prompt, expectedSkill: task.expected_skill }) : { passed: true, audit_scope: "not_applicable" };
+    const coreOrder = arm === "core" ? assessCoreOrder(transcriptText, targetPath) : { passed: true, audit_scope: "not_applicable" };
+    const oracle = evaluateOracle(workspacePath, task.oracle, { transcript: transcriptText, targetPackage: dirname(targetPath), parentVerificationAuthority: { mode: "historical_untrusted" } });
+    results.push({ task: task.id, arm, root, recomputed: true, formal_evidence_accepted: null, post_hoc_only: true, recomputed_dimensions: { transcript: transcript.passed, retrieval: arm === "core" ? null : Boolean(retrieval.top1_correct && retrieval.returned_path_exact && !retrieval.contract_violation), load: load.passed, route_order: arm === "core" ? null : routeOrder.passed, core_order: arm === "core" ? coreOrder.passed : null, oracle: oracle.passed, parent_correctness: task.oracle.archify_receipt_contract ? oracle.archify_parent_verification?.passed ?? null : null, workspace: workspace.passed }, transcript, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, historical_evidence_limitations: ["post-hoc result is not an Issue #129 formal gate", "model-visible surface, earliest protected-scope baselines, and original suite ledger were not persisted"] });
+  }
+  const sourceDigestAfter = stateDigest(suiteRoot); if (sourceDigestAfter !== sourceDigestBefore) fail("reevaluation changed the source run tree");
+  return { status: "reevaluated", source_root: canonicalPath(suiteRoot), source_tree_sha256_before: sourceDigestBefore, source_tree_sha256_after: sourceDigestAfter, raw_runs_modified: false, formal_gate_eligible: false, results };
+}
+
 export function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
+  const manifest = validateManifest(JSON.parse(readFileSync(options.manifest, "utf8")));
+  if (options.reevaluateRoot) {
+    if (!existsSync(options.reevaluateRoot) || !statSync(options.reevaluateRoot).isDirectory()) fail("--reevaluate-root must be an existing directory");
+    const canonicalSource = realpathSync(options.reevaluateRoot); const output = options.reevaluateOutput ?? join(dirname(canonicalSource), `${basename(canonicalSource)}-reevaluated-${Date.now()}.json`);
+    if (inside(resolve(output), canonicalSource) || existingAncestorResolvesInside(output, canonicalSource)) fail("reevaluation output must stay outside the source run root");
+    if (existsSync(output)) fail("reevaluation output already exists"); const summary = reevaluateExistingRuns(canonicalSource, manifest); writeFileSync(output, `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600 });
+    process.stdout.write(`${JSON.stringify({ status: summary.status, formal_gate_eligible: false, output, results: summary.results.map(({ task, arm, formal_evidence_accepted, recomputed_dimensions }) => ({ task, arm, formal_evidence_accepted, post_hoc_only: true, recomputed_dimensions })) }, null, 2)}\n`); return 0;
+  }
   if (inside(options.runsDir, REPO)) fail("--runs-dir must stay outside the repository so transcripts cannot be committed");
   if (existingAncestorResolvesInside(options.runsDir, REPO)) fail("--runs-dir ancestor resolves inside the repository so transcripts cannot be committed");
   mkdirSync(options.runsDir, { recursive: true });
   if (inside(realpathSync(options.runsDir), realpathSync(REPO))) fail("--runs-dir resolves inside the repository so transcripts cannot be committed");
-  const manifest = validateManifest(JSON.parse(readFileSync(options.manifest, "utf8")));
   if (!options.execute) { process.stdout.write(`${JSON.stringify(dryRun(manifest, options), null, 2)}\n`); return 0; }
   for (const path of [options.bootstrap, options.cli, options.skillsRoot, options.authSource]) if (!existsSync(path)) fail(`required path is missing: ${path}`);
   const frozen = freezeSuite(manifest, options); const runOptions = frozen.options;

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { assessCoreOrder, assessExactLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, main, parseArgs, parseFindAudit, parseFindEnvelope, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest } from "./driver.mjs";
+import { assessCoreOrder, assessExactLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, main, parseArgs, parseFindAudit, parseFindEnvelope, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
 
 const digest = async (value) => {
   const { createHash } = await import("node:crypto"); return createHash("sha256").update(value).digest("hex");
@@ -16,12 +16,21 @@ test("default is a non-executing plan and execution requires explicit auth", () 
   assert.equal(parseArgs([]).execute, false);
   assert.throws(() => parseArgs(["--execute"]), /explicit --auth-source/u);
   assert.equal(parseArgs(["--execute", "--auth-source", "/tmp/auth.json"]).execute, true);
+  assert.equal(parseArgs(["--reevaluate-root", "/tmp/existing-runs"]).execute, false);
+  assert.throws(() => parseArgs(["--execute", "--auth-source", "/tmp/auth.json", "--reevaluate-root", "/tmp/runs"]), /mutually exclusive/u);
   assert.throws(() => main(["--runs-dir", fileURLToPath(new URL("../../../tests/transcripts", import.meta.url))]), /outside the repository/u);
 });
 
 test("runs directory cannot hide a repository target behind a symlink", { skip: process.platform === "win32" }, () => {
   const root = mkdtempSync(join(tmpdir(), "codex-runs-link-")); const alias = join(root, "runs"); const repo = new URL("../../../", import.meta.url).pathname;
   symlinkSync(repo, alias, "dir"); assert.throws(() => main(["--runs-dir", alias]), /resolves inside the repository/u);
+});
+
+test("offline reevaluation writes only outside the immutable source run tree", () => {
+  const parent = mkdtempSync(join(tmpdir(), "codex-reevaluate-")); const source = join(parent, "runs"); mkdirSync(source); const fixture = JSON.parse(readFileSync(new URL("../../fixtures/codex-cold-routing-transfer.json", import.meta.url)));
+  assert.throws(() => main(["--reevaluate-root", source, "--reevaluate-output", join(source, "summary.json")]), /outside the source run root/u);
+  for (const task of fixture.tasks) for (const arm of ["core", "on_demand"]) { const root = join(source, `${task.id}-${arm}-fixture`); mkdirSync(join(root, "workspace"), { recursive: true }); for (const [path, value] of Object.entries(task.workspace_files)) writeFileSync(join(root, "workspace", path), value); writeFileSync(join(root, "codex-events.jsonl"), ""); }
+  const before = snapshotWorkspace(source); const output = join(parent, "post-hoc.json"); assert.equal(main(["--reevaluate-root", source, "--reevaluate-output", output]), 0); assert.deepEqual(snapshotWorkspace(source), before); const summary = JSON.parse(readFileSync(output)); assert.equal(summary.raw_runs_modified, false); assert.equal(summary.formal_gate_eligible, false); assert.equal(summary.source_tree_sha256_before, summary.source_tree_sha256_after); assert.ok(summary.results.every((result) => result.formal_evidence_accepted === null && result.post_hoc_only === true));
 });
 
 test("manifest is restricted to the two-family Codex transfer contract", () => {
@@ -137,6 +146,7 @@ test("exact target load is established from audited Codex command text", () => {
   const canonical = realpathSync(path);
   const transcript = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: `cat -- '${canonical}'`, aggregated_output: "skill", exit_code: 0, status: "completed" } });
   assert.equal(assessExactLoad(transcript, path).passed, true);
+  const failed = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: `cat -- '${canonical}'`, aggregated_output: "skill", exit_code: 0, status: "failed" } }); assert.equal(assessExactLoad(failed, path).passed, false);
   assert.equal(assessExactLoad(transcript, join(root, "source", "other", "SKILL.md")).passed, false);
 });
 
@@ -193,6 +203,9 @@ test("target read cannot start until the matching Find completion is ledger-auth
   const transcript = [started("boot", boot), completed("boot", boot, "bootstrap"), started("find", find), started("load", load), completed("load", load, "target"), completed("find", find, "")].join("\n");
   const call = { argv_shape_valid: true, envelope_valid: true, exit_code: 0, hint_count: 1, hint_nonempty: true, task_sha256: await digest("完整任务"), top1_skill: "sample", top1_path_sha256: await digest(realpathSync(target)) };
   assert.match(assessRouteOrder(transcript, { bootstrapPath: bootstrap, targetPath: target, findAudit: { count: 1, calls: [call] }, expectedTask: "完整任务", expectedSkill: "sample" }).violations.join(","), /target_load_before_find_complete/u);
+  const failedFind = JSON.stringify({ type: "item.completed", item: { id: "find", type: "command_execution", command: find, aggregated_output: "failed", exit_code: 1, status: "failed" } });
+  const failedTranscript = [started("boot", boot), completed("boot", boot, "bootstrap"), started("find", find), failedFind, started("load", load), completed("load", load, "target")].join("\n");
+  assert.match(assessRouteOrder(failedTranscript, { bootstrapPath: bootstrap, targetPath: target, findAudit: { count: 1, calls: [{ ...call, exit_code: 1, envelope_valid: false }] }, expectedTask: "完整任务", expectedSkill: "sample" }).violations.join(","), /target_load_before_find_complete/u);
 });
 
 test("Core control rejects todo or workspace action before exact target full load", () => {
@@ -220,6 +233,9 @@ test("transcript integrity requires complete JSONL, one turn completion, and a s
   assert.equal(assessTranscriptIntegrity(`${command}\nnot-json\n${completed}`).passed, false);
   assert.equal(assessTranscriptIntegrity(command).passed, false);
   assert.equal(assessTranscriptIntegrity(JSON.stringify({ type: "turn.completed" })).passed, false);
+  const failed = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "false", exit_code: 1, status: "failed" } });
+  const assessed = assessTranscriptIntegrity(`${failed}\n${command}\n${completed}`);
+  assert.equal(assessed.passed, true); assert.equal(assessed.unsuccessful_command_count, 1); assert.doesNotMatch(assessed.violations.join(","), /incomplete/u);
 });
 
 test("oracle and safety remain independent outcome dimensions", () => {
@@ -234,24 +250,52 @@ test("oracle and safety remain independent outcome dimensions", () => {
   assert.equal(coreWithoutLoad.load, "load_wrong"); assert.equal(coreWithoutLoad.accepted, false);
 });
 
-test("Archify oracle requires bound validate and deliver receipts with final artifact digest", async () => {
+test("Archify transcript attempts require exact shape and lifecycle order", () => {
   const root = mkdtempSync(join(tmpdir(), "codex-archify-receipts-")); const workspace = join(root, "workspace"); const target = join(root, "archify"); const spec = join(workspace, "scratch", "order.spec.json"); const artifact = join(workspace, "outputs", "order.html"); const script = join(target, "bin", "archify.mjs");
   mkdirSync(join(workspace, "scratch"), { recursive: true }); mkdirSync(join(workspace, "outputs"), { recursive: true }); mkdirSync(join(target, "bin"), { recursive: true }); writeFileSync(spec, "{\"type\":\"architecture\"}\n"); writeFileSync(artifact, "<html>static token stuffing</html>\n"); writeFileSync(script, "// frozen tool");
   const contract = { type: "architecture", spec_path: "scratch/order.spec.json", artifact_path: "outputs/order.html", quality: "showcase", validation_check_count: 9 };
-  assert.match(evaluateArchifyReceipts("", workspace, target, contract).join(","), /validate_missing/u);
-  const checks = Array.from({ length: 9 }, (_, index) => ({ name: `check_${index}`, ok: true, details: [] }));
-  const validateReceipt = { schemaVersion: 1, ok: true, command: "validate", type: "architecture", input: spec, checks, composition: { status: "pass", summary: { errors: 0, warnings: 0 } } };
-  const deliverReceipt = { schemaVersion: 1, ok: true, command: "deliver", type: "architecture", input: spec, output: artifact, specification: { sha256: await digest(readFileSync(spec)), bytes: readFileSync(spec).length }, artifact: { sha256: await digest(readFileSync(artifact)), bytes: readFileSync(artifact).length }, validation: { checksPassed: 9, checkCount: 9, compositionProfile: "showcase", compositionStatus: "pass", errors: 0, warnings: 0 } };
+  assert.match(evaluateArchifyReceipts("", workspace, contract).join(","), /validate_attempt_missing/u);
   const started = (id, command) => JSON.stringify({ type: "item.started", item: { id, type: "command_execution", command } });
-  const completed = (id, command, receipt) => JSON.stringify({ type: "item.completed", item: { id, type: "command_execution", command, aggregated_output: JSON.stringify(receipt), exit_code: 0, status: "completed" } });
-  const validateCommand = `node '${realpathSync(script)}' validate architecture '${realpathSync(spec)}' --quality showcase --json`; const deliverCommand = `node '${realpathSync(script)}' deliver architecture '${realpathSync(spec)}' '${realpathSync(artifact)}' --quality showcase --json`;
-  const transcript = [started("validate", validateCommand), completed("validate", validateCommand, validateReceipt), started("deliver", deliverCommand), completed("deliver", deliverCommand, deliverReceipt)].join("\n");
-  assert.deepEqual(evaluateArchifyReceipts(transcript, workspace, target, contract), []);
-  const overlapping = [started("validate", validateCommand), started("deliver", deliverCommand), completed("validate", validateCommand, validateReceipt), completed("deliver", deliverCommand, deliverReceipt)].join("\n");
-  assert.match(evaluateArchifyReceipts(overlapping, workspace, target, contract).join(","), /deliver_started_before_validate_completed/u);
-  const forged = { ...deliverReceipt, artifact: { ...deliverReceipt.artifact, sha256: "0".repeat(64) } };
-  const forgedTranscript = [started("validate", validateCommand), completed("validate", validateCommand, validateReceipt), started("deliver", deliverCommand), completed("deliver", deliverCommand, forged)].join("\n");
-  assert.match(evaluateArchifyReceipts(forgedTranscript, workspace, target, contract).join(","), /deliver_missing_or_invalid/u);
+  const completed = (id, command) => JSON.stringify({ type: "item.completed", item: { id, type: "command_execution", command, aggregated_output: "untrusted agent output", exit_code: 0, status: "completed" } });
+  const validateCommand = `node bin/archify.mjs validate architecture '${realpathSync(spec)}' --quality showcase --json`; const deliverCommand = `/bin/zsh -lc 'mkdir -p ${realpathSync(join(workspace, "outputs"))} && node bin/archify.mjs deliver architecture ${realpathSync(spec)} ${realpathSync(artifact)} --quality showcase --json'`;
+  const transcript = [started("validate", validateCommand), completed("validate", validateCommand), started("deliver", deliverCommand), completed("deliver", deliverCommand)].join("\n");
+  assert.deepEqual(evaluateArchifyReceipts(transcript, workspace, contract), []);
+  const overlapping = [started("validate", validateCommand), started("deliver", deliverCommand), completed("validate", validateCommand), completed("deliver", deliverCommand)].join("\n");
+  assert.match(evaluateArchifyReceipts(overlapping, workspace, contract).join(","), /deliver_started_before_validate_completed/u);
+  assert.match(evaluateArchifyReceipts(transcript.replace("mkdir -p", "echo unsafe && mkdir -p"), workspace, contract).join(","), /command_shape_invalid/u);
+});
+
+test("parent-owned Archify verification reproduces final bytes with frozen tooling", async () => {
+  const root = mkdtempSync(join(tmpdir(), "codex-parent-archify-")); const workspace = join(root, "workspace"); const target = join(root, "archify"); const spec = join(workspace, "scratch", "order.spec.json"); const artifact = join(workspace, "outputs", "order.html"); const script = join(target, "bin", "archify.mjs");
+  for (const path of [join(workspace, "scratch"), join(workspace, "outputs"), join(target, "bin")]) mkdirSync(path, { recursive: true });
+  writeFileSync(spec, JSON.stringify({ meta: { output: artifact } })); writeFileSync(artifact, "<html>frozen reproduction</html>\n");
+  writeFileSync(script, `import fs from "node:fs"; const [command,type,input,output]=process.argv.slice(2); const checks=Array.from({length:9},(_,i)=>({name:String(i),ok:true})); if(command==="validate") process.stdout.write(JSON.stringify({schemaVersion:1,ok:true,command,type,input,checks,composition:{status:"pass",summary:{errors:0,warnings:0}}})); else { fs.writeFileSync(output,"<html>frozen reproduction</html>\\n"); process.stdout.write(JSON.stringify({schemaVersion:1,ok:true,command,type,input,output})); }`);
+  const contract = { type: "architecture", spec_path: "scratch/order.spec.json", artifact_path: "outputs/order.html", quality: "showcase", validation_check_count: 9 };
+  const scriptDigest = await digest(readFileSync(script)); const authority = { protected_scopes_passed: true, expected: { script_content_sha256: scriptDigest, package_tree_sha256: await digest(`bin/archify.mjs\0${scriptDigest}`) } };
+  const verified = verifyArchifyParent(workspace, target, contract, authority); assert.equal(verified.passed, true, verified.failures.join(",")); assert.equal(verified.source_workspace_sha256_before, verified.source_workspace_sha256_after); writeFileSync(artifact, "tampered\n"); assert.match(verifyArchifyParent(workspace, target, contract, authority).failures.join(","), /artifact_reproduction_mismatch/u);
+});
+
+test("parent verification rejects linked or digest-drifted frozen tools without execution", async () => {
+  const root = mkdtempSync(join(tmpdir(), "codex-parent-tool-attack-")); const workspace = join(root, "workspace"); const spec = join(workspace, "scratch", "order.spec.json"); const artifact = join(workspace, "outputs", "order.html"); const external = join(root, "external"); const marker = join(root, "executed.marker");
+  for (const path of [join(workspace, "scratch"), join(workspace, "outputs"), join(external, "bin")]) mkdirSync(path, { recursive: true }); writeFileSync(spec, JSON.stringify({ meta: { output: artifact } })); writeFileSync(artifact, "agent\n"); const malicious = join(external, "bin", "archify.mjs"); writeFileSync(malicious, `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(marker)},"executed");`);
+  const scriptDigest = await digest(readFileSync(malicious)); const expected = { script_content_sha256: scriptDigest, package_tree_sha256: await digest(`bin/archify.mjs\0${scriptDigest}`) }; const contract = { type: "architecture", spec_path: "scratch/order.spec.json", artifact_path: "outputs/order.html", quality: "showcase", validation_check_count: 9 };
+  const linkType = process.platform === "win32" ? "junction" : "dir";
+  const rootLink = join(root, "root-link"); symlinkSync(external, rootLink, linkType); assert.match(verifyArchifyParent(workspace, rootLink, contract, { protected_scopes_passed: true, expected }).failures.join(","), /frozen_tool_(unsafe|escape)/u); assert.equal(existsSync(marker), false);
+  const packageWithLinkedBin = join(root, "linked-bin-package"); mkdirSync(packageWithLinkedBin); symlinkSync(join(external, "bin"), join(packageWithLinkedBin, "bin"), linkType); assert.match(verifyArchifyParent(workspace, packageWithLinkedBin, contract, { protected_scopes_passed: true, expected }).failures.join(","), /frozen_tool_(unsafe|escape)/u); assert.equal(existsSync(marker), false);
+  assert.match(verifyArchifyParent(workspace, external, contract, { protected_scopes_passed: true, expected: { ...expected, script_content_sha256: "0".repeat(64) } }).failures.join(","), /digest_mismatch/u); assert.equal(existsSync(marker), false);
+});
+
+test("architecture spec contract requires the exact bounded topology and partition", () => {
+  const fixture = JSON.parse(readFileSync(new URL("../../fixtures/codex-cold-routing-transfer.json", import.meta.url))); const contract = fixture.tasks.find((task) => task.expected_skill === "archify").oracle.architecture_spec_contract;
+  const root = mkdtempSync(join(tmpdir(), "codex-architecture-spec-")); const path = join(root, contract.spec_path); mkdirSync(join(root, "scratch"));
+  const value = {
+    components: contract.components.map((component) => ({ ...component, type: "backend" })),
+    boundaries: contract.boundaries.map((boundary) => ({ label: `信任边界：${boundary.label}`, wraps: boundary.members })),
+    connections: contract.connections.map((edge) => ({ id: edge.id, from: edge.from, to: edge.to, label: ({ "web-to-gateway": "HTTPS", "gateway-to-order": "HTTPS", "order-to-db": "SQL", "gateway-to-auth": "HTTPS 认证检查", "order-to-queue": "发布异步事件", "queue-to-worker": "消费异步事件", "worker-to-storage": "写入订单文档" })[edge.id] })),
+  };
+  writeFileSync(path, JSON.stringify(value)); assert.deepEqual(evaluateArchitectureSpec(root, contract), []);
+  writeFileSync(path, JSON.stringify({ ...value, components: [...value.components, { id: "extra", label: "Extra" }] })); assert.match(evaluateArchitectureSpec(root, contract).join(","), /component_set_mismatch/u);
+  writeFileSync(path, JSON.stringify({ ...value, boundaries: value.boundaries.map((boundary, index) => index ? boundary : { ...boundary, wraps: [...boundary.wraps, "api-gateway"] }) })); assert.match(evaluateArchitectureSpec(root, contract).join(","), /boundary_(members_mismatch|partition_invalid)/u);
 });
 
 test("a failed Core control prevents cold-routing attribution", () => {

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -257,7 +257,8 @@ test("Archify transcript attempts require exact shape and lifecycle order", () =
   assert.match(evaluateArchifyReceipts("", workspace, contract).join(","), /validate_attempt_missing/u);
   const started = (id, command) => JSON.stringify({ type: "item.started", item: { id, type: "command_execution", command } });
   const completed = (id, command) => JSON.stringify({ type: "item.completed", item: { id, type: "command_execution", command, aggregated_output: "untrusted agent output", exit_code: 0, status: "completed" } });
-  const validateCommand = `node bin/archify.mjs validate architecture '${realpathSync(spec)}' --quality showcase --json`; const deliverCommand = `/bin/zsh -lc 'mkdir -p ${realpathSync(join(workspace, "outputs"))} && node bin/archify.mjs deliver architecture ${realpathSync(spec)} ${realpathSync(artifact)} --quality showcase --json'`;
+  const transcriptPath = (path) => realpathSync(path).replaceAll("\\", "/");
+  const validateCommand = `node bin/archify.mjs validate architecture '${transcriptPath(spec)}' --quality showcase --json`; const deliverCommand = `/bin/zsh -lc 'mkdir -p ${transcriptPath(join(workspace, "outputs"))} && node bin/archify.mjs deliver architecture ${transcriptPath(spec)} ${transcriptPath(artifact)} --quality showcase --json'`;
   const transcript = [started("validate", validateCommand), completed("validate", validateCommand), started("deliver", deliverCommand), completed("deliver", deliverCommand)].join("\n");
   assert.deepEqual(evaluateArchifyReceipts(transcript, workspace, contract), []);
   const overlapping = [started("validate", validateCommand), started("deliver", deliverCommand), completed("validate", validateCommand), completed("deliver", deliverCommand)].join("\n");


### PR DESCRIPTION
## Summary

- distinguish terminal failed Codex commands from incomplete lifecycle events without allowing failed commands to authorize retrieval, loading, or validation
- replace brittle Archify HTML wording checks with an exact 8-component / 3-boundary / 7-connection spec contract
- separate transcript attempt evidence from parent-owned frozen-tool verification for fresh runs
- add read-only post-hoc reevaluation that never writes into the source run tree and never promotes historical evidence into Issue #129 formal acceptance
- reject linked, escaped, drifted, or otherwise untrusted frozen tools before any parent execution

## Post-hoc result

The preserved four-arm diagnostic now says:

- Humanizer Core: invalid because only 240/484 Skill lines were loaded
- Humanizer On-demand: all available post-hoc dimensions pass
- Architecture Core and On-demand: routing/load/order and static topology pass; both artifacts still fail the self-contained requirement because they contain an external stylesheet
- every historical arm remains `formal_evidence_accepted: null`; no historical run-local tool is executed

This is diagnostic evidence only and does not close #129.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (208 unit + 7 acceptance + 57 CLI)
- `node --test tests/harness/pi-cold-routing/*.test.mjs tests/harness/codex-cold-routing/*.test.mjs` (95 tests)
- `node --check tests/harness/codex-cold-routing/driver.mjs`
- `git diff --check`
- real preserved four-arm post-hoc reevaluation with unchanged source-tree digest

Refs #129
