### PR TITLE
fix: model agent-specific skill exposure

### DIFF
--- a/src/harness.rs
+++ b/src/harness.rs
@@ -16,6 +16,20 @@ pub enum AgentKind {
     GitHubCopilot,
 }
 
+/// The first-party Skill discovery behavior verified for an Agent adapter.
+///
+/// This is deliberately a small policy vocabulary: adapters whose loader has
+/// not been verified retain the historical conservative recursive scan.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillDiscoverySemantics {
+    Codex,
+    ClaudeCode,
+    Pi,
+    Hermes,
+    Conservative,
+}
+
 impl AgentKind {
     pub const ALL: [Self; 8] = [
         Self::Codex,
@@ -51,6 +65,18 @@ impl AgentKind {
             Self::Cursor => "Cursor",
             Self::GeminiCli => "Gemini CLI",
             Self::GitHubCopilot => "GitHub Copilot",
+        }
+    }
+
+    pub const fn skill_discovery_semantics(self) -> SkillDiscoverySemantics {
+        match self {
+            Self::Codex => SkillDiscoverySemantics::Codex,
+            Self::ClaudeCode => SkillDiscoverySemantics::ClaudeCode,
+            Self::Pi => SkillDiscoverySemantics::Pi,
+            Self::Hermes => SkillDiscoverySemantics::Hermes,
+            Self::OpenCode | Self::Cursor | Self::GeminiCli | Self::GitHubCopilot => {
+                SkillDiscoverySemantics::Conservative
+            }
         }
     }
 }
