### PR TITLE
test: record Codex Luna cold-routing transfer gate

### DIFF
--- a/docs/acceptance/artifacts/codex-luna-transfer-gate-v1.json
+++ b/docs/acceptance/artifacts/codex-luna-transfer-gate-v1.json
@@ -4,6 +4,10 @@
   "scope": "codex_luna_cold_routing_transfer_gate",
   "issues": [129, 145],
   "status": "failed",
+  "formal_gate_eligible": false,
+  "eligibility_limitations": [
+    "Pair invariant values matched across each pair but were calculated and emitted after model invocation rather than frozen in the pre-invocation suite snapshot."
+  ],
   "execution": {
     "agent": "codex",
     "codex_version": "0.147.0",
@@ -19,6 +23,14 @@
     "private_run_tree_sha256": "a6365dbe5a5438816a3eb91ebe990c880308939fd7474c5b8b0e07b627acea44",
     "auth_copies_remaining": 0
   },
+  "preflight": {
+    "driver_syntax": "passed",
+    "harness_tests": {"passed": 32, "failed": 0},
+    "cargo_build_locked": "passed",
+    "dry_run": {"status": "planned", "model": "gpt-5.6-luna", "run_count": 4},
+    "pre_run_spec_review": "passed",
+    "pre_run_standards_review": "passed"
+  },
   "frozen_inputs": {
     "snapshot_sha256": "17b524c365f87cea88c9f902802813c332bd3b6bea1323e0ba6869aaee6192ef",
     "manifest_sha256": "61fad881f9191c4f568d3ca5028c85bc149568bb68057d952e9b2353c59034c0",
@@ -26,7 +38,23 @@
     "bootstrap_sha256": "3e28f02ed580180b8543be8ea23507c8c1b9f22a01adec696ee7d455c0676c57",
     "targets_sha256": "71e3d2e90d77dc5dcef356559f1364363ba88dc166cea7aef891eb9f38f3e8b9",
     "codex_version_sha256": "7aa31f8b0864fa0a787657d21167487f49ed01497802a4e5955ef02db3e94272",
-    "driver_sha256": "627b93134794c79ce4384642f86325a2c233dd403e1b84d949e62cf6349efa93"
+    "driver_sha256": "627b93134794c79ce4384642f86325a2c233dd403e1b84d949e62cf6349efa93",
+    "real_node_sha256": "595af80a2a1276b139d20ef9d8ae4d2c0d358f1895c446b0d8717f2b82943adf",
+    "parent_verifier_identity_sha256": "71166db3c986b3ee6ad52ae77bc7e2786fb5e1e23ce3ce3740c0a9bf240fa291",
+    "target_packages": {
+      "humanizer-zh": {
+        "package_tree_sha256": "8c4d15f60d1debb58e88a2a83a56fdf06b9a20a8c6eec78dfe6137a40948cc2d",
+        "script_content_sha256": null
+      },
+      "archify": {
+        "package_tree_sha256": "5601eb1ed6d8c65806e010c376c7aebd8fb41e7de44e438f822e6894081770c0",
+        "script_content_sha256": "4ce95433141a503c569235e7dfbe6964da626d230cab31960b676af862b3397d"
+      }
+    },
+    "observed_post_invocation_pair_invariants": {
+      "transfer-humanize-001": "d883b5a5c40e89330cc8c8b076cdc03b522c4ba7cfff872402a96465fa2500b2",
+      "transfer-architecture-001": "f709314fd16c1ac0f6d15c8f1e788e96eb3623f160d4cab2fcb608a6d98ed506"
+    }
   },
   "results": [
     {
@@ -121,6 +149,7 @@
     "One frozen two-task run with one Codex model is not a general task-success claim.",
     "Raw prompts, transcripts, absolute run paths, receipts, and credentials are not committed.",
     "The private run root is retained locally and referenced only by its aggregate digest.",
+    "SIGINT and SIGTERM cleanup is best effort; SIGKILL cannot guarantee isolated auth cleanup.",
     "The historical driver containment enum has a legacy name; this execution invoked Codex only."
   ]
 }

--- a/docs/acceptance/artifacts/codex-luna-transfer-gate-v1.json
+++ b/docs/acceptance/artifacts/codex-luna-transfer-gate-v1.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 1,
+  "date": "2026-08-24",
+  "scope": "codex_luna_cold_routing_transfer_gate",
+  "issues": [129, 145],
+  "status": "failed",
+  "execution": {
+    "agent": "codex",
+    "codex_version": "0.147.0",
+    "model": "gpt-5.6-luna",
+    "suite_id": "codex-transfer-replication-v1",
+    "revision": "2623693036089e31b26e110a2d3facc985a1a3aa",
+    "started_at": "2026-08-24T13:17:28+08:00",
+    "finished_at": "2026-08-24T13:24:22+08:00",
+    "run_count": 4,
+    "reruns": 0,
+    "summary_mode": "0600",
+    "summary_sha256": "6ff164659c25c4bb2420d12c38559c69d30eb8fdda9dfd2a3ba607e14c3a3298",
+    "private_run_tree_sha256": "a6365dbe5a5438816a3eb91ebe990c880308939fd7474c5b8b0e07b627acea44",
+    "auth_copies_remaining": 0
+  },
+  "frozen_inputs": {
+    "snapshot_sha256": "17b524c365f87cea88c9f902802813c332bd3b6bea1323e0ba6869aaee6192ef",
+    "manifest_sha256": "61fad881f9191c4f568d3ca5028c85bc149568bb68057d952e9b2353c59034c0",
+    "cli_sha256": "1b48bd605359b49538648d3cff8d549b3956e418cdbefc819efe69cda9fa4f28",
+    "bootstrap_sha256": "3e28f02ed580180b8543be8ea23507c8c1b9f22a01adec696ee7d455c0676c57",
+    "targets_sha256": "71e3d2e90d77dc5dcef356559f1364363ba88dc166cea7aef891eb9f38f3e8b9",
+    "codex_version_sha256": "7aa31f8b0864fa0a787657d21167487f49ed01497802a4e5955ef02db3e94272",
+    "driver_sha256": "627b93134794c79ce4384642f86325a2c233dd403e1b84d949e62cf6349efa93"
+  },
+  "results": [
+    {
+      "task": "transfer-humanize-001",
+      "arm": "core",
+      "codex_exit_code": 0,
+      "surface": true,
+      "transcript": true,
+      "protected_scopes": true,
+      "load": false,
+      "order": false,
+      "oracle": false,
+      "oracle_failures": ["minimum_characters:79"],
+      "workspace": true,
+      "accepted": false
+    },
+    {
+      "task": "transfer-humanize-001",
+      "arm": "on_demand",
+      "codex_exit_code": 0,
+      "surface": true,
+      "governance": {
+        "roster_state": "on_demand",
+        "target_default_exposure": 0,
+        "receipt_verification": "passed",
+        "recovery_state": "clear"
+      },
+      "transcript": true,
+      "protected_scopes": true,
+      "find_calls": 3,
+      "find_retry_classification": "recovered_after_argument_mismatch",
+      "top1_correct": true,
+      "returned_path_exact": true,
+      "contract_violation": true,
+      "load": false,
+      "order": false,
+      "oracle": true,
+      "workspace": true,
+      "accepted": false
+    },
+    {
+      "task": "transfer-architecture-001",
+      "arm": "core",
+      "codex_exit_code": 0,
+      "surface": true,
+      "transcript": true,
+      "protected_scopes": true,
+      "load": true,
+      "order": true,
+      "oracle": false,
+      "oracle_failure_classes": ["external_stylesheet", "architecture_spec", "archify_receipt"],
+      "workspace": true,
+      "accepted": false
+    },
+    {
+      "task": "transfer-architecture-001",
+      "arm": "on_demand",
+      "codex_exit_code": 0,
+      "surface": true,
+      "governance": {
+        "roster_state": "on_demand",
+        "target_default_exposure": 0,
+        "receipt_verification": "passed",
+        "recovery_state": "clear"
+      },
+      "transcript": true,
+      "protected_scopes": true,
+      "find_calls": 1,
+      "find_retry_classification": "single_attempt",
+      "top1_correct": true,
+      "returned_path_exact": true,
+      "contract_violation": false,
+      "load": true,
+      "order": true,
+      "oracle": false,
+      "oracle_failure_classes": ["external_stylesheet", "architecture_spec", "archify_receipt"],
+      "workspace": true,
+      "accepted": false
+    }
+  ],
+  "pair_attribution": [
+    {"task": "transfer-humanize-001", "classification": "invalid_core_control", "cold_routing_regression": null},
+    {"task": "transfer-architecture-001", "classification": "invalid_core_control", "cold_routing_regression": null}
+  ],
+  "conclusions": [
+    "Both On-demand arms ultimately retrieved the correct Skill and exact path.",
+    "Only the Architecture On-demand arm completed the clean Find-load-order chain.",
+    "Neither paired Core control passed the task oracle, so cold-routing attribution is invalid.",
+    "No protected scope, input, or unexpected workspace mutation was observed."
+  ],
+  "limitations": [
+    "One frozen two-task run with one Codex model is not a general task-success claim.",
+    "Raw prompts, transcripts, absolute run paths, receipts, and credentials are not committed.",
+    "The private run root is retained locally and referenced only by its aggregate digest.",
+    "The historical driver containment enum has a legacy name; this execution invoked Codex only."
+  ]
+}