@@ -421,6 +447,37 @@ mod tests {
         assert_eq!(AgentKind::ALL.len(), 8);
         assert!(roots.iter().all(|roots| !roots.skill_roots.is_empty()));
         assert!(roots.iter().all(|roots| !roots.session_roots.is_empty()));
+    }
+
+    #[test]
+    fn verified_adapters_have_explicit_discovery_semantics() {
+        assert_eq!(
+            AgentKind::Codex.skill_discovery_semantics(),
+            SkillDiscoverySemantics::Codex
+        );
+        assert_eq!(
+            AgentKind::ClaudeCode.skill_discovery_semantics(),
+            SkillDiscoverySemantics::ClaudeCode
+        );
+        assert_eq!(
+            AgentKind::Pi.skill_discovery_semantics(),
+            SkillDiscoverySemantics::Pi
+        );
+        assert_eq!(
+            AgentKind::Hermes.skill_discovery_semantics(),
+            SkillDiscoverySemantics::Hermes
+        );
+        for agent in [
+            AgentKind::OpenCode,
+            AgentKind::Cursor,
+            AgentKind::GeminiCli,
+            AgentKind::GitHubCopilot,
+        ] {
+            assert_eq!(
+                agent.skill_discovery_semantics(),
+                SkillDiscoverySemantics::Conservative
+            );
+        }
     }
 
     #[test]

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,4 +1,7 @@
-use crate::harness::{AgentKind, SessionSignal, known_agent_roots, session_record_observations};
+use crate::harness::{
+    AgentKind, SessionSignal, SkillDiscoverySemantics, known_agent_roots,
+    session_record_observations,
+};
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
 use chrono::{DateTime, Datelike, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
@@ -372,6 +375,7 @@ struct EntryCandidate {
     expected_physical_directory: Option<PathBuf>,
     link_target: Option<PathBuf>,
     link_status: LinkStatus,
+    default_exposed: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -381,6 +385,20 @@ struct SkillRootPolicy {
     governable: bool,
     detail: Option<String>,
     provider: Option<String>,
+}
+
+struct DiscoveryContext<'a> {
+    policy: &'a SkillRootPolicy,
+    placement_root: &'a Path,
+    approved_roots: &'a [PathBuf],
+    max_depth: usize,
+}
+
+#[derive(Clone, Copy, Default)]
+struct DiscoveryState {
+    hidden_ancestor: bool,
+    inside_skill_package: bool,
+    harness_excluded: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -978,15 +996,13 @@ fn observe_skill_root(
         return;
     }
 
-    match discover_entrypoints(
-        &policy,
-        root,
+    let context = DiscoveryContext {
+        policy: &policy,
+        placement_root: root,
         approved_roots,
-        root,
-        0,
         max_depth,
-        candidates,
-    ) {
+    };
+    match discover_entrypoints(&context, root, 0, DiscoveryState::default(), candidates) {
         Ok(true) => {}
         Ok(false) => {
             let detail = format!("Skill discovery was bounded at depth {max_depth}");
@@ -1100,66 +1116,164 @@ fn observe_durable_skill_root_with_hook(
 }
 
 fn discover_entrypoints(
-    policy: &SkillRootPolicy,
-    placement_root: &Path,
-    approved_roots: &[PathBuf],
+    context: &DiscoveryContext<'_>,
     directory: &Path,
     depth: usize,
-    max_depth: usize,
+    state: DiscoveryState,
     output: &mut Vec<EntryCandidate>,
 ) -> io::Result<bool> {
-    if depth > max_depth {
+    if depth > context.max_depth {
         return Ok(false);
     }
     let mut complete = true;
     let mut entries = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
     entries.sort_by_key(|entry| entry.file_name());
+    let directory_has_skill = directory.join("SKILL.md").is_file();
     for entry in entries {
         let path = entry.path();
         let metadata = fs::symlink_metadata(&path)?;
         let file_name = entry.file_name();
         if file_name == "SKILL.md" {
-            let (target, link_status) = inspect_link(approved_roots, &path, &metadata);
+            let (target, link_status) = inspect_link(context.approved_roots, &path, &metadata);
+            let default_exposed = default_exposure_for_candidate(
+                context.policy,
+                context.placement_root,
+                &path,
+                depth,
+                state.hidden_ancestor,
+                state.inside_skill_package,
+                state.harness_excluded,
+            );
             output.push(EntryCandidate {
-                agent: policy.agent,
-                root: placement_root.to_path_buf(),
-                governable: policy.governable,
-                provider: policy.provider.clone(),
+                agent: context.policy.agent,
+                root: context.placement_root.to_path_buf(),
+                governable: context.policy.governable,
+                provider: context.policy.provider.clone(),
                 expected_physical_directory: canonical_entrypoint_directory(&path),
                 entrypoint: path,
                 link_target: target,
                 link_status,
+                default_exposed,
             });
         } else if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
-            complete &= discover_entrypoints(
-                policy,
-                placement_root,
-                approved_roots,
-                &path,
-                depth + 1,
-                max_depth,
-                output,
-            )?;
+            let child_name = file_name.to_string_lossy();
+            let child_state = DiscoveryState {
+                hidden_ancestor: state.hidden_ancestor || child_name.starts_with('.'),
+                inside_skill_package: state.inside_skill_package || directory_has_skill,
+                harness_excluded: state.harness_excluded
+                    || hermes_excludes_directory(
+                        context.policy.agent,
+                        &child_name,
+                        directory_has_skill,
+                    ),
+            };
+            complete &= discover_entrypoints(context, &path, depth + 1, child_state, output)?;
         } else if metadata.file_type().is_symlink() {
             // A linked Skill directory is a placement too, but it is never
             // traversed recursively before the boundary has been evaluated.
             let linked_entrypoint = path.join("SKILL.md");
-            let (target, status) = inspect_link(approved_roots, &path, &metadata);
+            let (target, status) = inspect_link(context.approved_roots, &path, &metadata);
             if linked_entrypoint.exists() || status != LinkStatus::Valid {
+                let child_name = file_name.to_string_lossy();
+                let child_state = DiscoveryState {
+                    hidden_ancestor: state.hidden_ancestor || child_name.starts_with('.'),
+                    inside_skill_package: state.inside_skill_package || directory_has_skill,
+                    harness_excluded: state.harness_excluded
+                        || hermes_excludes_directory(
+                            context.policy.agent,
+                            &child_name,
+                            directory_has_skill,
+                        ),
+                };
+                let default_exposed = default_exposure_for_candidate(
+                    context.policy,
+                    context.placement_root,
+                    &linked_entrypoint,
+                    depth + 1,
+                    child_state.hidden_ancestor,
+                    child_state.inside_skill_package,
+                    child_state.harness_excluded,
+                );
                 output.push(EntryCandidate {
-                    agent: policy.agent,
-                    root: placement_root.to_path_buf(),
-                    governable: policy.governable,
-                    provider: policy.provider.clone(),
+                    agent: context.policy.agent,
+                    root: context.placement_root.to_path_buf(),
+                    governable: context.policy.governable,
+                    provider: context.policy.provider.clone(),
                     expected_physical_directory: canonical_entrypoint_directory(&linked_entrypoint),
                     entrypoint: linked_entrypoint,
                     link_target: target,
                     link_status: status,
+                    default_exposed,
                 });
             }
         }
     }
     Ok(complete)
+}
+
+const HERMES_EXCLUDED_SKILL_DIRS: &[&str] = &[
+    ".git",
+    ".github",
+    ".hub",
+    ".archive",
+    ".venv",
+    "venv",
+    "node_modules",
+    "site-packages",
+    "__pycache__",
+    ".tox",
+    ".nox",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+];
+
+const HERMES_SKILL_SUPPORT_DIRS: &[&str] = &["references", "templates", "assets", "scripts"];
+
+fn hermes_excludes_directory(agent: Option<AgentKind>, name: &str, containing_skill: bool) -> bool {
+    agent == Some(AgentKind::Hermes)
+        && (HERMES_EXCLUDED_SKILL_DIRS.contains(&name)
+            || (containing_skill && HERMES_SKILL_SUPPORT_DIRS.contains(&name)))
+}
+
+fn default_exposure_for_candidate(
+    policy: &SkillRootPolicy,
+    placement_root: &Path,
+    entrypoint: &Path,
+    depth: usize,
+    hidden_ancestor: bool,
+    inside_skill_package: bool,
+    harness_excluded: bool,
+) -> bool {
+    let Some(agent) = policy.agent else {
+        return false;
+    };
+    match agent.skill_discovery_semantics() {
+        SkillDiscoverySemantics::Codex => {
+            let relative = entrypoint.strip_prefix(placement_root).ok();
+            let system_root = placement_root
+                .file_name()
+                .is_some_and(|name| name == ".system")
+                || relative
+                    .and_then(|path| path.components().next())
+                    .is_some_and(|component| component.as_os_str() == ".system");
+            system_root || !hidden_ancestor && !harness_excluded
+        }
+        SkillDiscoverySemantics::ClaudeCode => {
+            depth == 1
+                && !hidden_ancestor
+                && !harness_excluded
+                && entrypoint
+                    .parent()
+                    .and_then(Path::file_name)
+                    .is_some_and(|name| !name.to_string_lossy().starts_with('.'))
+        }
+        SkillDiscoverySemantics::Pi => {
+            !hidden_ancestor && !inside_skill_package && !harness_excluded
+        }
+        SkillDiscoverySemantics::Hermes => !harness_excluded,
+        SkillDiscoverySemantics::Conservative => true,
+    }
 }
 
 fn inspect_link(
@@ -1449,7 +1563,7 @@ fn materialize_candidates_with_hook(
             fingerprint_detail,
             link_target: candidate.link_target,
             link_status: candidate.link_status,
-            default_exposed: candidate.agent.is_some(),
+            default_exposed: candidate.agent.is_some() && candidate.default_exposed,
             owned_by_agent: Some(candidate.agent.is_some()),
             mutation_scope: Some(mutation_scope),
             governable: mutation_scope == MutationScope::Mutable,
@@ -3103,6 +3217,7 @@ enabled = true
             entrypoint: linked.join("SKILL.md"),
             link_target: Some(source.clone()),
             link_status: LinkStatus::Valid,
+            default_exposed: true,
         };
         let mut result = ScanResult::default();
         let mut replaced = false;
@@ -3180,6 +3295,7 @@ enabled = true
             expected_physical_directory: Some(source.clone()),
             link_target: Some(source),
             link_status: LinkStatus::Valid,
+            default_exposed: true,
         };
         let mut result = ScanResult::default();
         materialize_candidates_with_hook(vec![candidate], &[anchor], &[], &mut result, |_| {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -387,18 +387,22 @@ struct SkillRootPolicy {
     provider: Option<String>,
 }
 
-struct DiscoveryContext<'a> {
-    policy: &'a SkillRootPolicy,
-    placement_root: &'a Path,
-    approved_roots: &'a [PathBuf],
-    max_depth: usize,
-}
-
 #[derive(Clone, Copy, Default)]
 struct DiscoveryState {
     hidden_ancestor: bool,
     inside_skill_package: bool,
     harness_excluded: bool,
+}
+
+impl DiscoveryState {
+    fn descend(self, agent: Option<AgentKind>, child_name: &str, containing_skill: bool) -> Self {
+        Self {
+            hidden_ancestor: self.hidden_ancestor || child_name.starts_with('.'),
+            inside_skill_package: self.inside_skill_package || containing_skill,
+            harness_excluded: self.harness_excluded
+                || hermes_excludes_directory(agent, child_name, containing_skill),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -996,13 +1000,15 @@ fn observe_skill_root(
         return;
     }
 
-    let context = DiscoveryContext {
-        policy: &policy,
-        placement_root: root,
+    match discover_entrypoints(
+        &policy,
+        root,
         approved_roots,
+        root,
         max_depth,
-    };
-    match discover_entrypoints(&context, root, 0, DiscoveryState::default(), candidates) {
+        DiscoveryState::default(),
+        candidates,
+    ) {
         Ok(true) => {}
         Ok(false) => {
             let detail = format!("Skill discovery was bounded at depth {max_depth}");
@@ -1116,13 +1122,19 @@ fn observe_durable_skill_root_with_hook(
 }
 
 fn discover_entrypoints(
-    context: &DiscoveryContext<'_>,
+    policy: &SkillRootPolicy,
+    placement_root: &Path,
+    approved_roots: &[PathBuf],
     directory: &Path,
-    depth: usize,
+    max_depth: usize,
     state: DiscoveryState,
     output: &mut Vec<EntryCandidate>,
 ) -> io::Result<bool> {
-    if depth > context.max_depth {
+    let depth = directory
+        .strip_prefix(placement_root)
+        .map(|path| path.components().count())
+        .unwrap_or(max_depth.saturating_add(1));
+    if depth > max_depth {
         return Ok(false);
     }
     let mut complete = true;
@@ -1134,21 +1146,14 @@ fn discover_entrypoints(
         let metadata = fs::symlink_metadata(&path)?;
         let file_name = entry.file_name();
         if file_name == "SKILL.md" {
-            let (target, link_status) = inspect_link(context.approved_roots, &path, &metadata);
-            let default_exposed = default_exposure_for_candidate(
-                context.policy,
-                context.placement_root,
-                &path,
-                depth,
-                state.hidden_ancestor,
-                state.inside_skill_package,
-                state.harness_excluded,
-            );
+            let (target, link_status) = inspect_link(approved_roots, &path, &metadata);
+            let default_exposed =
+                default_exposure_for_candidate(policy, placement_root, &path, depth, state);
             output.push(EntryCandidate {
-                agent: context.policy.agent,
-                root: context.placement_root.to_path_buf(),
-                governable: context.policy.governable,
-                provider: context.policy.provider.clone(),
+                agent: policy.agent,
+                root: placement_root.to_path_buf(),
+                governable: policy.governable,
+                provider: policy.provider.clone(),
                 expected_physical_directory: canonical_entrypoint_directory(&path),
                 entrypoint: path,
                 link_target: target,
@@ -1157,48 +1162,36 @@ fn discover_entrypoints(
             });
         } else if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
             let child_name = file_name.to_string_lossy();
-            let child_state = DiscoveryState {
-                hidden_ancestor: state.hidden_ancestor || child_name.starts_with('.'),
-                inside_skill_package: state.inside_skill_package || directory_has_skill,
-                harness_excluded: state.harness_excluded
-                    || hermes_excludes_directory(
-                        context.policy.agent,
-                        &child_name,
-                        directory_has_skill,
-                    ),
-            };
-            complete &= discover_entrypoints(context, &path, depth + 1, child_state, output)?;
+            let child_state = state.descend(policy.agent, &child_name, directory_has_skill);
+            complete &= discover_entrypoints(
+                policy,
+                placement_root,
+                approved_roots,
+                &path,
+                max_depth,
+                child_state,
+                output,
+            )?;
         } else if metadata.file_type().is_symlink() {
             // A linked Skill directory is a placement too, but it is never
             // traversed recursively before the boundary has been evaluated.
             let linked_entrypoint = path.join("SKILL.md");
-            let (target, status) = inspect_link(context.approved_roots, &path, &metadata);
+            let (target, status) = inspect_link(approved_roots, &path, &metadata);
             if linked_entrypoint.exists() || status != LinkStatus::Valid {
                 let child_name = file_name.to_string_lossy();
-                let child_state = DiscoveryState {
-                    hidden_ancestor: state.hidden_ancestor || child_name.starts_with('.'),
-                    inside_skill_package: state.inside_skill_package || directory_has_skill,
-                    harness_excluded: state.harness_excluded
-                        || hermes_excludes_directory(
-                            context.policy.agent,
-                            &child_name,
-                            directory_has_skill,
-                        ),
-                };
+                let child_state = state.descend(policy.agent, &child_name, directory_has_skill);
                 let default_exposed = default_exposure_for_candidate(
-                    context.policy,
-                    context.placement_root,
+                    policy,
+                    placement_root,
                     &linked_entrypoint,
                     depth + 1,
-                    child_state.hidden_ancestor,
-                    child_state.inside_skill_package,
-                    child_state.harness_excluded,
+                    child_state,
                 );
                 output.push(EntryCandidate {
-                    agent: context.policy.agent,
-                    root: context.placement_root.to_path_buf(),
-                    governable: context.policy.governable,
-                    provider: context.policy.provider.clone(),
+                    agent: policy.agent,
+                    root: placement_root.to_path_buf(),
+                    governable: policy.governable,
+                    provider: policy.provider.clone(),
                     expected_physical_directory: canonical_entrypoint_directory(&linked_entrypoint),
                     entrypoint: linked_entrypoint,
                     link_target: target,
@@ -1241,9 +1234,7 @@ fn default_exposure_for_candidate(
     placement_root: &Path,
     entrypoint: &Path,
     depth: usize,
-    hidden_ancestor: bool,
-    inside_skill_package: bool,
-    harness_excluded: bool,
+    state: DiscoveryState,
 ) -> bool {
     let Some(agent) = policy.agent else {
         return false;
@@ -1251,27 +1242,42 @@ fn default_exposure_for_candidate(
     match agent.skill_discovery_semantics() {
         SkillDiscoverySemantics::Codex => {
             let relative = entrypoint.strip_prefix(placement_root).ok();
-            let system_root = placement_root
+            let scanning_system_root = placement_root
                 .file_name()
-                .is_some_and(|name| name == ".system")
-                || relative
-                    .and_then(|path| path.components().next())
-                    .is_some_and(|component| component.as_os_str() == ".system");
-            system_root || !hidden_ancestor && !harness_excluded
+                .is_some_and(|name| name == ".system");
+            let visible_below_system_root = relative
+                .and_then(Path::parent)
+                .and_then(|path| {
+                    let mut components = path.components();
+                    (components.next()?.as_os_str() == ".system").then(|| {
+                        components.all(|component| {
+                            !component.as_os_str().to_string_lossy().starts_with('.')
+                        })
+                    })
+                })
+                .unwrap_or(false);
+            !state.harness_excluded
+                && if scanning_system_root {
+                    !state.hidden_ancestor
+                } else if visible_below_system_root {
+                    true
+                } else {
+                    !state.hidden_ancestor
+                }
         }
         SkillDiscoverySemantics::ClaudeCode => {
             depth == 1
-                && !hidden_ancestor
-                && !harness_excluded
+                && !state.hidden_ancestor
+                && !state.harness_excluded
                 && entrypoint
                     .parent()
                     .and_then(Path::file_name)
                     .is_some_and(|name| !name.to_string_lossy().starts_with('.'))
         }
         SkillDiscoverySemantics::Pi => {
-            !hidden_ancestor && !inside_skill_package && !harness_excluded
+            !state.hidden_ancestor && !state.inside_skill_package && !state.harness_excluded
         }
-        SkillDiscoverySemantics::Hermes => !harness_excluded,
+        SkillDiscoverySemantics::Hermes => !state.harness_excluded,
         SkillDiscoverySemantics::Conservative => true,
     }
 }

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -177,6 +177,7 @@ fn public_scan_and_report_use_verified_agent_exposure_rules() {
                 placement["agent"] == agent
                     && placement["entrypoint"]
                         .as_str()
+                        .map(|path| path.replace('\\', "/"))
                         .is_some_and(|path| path.ends_with(suffix))
             })
             .unwrap_or_else(|| panic!("missing {agent} placement ending in {suffix}"))
@@ -201,6 +202,7 @@ fn public_scan_and_report_use_verified_agent_exposure_rules() {
                 placement["agent"] == "codex"
                     && placement["entrypoint"]
                         .as_str()
+                        .map(|path| path.replace('\\', "/"))
                         .is_some_and(|path| path.ends_with(".system/system/SKILL.md"))
             })
             .count(),

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -135,6 +135,7 @@ fn public_scan_and_report_use_verified_agent_exposure_rules() {
     skill(".codex/skills/visible");
     skill(".codex/skills/.bak-test/hidden");
     skill(".codex/skills/.system/system");
+    skill(".codex/skills/.system/.bak-test/hidden");
     skill(".claude/skills/direct");
     skill(".claude/skills/.hidden");
     skill(".claude/skills/category/nested");
@@ -187,6 +188,10 @@ fn public_scan_and_report_use_verified_agent_exposure_rules() {
     assert!(exposed("codex", ".codex/skills/visible/SKILL.md"));
     assert!(!exposed("codex", ".codex/skills/.bak-test/hidden/SKILL.md"));
     assert!(exposed("codex", ".codex/skills/.system/system/SKILL.md"));
+    assert!(!exposed(
+        "codex",
+        ".codex/skills/.system/.bak-test/hidden/SKILL.md"
+    ));
     assert_eq!(
         scan_json["placements"]
             .as_array()

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -115,6 +115,166 @@ fn public_skill_ids(home: &Path, state: &Path, names: &[String]) -> BTreeMap<Str
         .collect()
 }
 
+#[test]
+fn public_scan_and_report_use_verified_agent_exposure_rules() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path();
+    let skill = |relative: &str| {
+        let entrypoint = home.join(relative).join("SKILL.md");
+        fs::create_dir_all(entrypoint.parent().unwrap()).unwrap();
+        fs::write(
+            entrypoint,
+            format!(
+                "---\nname: {}\ndescription: fixture\n---\n",
+                relative.replace('/', "-")
+            ),
+        )
+        .unwrap();
+    };
+
+    skill(".codex/skills/visible");
+    skill(".codex/skills/.bak-test/hidden");
+    skill(".codex/skills/.system/system");
+    skill(".claude/skills/direct");
+    skill(".claude/skills/.hidden");
+    skill(".claude/skills/category/nested");
+    skill(".claude/skills/.personal/hidden");
+    skill(".pi/agent/skills/visible");
+    skill(".pi/agent/skills/.bak-test/hidden");
+    skill(".pi/agent/skills/package");
+    skill(".pi/agent/skills/package/nested");
+    skill(".hermes/skills/visible");
+    skill(".hermes/skills/.bak-test/hidden");
+    skill(".hermes/skills/.archive/hidden");
+
+    let duplicate_contents =
+        "---\nname: codex-duplicate\ndescription: identical active and backup copies\n---\n";
+    fs::write(
+        home.join(".codex/skills/visible/SKILL.md"),
+        duplicate_contents,
+    )
+    .unwrap();
+    fs::write(
+        home.join(".codex/skills/.bak-test/hidden/SKILL.md"),
+        duplicate_contents,
+    )
+    .unwrap();
+
+    let mut options = ScanOptions::for_home(home);
+    options.include_session_evidence = false;
+    let scanned = scan(&options).unwrap();
+    let report = build_report(&scanned);
+    let scan_json = serde_json::to_value(&scanned).unwrap();
+    let report_json = serde_json::to_value(&report).unwrap();
+
+    let exposed = |agent: &str, suffix: &str| {
+        scan_json["placements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|placement| {
+                placement["agent"] == agent
+                    && placement["entrypoint"]
+                        .as_str()
+                        .is_some_and(|path| path.ends_with(suffix))
+            })
+            .unwrap_or_else(|| panic!("missing {agent} placement ending in {suffix}"))
+            ["default_exposed"]
+            .as_bool()
+            .unwrap()
+    };
+
+    assert!(exposed("codex", ".codex/skills/visible/SKILL.md"));
+    assert!(!exposed("codex", ".codex/skills/.bak-test/hidden/SKILL.md"));
+    assert!(exposed("codex", ".codex/skills/.system/system/SKILL.md"));
+    assert_eq!(
+        scan_json["placements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|placement| {
+                placement["agent"] == "codex"
+                    && placement["entrypoint"]
+                        .as_str()
+                        .is_some_and(|path| path.ends_with(".system/system/SKILL.md"))
+            })
+            .count(),
+        1
+    );
+    assert!(exposed("claude_code", ".claude/skills/direct/SKILL.md"));
+    assert!(!exposed("claude_code", ".claude/skills/.hidden/SKILL.md"));
+    assert!(!exposed(
+        "claude_code",
+        ".claude/skills/category/nested/SKILL.md"
+    ));
+    assert!(!exposed(
+        "claude_code",
+        ".claude/skills/.personal/hidden/SKILL.md"
+    ));
+    assert!(exposed("pi", ".pi/agent/skills/visible/SKILL.md"));
+    assert!(!exposed("pi", ".pi/agent/skills/.bak-test/hidden/SKILL.md"));
+    assert!(exposed("pi", ".pi/agent/skills/package/SKILL.md"));
+    assert!(!exposed("pi", ".pi/agent/skills/package/nested/SKILL.md"));
+    assert!(exposed("hermes", ".hermes/skills/visible/SKILL.md"));
+    assert!(exposed(
+        "hermes",
+        ".hermes/skills/.bak-test/hidden/SKILL.md"
+    ));
+    assert!(!exposed(
+        "hermes",
+        ".hermes/skills/.archive/hidden/SKILL.md"
+    ));
+    assert!(
+        scan_json["placements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|placement| placement["agent"].is_string())
+            .filter(|placement| placement["default_exposed"] == false)
+            .all(|placement| {
+                placement["owned_by_agent"] == true
+                    && placement["governable"] == true
+                    && placement["mutation_scope"] == "mutable"
+            })
+    );
+
+    assert_eq!(report_json["metrics"]["default_exposure"], 7);
+
+    let state = home.join("state");
+    let cli_scan = cli_json(home, &state, &["scan"], None);
+    assert_eq!(
+        cli_scan["result"]["placement_count"],
+        scanned.placements.len()
+    );
+    let cli_report = cli_json(home, &state, &["report", "--full"], None);
+    assert_eq!(cli_report["result"]["default_exposure"], 7);
+    let duplicate_finding_id = cli_report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Exact duplicate Skill placements")
+        .and_then(|finding| finding["id"].as_str())
+        .expect("active and hidden backup copies remain duplicate inventory");
+    let duplicate_detail = cli_json(
+        home,
+        &state,
+        &["report", "--finding", duplicate_finding_id, "--full"],
+        None,
+    );
+    let duplicate_placements = duplicate_detail["result"]["placements"].as_array().unwrap();
+    assert_eq!(duplicate_placements.len(), 2);
+    assert!(
+        duplicate_placements
+            .iter()
+            .any(|placement| placement["default_exposed"] == true)
+    );
+    assert!(
+        duplicate_placements
+            .iter()
+            .any(|placement| placement["default_exposed"] == false)
+    );
+}
+
 fn evaluate_capabilities(home: &Path, state: &Path, routes: &[RouteCase]) -> (usize, usize) {
     let mut routed = 0;
     let mut succeeded = 0;


### PR DESCRIPTION
## Summary

- derive `default_exposed` from verified Codex, Claude Code, Pi, and Hermes discovery semantics
- retain safely readable hidden and nested Skills as inventory without inflating default exposure
- preserve Exact Duplicate evidence for hidden backup copies and keep unverified Agents conservative
- cover public Scan/Report JSON, Codex `.system`, mutation authority, and downstream governance facts

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (211 unit, 8 acceptance, 57 CLI)
- independent Standards review: PASS
- independent Spec review: PASS
- real-home isolated read-only replay: 258 Skills, 882 placements, default exposure 656 -> 517; `files_changed=false`

Closes #143