--- a/docs/acceptance/codex-luna-transfer-gate-v1.md
+++ b/docs/acceptance/codex-luna-transfer-gate-v1.md
@@ -1,0 +1,57 @@
+# Codex Luna cold-routing transfer gate
+
+Date: 2026-08-24 (Asia/Shanghai)
+
+Scope: the bounded execution requested by Issue #145 and evidence toward Issue #129.
+This is not completion of the broader cross-harness recovery goal.
+
+## Outcome
+
+The single frozen four-arm run **failed**. All four Codex processes exited
+normally, prompt surfaces were correct, protected scopes stayed unchanged, and
+workspace safety passed. No arm was retried.
+
+| Task | Arm | Find | Exact load / order | Oracle | Result |
+|---|---|---|---|---|---|
+| Humanizer | Core | N/A | No / no | Failed | Control invalid |
+| Humanizer | On-demand | Correct Top-1 after two invalid calls | No / no | Passed | Rejected |
+| Architecture | Core | N/A | Yes / yes | Failed | Control invalid |
+| Architecture | On-demand | Correct Top-1 on first call | Yes / yes | Failed | Rejected |
+
+Both On-demand arms eventually retrieved the correct Skill and exact path. The
+Architecture arm proved the intended Bootstrap -> Find -> exact load -> task
+sequence. Humanizer recovered from two malformed Find invocations, but the
+audit did not establish a full Skill read and classified the retries as a
+contract violation.
+
+The paired inference is deliberately `invalid_core_control` for both tasks.
+Humanizer Core did not load the visible Skill before acting and missed the
+minimum-length oracle. Architecture Core loaded its Skill in order but, like
+On-demand, failed the self-contained HTML, topology, and Archify receipt gates.
+These facts do not support blaming cold routing for either task failure.
+
+## Frozen evidence
+
+The run used Codex CLI `0.147.0`, model `gpt-5.6-luna`, revision `2623693`, and
+the immutable `codex-transfer-replication-v1` manifest. The suite snapshot is
+`17b524c365f87cea88c9f902802813c332bd3b6bea1323e0ba6869aaee6192ef`.
+Execution ran from 13:17:28 to 13:24:22 +08:00.
+
+The external summary was created once with mode `0600`; its SHA-256 is
+`6ff164659c25c4bb2420d12c38559c69d30eb8fdda9dfd2a3ba607e14c3a3298`.
+The retained private run tree has aggregate SHA-256
+`a6365dbe5a5438816a3eb91ebe990c880308939fd7474c5b8b0e07b627acea44`.
+No isolated authentication copy remained after completion.
+
+The committed [redacted artifact](artifacts/codex-luna-transfer-gate-v1.json)
+contains the reviewable facts and frozen digests. Raw prompts, transcripts,
+absolute temporary paths, receipts, and credentials remain uncommitted.
+
+## Product implication
+
+This run supports the deterministic retrieval layer more than the end-to-end
+Agent contract: both cold queries ultimately ranked the correct Skill first,
+but only one Agent run followed the complete route cleanly. The next
+investigation should focus on making Bootstrap, Find arguments, and exact Skill
+loading easier for an Agent to execute, while keeping semantic intent and task
+judgment in the model. More ranking heuristics are not justified by this run.

--- a/docs/acceptance/codex-luna-transfer-gate-v1.md
+++ b/docs/acceptance/codex-luna-transfer-gate-v1.md
@@ -7,7 +7,8 @@ This is not completion of the broader cross-harness recovery goal.
 
 ## Outcome
 
-The single frozen four-arm run **failed**. All four Codex processes exited
+The single frozen four-arm run **failed** and is **not eligible as a formal
+transfer-gate result**. All four Codex processes exited
 normally, prompt surfaces were correct, protected scopes stayed unchanged, and
 workspace safety passed. No arm was retried.
 
@@ -30,6 +31,12 @@ minimum-length oracle. Architecture Core loaded its Skill in order but, like
 On-demand, failed the self-contained HTML, topology, and Archify receipt gates.
 These facts do not support blaming cold routing for either task failure.
 
+The driver emitted identical pair invariant values for each task's two arms,
+but calculated them after invocation instead of recording them in the frozen
+pre-run suite snapshot. That procedural miss invalidates formal eligibility
+without invalidating the observed run facts. It was discovered during final
+Spec review; the experiment was not rerun.
+
 ## Frozen evidence
 
 The run used Codex CLI `0.147.0`, model `gpt-5.6-luna`, revision `2623693`, and
@@ -43,6 +50,12 @@ The retained private run tree has aggregate SHA-256
 `a6365dbe5a5438816a3eb91ebe990c880308939fd7474c5b8b0e07b627acea44`.
 No isolated authentication copy remained after completion.
 
+Before invocation, driver syntax, 32 harness tests, `cargo build --locked`, the
+four-arm Luna dry-run, and pre-run Spec/Standards review passed. The frozen
+summary also records the real Node verifier identity and both target package
+identities. Signal cleanup is best effort for SIGINT/SIGTERM; SIGKILL cannot
+guarantee removal of an isolated auth copy.
+
 The committed [redacted artifact](artifacts/codex-luna-transfer-gate-v1.json)
 contains the reviewable facts and frozen digests. Raw prompts, transcripts,
 absolute temporary paths, receipts, and credentials remain uncommitted.
@@ -55,3 +68,6 @@ but only one Agent run followed the complete route cleanly. The next
 investigation should focus on making Bootstrap, Find arguments, and exact Skill
 loading easier for an Agent to execute, while keeping semantic intent and task
 judgment in the model. More ranking heuristics are not justified by this run.
+The driver now freezes pair invariants before invocation for a future experiment;
+this ledger remains bound to the original revision and is not upgraded
+retroactively.

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -39,13 +39,13 @@ export function parseArgs(argv) {
     codex: "codex", bootstrap: join(REPO, "skill/skillroster/SKILL.md"),
     skillsRoot: join(homedir(), ".agents_skills"), cli: join(REPO, "target/debug/skillroster"),
     runsDir: join(tmpdir(), "skillroster-codex-transfer"), authSource: null,
-    timeoutMs: 300_000, execute: false, reevaluateRoot: null, reevaluateOutput: null,
+    timeoutMs: 300_000, execute: false, reevaluateRoot: null, reevaluateOutput: null, summaryOutput: null,
   };
   const values = new Map([
     ["--manifest", "manifest"], ["--task", "task"], ["--arm", "arm"], ["--model", "model"],
     ["--codex", "codex"], ["--bootstrap", "bootstrap"], ["--skills-root", "skillsRoot"],
     ["--cli", "cli"], ["--runs-dir", "runsDir"], ["--auth-source", "authSource"], ["--timeout-ms", "timeoutMs"],
-    ["--reevaluate-root", "reevaluateRoot"], ["--reevaluate-output", "reevaluateOutput"],
+    ["--reevaluate-root", "reevaluateRoot"], ["--reevaluate-output", "reevaluateOutput"], ["--summary-output", "summaryOutput"],
   ]);
   for (let index = 0; index < argv.length;) {
     if (argv[index] === "--execute") { options.execute = true; index += 1; continue; }
@@ -59,6 +59,7 @@ export function parseArgs(argv) {
   if (options.execute && options.reevaluateRoot) fail("--execute and --reevaluate-root are mutually exclusive");
   if (options.execute && !options.authSource) fail("--execute requires an explicit --auth-source");
   if (options.reevaluateOutput && !options.reevaluateRoot) fail("--reevaluate-output requires --reevaluate-root");
+  if (options.summaryOutput && options.reevaluateRoot) fail("--summary-output and --reevaluate-root are mutually exclusive");
   return options;
 }
 
@@ -511,6 +512,22 @@ function copyAuth(authSource, codexHome) {
 
 function cleanupAuth(path) { rmSync(path, { force: true }); ACTIVE_AUTH_COPIES.delete(path); }
 
+function validateSummaryOutput(path, runsDir) {
+  if (!path) return;
+  try { lstatSync(path); fail("summary output already exists"); } catch (error) { if (error.code !== "ENOENT") throw error; }
+  const parent = dirname(path); let stat;
+  try { stat = lstatSync(parent); } catch { fail("summary output parent must already exist"); }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) fail("summary output parent must be a real directory");
+  if (inside(path, REPO) || existingAncestorResolvesInside(path, REPO)) fail("summary output must stay outside the repository");
+  if (inside(path, runsDir) || existingAncestorResolvesInside(path, runsDir)) fail("summary output must stay outside the run root");
+}
+
+function emitSummary(summary, options) {
+  const encoded = `${JSON.stringify(summary, null, 2)}\n`;
+  if (options.summaryOutput) writeFileSync(options.summaryOutput, encoded, { flag: "wx", mode: 0o600 });
+  process.stdout.write(encoded);
+}
+
 function run(command, args, options) {
   const result = spawnSync(command, args, { encoding: "utf8", shell: false, maxBuffer: 64 * 1024 * 1024, ...options });
   return { ...result, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
@@ -724,7 +741,8 @@ export function main(argv = process.argv.slice(2)) {
   if (existingAncestorResolvesInside(options.runsDir, REPO)) fail("--runs-dir ancestor resolves inside the repository so transcripts cannot be committed");
   mkdirSync(options.runsDir, { recursive: true });
   if (inside(realpathSync(options.runsDir), realpathSync(REPO))) fail("--runs-dir resolves inside the repository so transcripts cannot be committed");
-  if (!options.execute) { process.stdout.write(`${JSON.stringify(dryRun(manifest, options), null, 2)}\n`); return 0; }
+  validateSummaryOutput(options.summaryOutput, options.runsDir);
+  if (!options.execute) { emitSummary(dryRun(manifest, options), options); return 0; }
   for (const path of [options.bootstrap, options.cli, options.skillsRoot, options.authSource]) if (!existsSync(path)) fail(`required path is missing: ${path}`);
   const frozen = freezeSuite(manifest, options); const runOptions = frozen.options;
   const tasks = options.task === "all" ? manifest.tasks : manifest.tasks.filter((task) => task.id === options.task); if (!tasks.length) fail(`unknown task: ${options.task}`);
@@ -736,7 +754,7 @@ export function main(argv = process.argv.slice(2)) {
     return coreResult && onDemandResult ? { task: task.id, ...classifyPair(coreResult.outcome, onDemandResult.outcome) } : { task: task.id, attribution: "pair_incomplete", cold_routing_regression: null };
   });
   const summary = { status: results.every((result) => result.outcome?.accepted) && pairs.every((pair) => pair.attribution !== "pair_invariant_mismatch") ? "passed" : "failed", suite_id: manifest.suite_id, suite_snapshot: frozen.facts, signal_cleanup: "SIGINT/SIGTERM best effort; SIGKILL cannot guarantee auth cleanup", results, pairs };
-  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`); return summary.status === "passed" ? 0 : 2;
+  emitSummary(summary, options); return summary.status === "passed" ? 0 : 2;
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -651,11 +651,12 @@ function freezeSuite(manifest, options) {
   const version = run(options.codex, ["--version"], { encoding: "utf8", timeout: 30_000 });
   if (version.status !== 0 || !version.stdout.trim()) fail("unable to freeze Codex version identity");
   const driverSha256 = sha(readFileSync(fileURLToPath(import.meta.url))); const frozenTreeDigest = stateDigest(root); const realNode = canonicalPath(process.execPath); const parentVerifierIdentity = sha(`${realNode}\0${driverSha256}`);
+  const snapshotDigest = sha(`${frozenTreeDigest}\0${options.model}\0${driverSha256}\0${parentVerifierIdentity}`);
   const facts = {
-    snapshot_digest: sha(`${frozenTreeDigest}\0${options.model}\0${driverSha256}\0${parentVerifierIdentity}`), manifest_sha256: sha(readFileSync(manifestPath)), cli_sha256: sha(readFileSync(cli)),
+    snapshot_digest: snapshotDigest, manifest_sha256: sha(readFileSync(manifestPath)), cli_sha256: sha(readFileSync(cli)),
     bootstrap_sha256: stateDigest(bootstrapRoot), targets_sha256: stateDigest(targets), codex_version_sha256: sha(version.stdout.trim()), model: options.model, driver_sha256: driverSha256,
     real_node_sha256: sha(realNode), parent_verifier_identity_sha256: parentVerifierIdentity,
-    target_packages: targetPackages,
+    target_packages: targetPackages, pair_invariants: Object.fromEntries(manifest.tasks.map((task) => [task.id, pairInvariant(snapshotDigest, task)])),
   };
   return { options: { ...options, skillsRoot: targets, bootstrap: join(bootstrapRoot, basename(options.bootstrap)), cli }, facts };
 }
@@ -697,7 +698,10 @@ export function prepareOnDemand(paths, task, options, env) {
   return { bin, governance: { roster_state: top.roster_state, target_default_exposure: 0, receipt_id: applied.result.receipt_id, receipt_verification: applied.result.verification, recovery_state: status.result.recovery_state } };
 }
 
+export function pairInvariant(snapshotDigest, task) { return sha(`${snapshotDigest}\0${JSON.stringify(task)}`); }
+
 function executeArm(task, arm, options, suiteFacts) {
+  const frozenPairInvariant = suiteFacts.pair_invariants?.[task.id]; if (!frozenPairInvariant) fail(`pair invariant was not frozen before invocation: ${task.id}`);
   const root = mkdtempSync(join(options.runsDir, `${task.id}-${arm}-`)); const paths = setupArm(root, task, arm, options);
   const authCopy = copyAuth(options.authSource, paths.codexHome);
   const env = { ...process.env, HOME: paths.home, CODEX_HOME: paths.codexHome, TMPDIR: paths.temp };
@@ -725,7 +729,7 @@ function executeArm(task, arm, options, suiteFacts) {
     const coreOrder = arm === "core" ? assessCoreOrder(result.stdout, paths.targetPath) : { passed: true, audit_scope: "not_applicable" };
     const transcript = assessTranscriptIntegrity(result.stdout);
     const outcome = deriveArmOutcome({ arm, surface, retrieval, load, oracle, workspace, routeOrder, coreOrder, transcript, protectedScopes });
-    return { task: task.id, arm, root, pair_invariant: sha(`${suiteFacts.snapshot_digest}\0${JSON.stringify(task)}`), codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
+    return { task: task.id, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
   } finally {
     cleanupAuth(authCopy);
   }

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
-import { chmodSync, copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, closeSync, constants as fsConstants, copyFileSync, cpSync, existsSync, fchmodSync, fstatSync, lstatSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
@@ -513,19 +513,50 @@ function copyAuth(authSource, codexHome) {
 function cleanupAuth(path) { rmSync(path, { force: true }); ACTIVE_AUTH_COPIES.delete(path); }
 
 function validateSummaryOutput(path, runsDir) {
-  if (!path) return;
-  try { lstatSync(path); fail("summary output already exists"); } catch (error) { if (error.code !== "ENOENT") throw error; }
-  const parent = dirname(path); let stat;
+  if (!path) return null;
+  const absolute = resolve(path);
+  try { lstatSync(absolute); fail("summary output already exists"); } catch (error) { if (error.code !== "ENOENT") throw error; }
+  const parent = dirname(absolute); let stat;
   try { stat = lstatSync(parent); } catch { fail("summary output parent must already exist"); }
   if (!stat.isDirectory() || stat.isSymbolicLink()) fail("summary output parent must be a real directory");
-  if (inside(path, REPO) || existingAncestorResolvesInside(path, REPO)) fail("summary output must stay outside the repository");
-  if (inside(path, runsDir) || existingAncestorResolvesInside(path, runsDir)) fail("summary output must stay outside the run root");
+  let current = parse(parent).root;
+  for (const part of relative(current, parent).split(sep).filter(Boolean)) {
+    current = join(current, part);
+    if (lstatSync(current).isSymbolicLink()) fail("summary output path must not contain linked ancestors");
+  }
+  if (inside(absolute, REPO) || existingAncestorResolvesInside(absolute, REPO)) fail("summary output must stay outside the repository");
+  if (inside(absolute, runsDir) || existingAncestorResolvesInside(absolute, runsDir)) fail("summary output must stay outside the run root");
+  return { path: absolute, parent, parentDevice: stat.dev, parentInode: stat.ino, canonicalParent: realpathSync(parent) };
+}
+
+function assertSummaryBoundary(boundary, descriptor = null) {
+  const parent = lstatSync(boundary.parent);
+  if (!parent.isDirectory() || parent.isSymbolicLink() || parent.dev !== boundary.parentDevice || parent.ino !== boundary.parentInode || realpathSync(boundary.parent) !== boundary.canonicalParent) fail("summary output parent changed during persistence");
+  if (descriptor !== null) {
+    const opened = fstatSync(descriptor); const named = lstatSync(boundary.path);
+    if (!opened.isFile() || named.isSymbolicLink() || opened.dev !== named.dev || opened.ino !== named.ino || opened.nlink !== 1) fail("summary output changed during persistence");
+  }
+}
+
+function persistSummary(encoded, options) {
+  const boundary = validateSummaryOutput(options.summaryOutput, options.runsDir); let descriptor = null;
+  try {
+    descriptor = openSync(boundary.path, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW, 0o600);
+    assertSummaryBoundary(boundary, descriptor); writeFileSync(descriptor, encoded); fchmodSync(descriptor, 0o600); assertSummaryBoundary(boundary, descriptor);
+  } catch (error) {
+    if (descriptor !== null) {
+      try { const opened = fstatSync(descriptor); const named = lstatSync(boundary.path); if (opened.dev === named.dev && opened.ino === named.ino) rmSync(boundary.path, { force: true }); } catch {}
+    }
+    fail(`summary output persistence failed: ${error.message}`);
+  } finally { if (descriptor !== null) closeSync(descriptor); }
 }
 
 function emitSummary(summary, options) {
   const encoded = `${JSON.stringify(summary, null, 2)}\n`;
-  if (options.summaryOutput) writeFileSync(options.summaryOutput, encoded, { flag: "wx", mode: 0o600 });
+  let persistenceError = null;
+  if (options.summaryOutput) try { persistSummary(encoded, options); } catch (error) { persistenceError = error; }
   process.stdout.write(encoded);
+  if (persistenceError) throw persistenceError;
 }
 
 function run(command, args, options) {

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import { assessCoreOrder, assessExactLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, main, parseArgs, parseFindAudit, parseFindEnvelope, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
+
+const DRIVER = fileURLToPath(new URL("./driver.mjs", import.meta.url));
 
 const digest = async (value) => {
   const { createHash } = await import("node:crypto"); return createHash("sha256").update(value).digest("hex");
@@ -19,6 +21,26 @@ test("default is a non-executing plan and execution requires explicit auth", () 
   assert.equal(parseArgs(["--reevaluate-root", "/tmp/existing-runs"]).execute, false);
   assert.throws(() => parseArgs(["--execute", "--auth-source", "/tmp/auth.json", "--reevaluate-root", "/tmp/runs"]), /mutually exclusive/u);
   assert.throws(() => main(["--runs-dir", fileURLToPath(new URL("../../../tests/transcripts", import.meta.url))]), /outside the repository/u);
+});
+
+test("summary output preserves stdout JSON in a private external file", { skip: process.platform === "win32" }, () => {
+  const root = mkdtempSync(join(tmpdir(), "codex-summary-output-")); const runs = join(root, "runs"); const output = join(root, "summary.json");
+  const result = spawnSync(process.execPath, [DRIVER, "--runs-dir", runs, "--model", "gpt-5.6-luna", "--summary-output", output], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr); assert.equal(existsSync(output), true);
+  assert.deepEqual(JSON.parse(readFileSync(output, "utf8")), JSON.parse(result.stdout));
+  assert.equal(statSync(output).mode & 0o777, 0o600);
+});
+
+test("summary output refuses existing, run-root, repository, and linked-parent targets", { skip: process.platform === "win32" }, () => {
+  const root = mkdtempSync(join(tmpdir(), "codex-summary-boundary-")); const runs = join(root, "runs");
+  const invoke = (output) => spawnSync(process.execPath, [DRIVER, "--runs-dir", runs, "--summary-output", output], { encoding: "utf8" });
+  const existing = join(root, "existing.json"); writeFileSync(existing, "keep");
+  const existingResult = invoke(existing); assert.notEqual(existingResult.status, 0); assert.equal(readFileSync(existing, "utf8"), "keep");
+  const runOutput = join(runs, "summary.json"); const runResult = invoke(runOutput); assert.notEqual(runResult.status, 0); assert.equal(existsSync(runOutput), false);
+  const repositoryOutput = join(fileURLToPath(new URL("../../../", import.meta.url)), `.forbidden-summary-${process.pid}.json`);
+  const repositoryResult = invoke(repositoryOutput); assert.notEqual(repositoryResult.status, 0); assert.equal(existsSync(repositoryOutput), false);
+  const realParent = join(root, "real-parent"); const linkedParent = join(root, "linked-parent"); mkdirSync(realParent); symlinkSync(realParent, linkedParent, "dir");
+  const linkedOutput = join(linkedParent, "summary.json"); const linkedResult = invoke(linkedOutput); assert.notEqual(linkedResult.status, 0); assert.equal(existsSync(linkedOutput), false);
 });
 
 test("runs directory cannot hide a repository target behind a symlink", { skip: process.platform === "win32" }, () => {

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -24,7 +24,7 @@ test("default is a non-executing plan and execution requires explicit auth", () 
 });
 
 test("summary output preserves stdout JSON in a private external file", { skip: process.platform === "win32" }, () => {
-  const root = mkdtempSync(join(tmpdir(), "codex-summary-output-")); const runs = join(root, "runs"); const output = join(root, "summary.json");
+  const root = mkdtempSync(join(realpathSync(tmpdir()), "codex-summary-output-")); const runs = join(root, "runs"); const output = join(root, "summary.json");
   const result = spawnSync(process.execPath, [DRIVER, "--runs-dir", runs, "--model", "gpt-5.6-luna", "--summary-output", output], { encoding: "utf8" });
   assert.equal(result.status, 0, result.stderr); assert.equal(existsSync(output), true);
   assert.deepEqual(JSON.parse(readFileSync(output, "utf8")), JSON.parse(result.stdout));
@@ -32,7 +32,7 @@ test("summary output preserves stdout JSON in a private external file", { skip: 
 });
 
 test("summary output refuses existing, run-root, repository, and linked-parent targets", { skip: process.platform === "win32" }, () => {
-  const root = mkdtempSync(join(tmpdir(), "codex-summary-boundary-")); const runs = join(root, "runs");
+  const root = mkdtempSync(join(realpathSync(tmpdir()), "codex-summary-boundary-")); const runs = join(root, "runs");
   const invoke = (output) => spawnSync(process.execPath, [DRIVER, "--runs-dir", runs, "--summary-output", output], { encoding: "utf8" });
   const existing = join(root, "existing.json"); writeFileSync(existing, "keep");
   const existingResult = invoke(existing); assert.notEqual(existingResult.status, 0); assert.equal(readFileSync(existing, "utf8"), "keep");
@@ -41,6 +41,16 @@ test("summary output refuses existing, run-root, repository, and linked-parent t
   const repositoryResult = invoke(repositoryOutput); assert.notEqual(repositoryResult.status, 0); assert.equal(existsSync(repositoryOutput), false);
   const realParent = join(root, "real-parent"); const linkedParent = join(root, "linked-parent"); mkdirSync(realParent); symlinkSync(realParent, linkedParent, "dir");
   const linkedOutput = join(linkedParent, "summary.json"); const linkedResult = invoke(linkedOutput); assert.notEqual(linkedResult.status, 0); assert.equal(existsSync(linkedOutput), false);
+  const nestedParent = join(realParent, "nested"); mkdirSync(nestedParent);
+  const nestedLinkedOutput = join(linkedParent, "nested", "summary.json"); const nestedLinkedResult = invoke(nestedLinkedOutput); assert.notEqual(nestedLinkedResult.status, 0); assert.equal(existsSync(nestedLinkedOutput), false);
+});
+
+test("summary persistence failure keeps the stdout JSON contract and fails the command", { skip: process.platform === "win32" || process.getuid?.() === 0 }, () => {
+  const root = mkdtempSync(join(realpathSync(tmpdir()), "codex-summary-failure-")); const runs = join(root, "runs"); const outputParent = join(root, "read-only"); mkdirSync(outputParent); chmodSync(outputParent, 0o500);
+  try {
+    const result = spawnSync(process.execPath, [DRIVER, "--runs-dir", runs, "--model", "gpt-5.6-luna", "--summary-output", join(outputParent, "summary.json")], { encoding: "utf8" });
+    assert.notEqual(result.status, 0); assert.equal(JSON.parse(result.stdout).status, "planned"); assert.match(result.stderr, /summary output persistence failed/u);
+  } finally { chmodSync(outputParent, 0o700); }
 });
 
 test("runs directory cannot hide a repository target behind a symlink", { skip: process.platform === "win32" }, () => {

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { assessCoreOrder, assessExactLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, main, parseArgs, parseFindAudit, parseFindEnvelope, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
+import { assessCoreOrder, assessExactLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
 
 const DRIVER = fileURLToPath(new URL("./driver.mjs", import.meta.url));
 
@@ -73,6 +73,14 @@ test("manifest is restricted to the two-family Codex transfer contract", () => {
   assert.equal(validateManifest(manifest), manifest);
   assert.throws(() => validateManifest({ ...manifest, harness: "pi" }), /unsupported/u);
   assert.throws(() => validateManifest({ ...manifest, tasks: [manifest.tasks[0]] }), /unsupported/u);
+});
+
+test("pair invariant is frozen from the suite snapshot and complete task input", () => {
+  const task = { id: "transfer-a", prompt: "fixed", workspace_files: { "input.txt": "one" } };
+  const frozen = pairInvariant("suite-snapshot", task);
+  assert.equal(pairInvariant("suite-snapshot", task), frozen);
+  assert.notEqual(pairInvariant("other-snapshot", task), frozen);
+  assert.notEqual(pairInvariant("suite-snapshot", { ...task, prompt: "changed" }), frozen);
 });
 
 test("prompt-input preflight permits only fixed Codex system skills plus the arm skill", () => {


### PR DESCRIPTION
## Summary

- add a private, create-once `--summary-output` seam for the Codex transfer harness
- reject existing, linked, repository-contained, and run-root-contained summary targets
- preserve stdout JSON when summary persistence fails, while returning a non-zero status
- execute the frozen Humanizer/Architecture Core + On-demand suite once on `gpt-5.6-luna`
- commit a bounded redacted failed-run ledger and machine artifact
- freeze pair invariants before future model invocation

## Result

The four-arm run is an honest failed experiment, not a cold-routing regression claim:

- both On-demand arms ultimately retrieved the correct Skill and exact path
- only Architecture On-demand passed the clean Find -> exact load -> order chain
- neither Core pair passed its task oracle, so both pair attributions are `invalid_core_control`
- protected scopes and workspace safety passed in all four arms
- no arm was rerun

Final Spec review found that the historical run's pair invariant was calculated after invocation. The committed artifact therefore marks `formal_gate_eligible: false`; the future driver fix does not retroactively upgrade that evidence. This PR does not claim Issue #129 complete and intentionally uses `Refs #145` rather than closing it.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked --all-targets --all-features` (276 passed)
- [x] `node --check tests/harness/codex-cold-routing/driver.mjs`
- [x] `node --test tests/harness/codex-cold-routing/driver.test.mjs` (33 passed)
- [x] artifact JSON parse and `git diff --check`
- [x] final independent Spec and Standards reviews: no blocker / should-fix

Refs #145
Refs #129
