### PR TITLE
feat: add verified one-call Skill loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.21"
+version = "1.8.22"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.21"
+version = "1.8.22"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ skillroster find "database migration" --json
 skillroster find "把中文改自然一点" --json
 skillroster find "诊断命令性能回归" --hint "diagnose command performance regression" --json
 skillroster find "分析本地表格" --hint "analyze standalone spreadsheet file workbook data" --json
+skillroster find "build an event manifest" --load --limit 1 --json
 skillroster plan --stdin --json
 skillroster plan --show <plan-id> --json
 skillroster apply <plan-id> --json

--- a/docs/acceptance/artifacts/codex-skill-protocol-isolation-v7.json
+++ b/docs/acceptance/artifacts/codex-skill-protocol-isolation-v7.json
@@ -4,7 +4,7 @@
   "status": "passed",
   "formal_gate_eligible": true,
   "projection": "redacted_bounded_projection_of_external_raw_summary",
-  "raw_summary_sha256": "bbeb07921333500921cfd4faec34dc8aa6932d4178639eea1033ac86f294d143",
+  "raw_summary_sha256": "4ee49726b7cc288d215d31f449139c5a5522c793f6918de222b4318537d2d105",
   "source_identity_stable": true,
   "codex_executable_stable": true,
   "protocol_decision": {
@@ -15,23 +15,23 @@
     "on_demand_contract_failures": 0
   },
   "frozen": {
-    "source_commit": "549f5a233a9f05f76716ad8f9cd75c6ddbe55d11",
-    "source_tree": "c9680400a99371d66df63aa96552f284969c985c",
-    "snapshot_digest": "b369644e6a243076eae1acb762232c9845426e980e62ed93b8d075e39000988b",
+    "source_commit": "eaa0ce0fced0d7bb6a4c8569111cf24acdf054f6",
+    "source_tree": "a28d41ab88a33d0a8feacef933a7acfb5bb10ed3",
+    "snapshot_digest": "58975da7514d5479cb880483dd11820c21257366bb28090601cacc5478f7dd17",
     "manifest_sha256": "93381b3fad2ef8a1f1d7cf0926eb74686c3f3d540d99569a78a7cf2f4de1ae06",
     "cli_sha256": "3c6790e0bc1774f922fb51a66607e1d69c2e2ed6d6aed9491b03c0d5f17e4cd4",
     "bootstrap_sha256": "19ad3d2d59161b8aa7e034d9a4224448fc79594471815523c2c6e3fd678d5656",
-    "targets_sha256": "13d8055a97e0e0fcb2d6eb7c96c6f352bc5d0ad0c2e7a5a87e4df0ff8cc3eb45",
+    "targets_sha256": "6bffb2cc895abd550535a74d68b4860b830769885a4d74ab94af7ef30ac8f85c",
     "codex_version_sha256": "7aa31f8b0864fa0a787657d21167487f49ed01497802a4e5955ef02db3e94272",
     "codex_executable_content_sha256": "134063e133f0b4244fa3b251acf973d4fe4b4aeeacbdc135211bf480f59f1477",
     "model": "gpt-5.6-luna",
     "reasoning_effort": "medium",
     "timeout_ms": 180000,
-    "driver_sha256": "d986a4406ea6106dfafade6e28cc2344d23a58b230aa95bf2db7e2d02d3e59f9",
+    "driver_sha256": "1fdf629d1b04c814c6707056f9fb9138a129c63d613f01bdf953b0b0f3c25bf8",
     "pair_invariants": {
-      "event-manifest-001#1": "48dc358df1a741445effb6516745ac66a483b81411859c34f1eb165828fc7c4f",
-      "event-manifest-001#2": "f27fb42d64d8371286da333892762fbda6dfd1d9498a41988cde73dd86afd0c4",
-      "event-manifest-001#3": "2099d9d33d915fda0adf0eb527c50a703485e7c96601c618070769ed32d64880"
+      "event-manifest-001#1": "0954c9cf669b7a4c1ed2b87184c0f5723b152b403066fc88e12f9d54b0c6db2c",
+      "event-manifest-001#2": "049c124304c0ef14547d33dc0810ebd914f21316459fb06de0888da718e040fd",
+      "event-manifest-001#3": "b72df7520b5a4532bd78ae3a333bfd7961ca1633446319a8455990567602c160"
     }
   },
   "results": [

--- a/docs/acceptance/artifacts/codex-skill-protocol-isolation-v7.json
+++ b/docs/acceptance/artifacts/codex-skill-protocol-isolation-v7.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "suite_id": "codex-skill-protocol-isolation-v7",
+  "status": "passed",
+  "formal_gate_eligible": true,
+  "projection": "redacted_bounded_projection_of_external_raw_summary",
+  "raw_summary_sha256": "bbeb07921333500921cfd4faec34dc8aa6932d4178639eea1033ac86f294d143",
+  "source_identity_stable": true,
+  "codex_executable_stable": true,
+  "protocol_decision": {
+    "decision": "retain_current_design",
+    "required_trials_per_arm": 3,
+    "core_accepted": 3,
+    "on_demand_accepted": 3,
+    "on_demand_contract_failures": 0
+  },
+  "frozen": {
+    "source_commit": "549f5a233a9f05f76716ad8f9cd75c6ddbe55d11",
+    "source_tree": "c9680400a99371d66df63aa96552f284969c985c",
+    "snapshot_digest": "b369644e6a243076eae1acb762232c9845426e980e62ed93b8d075e39000988b",
+    "manifest_sha256": "93381b3fad2ef8a1f1d7cf0926eb74686c3f3d540d99569a78a7cf2f4de1ae06",
+    "cli_sha256": "3c6790e0bc1774f922fb51a66607e1d69c2e2ed6d6aed9491b03c0d5f17e4cd4",
+    "bootstrap_sha256": "19ad3d2d59161b8aa7e034d9a4224448fc79594471815523c2c6e3fd678d5656",
+    "targets_sha256": "13d8055a97e0e0fcb2d6eb7c96c6f352bc5d0ad0c2e7a5a87e4df0ff8cc3eb45",
+    "codex_version_sha256": "7aa31f8b0864fa0a787657d21167487f49ed01497802a4e5955ef02db3e94272",
+    "codex_executable_content_sha256": "134063e133f0b4244fa3b251acf973d4fe4b4aeeacbdc135211bf480f59f1477",
+    "model": "gpt-5.6-luna",
+    "reasoning_effort": "medium",
+    "timeout_ms": 180000,
+    "driver_sha256": "d986a4406ea6106dfafade6e28cc2344d23a58b230aa95bf2db7e2d02d3e59f9",
+    "pair_invariants": {
+      "event-manifest-001#1": "48dc358df1a741445effb6516745ac66a483b81411859c34f1eb165828fc7c4f",
+      "event-manifest-001#2": "f27fb42d64d8371286da333892762fbda6dfd1d9498a41988cde73dd86afd0c4",
+      "event-manifest-001#3": "2099d9d33d915fda0adf0eb527c50a703485e7c96601c618070769ed32d64880"
+    }
+  },
+  "results": [
+    { "trial": 1, "arm": "core", "surface": true, "transcript": true, "harness_valid": true, "load": true, "core_order": true, "oracle": true, "workspace": true, "protected_scopes": true, "accepted": true },
+    { "trial": 1, "arm": "on_demand", "surface": true, "transcript": true, "harness_valid": true, "find_count": 1, "first_call_argv_exact": true, "first_call_hint_valid": true, "top1_correct": true, "returned_path_exact": true, "loaded_content_complete": true, "loaded_content_exact": true, "load": true, "load_evidence": "verified_find_json_content", "route_order": true, "route_violations": [], "oracle": true, "workspace": true, "protected_scopes": true, "accepted": true },
+    { "trial": 2, "arm": "core", "surface": true, "transcript": true, "harness_valid": true, "load": true, "core_order": true, "oracle": true, "workspace": true, "protected_scopes": true, "accepted": true },
+    { "trial": 2, "arm": "on_demand", "surface": true, "transcript": true, "harness_valid": true, "find_count": 1, "first_call_argv_exact": true, "first_call_hint_valid": true, "top1_correct": true, "returned_path_exact": true, "loaded_content_complete": true, "loaded_content_exact": true, "load": true, "load_evidence": "verified_find_json_content", "route_order": true, "route_violations": [], "oracle": true, "workspace": true, "protected_scopes": true, "accepted": true },
+    { "trial": 3, "arm": "core", "surface": true, "transcript": true, "harness_valid": true, "load": true, "core_order": true, "oracle": true, "workspace": true, "protected_scopes": true, "accepted": true },
+    { "trial": 3, "arm": "on_demand", "surface": true, "transcript": true, "harness_valid": true, "find_count": 1, "first_call_argv_exact": true, "first_call_hint_valid": true, "top1_correct": true, "returned_path_exact": true, "loaded_content_complete": true, "loaded_content_exact": true, "load": true, "load_evidence": "verified_find_json_content", "route_order": true, "route_violations": [], "oracle": true, "workspace": true, "protected_scopes": true, "accepted": true }
+  ],
+  "raw_evidence_committed": false,
+  "auth_copies_remaining": 0
+}

--- a/docs/acceptance/codex-skill-protocol-isolation-v7.md
+++ b/docs/acceptance/codex-skill-protocol-isolation-v7.md
@@ -42,7 +42,9 @@ copied into external raw evidence, and the temporary state was removed.
 The target fixture treats a complete verified activation result as equivalent
 to a complete visible-Skill load; the gate still rejects any redundant target
 read. Earlier diagnostic attempts are not promoted: one exposed an unwritable
-harness audit path, and the next exposed a contradictory legacy fixture contract.
+harness audit path, another exposed a contradictory legacy fixture contract,
+and a later rerun exposed that the Core description no longer required direct
+loading. The final fixture states the two activation branches explicitly.
 
 The [redacted artifact](artifacts/codex-skill-protocol-isolation-v7.json) omits
 prompts, transcripts, absolute paths, full Skill content, task output, and

--- a/docs/acceptance/codex-skill-protocol-isolation-v7.md
+++ b/docs/acceptance/codex-skill-protocol-isolation-v7.md
@@ -1,0 +1,50 @@
+# Codex Skill protocol isolation v7
+
+Date: 2026-08-24 (Asia/Shanghai)
+
+Scope: Issue #149 under Issue #129. This frozen six-run comparison tests one
+Skill exposed as Core against the same Skill governed as On-demand and activated
+through one verified `find --load` result. It does not claim catalog-scale
+routing quality or cross-harness generality.
+
+## Outcome
+
+The experiment is **formally eligible and passed its protocol gate**. Core
+passed 3/3; On-demand passed 3/3. The frozen decision is
+`retain_current_design`.
+
+Every On-demand trial made exactly one audited Find call with the complete task
+and one non-empty hint, returned `event-manifest` at Top-1 with its exact path,
+and received the exact complete Skill content in the same verified JSON result.
+No trial read the target `SKILL.md` again. All six trials produced the expected
+JSON, changed only `outputs/events.json`, preserved the target Skill, exposed
+Bootstrap, and authentication scopes, and completed with a valid transcript.
+
+| Trial | Core | On-demand | Task / safety |
+|---|---|---|---|
+| 1 | Pass | Pass: one-call verified activation | Pass / pass |
+| 2 | Pass | Pass: one-call verified activation | Pass / pass |
+| 3 | Pass | Pass: one-call verified activation | Pass / pass |
+
+The result supports retaining deterministic lexical retrieval plus Agent-owned
+intent and hint generation. It does not justify embeddings, reranking, a built-in
+model, MCP, or another routing Skill.
+
+## Evidence boundary
+
+The run froze the clean source commit/tree, CLI, Bootstrap, target package,
+manifest, driver, Codex executable/version, model, reasoning effort, timeout,
+sandbox, arm schedule, and pair invariants. All source and executable identities
+remained stable. Runtime SQLite and Find audit files lived in a unique
+sandbox-writable temporary boundary per trial; only the redacted audit was
+copied into external raw evidence, and the temporary state was removed.
+
+The target fixture treats a complete verified activation result as equivalent
+to a complete visible-Skill load; the gate still rejects any redundant target
+read. Earlier diagnostic attempts are not promoted: one exposed an unwritable
+harness audit path, and the next exposed a contradictory legacy fixture contract.
+
+The [redacted artifact](artifacts/codex-skill-protocol-isolation-v7.json) omits
+prompts, transcripts, absolute paths, full Skill content, task output, and
+authentication. Raw evidence remains outside the repository; isolated auth
+copies remaining after the run: `0`.

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -158,8 +158,8 @@ The Agent uses stable IDs internally and displays them where they help follow-up
 The single `skillroster` bootstrap Skill must instruct every supported Agent to:
 
 - route a task through `skillroster find` before acting when its required
-  specialized instructions are not already visible, then read the selected
-  result's exact `SKILL.md` path;
+  specialized instructions are not already visible, using `--load --limit 1`
+  to receive the selected complete verified `SKILL.md` in the same result;
 - invoke commands with explicit `--json`;
 - validate `schema_version` and `ok` before reading `result`;
 - set `schema_version: 1` on every declarative Plan request;
@@ -197,6 +197,9 @@ Machine results should expose facts, not preformatted prose:
 - Findings with stable ID, category, severity, Evidence quality, impact fields, and affected IDs;
 - a bounded selector-free `report --json` first view (`--summary` is an explicit alias) with no more than three Findings, one primary Evidence reference per selected Finding, and complete `finding_rollups` grouped by category, severity, and title with deduplicated affected counts; explicit `report --full --json` for exhaustive diagnostics; a category/severity-filterable `report --findings --json` page for enumerating compact Finding summaries; and compact paged Evidence items from `report --finding ID --json`; exact complete records require `--full`, exact-duplicate detail exposes at most five ranked owned canonical candidates, and large-Roster detail exposes bounded per-Agent Core selection previews without requiring pagination;
 - Find results that keep the original task, expose Agent-authored retrieval hints, name the ranking strategy, retain task and augmented channel ranks, and collapse same-name identities into one explicitly variant capability result; the linked divergent-content Finding groups readable paths, digests, Agents, providers, and governance facts by variant and requires a canonical-content choice before Plan;
+- an opt-in Find load result that separates Top-1 selection, complete bounded
+  content, governance, and verification facts; load failure returns no partial
+  instructions, and task success remains model- and task-evidence-owned;
 - bounded Plan `change_summary`, `operation_groups`, affected-scope counts and `impact` deltas for current and proposed state; exact-duplicate Library impact compares physical sources, total placements, and default-exposed placements before and after, while retaining relinked placements as an operation fact; its aggregate totals remain complete when the per-Skill preview is truncated and are identical in the summary and `plan --show`; semantic Roster summaries expose at most five named Core selections with reasons per Agent, while `plan --show PLAN_ID` exposes the exact immutable Core selections; `diff_summary` contains at most three semantic Roster, Library, and filesystem items, or bounded line details for a source update; full operations are loaded only through `plan --show PLAN_ID` when needed;
 - affected Agents, Skills, placements, operation groups, exclusions, and deletion count;
 - risk, reversibility, drift, confirmation, and recovery state;

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -131,7 +131,10 @@ actionable lexical-retrieval warning when English metadata may be missed.
 Hints describe the desired surface, object, operation, and state. Results below
 the deterministic confidence floor are omitted instead of filling the first
 view with incidental body-token matches. Empty results are calm, successful
-output. Find never implies activation.
+output. `--load` is an Agent-oriented opt-in that returns the complete verified
+Top-1 `SKILL.md` in JSON after roster, trust, path, 128 KiB transport bound,
+identity, and drift checks. A load blocker fails the whole command without
+partial instructions. Find/load never implies activation or task success.
 
 ### `plan`
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -138,7 +138,7 @@ The first complete command surface is:
 ```bash
 skillroster scan [--json]
 skillroster report [--summary | --full | --findings [--category <category>] [--severity <severity>] | --finding <id> [--full]] [--limit <n>] [--offset <n>] [--json]
-skillroster find <task> [--hint <text>]... [--json]
+skillroster find <task> [--hint <text>]... [--limit <n>] [--load] [--json]
 skillroster plan --stdin [--json]
 skillroster plan --show <plan-id> [--json]
 skillroster apply <plan-id> [--json]
@@ -234,6 +234,18 @@ non-governable placement. Read-only placements that remain unchanged may stay in
 the wider Finding scope. Typed reasons distinguish provider read-only, durable
 read-only, untrusted external, and legacy-unknown authority without asking the
 Agent to reconstruct policy.
+
+`find --load` keeps ordinary Find ranking compatible and atomically adds a
+verified Top-1 content result. It requires one unambiguous routable identity, a
+current non-Archived roster state, an eligible placement, complete package and
+entrypoint digests from the latest Snapshot, a regular file contained by an
+approved root, valid UTF-8, and at most 128 KiB of raw `SKILL.md` bytes. The
+success result separates selection, complete content, governance, and
+verification facts. Digest or path drift, legacy Snapshot data, ambiguity,
+Archived state, untrusted source, unreadable content, escape, or oversize fails
+the whole command with typed details and no partial body. The 128 KiB limit is a
+SkillRoster Agent-transport limit, not an Agent Skills format restriction.
+`task_success` remains `not_evaluated`.
 
 All JSON responses use a versioned envelope:
 

--- a/docs/research/agent-skill-governance-and-routing.md
+++ b/docs/research/agent-skill-governance-and-routing.md
@@ -9,9 +9,9 @@
 
 因此 SkillRoster 最有价值的定位不是替模型做语义理解，而是提供本地、确定性、可审计的治理与事实层：统一盘点、保留身份和来源、计算各宿主的有效暴露面、发现重复/漂移/失效/信任风险、记录使用证据、生成可确认的分层方案，并提供 Receipt 与 Undo。语义意图、候选取舍和最终回答仍由 Agent 完成。
 
-对已合并 PR #146 的正确解读也应保守：两个 On-demand 臂最终都找到了正确 Skill；Humanizer 臂出现 malformed `Find` 且未完成 full load，更像调用接口契约或提示遵循问题；Architecture 臂才形成干净的 Find→load 链。两个 Core 控制臂都没有通过任务 oracle，且历史 run pair 的 `formal_gate_eligible=false`，所以该实验不能证明 On-demand 优于 Core、Core 优于 On-demand，也不能证明需要新的排序或语义检索子系统。
+对已合并 PR #146 的正确解读也应保守：两个 On-demand 臂最终都找到了正确 Skill；Humanizer 臂出现 malformed `Find` 且未完成 full load，更像调用接口契约或提示遵循问题；Architecture 臂才形成干净的 Find→load 链。两个 Core 控制臂都没有通过任务 oracle，且历史 run pair 的 `formal_gate_eligible=false`，所以该实验不能证明 On-demand 优于 Core、Core 优于 On-demand，也不能证明需要新的排序或语义检索子系统。后续 PR #148 已完成正式协议隔离：Core 3/3，On-demand 1/3；但三个 On-demand trial 的 retrieval、Top-1、精确路径、完整加载、任务 oracle 和安全性均为 3/3，两个拒绝仅来自 Find→load 之间的额外动作和不安全 compound shell shape。
 
-下一步最小且能改变产品决策的动作，是先做一个“协议隔离实验”，验证 Core 控制、oracle、Find 调用和 full-load 链本身是否稳定。只有这层稳定后，才值得研究目录规模、描述重叠和 shortlist 深度。
+因此当前最小动作不是继续研究目录规模或排名，而是 Issue #149：把确定性 Find、治理验证和完整 Skill 加载合成一次可观察的 Agent 调用。该调用减少模型需要正确编排的步骤，但不能替模型判断任务语义，也不能替 harness 证明原始用户文本在进入 CLI 前未被 shell 转义或改写。
 
 ## 证据标签与术语
 
@@ -191,6 +191,127 @@ Codex 的 [app-server 协议文档](https://github.com/openai/codex/blob/main/co
 
 它真正暴露的是评测基础设施和 Agent 接口的优先问题：控制臂有效性、调用契约、full-load 可观测性、非脆弱 oracle、配对时序与不可变 ledger。
 
+## Issue #149：一次 Find + 可信完整加载契约
+
+### 是否符合 Agent harness
+
+**官方事实。** Agent Skills 的[客户端实现指南](https://agentskills.io/client-implementation/adding-skills-support) 把专用 activation tool 列为正式实现模式：模型选择 Skill 后，工具可在一次调用中返回完整 instructions、结构化身份标签、Skill 目录和资源清单，并在返回前执行权限检查。指南还明确说，大多数实现把相关性判断留给模型，而不是在 harness 中做关键词触发；专用工具的价值是控制返回内容、施加权限、记录 activation 和避免模型虚构 Skill 名称。
+
+**官方事实。** OpenAI [Agents SDK Function tools](https://openai.github.io/openai-agents-python/tools/) 支持由 JSON Schema 约束输入，并从本地 runtime 返回文本或结构化 tool output。其工具生命周期保留 schema validation、guardrails、timeout、failure handling 和 tracing。Codex 当前也能从本地 shell/exec 工具接收进程输出。因此“一次 Agent tool call 得到完整 Skill bytes”符合常见 harness 的 request→tool result 模型，不要求 MCP、daemon 或内置模型。
+
+**SkillRoster 推论。** #149 应是现有 `find` 的窄扩展，例如显式 `load` mode，而不是第二个路由子系统。这里的“一次”定义为：Agent 发出一个 SkillRoster 调用，并在该调用的单个成功结果中同时取得选中事实和完整、已验证的 `SKILL.md`；不需要再调用文件读取、打开 workspace、使用 MCP 或创建临时 TASK 文件。
+
+“一次调用”不是跨 SQLite 和文件系统的数学事务。准确承诺应是**观察原子性**：一个 CLI 进程要么返回一份内部一致的成功 envelope，要么返回 typed failure；不得返回截断 instructions、部分成功或“路径可用，请自行再读”。
+
+### 一次操作内的确定性边界
+
+推荐顺序如下，全部在同一进程、同一结果边界内完成：
+
+1. 接收完整自然语言 TASK 和可选 HINT；对输入做类型、长度和编码检查，但不改写、翻译或总结。
+2. 在一致的 roster/snapshot 视图上运行现有确定性 ranking，只考虑当前 Agent 可用且允许路由的 placement。
+3. 固定 Top-1 的 identity、logical path、canonical path、expected digest、roster state 和 source baseline。
+4. 在读取前验证 placement 未 archived/disabled，路径可读、是 regular file、没有越出受信 roots，来源状态满足现有信任策略。
+5. 从已验证目标读取**完整原始 bytes**，同时执行硬 byte cap；按真实返回 bytes 计算 digest。读取后复核路径/元数据/expected digest，任何不一致都判 drift。
+6. 解析 UTF-8 和必要的 Agent Skills frontmatter；返回完整 `SKILL.md`，不提前读取 `references/`、`scripts/` 或 `assets/`。
+7. 只在上述全部成立时返回 `ok: true`；成功 envelope 将 retrieval evidence、loaded-content identity 和 governance facts 分开。
+
+这是一种产品设计推论，不是 Agent Skills 标准强制的算法。标准只规定 `SKILL.md` 格式，并明确 activation 时会加载整个文件；它没有规定 path trust、digest、drift、roster 或 byte cap。
+
+### CLI 必须验证的事实
+
+| 事实 | CLI 可验证内容 | 成功结果应提供的证据 |
+|---|---|---|
+| 请求完整性 | CLI 实际收到的 TASK/HINT bytes、编码、长度 | request digest、byte count；不得声称等同于原始用户消息 |
+| 检索 | ranking strategy、query/hint、候选数、Top-1、score/match basis | retrieval block，与内容加载分离 |
+| 治理资格 | Agent、placement、roster state、implicit/explicit eligibility、snapshot | stable IDs、state、snapshot/evidence ID |
+| 路径 | logical path、canonical path、symlink resolution、allowed-root containment、regular file | 两种路径及 containment decision |
+| 来源信任 | source/manager/provider、已确认 root、first-observed baseline、当前 policy state | trust **evidence/state**，而不是笼统 `trusted: true` |
+| 漂移 | expected digest/identity 与本次读取 bytes、metadata 的一致性 | expected/observed content digest、size、checked-at |
+| 内容完整性 | 全量读取、byte cap、UTF-8、frontmatter、name/path consistency | `content_complete: true`、raw-byte digest、byte/line count |
+| 副作用 | 操作是只读的，未创建 Plan/Receipt、未改 roster/Skill/workspace | operation/read-only marker；协议 suite 再用文件 diff 验证 |
+
+两个边界尤其重要：
+
+- CLI 只能证明“它收到的 TASK 是什么”，不能证明上层 shell harness 没有在 argv 构造时丢字符、展开变量或改变引号。若 harness 只有 shell-string 而没有原生 argv/stdin 参数，任意自然语言的安全传输仍是 harness 契约问题。Bootstrap 应给出一个 canonical shape，正式 suite 必须验证 TASK digest；不能让 CLI 宣称自己证明了调用前历史。
+- digest 证明本次 bytes 的完整性与某 baseline 是否一致，不证明内容善意。Agent Skills frontmatter 的 `author`、`version` 属于自声明 metadata；“来源已确认”也不等于“说明无恶意”。执行安全仍由 sandbox、审批和 Agent policy 控制。
+
+### 留给模型的语义
+
+模型继续负责：
+
+- 从完整用户任务产生可选、忠实的 capability HINT；
+- 判断返回的 Top-1 是否与当前任务语义相关；
+- 阅读 instructions，并决定何时按需读取其引用资源；
+- 综合对话、用户偏好和任务状态执行 Skill；
+- 判断最终答案是否解决用户问题。
+
+CLI 不应负责翻译/总结 TASK、生成语义 hint、用 LLM 重排、判断最终任务成功，或把一个低词法分数包装成“语义正确”。如果现有确定性策略返回 empty、wrong-domain evidence 或现有 ambiguity signal，保持 typed branch，让 Agent 安全重试一次；不要用隐藏模型填空。
+
+### fail-closed 的精确定义
+
+`fail-closed` 应满足四个可测试条件：
+
+1. 任何资格、路径、信任、漂移、读取、编码、格式或大小检查失败，整体 `ok: false`。
+2. error envelope 不包含部分 `SKILL.md`、文件前缀或可被误当作 instructions 的正文。
+3. error 使用稳定 code 和机器可读 details，保留 candidate identity 与非敏感诊断；`suggested_actions` 只是下一步选项，不是授权，也不能在同一失败调用中自动执行。
+4. 安全 retry 修复失败原因，而非绕过检查：oversized → 将细节拆到按需 references；drifted → rescan/reconcile；untrusted → 走显式 source confirmation/adopt Plan；archived/disabled → 由用户明确改变 roster 或显式调用策略；path escape/unreadable → 修路径或权限。不要提供通用 `--force`。
+
+建议 typed codes 至少覆盖现有语义中的：`no_match`、`ambiguous`、`placement_ineligible`、`archived`、`source_untrusted`、`path_escape`、`broken_link`、`not_regular_file`、`unreadable`、`content_drifted`、`content_too_large`、`invalid_utf8`、`invalid_skill_format`。最终命名应复用仓库现有 error taxonomy，避免为 #149 建第二套错误系统。
+
+### 内容上限与响应形状
+
+**官方事实。** [Agent Skills specification](https://agentskills.io/specification) 对 `name`（64 chars）、`description`（1,024 chars）等 frontmatter 有限制，但没有给 `SKILL.md` body 设硬上限；它只提醒 activation 会加载整个文件，较长内容应拆到 references。客户端指南也建议 resources 只列出、不要 eager-load。
+
+**SkillRoster 推论。** 因此 byte cap 是 SkillRoster/harness 的安全运输约束，不应伪装成标准限制，也不应随模型 tokenizer 变化。实现应使用版本化、文档化的原始 byte 上限：在分配/读取前检查 metadata size，并在 streaming read 时再次硬限制，以防 metadata 漂移或特殊文件；超过上限整单失败。上限数值应由当前 CLI JSON envelope、Codex tool-output 截断行为和真实 Skill 分布的 fixture 测试决定，不应从论文或猜测得出。
+
+**本机测量（2026-08-24）。** 对最新 SkillRoster Snapshot 的 882 个可读 placement 统计原始 `SKILL.md` 大小：中位数 6,187 bytes，P90 15,311，P95 23,717，P99 56,848，最大 87,253；placement 包含跨 Agent 软链接重复，因此这不是生态总体分布。首版 load transport cap 取 128 KiB，可覆盖当前最大样本并保留约 50% 余量，同时远小于 inventory parser 的 2 MiB 上限。这个数值是本地运输决策，不是 Agent Skills 标准限制；未来只能由真实宿主截断证据和用户 Skill 分布调整。
+
+成功响应至少需要以下逻辑分区，字段可按现有 schema 命名：
+
+```json
+{
+  "retrieval": {
+    "strategy": "existing-deterministic-strategy",
+    "rank": 1,
+    "candidate_count": 1,
+    "match_basis": []
+  },
+  "skill": {
+    "skill_id": "...",
+    "placement_id": "...",
+    "name": "...",
+    "provider": "...",
+    "logical_path": ".../SKILL.md",
+    "canonical_path": ".../SKILL.md"
+  },
+  "governance": {
+    "agent": "codex",
+    "roster_state": "on_demand",
+    "source_trust_state": "confirmed",
+    "snapshot_id": "..."
+  },
+  "loaded_content": {
+    "content": "---\n...complete raw UTF-8 SKILL.md...",
+    "content_complete": true,
+    "content_bytes": 1234,
+    "content_digest": "sha256:..."
+  }
+}
+```
+
+digest 必须针对 JSON 解码后的原始 UTF-8 file bytes，而不是转义后的 JSON 文本。不要在成功 envelope 中声称 `task_success`、`skill_safe` 或 `semantic_match_confirmed`。
+
+### 对 #149 的验收推论
+
+已有[协议隔离 v6](../acceptance/codex-skill-protocol-isolation-v6.md) 是正式 eligible 证据：Core 3/3、On-demand 1/3；三个 On-demand 的 ranking、load、task 和 safety 实际均通过，两个失败只在 ordered Agent contract。因此 #149 的验收重点应是缩短协议，而不是改排名：
+
+- 兼容现有 `find`；load mode 是显式 opt-in。
+- 一条 canonical invocation 返回 Top-1 + 完整内容；不允许中间 workspace/MCP/read 动作。
+- 对 oversized、archived、untrusted、unreadable、escape、drift 分别做 focused core tests，断言无部分 content。
+- 使用完整冻结的 3×2 Codex suite；Core 3/3、On-demand 3/3、formal eligibility、任务和 safety 都是独立门槛。
+- 若 On-demand 仍因 shell argv shape 失败，停止继续堆 CLI 逻辑，确认是否需要 harness-native argv/stdin 支持；这不是 embedding 或 ranking 问题。
+- 若 one-call 全通过，停止扩展 activation 机制，不新增第二个 routing Skill。
+
 ## 产品边界
 
 ### SkillRoster 应该负责
@@ -198,7 +319,7 @@ Codex 的 [app-server 协议文档](https://github.com/openai/codex/blob/main/co
 1. **盘点与规范化**：扫描多个宿主的 present/discovered/enabled/listed 状态，保留 provider、scope、namespace、logical/canonical path。
 2. **事实型诊断**：同名/同源/内容重复、破损软链接、版本漂移、来源不明、宿主预算与潜在省略、默认暴露面和跨 Agent 复制。
 3. **保守 usage evidence**：区分明确调用、读取、命令痕迹和仅被发现；证据不足时标 `unknown`，不能把“没看到”写成“从未使用”。
-4. **Agent-facing Find**：输出有界、结构化、可解释候选，包括名称、description、provider、路径、scope 和匹配原因；让模型完成语义判断。
+4. **Agent-facing Find/Load**：默认 Find 输出有界、结构化、可解释候选；显式 load mode 可在同一只读调用中验证并返回完整 Top-1 `SKILL.md`。两者都让模型完成语义判断。
 5. **治理建议**：Core / On-demand / Explicit-only / Archived 分层，按宿主生成 roster；建议必须附证据和不确定性。
 6. **安全执行**：不可变 Plan、一次显式确认、Apply、Receipt、Undo、漂移检测和恢复；不读未信任目标，不静默覆盖用户来源。
 7. **评测 ledger**：分开记录 listing、retrieval、call-shape、load、oracle、safety、Core validity 和 formal eligibility。
@@ -212,11 +333,11 @@ Codex 的 [app-server 协议文档](https://github.com/openai/codex/blob/main/co
 - 当前不需要 MCP、daemon、云同步、TUI、HTML 仪表盘、插件 SDK 或自动联网 telemetry。
 - 不在没有稳定控制臂和任务 oracle 时，用昂贵 benchmark 推动新检索子系统。
 
-一个 Bootstrap Skill 可以作为“如何调用 SkillRoster”的窄入口，但应保持单一职责：精确保留 TASK、调用 Find、读取返回的精确路径、在 typed error 下有限重试。治理功能本身继续收敛在 CLI，而不是拆成许多互相竞争的 Skills。
+一个 Bootstrap Skill 可以作为“如何调用 SkillRoster”的窄入口，但应保持单一职责：精确保留 TASK、用 canonical shape 调用 Find/Load、验证 envelope，并在 typed error 下有限重试。治理功能本身继续收敛在 CLI，而不是拆成许多互相竞争的 Skills。
 
 ## 下一步实验：按是否能改变决策排序
 
-### 实验 1：协议隔离与控制臂有效性（现在做）
+### 实验 1：协议隔离与控制臂有效性（已完成）
 
 **问题。** 失败究竟来自路由、Find 调用、full-load、Skill 内容还是 oracle？
 
@@ -224,13 +345,13 @@ Codex 的 [app-server 协议文档](https://github.com/openai/codex/blob/main/co
 
 评分器应只对真实产品不变量严格：文件是否创建、字段是否存在、是否越界、返回路径是否被读取。表达质量用 rubric + 盲审，不用精确句子或任意字符阈值。
 
-**停止条件。**
+PR #148 的 v6 suite 已按该设计形成正式 eligible 证据：Core 3/3，On-demand 1/3；后者的 retrieval、full-load、task oracle 和 safety 均为 3/3，失败集中在 ordered contract。因此已经触发下列原定停止条件中的“只修 Bootstrap/CLI seam，不改排名器”。历史设计和停止条件保留如下，作为决策审计：
 
 - Core 少于 3/3 协议有效：停止比较，先修 task/oracle/harness；不得做产品归因。
-- Core 有效，但 On-demand 至少 2/3 malformed Find 或未 load：只改 Bootstrap/CLI schema、错误返回或示例；不改排名器。
+- Core 有效，但 On-demand 至少 2/3 发生调用/加载协议失败：只改 Bootstrap/CLI schema、错误返回或示例；不改排名器。v6 正是这一分支。
 - 两臂 route/load 都稳定但共同 fail oracle：修目标 Skill 或 oracle；不归因路由。
 - 两臂均稳定且任务通过：停止增加机制，保留现状。
-- 只有在控制有效且差异能跨 trial 重现时，才进入实验 2。
+- 只有在 #149 one-call 验收稳定后，才考虑进入实验 2。
 
 ### 实验 2：目录规模 × 描述重叠 × shortlist K（条件触发）
 
@@ -256,13 +377,13 @@ Codex 的 [app-server 协议文档](https://github.com/openai/codex/blob/main/co
 
 | 决策 | 现在 | 触发重新评估的证据 |
 |---|---|---|
-| 保持 Agent-first CLI + 一个 Bootstrap Skill | 是 | 协议隔离实验显示该入口反复且不可修复地失败 |
+| 保持 Agent-first CLI + 一个 Bootstrap Skill | 是；用 #149 收窄为一次 Find/Load | one-call 在冻结 suite 中仍反复因 CLI 自身契约失败 |
 | 继续 Core / On-demand / Explicit-only / Archived 分层 | 是，但建议需附证据和确认 | 真实任务显示分层导致稳定回归 |
 | 增加 embedding/reranker | 否 | 控制有效、correct-listed 高、词法 Find 的 correct-in-K 稳定不足，且语义方法提升端到端 |
 | 设置统一 Core 数量上限 | 否 | 多宿主因子实验给出稳定阈值并能跨任务复现 |
 | 自动归档“未使用”Skill | 否 | 有覆盖足够时间和宿主的高置信 invocation 证据，并仍需用户确认 |
 | 做云端同步/MCP/daemon/TUI | 否 | 出现本地 CLI 无法解决且被多用户重复验证的需求 |
-| 扩大昂贵端到端 benchmark | 暂缓 | 实验 1 的控制、oracle、formal eligibility 全部稳定 |
+| 扩大目录规模 benchmark | 暂缓 | #149 one-call 的 3×2 协议、任务、安全与 formal eligibility 全部稳定 |
 
 ## 限制与反例
 
@@ -277,4 +398,4 @@ Codex 的 [app-server 协议文档](https://github.com/openai/codex/blob/main/co
 
 把当前路线概括为一句话：**SkillRoster 管理事实、暴露面和可逆变更；Agent 管理语义与意图；实验负责证明两者的接口是否稳定。**
 
-下一步不要扩展功能面。先完成 3×2 个全新 trial 的协议隔离实验，并严格执行停止条件。若问题落在 malformed Find/full-load，就做一次窄接口修复；若落在共同 oracle，就修评测；若两臂稳定，就停止优化。只有当这些基础门槛全部成立，目录规模和检索机制的实验才有能力改变产品决策。
+下一步不要扩展功能面。按 Issue #149 给现有 Find 增加显式 one-call load mode：同一只读进程完成确定性 Top-1、roster/path/source/drift/content-bound 验证，并只在全部通过时返回完整 `SKILL.md` 和 digest 事实。随后重跑冻结的 3×2 suite；若 Core/On-demand 都达到 3/3 且任务、安全、formal eligibility 不回归，就停止扩展 activation 机制。若仍只失败在 shell argv 形状，问题升级到 harness-native 参数传输边界，而不是排名、embedding 或更多 Skills。只有这条接口稳定后，目录规模和检索机制的实验才可能改变产品决策。

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -5,15 +5,15 @@ description: >
   local Skill roster. Before reading or changing the workspace for a task that
   may need instructions not already visible, preserve the complete user message
   verbatim as TASK. For non-English or mixed input, run
-  `skillroster find "TASK" --hint "ONE FAITHFUL ENGLISH CAPABILITY PARAPHRASE" --json`;
-  for English input omit `--hint`. Then read the exact returned SKILL.md with
-  the harness file-read tool. There is no load or activation command. Also use
+  `skillroster find "TASK" --hint "ONE FAITHFUL ENGLISH CAPABILITY PARAPHRASE" --load --limit 1 --json`;
+  for English input omit `--hint`. Follow the complete verified SKILL.md in
+  `result.loaded_skill.content.text`. Also use
   for inventory, usage evidence, duplicates, broken links, Core/On-demand
   recommendations, Plans, Receipts, Apply, and Undo. Not for installing
   third-party Skills or migrating, distributing, synchronizing, or repairing shared
   Skill-manager directories.
 metadata:
-  bootstrap-version: "1.8.21"
+  bootstrap-version: "1.8.22"
   skillroster-routing-triggers: "route task to local Skill; inventory installed Agent Skills; analyze duplicate or unused Agent Skills; govern a Skill Roster; prepare or apply approved Skill Plan; create or undo Skill Receipt"
 ---
 
@@ -43,16 +43,18 @@ change the workspace and do not execute a non-routing command:
    capability paraphrase as `HINT`. It supplements `TASK`; it never replaces it.
 3. Invoke the fixed SkillRoster executable with `TASK` and `HINT` as separate,
    literal argv values; never interpolate either into shell syntax. Use:
-   - English: `skillroster find "TASK" --json`
-   - Otherwise: `skillroster find "TASK" --hint "HINT" --json`
+   - English: `skillroster find "TASK" --load --limit 1 --json`
+   - Otherwise: `skillroster find "TASK" --hint "HINT" --load --limit 1 --json`
 4. When `HINT` was used, first require
    `ranking_strategy: task_hint_reciprocal_rank_fusion`.
-5. For every unambiguous result, immediately read its exact returned `SKILL.md`
-   path with the harness's existing file-read tool. Do not call or invent
-   `load`, `activate`, `use`, `select`, or another SkillRoster command. For an
-   empty or wrong-domain result, `variant_count > 1`, `variants_truncated`, or
-   `report_required`, read `references/routing.md` and follow its typed branch.
-6. Only after that file is read, follow it and perform the original task.
+5. Require `loaded_skill.selection.rank: 1`, `content.complete: true`, and all
+   `verification` identity/digest checks to be true. The complete instructions
+   are `loaded_skill.content.text`; no second filesystem, workspace, MCP, or
+   SkillRoster read is needed. For a wrong-domain result or typed load blocker,
+   read `references/routing.md` and follow its bounded branch.
+6. Follow the loaded instructions and perform the original task. Treat
+   `task_success: not_evaluated` literally; only the task's own evidence can
+   establish success.
 
 If the result is empty or clearly from another domain, retry once. Keep `TASK`
 unchanged; refine the existing hint, or add one capability hint when the first

--- a/skill/skillroster/references/routing.md
+++ b/skill/skillroster/references/routing.md
@@ -1,9 +1,8 @@
 # Routing details
 
-The root Route gate is authoritative. Read this file for an empty or
-wrong-domain result, `variant_count > 1`, `variants_truncated`, or
-`report_required`. Keep `TASK` verbatim. A non-English or mixed task receives
-exactly one faithful English `--hint` on the first call.
+The root Route gate is authoritative. Read this file for a wrong-domain result
+or `verified_skill_load_blocked`. Keep `TASK` verbatim. A non-English or mixed
+task receives exactly one faithful English `--hint` on the first call.
 Build the hint from the desired surface, object, operation, and state; never
 guess a Skill name.
 
@@ -13,15 +12,16 @@ and `augmented_channel_rank` to distinguish native task evidence from
 hint-expanded evidence. Retry at most once, only for an empty or wrong-domain
 result. Change only the hint; an English task may add one on its retry.
 
-When `variant_count` is above one, keep each path and provider together. Respect
-`variants_truncated` and run the returned read-only `variant_finding.argv`.
-Materialize the current Report first only when the result says
-`report_required`; inspect that exact Finding before choosing content.
+When the blocker reason is `same_name_variants_ambiguous`, use the ordinary
+Find result and its read-only `variant_finding.argv`; keep each path and provider
+together. Materialize the current Report only when the result says
+`report_required`, then inspect that exact Finding before choosing content.
 
-Only after ambiguity is resolved, or when `variant_count == 1`, read the
-selected result's exact `SKILL.md` path directly. Finding a Skill does not
-activate, install, or authorize it, and SkillRoster has no load or activate
-step.
+For `no_routable_match`, retry once with a refined capability hint. For drift,
+legacy Snapshot, unreadable, oversized, escaping, or untrusted-source reasons,
+follow `error.details.next_action`; never bypass the check or recover partial
+instructions. A successful load returns complete instructions but does not
+activate, install, authorize, endorse, or establish task success.
 
 Read `owned_by_agent` as placement-path structure only, never as ownership or
 endorsement of linked source content. Read `mutation_scopes` before governance:

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,6 +30,9 @@ use crate::scan::{self, ExplicitSkillRoot, RootKind, ScanOptions, ScanResult};
 use crate::sqlite::StateStore;
 
 const STATUS_PENDING_PLAN_LIMIT: usize = 20;
+/// Agent tool-result transport bound, deliberately narrower than the 2 MiB
+/// inventory parser bound. Larger Skills should disclose references on demand.
+const MAX_AGENT_LOADED_SKILL_BYTES: u64 = 128 * 1024;
 
 /// Global discovery and state options that a suggested action must retain to
 /// operate on the same local analysis context as the command that produced it.
@@ -386,6 +389,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                 &args.task,
                 &args.hints,
                 usize::from(args.limit),
+                args.load,
             )?;
             ("find", result, vec![], actions)
         }
@@ -778,6 +782,33 @@ fn fingerprint_remediation(completeness: scan::FingerprintCompleteness) -> Value
 }
 
 fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError {
+    if let Some(blocker) = error.downcast_ref::<SkillLoadBlocked>() {
+        let next_action = match blocker.reason {
+            "same_name_variants_ambiguous" => "inspect_variant_finding",
+            "untrusted_external_source" => "confirm_exact_source_root_then_scan",
+            "archived_skill_not_routable" => "choose_non_archived_skill",
+            _ => "scan",
+        };
+        return ClassifiedError {
+            code: "verified_skill_load_blocked",
+            retryable: false,
+            details: Some(json!({
+                "reason": blocker.reason,
+                "skill_id": blocker.skill_id,
+                "skill_name": blocker.skill_name,
+                "path": blocker.path,
+                "roster_state": blocker.roster_state,
+                "mutation_scopes": blocker.mutation_scopes,
+                "expected_digest": blocker.expected_digest,
+                "actual_digest": blocker.actual_digest,
+                "content_limit_bytes": MAX_AGENT_LOADED_SKILL_BYTES,
+                "files_changed": false,
+                "state_files_changed": false,
+                "task_success": "not_evaluated",
+                "next_action": next_action,
+            })),
+        };
+    }
     if let Some(policy) = error.downcast_ref::<crate::source_policy::SourceRootPolicyError>() {
         use crate::source_policy::SourceRootPolicyError as PolicyError;
         let facts = match policy {
@@ -4140,6 +4171,7 @@ fn find_command(
     task: &str,
     hints: &[String],
     limit: usize,
+    load: bool,
 ) -> Result<(Value, Vec<SuggestedAction>)> {
     let (scan_id, scan) = latest_scan(store)?;
     let retrieval_hints = normalize_retrieval_hints(hints);
@@ -4157,11 +4189,13 @@ fn find_command(
         .iter()
         .map(|skill| skill.id.clone())
         .collect::<std::collections::BTreeSet<_>>();
+    let mut archived_ids = BTreeSet::new();
     for skill_id in routable_ids.clone() {
         let id = SkillId::parse(skill_id.clone())?;
         let states = store.roster_states_for_skill(&id)?;
         if !states.is_empty() && states.iter().all(|state| *state == RosterState::Archived) {
             routable_ids.remove(&skill_id);
+            archived_ids.insert(skill_id);
         }
     }
     if crate::query::contains_cjk(retrieval_query.text()) {
@@ -4251,6 +4285,50 @@ fn find_command(
         &mut matches,
     )?;
     rescan_required |= variant_rescan_required;
+    if load && matches.is_empty() {
+        let archived_match = crate::query::find_matching(
+            &scan,
+            &retrieval_query,
+            1,
+            Some(&archived_ids),
+            Some(&archived_ids),
+        )
+        .into_iter()
+        .next();
+        return Err(SkillLoadBlocked {
+            reason: if archived_match.is_some() {
+                "archived_skill_not_routable"
+            } else {
+                "no_routable_match"
+            },
+            skill_id: archived_match
+                .as_ref()
+                .map(|matched| matched.skill_id.clone())
+                .unwrap_or_default(),
+            skill_name: archived_match
+                .as_ref()
+                .map(|matched| matched.name.clone())
+                .unwrap_or_else(|| "Top-1".into()),
+            path: None,
+            roster_state: archived_match
+                .map(|_| "archived".to_owned())
+                .unwrap_or_else(|| "unassigned".into()),
+            mutation_scopes: Vec::new(),
+            expected_digest: None,
+            actual_digest: None,
+        }
+        .into());
+    }
+    let loaded_skill = if load && !matches.is_empty() {
+        Some(verified_top_skill_load(
+            &scan_id,
+            &scan,
+            state_dir,
+            &matches[0],
+        )?)
+    } else {
+        None
+    };
     for found in matches
         .iter()
         .take(3)
@@ -4297,19 +4375,20 @@ fn find_command(
     }
     warnings.sort();
     warnings.dedup();
-    Ok((
-        json!({
-            "snapshot_id": scan_id,
-            "task": task,
-            "retrieval_hints": retrieval_hints,
-            "ranking_strategy": ranking_strategy,
-            "matches": matches,
-            "rescan_required": rescan_required,
-            "warnings": warnings,
-            "files_changed": false
-        }),
-        actions,
-    ))
+    let mut result = json!({
+        "snapshot_id": scan_id,
+        "task": task,
+        "retrieval_hints": retrieval_hints,
+        "ranking_strategy": ranking_strategy,
+        "matches": matches,
+        "rescan_required": rescan_required,
+        "warnings": warnings,
+        "files_changed": false
+    });
+    if let Some(loaded_skill) = loaded_skill {
+        result["loaded_skill"] = loaded_skill;
+    }
+    Ok((result, actions))
 }
 
 fn bind_variant_findings(
@@ -4590,6 +4669,257 @@ fn current_readable_skill_paths(
 struct CurrentSkillPaths {
     paths: Vec<String>,
     drifted: bool,
+}
+
+#[derive(Debug)]
+struct SkillLoadBlocked {
+    reason: &'static str,
+    skill_id: String,
+    skill_name: String,
+    path: Option<PathBuf>,
+    roster_state: String,
+    mutation_scopes: Vec<String>,
+    expected_digest: Option<String>,
+    actual_digest: Option<String>,
+}
+
+impl std::fmt::Display for SkillLoadBlocked {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "verified Skill load blocked for {} ({}): {}",
+            self.skill_name, self.skill_id, self.reason
+        )
+    }
+}
+
+impl std::error::Error for SkillLoadBlocked {}
+
+fn verified_top_skill_load(
+    scan_id: &ScanId,
+    scan: &ScanResult,
+    state_dir: &Path,
+    matched: &crate::query::FindMatch,
+) -> Result<Value> {
+    let blocked = |reason, path, expected_digest, actual_digest| SkillLoadBlocked {
+        reason,
+        skill_id: matched.skill_id.clone(),
+        skill_name: matched.name.clone(),
+        path,
+        roster_state: matched.roster_state.clone(),
+        mutation_scopes: matched
+            .mutation_scopes
+            .iter()
+            .map(|scope| scope.id().to_owned())
+            .collect(),
+        expected_digest,
+        actual_digest,
+    };
+
+    if matched.variant_count != 1 {
+        return Err(blocked("same_name_variants_ambiguous", None, None, None).into());
+    }
+    if matched.roster_state == "archived" {
+        return Err(blocked("archived_skill_not_routable", None, None, None).into());
+    }
+
+    let mut placements = scan
+        .placements
+        .iter()
+        .filter(|placement| placement.skill_id == matched.skill_id)
+        .collect::<Vec<_>>();
+    placements.sort_by(|left, right| left.entrypoint.cmp(&right.entrypoint));
+    if placements.is_empty() {
+        return Err(blocked("placement_missing_from_snapshot", None, None, None).into());
+    }
+    if placements.iter().all(|placement| {
+        placement
+            .mutation_scope
+            .is_none_or(|scope| scope == scan::MutationScope::UntrustedExternal)
+    }) {
+        return Err(blocked("untrusted_external_source", None, None, None).into());
+    }
+    if placements.iter().all(|placement| {
+        placement.fingerprint_completeness != scan::FingerprintCompleteness::Complete
+    }) {
+        return Err(blocked("package_fingerprint_incomplete", None, None, None).into());
+    }
+    if placements
+        .iter()
+        .filter(|placement| {
+            placement.mutation_scope != Some(scan::MutationScope::UntrustedExternal)
+                && placement.fingerprint_completeness == scan::FingerprintCompleteness::Complete
+        })
+        .all(|placement| placement.entrypoint_digest.is_none())
+    {
+        return Err(blocked("legacy_snapshot_requires_rescan", None, None, None).into());
+    }
+
+    let placement = placements
+        .into_iter()
+        .find(|placement| {
+            placement.mutation_scope != Some(scan::MutationScope::UntrustedExternal)
+                && placement.fingerprint_completeness == scan::FingerprintCompleteness::Complete
+                && placement.entrypoint_digest.is_some()
+        })
+        .ok_or_else(|| blocked("eligible_placement_missing", None, None, None))?;
+    let path = placement.entrypoint.clone();
+    let expected_entrypoint_digest = placement.entrypoint_digest.clone().ok_or_else(|| {
+        blocked(
+            "legacy_snapshot_requires_rescan",
+            Some(path.clone()),
+            None,
+            None,
+        )
+    })?;
+    let before = std::fs::canonicalize(&path).map_err(|_| {
+        blocked(
+            "entrypoint_unreadable",
+            Some(path.clone()),
+            Some(expected_entrypoint_digest.clone()),
+            None,
+        )
+    })?;
+    let mut allowed_roots = scan
+        .roots
+        .iter()
+        .filter(|root| root.kind == RootKind::Skills && root.status == scan::RootStatus::Included)
+        .filter_map(|root| std::fs::canonicalize(&root.path).ok())
+        .collect::<Vec<_>>();
+    if let Ok(library) = std::fs::canonicalize(state_dir.join("library")) {
+        allowed_roots.push(library);
+    }
+    if !before.is_file() || !allowed_roots.iter().any(|root| before.starts_with(root)) {
+        return Err(blocked(
+            "entrypoint_escapes_approved_roots",
+            Some(path),
+            Some(expected_entrypoint_digest),
+            None,
+        )
+        .into());
+    }
+    let metadata = std::fs::metadata(&before).map_err(|_| {
+        blocked(
+            "entrypoint_unreadable",
+            Some(path.clone()),
+            Some(expected_entrypoint_digest.clone()),
+            None,
+        )
+    })?;
+    if metadata.len() > MAX_AGENT_LOADED_SKILL_BYTES {
+        return Err(blocked(
+            "entrypoint_exceeds_content_limit",
+            Some(path),
+            Some(expected_entrypoint_digest),
+            None,
+        )
+        .into());
+    }
+    let bytes = std::fs::read(&before).map_err(|_| {
+        blocked(
+            "entrypoint_unreadable",
+            Some(path.clone()),
+            Some(expected_entrypoint_digest.clone()),
+            None,
+        )
+    })?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > MAX_AGENT_LOADED_SKILL_BYTES {
+        return Err(blocked(
+            "entrypoint_exceeds_content_limit",
+            Some(path),
+            Some(expected_entrypoint_digest),
+            None,
+        )
+        .into());
+    }
+    let actual_entrypoint_digest = content_digest(&bytes);
+    if actual_entrypoint_digest != expected_entrypoint_digest {
+        return Err(blocked(
+            "entrypoint_content_drift",
+            Some(path),
+            Some(expected_entrypoint_digest),
+            Some(actual_entrypoint_digest),
+        )
+        .into());
+    }
+    let content = String::from_utf8(bytes).map_err(|_| {
+        blocked(
+            "entrypoint_not_utf8",
+            Some(path.clone()),
+            Some(expected_entrypoint_digest.clone()),
+            Some(actual_entrypoint_digest.clone()),
+        )
+    })?;
+    let (actual_id, actual_package_digest) = scan::inspect_skill_identity(&path).map_err(|_| {
+        blocked(
+            "package_identity_unreadable",
+            Some(path.clone()),
+            Some(placement.content_digest.clone()),
+            None,
+        )
+    })?;
+    let after = std::fs::canonicalize(&path).map_err(|_| {
+        blocked(
+            "entrypoint_unreadable",
+            Some(path.clone()),
+            Some(expected_entrypoint_digest.clone()),
+            None,
+        )
+    })?;
+    if before != after
+        || actual_id != matched.skill_id
+        || actual_package_digest != placement.content_digest
+    {
+        return Err(blocked(
+            "package_identity_drift",
+            Some(path),
+            Some(placement.content_digest.clone()),
+            Some(actual_package_digest),
+        )
+        .into());
+    }
+
+    let read_authority = match placement.mutation_scope {
+        Some(scan::MutationScope::Mutable) => "agent_or_managed_root",
+        Some(scan::MutationScope::ProviderReadOnly) => "provider_read_only",
+        Some(scan::MutationScope::DurableReadOnly) => "confirmed_durable_read_only",
+        Some(scan::MutationScope::UntrustedExternal) | None => unreachable!("filtered above"),
+    };
+    Ok(json!({
+        "selection": {
+            "rank": matched.rank,
+            "skill_id": matched.skill_id,
+            "name": matched.name,
+            "snapshot_id": scan_id,
+            "ranking_evidence": matched.match_reasons,
+        },
+        "content": {
+            "path": placement.entrypoint,
+            "media_type": "text/markdown; charset=utf-8",
+            "byte_length": content.len(),
+            "sha256": actual_entrypoint_digest,
+            "complete": true,
+            "text": content,
+        },
+        "governance": {
+            "roster_state": matched.roster_state,
+            "read_authority": read_authority,
+            "content_endorsed": false,
+            "owned_by_agent": placement.owned_by_agent,
+            "mutation_scope": placement.mutation_scope,
+            "governable": placement.is_mutable(),
+            "provider": placement.provider,
+        },
+        "verification": {
+            "identity_matches_snapshot": true,
+            "entrypoint_digest_matches_snapshot": true,
+            "package_fingerprint_matches_snapshot": true,
+            "package_fingerprint_complete": true,
+            "package_fingerprint": actual_package_digest,
+            "content_limit_bytes": MAX_AGENT_LOADED_SKILL_BYTES,
+        },
+        "task_success": "not_evaluated",
+    }))
 }
 
 fn plan_command(
@@ -8205,6 +8535,7 @@ mod recovery_tests {
             directory,
             physical_directory: None,
             content_digest: "legacy-digest".into(),
+            entrypoint_digest: None,
             fingerprint_completeness: scan::FingerprintCompleteness::Complete,
             fingerprint_detail: None,
             link_target: None,
@@ -8900,6 +9231,7 @@ mod recovery_tests {
             entrypoint: PathBuf::from(format!("/fixture/{id}/SKILL.md")),
             physical_directory: None,
             content_digest: "digest_shared".into(),
+            entrypoint_digest: None,
             fingerprint_completeness: scan::FingerprintCompleteness::Complete,
             fingerprint_detail: None,
             link_target: None,
@@ -8989,6 +9321,7 @@ mod recovery_tests {
             entrypoint: PathBuf::from(format!("/fixture/{id}/SKILL.md")),
             physical_directory: None,
             content_digest: "same-fallback-digest".into(),
+            entrypoint_digest: None,
             fingerprint_completeness: completeness,
             fingerprint_detail: Some("package exceeded fingerprint limit".into()),
             link_target: None,
@@ -9085,6 +9418,7 @@ mod recovery_tests {
                 entrypoint: PathBuf::from("/fixture/root/legacy/SKILL.md"),
                 physical_directory: None,
                 content_digest: "legacy-digest".into(),
+                entrypoint_digest: None,
                 fingerprint_completeness: scan::FingerprintCompleteness::Unknown,
                 fingerprint_detail: None,
                 link_target: None,
@@ -9146,6 +9480,7 @@ mod recovery_tests {
                 entrypoint: PathBuf::from("/fixture/root/legacy/SKILL.md"),
                 physical_directory: None,
                 content_digest: "legacy-digest".into(),
+                entrypoint_digest: None,
                 fingerprint_completeness: scan::FingerprintCompleteness::Complete,
                 fingerprint_detail: None,
                 link_target: None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -633,6 +633,45 @@ pub fn error_json_with_context(
         return serde_json::to_string(&envelope)
             .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into());
     }
+    if let Some(blocked) = error.downcast_ref::<SkillLoadBlocked>() {
+        let classified = classify_error(error);
+        let mut envelope = JsonEnvelope::<Value>::failure(
+            command,
+            ApiError {
+                code: classified.code.into(),
+                message: error.to_string(),
+                retryable: classified.retryable,
+                details: classified.details,
+                relevant_ids: extract_relevant_ids(&error.to_string()),
+                paths: extract_paths(&error.to_string()),
+            },
+        );
+        let safe_retry = match blocked.reason {
+            "same_name_variants_ambiguous" | "no_routable_match" => Some((
+                "inspect_current_report",
+                vec!["report", "--summary", "--json"],
+            )),
+            "placement_missing_from_snapshot"
+            | "package_fingerprint_incomplete"
+            | "legacy_snapshot_requires_rescan"
+            | "eligible_placement_missing"
+            | "entrypoint_content_drift"
+            | "package_identity_drift" => Some(("refresh_snapshot", vec!["scan", "--json"])),
+            _ => None,
+        };
+        if let Some((name, argv)) = safe_retry {
+            envelope.suggested_actions = vec![action(
+                name,
+                &argv,
+                false,
+                false,
+                "verified_skill_load_blocked",
+            )];
+            action_context.apply(&mut envelope.suggested_actions);
+        }
+        return serde_json::to_string(&envelope)
+            .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into());
+    }
     let classified = classify_error(error);
     serde_json::to_string(&JsonEnvelope::<Value>::failure(
         command,
@@ -783,11 +822,45 @@ fn fingerprint_remediation(completeness: scan::FingerprintCompleteness) -> Value
 
 fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError {
     if let Some(blocker) = error.downcast_ref::<SkillLoadBlocked>() {
-        let next_action = match blocker.reason {
-            "same_name_variants_ambiguous" => "inspect_variant_finding",
-            "untrusted_external_source" => "confirm_exact_source_root_then_scan",
-            "archived_skill_not_routable" => "choose_non_archived_skill",
-            _ => "scan",
+        let (next_action, retry_mode) = match blocker.reason {
+            "same_name_variants_ambiguous" => {
+                ("inspect_variant_finding", "read_only_command_available")
+            }
+            "no_routable_match" => (
+                "inspect_current_report_or_refine_task",
+                "read_only_command_available",
+            ),
+            "untrusted_external_source" => (
+                "confirm_exact_source_root_then_scan",
+                "user_decision_required",
+            ),
+            "archived_skill_not_routable" => ("choose_non_archived_skill", "agent_choice_required"),
+            "entrypoint_exceeds_content_limit" => (
+                "reduce_entrypoint_below_limit_then_scan",
+                "manual_resolution_required",
+            ),
+            "entrypoint_unreadable" | "package_identity_unreadable" => (
+                "repair_local_read_access_then_scan",
+                "manual_resolution_required",
+            ),
+            "entrypoint_escapes_approved_roots" => (
+                "move_under_approved_root_or_confirm_source_then_scan",
+                "user_decision_required",
+            ),
+            "entrypoint_not_utf8" => (
+                "convert_entrypoint_to_utf8_then_scan",
+                "manual_resolution_required",
+            ),
+            "package_fingerprint_incomplete" => (
+                "resolve_incomplete_package_then_scan",
+                "read_only_command_available",
+            ),
+            "placement_missing_from_snapshot"
+            | "legacy_snapshot_requires_rescan"
+            | "eligible_placement_missing"
+            | "entrypoint_content_drift"
+            | "package_identity_drift" => ("scan", "read_only_command_available"),
+            _ => ("inspect_blocker", "manual_resolution_required"),
         };
         return ClassifiedError {
             code: "verified_skill_load_blocked",
@@ -806,6 +879,7 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
                 "state_files_changed": false,
                 "task_success": "not_evaluated",
                 "next_action": next_action,
+                "retry_mode": retry_mode,
             })),
         };
     }
@@ -4850,14 +4924,15 @@ fn verified_top_skill_load(
             Some(actual_entrypoint_digest.clone()),
         )
     })?;
-    let (actual_id, actual_package_digest) = scan::inspect_skill_identity(&path).map_err(|_| {
-        blocked(
-            "package_identity_unreadable",
-            Some(path.clone()),
-            Some(placement.content_digest.clone()),
-            None,
-        )
-    })?;
+    let (actual_id, actual_package_digest) =
+        scan::inspect_skill_identity(&before).map_err(|_| {
+            blocked(
+                "package_identity_unreadable",
+                Some(path.clone()),
+                Some(placement.content_digest.clone()),
+                None,
+            )
+        })?;
     let after = std::fs::canonicalize(&path).map_err(|_| {
         blocked(
             "entrypoint_unreadable",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -202,6 +202,10 @@ pub struct FindArgs {
 
     #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(1..=i64::from(MAX_FIND_RESULTS)))]
     pub limit: u16,
+
+    /// Return the complete, verified SKILL.md for the unambiguous Top-1 match.
+    #[arg(long)]
+    pub load: bool,
 }
 
 pub const MAX_FIND_RESULTS: u16 = 100;

--- a/src/present.rs
+++ b/src/present.rs
@@ -1070,9 +1070,14 @@ fn find(value: &Value, lines: &mut Vec<String>, width: usize) {
             }
         }
     }
+    let loaded = value.get("loaded_skill").is_some_and(Value::is_object);
     lines.extend(summary(
         "Read-only · no Skill was activated",
-        "Read the selected SKILL.md directly",
+        if loaded {
+            "Top match verified and fully loaded in Agent JSON"
+        } else {
+            "Use --load for one-call verified instructions"
+        },
     ));
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -3536,6 +3536,7 @@ mod tests {
                     entrypoint: PathBuf::from(format!("/{}/skills/{index}/SKILL.md", agent.id())),
                     physical_directory: None,
                     content_digest: format!("digest_{index}"),
+                    entrypoint_digest: None,
                     fingerprint_completeness: crate::scan::FingerprintCompleteness::Complete,
                     fingerprint_detail: None,
                     link_target: None,

--- a/src/roster_recommendation.rs
+++ b/src/roster_recommendation.rs
@@ -759,6 +759,7 @@ mod tests {
                 )),
                 physical_directory: None,
                 content_digest: skill.content_digest.clone(),
+                entrypoint_digest: None,
                 fingerprint_completeness: crate::scan::FingerprintCompleteness::Complete,
                 fingerprint_detail: None,
                 link_target: None,

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -150,6 +150,10 @@ pub struct SkillPlacement {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub physical_directory: Option<PathBuf>,
     pub content_digest: String,
+    /// SHA-256 of the exact SKILL.md bytes observed during Scan. Missing on
+    /// legacy Snapshots cannot authorize a verified load.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entrypoint_digest: Option<String>,
     /// Whether `content_digest` covers the complete Skill package. Bounded or
     /// unreadable fingerprints are inventory facts only and cannot authorize
     /// exact-duplicate governance.
@@ -1565,6 +1569,7 @@ fn materialize_candidates_with_hook(
             entrypoint: candidate.entrypoint,
             physical_directory,
             content_digest: digest,
+            entrypoint_digest: safe_to_read.then(|| stable_digest(content.as_bytes())),
             fingerprint_completeness,
             fingerprint_detail,
             link_target: candidate.link_target,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6440,6 +6440,25 @@ fn public_find_uses_full_fts_body_and_archive_undo_restores_routing() {
         None,
     ));
     assert_eq!(archived["result"]["matches"], json!([]));
+    let archived_load = run(
+        &[
+            &common[..],
+            &["find", "phosphorescent reconciliation", "--load"],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!archived_load.status.success());
+    let archived_load: Value = serde_json::from_slice(&archived_load.stdout).unwrap();
+    assert_eq!(
+        archived_load["error"]["code"],
+        "verified_skill_load_blocked"
+    );
+    assert_eq!(
+        archived_load["error"]["details"]["reason"],
+        "archived_skill_not_routable"
+    );
+    assert!(archived_load["error"]["details"].get("content").is_none());
 
     json_output(&run(
         &[
@@ -6489,6 +6508,20 @@ fn archived_same_name_identity_cannot_return_through_active_variant() {
         None,
     ));
     assert_eq!(before["result"]["matches"][0]["variant_count"], 2);
+    let ambiguous_load = run(
+        &[
+            &common[..],
+            &["find", "active search marker", "--load", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!ambiguous_load.status.success());
+    let ambiguous_load: Value = serde_json::from_slice(&ambiguous_load.stdout).unwrap();
+    assert_eq!(
+        ambiguous_load["error"]["details"]["reason"],
+        "same_name_variants_ambiguous"
+    );
 
     let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
     let payload: String = database
@@ -6592,6 +6625,161 @@ fn find_rejects_content_drift_and_requests_rescan() {
             .unwrap()
             .contains("skillroster scan")
     );
+
+    let loaded = run(
+        &[
+            &common[..],
+            &["find", "needle before drift", "--load", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!loaded.status.success());
+    let loaded: Value = serde_json::from_slice(&loaded.stdout).unwrap();
+    assert_eq!(
+        loaded["error"]["details"]["reason"],
+        "entrypoint_content_drift"
+    );
+    assert!(loaded["error"]["details"].get("content").is_none());
+
+    fs::write(skill.join("SKILL.md"), vec![b'x'; 128 * 1024 + 1]).unwrap();
+    let oversized = run(
+        &[
+            &common[..],
+            &["find", "needle before drift", "--load", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!oversized.status.success());
+    let oversized: Value = serde_json::from_slice(&oversized.stdout).unwrap();
+    assert_eq!(
+        oversized["error"]["details"]["reason"],
+        "entrypoint_exceeds_content_limit"
+    );
+
+    fs::remove_file(skill.join("SKILL.md")).unwrap();
+    let unreadable = run(
+        &[
+            &common[..],
+            &["find", "needle before drift", "--load", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!unreadable.status.success());
+    let unreadable: Value = serde_json::from_slice(&unreadable.stdout).unwrap();
+    assert_eq!(
+        unreadable["error"]["details"]["reason"],
+        "entrypoint_unreadable"
+    );
+}
+
+#[test]
+fn find_load_returns_the_complete_verified_top_match_in_one_envelope() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill = home.join(".codex/skills/event-manifest");
+    fs::create_dir_all(&skill).unwrap();
+    let content = "---\nname: event-manifest\ndescription: Build a deterministic event manifest\n---\n\nFollow the complete event manifest instructions.\n";
+    fs::write(skill.join("SKILL.md"), content).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "build a deterministic event manifest",
+                "--load",
+                "--limit",
+                "1",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let loaded = &found["result"]["loaded_skill"];
+    assert_eq!(found["result"]["matches"][0]["name"], "event-manifest");
+    assert_eq!(loaded["selection"]["rank"], 1);
+    assert_eq!(loaded["content"]["text"], content);
+    assert_eq!(loaded["content"]["byte_length"], content.len());
+    assert_eq!(
+        loaded["content"]["sha256"],
+        format!("{:x}", Sha256::digest(content.as_bytes()))
+    );
+    assert_eq!(loaded["content"]["complete"], true);
+    assert_eq!(
+        loaded["verification"]["entrypoint_digest_matches_snapshot"],
+        true
+    );
+    assert_eq!(loaded["governance"]["content_endorsed"], false);
+    assert_eq!(loaded["task_success"], "not_evaluated");
+    assert_eq!(found["result"]["files_changed"], false);
+}
+
+#[test]
+fn find_load_rejects_an_untrusted_external_source_without_returning_content() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill = home.join(".codex/skills/external-helper");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: external-helper\ndescription: external trust fixture\n---\nsecret instructions\n",
+    )
+    .unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    let scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let snapshot = scan["result"]["snapshot_id"].as_str().unwrap();
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let payload: String = database
+        .query_row(
+            "SELECT payload_json FROM scan_payloads WHERE scan_id = ?1",
+            [snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut payload: Value = serde_json::from_str(&payload).unwrap();
+    payload["placements"][0]["mutation_scope"] = json!("untrusted_external");
+    payload["placements"][0]["governable"] = json!(false);
+    database
+        .execute(
+            "UPDATE scan_payloads SET payload_json = ?1 WHERE scan_id = ?2",
+            (payload.to_string(), snapshot),
+        )
+        .unwrap();
+
+    let loaded = run(
+        &[
+            &common[..],
+            &["find", "external trust fixture", "--load", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!loaded.status.success());
+    let loaded: Value = serde_json::from_slice(&loaded.stdout).unwrap();
+    assert_eq!(
+        loaded["error"]["details"]["reason"],
+        "untrusted_external_source"
+    );
+    assert!(!loaded.to_string().contains("secret instructions"));
 }
 
 #[test]
@@ -6676,6 +6864,21 @@ fn find_rejects_a_skill_symlink_that_now_escapes_approved_roots() {
     ));
     assert_eq!(found["result"]["matches"][0]["paths"], json!([]));
     assert_eq!(found["result"]["rescan_required"], true);
+
+    let loaded = run(
+        &[
+            &common[..],
+            &["find", "unique escape needle", "--load", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!loaded.status.success());
+    let loaded: Value = serde_json::from_slice(&loaded.stdout).unwrap();
+    assert_eq!(
+        loaded["error"]["details"]["reason"],
+        "entrypoint_escapes_approved_roots"
+    );
 }
 
 #[cfg(unix)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6458,6 +6458,11 @@ fn public_find_uses_full_fts_body_and_archive_undo_restores_routing() {
         archived_load["error"]["details"]["reason"],
         "archived_skill_not_routable"
     );
+    assert_eq!(
+        archived_load["error"]["details"]["retry_mode"],
+        "agent_choice_required"
+    );
+    assert_eq!(archived_load["suggested_actions"], json!([]));
     assert!(archived_load["error"]["details"].get("content").is_none());
 
     json_output(&run(
@@ -6521,6 +6526,17 @@ fn archived_same_name_identity_cannot_return_through_active_variant() {
     assert_eq!(
         ambiguous_load["error"]["details"]["reason"],
         "same_name_variants_ambiguous"
+    );
+    let retry_argv = ambiguous_load["suggested_actions"][0]["argv"]
+        .as_array()
+        .unwrap();
+    assert_eq!(
+        &retry_argv[retry_argv.len() - 3..],
+        &[json!("report"), json!("--summary"), json!("--json")]
+    );
+    assert_eq!(
+        ambiguous_load["suggested_actions"][0]["requires_confirmation"],
+        false
     );
 
     let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
@@ -6640,6 +6656,11 @@ fn find_rejects_content_drift_and_requests_rescan() {
         loaded["error"]["details"]["reason"],
         "entrypoint_content_drift"
     );
+    let retry_argv = loaded["suggested_actions"][0]["argv"].as_array().unwrap();
+    assert_eq!(
+        &retry_argv[retry_argv.len() - 2..],
+        &[json!("scan"), json!("--json")]
+    );
     assert!(loaded["error"]["details"].get("content").is_none());
 
     fs::write(skill.join("SKILL.md"), vec![b'x'; 128 * 1024 + 1]).unwrap();
@@ -6657,6 +6678,11 @@ fn find_rejects_content_drift_and_requests_rescan() {
         oversized["error"]["details"]["reason"],
         "entrypoint_exceeds_content_limit"
     );
+    assert_eq!(
+        oversized["error"]["details"]["retry_mode"],
+        "manual_resolution_required"
+    );
+    assert_eq!(oversized["suggested_actions"], json!([]));
 
     fs::remove_file(skill.join("SKILL.md")).unwrap();
     let unreadable = run(
@@ -6672,6 +6698,10 @@ fn find_rejects_content_drift_and_requests_rescan() {
     assert_eq!(
         unreadable["error"]["details"]["reason"],
         "entrypoint_unreadable"
+    );
+    assert_eq!(
+        unreadable["error"]["details"]["next_action"],
+        "repair_local_read_access_then_scan"
     );
 }
 

--- a/tests/fixtures/codex-protocol-skills/event-manifest/SKILL.md
+++ b/tests/fixtures/codex-protocol-skills/event-manifest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: event-manifest
-description: "Normalize pipe-delimited incident handoff records into the team's versioned event manifest JSON. Use for event handoff lists, PSV incident records, or the team event-manifest format."
+description: "Normalize pipe-delimited incident handoff records into the team's versioned event manifest JSON. Use for event handoff lists, PSV incident records, or the team event-manifest format. Activation contract: when this Skill is directly visible, load its entire SKILL.md in one standalone read before other commands; when a verified activation result already supplied the exact complete content, do not read SKILL.md again."
 ---
 
 # Event manifest

--- a/tests/fixtures/codex-protocol-skills/event-manifest/SKILL.md
+++ b/tests/fixtures/codex-protocol-skills/event-manifest/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: event-manifest
-description: "Normalize pipe-delimited incident handoff records into the team's versioned event manifest JSON. Use for event handoff lists, PSV incident records, or the team event-manifest format. Agent contract: load this entire SKILL.md in one standalone read command before any other command."
+description: "Normalize pipe-delimited incident handoff records into the team's versioned event manifest JSON. Use for event handoff lists, PSV incident records, or the team event-manifest format."
 ---
 
 # Event manifest
 
 Convert a pipe-delimited handoff file into the team's deterministic event manifest.
 
-Load this entire file in one standalone read command before reading task inputs or running any other command. Then run the bundled normalizer; do not recreate its rules manually:
+These instructions may be delivered either by the visible Skill loader or as the
+complete verified content of a SkillRoster `find --load` result. When the latter
+already returned this exact complete content, treat the Skill as loaded and do
+not read `SKILL.md` again. Otherwise, load this entire file in one standalone
+read before reading task inputs or running another command.
+
+Then run the bundled normalizer; do not recreate its rules manually:
 
 ```bash
 node <skill-directory>/scripts/normalize.mjs <input.psv> <output.json>

--- a/tests/fixtures/codex-skill-protocol-v7.json
+++ b/tests/fixtures/codex-skill-protocol-v7.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "harness": "codex-transfer",
+  "suite_id": "codex-skill-protocol-isolation-v7",
+  "trials_per_arm": 3,
+  "formal_protocol_gate": true,
+  "tasks": [
+    {
+      "id": "event-manifest-001",
+      "expected_skill": "event-manifest",
+      "required_find_calls": 1,
+      "one_call_load": true,
+      "prompt": "请把 handoff.psv 转成团队标准的事件交接清单，保存到 outputs/events.json。严格使用本机已有的团队规范，不要自行发明格式。完成后只告诉我输出路径和校验是否通过。",
+      "hint": "normalize PSV incident handoff records into team event manifest JSON",
+      "workspace_files": {
+        "handoff.psv": "evt-03|2026-08-23T09:30:00Z|billing|open\nevt-01|2026-08-22T14:05:00Z|identity|closed\nevt-02|2026-08-23T01:15:00Z|search|open\n"
+      },
+      "allowed_changed_paths": ["outputs/events.json"],
+      "oracle": {
+        "path": "outputs/events.json",
+        "json_equals": {
+          "schema_version": 1,
+          "records": [
+            { "id": "evt-01", "occurred_at": "2026-08-22T14:05:00Z", "owner": "identity", "state": "closed" },
+            { "id": "evt-02", "occurred_at": "2026-08-23T01:15:00Z", "owner": "search", "state": "open" },
+            { "id": "evt-03", "occurred_at": "2026-08-23T09:30:00Z", "owner": "billing", "state": "open" }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -12,8 +12,10 @@ const REPO = resolve(HERE, "../../..");
 const SYSTEM_SKILLS = ["imagegen", "openai-docs", "plugin-creator", "skill-creator", "skill-installer"];
 const DEFAULT_MANIFEST = join(REPO, "tests/fixtures/codex-cold-routing-transfer.json");
 const ACTIVE_AUTH_COPIES = new Set();
+const ACTIVE_RUNTIME_DIRS = new Set();
 for (const [signal, code] of [["SIGINT", 130], ["SIGTERM", 143]]) process.once(signal, () => {
   for (const path of ACTIVE_AUTH_COPIES) rmSync(path, { force: true });
+  for (const path of ACTIVE_RUNTIME_DIRS) rmSync(path, { recursive: true, force: true });
   process.exit(code);
 });
 
@@ -615,6 +617,7 @@ function copyAuth(authSource, codexHome) {
 }
 
 function cleanupAuth(path) { rmSync(path, { force: true }); ACTIVE_AUTH_COPIES.delete(path); }
+function cleanupRuntime(path) { rmSync(path, { recursive: true, force: true }); ACTIVE_RUNTIME_DIRS.delete(path); }
 
 function validateSummaryOutput(path, runsDir) {
   if (!path) return null;
@@ -765,14 +768,20 @@ process.stdout.write(result.stdout ?? ""); process.stderr.write(result.stderr ??
 export function setupArm(root, task, arm, options) {
   const home = join(root, "home"); const codexHome = join(home, ".codex"); const workspace = join(root, "workspace");
   const temp = mkdtempSync(join(canonicalPath(tmpdir()), "skillroster-codex-"));
-  for (const path of [codexHome, workspace]) mkdirSync(path, { recursive: true });
-  writeInputs(workspace, task.workspace_files);
-  const skillDestination = join(codexHome, "skills", arm === "core" ? task.expected_skill : "skillroster"); mkdirSync(dirname(skillDestination), { recursive: true });
-  const skillSource = arm === "core" ? join(options.skillsRoot, task.expected_skill) : dirname(options.bootstrap);
-  cpSync(skillSource, skillDestination, { recursive: true, dereference: true });
-  const targetPath = arm === "core" ? join(skillDestination, "SKILL.md") : join(root, "source", task.expected_skill, "SKILL.md");
-  if (arm === "on_demand") { const targetDir = dirname(targetPath); mkdirSync(dirname(targetDir), { recursive: true }); cpSync(join(options.skillsRoot, task.expected_skill), targetDir, { recursive: true, dereference: true }); }
-  return { home, codexHome, workspace, temp, targetPath, state: join(temp, "state"), runtimeAudit: join(temp, "find-audit.jsonl"), audit: join(root, "find-audit.jsonl"), transcript: join(root, "codex-events.jsonl") };
+  ACTIVE_RUNTIME_DIRS.add(temp);
+  try {
+    for (const path of [codexHome, workspace]) mkdirSync(path, { recursive: true });
+    writeInputs(workspace, task.workspace_files);
+    const skillDestination = join(codexHome, "skills", arm === "core" ? task.expected_skill : "skillroster"); mkdirSync(dirname(skillDestination), { recursive: true });
+    const skillSource = arm === "core" ? join(options.skillsRoot, task.expected_skill) : dirname(options.bootstrap);
+    cpSync(skillSource, skillDestination, { recursive: true, dereference: true });
+    const targetPath = arm === "core" ? join(skillDestination, "SKILL.md") : join(root, "source", task.expected_skill, "SKILL.md");
+    if (arm === "on_demand") { const targetDir = dirname(targetPath); mkdirSync(dirname(targetDir), { recursive: true }); cpSync(join(options.skillsRoot, task.expected_skill), targetDir, { recursive: true, dereference: true }); }
+    return { home, codexHome, workspace, temp, targetPath, state: join(temp, "state"), runtimeAudit: join(temp, "find-audit.jsonl"), audit: join(root, "find-audit.jsonl"), transcript: join(root, "codex-events.jsonl") };
+  } catch (error) {
+    cleanupRuntime(temp);
+    throw error;
+  }
 }
 
 function freezeSuite(manifest, options) {
@@ -899,7 +908,7 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     return { task: task.id, trial, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
   } finally {
     cleanupAuth(authCopy);
-    rmSync(paths.temp, { recursive: true, force: true });
+    cleanupRuntime(paths.temp);
   }
 }
 
@@ -964,7 +973,7 @@ export function main(argv = process.argv.slice(2)) {
   const sourceIdentityAfter = repositoryIdentity(); const sourceIdentityStable = JSON.stringify(sourceIdentityAfter) === JSON.stringify(frozen.facts.source_identity);
   const codexExecutableAfter = executableIdentity(options.codex); const codexExecutableStable = JSON.stringify(codexExecutableAfter) === JSON.stringify(frozen.facts.codex_executable);
   const formalGateEligible = completeSchedule && sourceIdentityStable && codexExecutableStable && results.every(formalResultEligible) && pairs.every((pair) => pair.attribution !== "pair_invariant_mismatch" && pair.attribution !== "pair_incomplete");
-  const summary = { status: results.every((result) => result.outcome?.accepted) && pairs.every((pair) => pair.attribution !== "pair_invariant_mismatch") ? "passed" : "failed", suite_id: manifest.suite_id, formal_gate_eligible: formalGateEligible, source_identity_stable: sourceIdentityStable, source_identity_after: sourceIdentityAfter, codex_executable_stable: codexExecutableStable, codex_executable_after: codexExecutableAfter, protocol_decision: manifest.formal_protocol_gate === true ? deriveProtocolDecision(results, trialsPerArm) : null, suite_snapshot: frozen.facts, signal_cleanup: "SIGINT/SIGTERM best effort; SIGKILL cannot guarantee auth cleanup", results, pairs };
+  const summary = { status: results.every((result) => result.outcome?.accepted) && pairs.every((pair) => pair.attribution !== "pair_invariant_mismatch") ? "passed" : "failed", suite_id: manifest.suite_id, formal_gate_eligible: formalGateEligible, source_identity_stable: sourceIdentityStable, source_identity_after: sourceIdentityAfter, codex_executable_stable: codexExecutableStable, codex_executable_after: codexExecutableAfter, protocol_decision: manifest.formal_protocol_gate === true ? deriveProtocolDecision(results, trialsPerArm) : null, suite_snapshot: frozen.facts, signal_cleanup: "SIGINT/SIGTERM remove auth copies and runtime state best effort; SIGKILL cannot guarantee cleanup", results, pairs };
   emitSummary(summary, options); return summary.status === "passed" ? 0 : 2;
 }
 

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -79,6 +79,7 @@ export function validateManifest(manifest) {
     const protocolTerms = new RegExp(`skillroster|${escapedSkill}|capability\\s+search|能力检索|技能检索|\\bfind\\b`, "iu");
     if (protocolTerms.test(task.prompt)) fail(`${task.id} prompt must not disclose the routing protocol or target Skill`);
     if (task.required_find_calls !== undefined && (!Number.isSafeInteger(task.required_find_calls) || task.required_find_calls < 1 || task.required_find_calls > 2)) fail(`${task.id} required_find_calls must be 1 or 2`);
+    if (task.one_call_load !== undefined && typeof task.one_call_load !== "boolean") fail(`${task.id} one_call_load must be boolean`);
     if (!Array.isArray(task.allowed_changed_paths)) fail(`${task.id} allowed_changed_paths is required`);
     for (const path of [...Object.keys(task.workspace_files ?? {}), ...task.allowed_changed_paths]) safeRelative(path, `${task.id} path`);
     if (task.allowed_changed_paths.some((path) => Object.hasOwn(task.workspace_files ?? {}, path))) fail(`${task.id} cannot mutate an input`);
@@ -241,8 +242,10 @@ export function parseFindAudit(text, expected) {
     first_call_argv_exact: first?.argv_shape_valid === true,
     top1_correct: Boolean(successful),
     returned_path_exact: successful?.top1_path_sha256 === sha(canonicalPath(expected.path)),
+    loaded_content_complete: expected.oneCall ? Boolean(successful?.loaded_content_complete) : null,
+    loaded_content_exact: expected.oneCall ? successful?.loaded_content_sha256 === sha(readFileSync(expected.path)) : null,
     retry_classification: calls.length === 0 ? "no_retrieval" : calls.length === 1 ? "single_attempt" : first?.task_sha256 !== sha(expected.task) || !first?.hint_nonempty ? "recovered_after_argument_mismatch" : "retried_after_valid_call",
-    contract_violation: calls.length > 2 || !first || first.argv_shape_valid !== true || first.envelope_valid !== true || first.task_sha256 !== sha(expected.task) || !(first.hint_count > 0 && first.hint_nonempty),
+    contract_violation: calls.length > 2 || !first || first.argv_shape_valid !== true || first.envelope_valid !== true || first.task_sha256 !== sha(expected.task) || !(first.hint_count > 0 && first.hint_nonempty) || (expected.oneCall === true && (!successful?.loaded_content_complete || successful?.loaded_content_sha256 !== sha(readFileSync(expected.path)))),
     calls,
   };
 }
@@ -475,6 +478,31 @@ export function assessExactLoad(transcript, targetPath) {
   return { passed: loadEventIndex !== null, evidence_mode: evidenceMode, target_path_sha256: sha(canonical), audited_command_count: commands.length, load_event_index: loadEventIndex, audit_scope: "completed exact-path reads with verified content echo; compound suffixes must be fully classified as read-only" };
 }
 
+function verifiedFindLoad(output, targetPath) {
+  if (typeof output !== "string") return null;
+  let value; try { value = JSON.parse(output); } catch { return null; }
+  const loaded = value?.result?.loaded_skill; const content = loaded?.content; const verification = loaded?.verification;
+  const target = readFileSync(targetPath); const text = target.toString("utf8");
+  if (value?.schema_version !== 1 || value?.ok !== true || value?.command !== "find"
+      || loaded?.selection?.rank !== 1 || canonicalPath(content?.path ?? "") !== canonicalPath(targetPath)
+      || content?.complete !== true || content?.text !== text || content?.byte_length !== target.length
+      || content?.sha256 !== sha(target) || loaded?.task_success !== "not_evaluated"
+      || verification?.identity_matches_snapshot !== true
+      || verification?.entrypoint_digest_matches_snapshot !== true
+      || verification?.package_fingerprint_matches_snapshot !== true
+      || verification?.package_fingerprint_complete !== true) return null;
+  return { evidence_mode: "verified_find_json_content", target_path_sha256: sha(canonicalPath(targetPath)), content_sha256: sha(target), content_bytes: target.length };
+}
+
+export function assessOneCallLoad(transcript, targetPath) {
+  const commands = extractCommandEvents(transcript); let loaded = null; let loadEventIndex = null;
+  for (const [index, event] of commands.entries()) {
+    if (event.kind !== "command" || !isFindCommand(event.command) || event.exit_code !== 0 || event.status !== "completed") continue;
+    loaded = verifiedFindLoad(event.output, targetPath); if (loaded) { loadEventIndex = index; break; }
+  }
+  return { passed: Boolean(loaded), evidence_mode: loaded?.evidence_mode ?? null, target_path_sha256: sha(canonicalPath(targetPath)), content_sha256: loaded?.content_sha256 ?? null, content_bytes: loaded?.content_bytes ?? null, audited_command_count: commands.length, load_event_index: loadEventIndex, audit_scope: "completed standalone Find command with exact verified SKILL.md content in the same JSON tool result" };
+}
+
 function findCommandShape(command) {
   const tokens = simpleCommandTokens(command);
   if (tokens && basename(tokens[0]) === "skillroster" && tokens[1] === "find") return "standalone";
@@ -487,7 +515,7 @@ function findCommandShape(command) {
 
 function isFindCommand(command) { return findCommandShape(command) !== null; }
 
-export function assessRouteOrder(transcript, { bootstrapPath, targetPath, findAudit, expectedTask = null, expectedSkill = null }) {
+export function assessRouteOrder(transcript, { bootstrapPath, targetPath, findAudit, expectedTask = null, expectedSkill = null, oneCall = false }) {
   const events = extractRouteEvents(transcript); const violations = []; const bootstrapRanges = []; const targetRanges = []; const bootstrapLines = targetLineCount(canonicalPath(bootstrapPath)); const targetLines = targetLineCount(canonicalPath(targetPath));
   const findAttempts = new Map(); let bootstrapLoaded = false; let findStarted = false; let findAuthorized = false; let targetLoaded = false; let transcriptFindCount = 0;
   for (const [index, event] of events.entries()) {
@@ -500,7 +528,8 @@ export function assessRouteOrder(transcript, { bootstrapPath, targetPath, findAu
         const attempt = findAttempts.get(event.id); const call = Number.isInteger(attempt) ? findAudit.calls?.[attempt] : null;
         const contractValid = Boolean(call && call.argv_shape_valid === true && call.envelope_valid === true && call.exit_code === 0 && call.hint_count > 0 && call.hint_nonempty === true && (!expectedTask || call.task_sha256 === sha(expectedTask)));
         const targetMatch = Boolean(call && (!expectedSkill || call.top1_skill === expectedSkill) && call.top1_path_sha256 === sha(canonicalPath(targetPath)));
-        if (event.exit_code === 0 && event.status === "completed" && contractValid && targetMatch) findAuthorized = true;
+        const loadedMatch = !oneCall || (call?.loaded_content_complete === true && call?.loaded_content_sha256 === sha(readFileSync(targetPath)));
+        if (event.exit_code === 0 && event.status === "completed" && contractValid && targetMatch && loadedMatch) { findAuthorized = true; if (oneCall) targetLoaded = true; }
         else if (!(event.exit_code === 0 && event.status === "completed" && contractValid)) violations.push(`find_completion_contract_invalid:${index}:${attempt ?? "unmatched"}`);
         continue;
       }
@@ -512,7 +541,7 @@ export function assessRouteOrder(transcript, { bootstrapPath, targetPath, findAu
     }
     if (isFindCommand(event.command)) { const attempt = transcriptFindCount; transcriptFindCount += 1; if (event.id) findAttempts.set(event.id, attempt); if (findCommandShape(event.command) === "unsafe_compound") violations.push(`find_shell_shape_invalid:${index}`); if (targetLoaded) violations.push(`find_after_load:${index}`); findStarted = true; continue; }
     if (!findStarted && bootstrapRead) continue;
-    if (targetRead) { if (!findAuthorized) violations.push(`target_load_before_find_complete:${index}`); continue; }
+    if (targetRead) { if (!findAuthorized) violations.push(`target_load_before_find_complete:${index}`); else if (oneCall) violations.push(`redundant_target_read_after_one_call_load:${index}`); continue; }
     if (!findStarted) violations.push(`task_command_before_find:${index}`);
     else if (!findAuthorized) violations.push(`task_command_before_find_complete:${index}`);
     else if (!targetLoaded) violations.push(`task_command_before_load:${index}`);
@@ -697,7 +726,7 @@ export function parseFindEnvelope(stdout) {
   if (value.result?.ranking_strategy !== "task_hint_reciprocal_rank_fusion") fail("Find did not use task_hint_reciprocal_rank_fusion");
   const candidates = value?.result?.matches ?? [];
   const top = candidates[0] ?? null;
-  return { skill: top?.name ?? null, path: top?.paths?.[0] ?? null, roster_state: top?.roster_state ?? null, agents: top?.agents ?? [], raw: value };
+  return { skill: top?.name ?? null, path: top?.paths?.[0] ?? null, roster_state: top?.roster_state ?? null, agents: top?.agents ?? [], loaded: value?.result?.loaded_skill ?? null, raw: value };
 }
 
 function parseEnvelope(stdout, command) {
@@ -707,9 +736,9 @@ function parseEnvelope(stdout, command) {
 }
 
 export function skillRosterScanArgs(paths, sourceRoot) { return ["--home", paths.home, "--state-dir", paths.state, "--json", "scan", "--source-root", sourceRoot]; }
-export function skillRosterFindArgs(paths, task) { return ["--home", paths.home, "--state-dir", paths.state, "--json", "find", task.prompt, "--hint", task.hint]; }
+export function skillRosterFindArgs(paths, task) { return ["--home", paths.home, "--state-dir", paths.state, "--json", "find", task.prompt, "--hint", task.hint, ...(task.one_call_load ? ["--load", "--limit", "1"] : [])]; }
 
-export function findWrapperSource() {
+export function findWrapperSource(oneCallLoad = false) {
   return `#!/usr/bin/env node
 import { createHash } from "node:crypto";
 import { appendFileSync } from "node:fs";
@@ -720,12 +749,15 @@ const sha = (value) => createHash("sha256").update(value).digest("hex");
 const args = process.argv.slice(2); const separator = args.indexOf("--hint");
 const task = args[0] === "find" ? (args[1] ?? "") : "";
 const hints = []; for (let i = 0; i < args.length; i += 1) if (args[i] === "--hint" && args[i + 1] !== undefined) hints.push(args[i + 1]);
-let result = { status: 64, stdout: "", stderr: "wrapper permits only: skillroster find TASK --hint HINT --json\\n" };
-const argvShapeValid = args.length === 5 && args[0] === "find" && args[2] === "--hint" && args[4] === "--json";
-if (argvShapeValid) result = spawnSync(process.env.SKILLROSTER_REAL_CLI, ["--home", process.env.SKILLROSTER_TEST_HOME, "--state-dir", process.env.SKILLROSTER_TEST_STATE, "--json", ...args.slice(0, 4)], { encoding: "utf8", shell: false });
-let top1 = {}; let envelopeValid = false; try { const value = JSON.parse(result.stdout ?? ""); envelopeValid = value?.schema_version === 1 && value?.ok === true && value?.command === "find" && value?.result?.ranking_strategy === "task_hint_reciprocal_rank_fusion"; const top = envelopeValid ? value?.result?.matches?.[0] ?? {} : {}; top1 = { skill: top.name ?? null, path: top.paths?.[0] ?? null }; } catch {}
+const oneCallLoad = ${JSON.stringify(oneCallLoad)};
+let result = { status: 64, stdout: "", stderr: oneCallLoad ? "wrapper permits only: skillroster find TASK --hint HINT --load --limit 1 --json\\n" : "wrapper permits only: skillroster find TASK --hint HINT --json\\n" };
+const argvShapeValid = oneCallLoad
+  ? args.length === 8 && args[0] === "find" && args[2] === "--hint" && args[4] === "--load" && args[5] === "--limit" && args[6] === "1" && args[7] === "--json"
+  : args.length === 5 && args[0] === "find" && args[2] === "--hint" && args[4] === "--json";
+if (argvShapeValid) result = spawnSync(process.env.SKILLROSTER_REAL_CLI, ["--home", process.env.SKILLROSTER_TEST_HOME, "--state-dir", process.env.SKILLROSTER_TEST_STATE, "--json", ...args.slice(0, oneCallLoad ? 7 : 4)], { encoding: "utf8", shell: false });
+let top1 = {}; let envelopeValid = false; let loadedContentComplete = false; let loadedContentSha256 = null; try { const value = JSON.parse(result.stdout ?? ""); envelopeValid = value?.schema_version === 1 && value?.ok === true && value?.command === "find" && value?.result?.ranking_strategy === "task_hint_reciprocal_rank_fusion"; const top = envelopeValid ? value?.result?.matches?.[0] ?? {} : {}; top1 = { skill: top.name ?? null, path: top.paths?.[0] ?? null }; const loaded = value?.result?.loaded_skill; loadedContentComplete = !oneCallLoad || (loaded?.selection?.rank === 1 && loaded?.content?.complete === true && typeof loaded?.content?.text === "string" && loaded?.content?.byte_length === Buffer.byteLength(loaded.content.text, "utf8") && loaded?.content?.sha256 === sha(loaded.content.text) && loaded?.verification?.identity_matches_snapshot === true && loaded?.verification?.entrypoint_digest_matches_snapshot === true && loaded?.verification?.package_fingerprint_matches_snapshot === true && loaded?.verification?.package_fingerprint_complete === true && loaded?.task_success === "not_evaluated"); loadedContentSha256 = loadedContentComplete && oneCallLoad ? sha(loaded.content.text) : null; envelopeValid = envelopeValid && (!oneCallLoad || loadedContentComplete); } catch {}
 let canonicalTopPath = null; try { canonicalTopPath = top1.path ? realpathSync(top1.path) : null; } catch { canonicalTopPath = top1.path ? resolve(top1.path) : null; }
-appendFileSync(process.env.SKILLROSTER_FIND_AUDIT, JSON.stringify({ kind: "find_call", argv_count: args.length, argv_shape_valid: argvShapeValid, envelope_valid: envelopeValid, task_sha256: sha(task), hint_count: hints.length, hint_nonempty: hints.length > 0 && hints.every((hint) => hint.trim().length > 0), hint_sha256: hints.map(sha), separator_index: separator, exit_code: result.status, top1_skill: top1.skill ?? null, top1_path_sha256: canonicalTopPath ? sha(canonicalTopPath) : null }) + "\\n", { mode: 0o600 });
+appendFileSync(process.env.SKILLROSTER_FIND_AUDIT, JSON.stringify({ kind: "find_call", argv_count: args.length, argv_shape_valid: argvShapeValid, envelope_valid: envelopeValid, task_sha256: sha(task), hint_count: hints.length, hint_nonempty: hints.length > 0 && hints.every((hint) => hint.trim().length > 0), hint_sha256: hints.map(sha), separator_index: separator, exit_code: result.status, top1_skill: top1.skill ?? null, top1_path_sha256: canonicalTopPath ? sha(canonicalTopPath) : null, loaded_content_complete: loadedContentComplete, loaded_content_sha256: loadedContentSha256 }) + "\\n", { mode: 0o600 });
 process.stdout.write(result.stdout ?? ""); process.stderr.write(result.stderr ?? ""); process.exit(result.status ?? 1);
 `;
 }
@@ -811,8 +843,9 @@ export function prepareOnDemand(paths, task, options, env) {
   if (findResult.status !== 0) fail(`SkillRoster Find preflight failed: ${findResult.stderr.trim()}`);
   const top = parseFindEnvelope(findResult.stdout); const status = invoke("status");
   if (top.skill !== task.expected_skill || !top.path || canonicalPath(top.path) !== canonicalTarget || top.roster_state !== "on_demand" || top.agents.length !== 0) fail("governed Find did not return one exact, non-exposed On-demand target");
+  if (task.one_call_load && !verifiedFindLoad(findResult.stdout, paths.targetPath)) fail("governed Find did not return one exact verified loaded Skill");
   if (status.result.recovery_state !== "clear" || status.result.journal_issues?.length || status.result.last_receipt?.receipt_id !== applied.result.receipt_id) fail("SkillRoster recovery or Receipt state is not clear");
-  const bin = join(dirname(paths.audit), "bin"); mkdirSync(bin, { recursive: true }); const wrapper = join(bin, "skillroster"); writeFileSync(wrapper, findWrapperSource(), { mode: 0o755 }); chmodSync(wrapper, 0o755);
+  const bin = join(dirname(paths.audit), "bin"); mkdirSync(bin, { recursive: true }); const wrapper = join(bin, "skillroster"); writeFileSync(wrapper, findWrapperSource(task.one_call_load === true), { mode: 0o755 }); chmodSync(wrapper, 0o755);
   return { bin, governance: { roster_state: top.roster_state, target_default_exposure: 0, receipt_id: applied.result.receipt_id, receipt_verification: applied.result.verification, recovery_state: status.result.recovery_state } };
 }
 
@@ -854,10 +887,10 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     writeFileSync(paths.transcript, result.stdout, { mode: 0o600 });
     const after = walk(paths.workspace); const workspace = assessWorkspaceChanges(initialWorkspace, after, Object.keys(task.workspace_files), task.allowed_changed_paths);
     const oracle = result.status === 0 ? evaluateOracle(paths.workspace, task.oracle, { transcript: result.stdout, targetPackage: dirname(paths.targetPath), parentVerificationAuthority: { protected_scopes_passed: protectedScopes.passed, expected: suiteFacts.target_packages?.[task.expected_skill] } }) : { passed: false, failures: [`codex_exit:${result.status ?? "signal"}`] };
-    const retrieval = arm === "on_demand" ? parseFindAudit(existsSync(paths.audit) ? readFileSync(paths.audit, "utf8") : "", { task: task.prompt, skill: task.expected_skill, path: paths.targetPath }) : { count: 0, contract_violation: false };
+    const retrieval = arm === "on_demand" ? parseFindAudit(existsSync(paths.audit) ? readFileSync(paths.audit, "utf8") : "", { task: task.prompt, skill: task.expected_skill, path: paths.targetPath, oneCall: task.one_call_load === true }) : { count: 0, contract_violation: false };
     if (arm === "on_demand" && task.required_find_calls !== undefined && retrieval.count !== task.required_find_calls) retrieval.contract_violation = true;
-    const load = assessExactLoad(result.stdout, paths.targetPath);
-    const routeOrder = arm === "on_demand" ? assessRouteOrder(result.stdout, { bootstrapPath: join(paths.codexHome, "skills", "skillroster", "SKILL.md"), targetPath: paths.targetPath, findAudit: retrieval, expectedTask: task.prompt, expectedSkill: task.expected_skill }) : { passed: true, audit_scope: "not_applicable" };
+    const load = arm === "on_demand" && task.one_call_load ? assessOneCallLoad(result.stdout, paths.targetPath) : assessExactLoad(result.stdout, paths.targetPath);
+    const routeOrder = arm === "on_demand" ? assessRouteOrder(result.stdout, { bootstrapPath: join(paths.codexHome, "skills", "skillroster", "SKILL.md"), targetPath: paths.targetPath, findAudit: retrieval, expectedTask: task.prompt, expectedSkill: task.expected_skill, oneCall: task.one_call_load === true }) : { passed: true, audit_scope: "not_applicable" };
     const coreOrder = arm === "core" ? assessCoreOrder(result.stdout, paths.targetPath) : { passed: true, audit_scope: "not_applicable" };
     const transcript = assessTranscriptIntegrity(result.stdout);
     const outcome = deriveArmOutcome({ arm, surface, retrieval, load, oracle, workspace, routeOrder, coreOrder, transcript, protectedScopes });
@@ -885,10 +918,10 @@ export function reevaluateExistingRuns(suiteRoot, manifest) {
     if (!existsSync(workspacePath) || !existsSync(transcriptPath)) { results.push({ task: task.id, trial, arm, root, recomputed: false, formal_evidence_accepted: null, post_hoc_only: true, failures: ["workspace_or_transcript_missing"] }); continue; }
     const transcriptText = readFileSync(transcriptPath, "utf8"); const targetPath = arm === "core" ? join(root, "home", ".codex", "skills", task.expected_skill, "SKILL.md") : join(root, "source", task.expected_skill, "SKILL.md");
     const initial = new Map(Object.entries(task.workspace_files).map(([path, content]) => [path, sha(content)])); const workspace = assessWorkspaceChanges(initial, walk(workspacePath), Object.keys(task.workspace_files), task.allowed_changed_paths);
-    const retrieval = arm === "on_demand" ? parseFindAudit(existsSync(join(root, "find-audit.jsonl")) ? readFileSync(join(root, "find-audit.jsonl"), "utf8") : "", { task: task.prompt, skill: task.expected_skill, path: targetPath }) : { count: 0, contract_violation: false };
+    const retrieval = arm === "on_demand" ? parseFindAudit(existsSync(join(root, "find-audit.jsonl")) ? readFileSync(join(root, "find-audit.jsonl"), "utf8") : "", { task: task.prompt, skill: task.expected_skill, path: targetPath, oneCall: task.one_call_load === true }) : { count: 0, contract_violation: false };
     if (arm === "on_demand" && task.required_find_calls !== undefined && retrieval.count !== task.required_find_calls) retrieval.contract_violation = true;
-    const load = assessExactLoad(transcriptText, targetPath); const transcript = assessTranscriptIntegrity(transcriptText);
-    const routeOrder = arm === "on_demand" ? assessRouteOrder(transcriptText, { bootstrapPath: join(root, "home", ".codex", "skills", "skillroster", "SKILL.md"), targetPath, findAudit: retrieval, expectedTask: task.prompt, expectedSkill: task.expected_skill }) : { passed: true, audit_scope: "not_applicable" };
+    const load = arm === "on_demand" && task.one_call_load ? assessOneCallLoad(transcriptText, targetPath) : assessExactLoad(transcriptText, targetPath); const transcript = assessTranscriptIntegrity(transcriptText);
+    const routeOrder = arm === "on_demand" ? assessRouteOrder(transcriptText, { bootstrapPath: join(root, "home", ".codex", "skills", "skillroster", "SKILL.md"), targetPath, findAudit: retrieval, expectedTask: task.prompt, expectedSkill: task.expected_skill, oneCall: task.one_call_load === true }) : { passed: true, audit_scope: "not_applicable" };
     const coreOrder = arm === "core" ? assessCoreOrder(transcriptText, targetPath) : { passed: true, audit_scope: "not_applicable" };
     const oracle = evaluateOracle(workspacePath, task.oracle, { transcript: transcriptText, targetPackage: dirname(targetPath), parentVerificationAuthority: { mode: "historical_untrusted" } });
     results.push({ task: task.id, trial, arm, root, recomputed: true, formal_evidence_accepted: null, post_hoc_only: true, recomputed_dimensions: { transcript: transcript.passed, retrieval: arm === "core" ? null : Boolean(retrieval.top1_correct && retrieval.returned_path_exact && !retrieval.contract_violation), load: load.passed, route_order: arm === "core" ? null : routeOrder.passed, core_order: arm === "core" ? coreOrder.passed : null, oracle: oracle.passed, parent_correctness: task.oracle.archify_receipt_contract ? oracle.archify_parent_verification?.passed ?? null : null, workspace: workspace.passed }, transcript, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, historical_evidence_limitations: ["post-hoc result is not a formal gate", "model-visible surface, earliest protected-scope baselines, and original suite ledger were not persisted"] });

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -763,15 +763,16 @@ process.stdout.write(result.stdout ?? ""); process.stderr.write(result.stderr ??
 }
 
 export function setupArm(root, task, arm, options) {
-  const home = join(root, "home"); const codexHome = join(home, ".codex"); const workspace = join(root, "workspace"); const temp = join(root, "tmp");
-  for (const path of [codexHome, workspace, temp]) mkdirSync(path, { recursive: true });
+  const home = join(root, "home"); const codexHome = join(home, ".codex"); const workspace = join(root, "workspace");
+  const temp = mkdtempSync(join(canonicalPath(tmpdir()), "skillroster-codex-"));
+  for (const path of [codexHome, workspace]) mkdirSync(path, { recursive: true });
   writeInputs(workspace, task.workspace_files);
   const skillDestination = join(codexHome, "skills", arm === "core" ? task.expected_skill : "skillroster"); mkdirSync(dirname(skillDestination), { recursive: true });
   const skillSource = arm === "core" ? join(options.skillsRoot, task.expected_skill) : dirname(options.bootstrap);
   cpSync(skillSource, skillDestination, { recursive: true, dereference: true });
   const targetPath = arm === "core" ? join(skillDestination, "SKILL.md") : join(root, "source", task.expected_skill, "SKILL.md");
   if (arm === "on_demand") { const targetDir = dirname(targetPath); mkdirSync(dirname(targetDir), { recursive: true }); cpSync(join(options.skillsRoot, task.expected_skill), targetDir, { recursive: true, dereference: true }); }
-  return { home, codexHome, workspace, temp, targetPath, state: join(root, "state"), audit: join(root, "find-audit.jsonl"), transcript: join(root, "codex-events.jsonl") };
+  return { home, codexHome, workspace, temp, targetPath, state: join(temp, "state"), runtimeAudit: join(temp, "find-audit.jsonl"), audit: join(root, "find-audit.jsonl"), transcript: join(root, "codex-events.jsonl") };
 }
 
 function freezeSuite(manifest, options) {
@@ -880,11 +881,12 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     let prepared = null;
     if (arm === "on_demand") prepared = prepareOnDemand(paths, task, options, env);
     const runEnv = { ...env };
-    if (prepared) Object.assign(runEnv, { SKILLROSTER_REAL_CLI: options.cli, SKILLROSTER_TEST_HOME: paths.home, SKILLROSTER_TEST_STATE: paths.state, SKILLROSTER_FIND_AUDIT: paths.audit });
+    if (prepared) Object.assign(runEnv, { SKILLROSTER_REAL_CLI: options.cli, SKILLROSTER_TEST_HOME: paths.home, SKILLROSTER_TEST_STATE: paths.state, SKILLROSTER_FIND_AUDIT: paths.runtimeAudit });
     if (prepared) runEnv.PATH = `${prepared.bin}:${process.env.PATH ?? "/usr/bin:/bin"}`;
     const result = run(options.codex, ["exec", "--ephemeral", "--ignore-user-config", "--sandbox", "workspace-write", "--skip-git-repo-check", "--json", ...codexModelConfig(options), "-C", paths.workspace, task.prompt], { cwd: paths.workspace, env: runEnv, timeout: options.timeoutMs });
     const protectedScopes = assessProtectedScopes(initialProtected, captureProtectedScopes(protectedPaths));
     writeFileSync(paths.transcript, result.stdout, { mode: 0o600 });
+    if (existsSync(paths.runtimeAudit)) copyFileSync(paths.runtimeAudit, paths.audit);
     const after = walk(paths.workspace); const workspace = assessWorkspaceChanges(initialWorkspace, after, Object.keys(task.workspace_files), task.allowed_changed_paths);
     const oracle = result.status === 0 ? evaluateOracle(paths.workspace, task.oracle, { transcript: result.stdout, targetPackage: dirname(paths.targetPath), parentVerificationAuthority: { protected_scopes_passed: protectedScopes.passed, expected: suiteFacts.target_packages?.[task.expected_skill] } }) : { passed: false, failures: [`codex_exit:${result.status ?? "signal"}`] };
     const retrieval = arm === "on_demand" ? parseFindAudit(existsSync(paths.audit) ? readFileSync(paths.audit, "utf8") : "", { task: task.prompt, skill: task.expected_skill, path: paths.targetPath, oneCall: task.one_call_load === true }) : { count: 0, contract_violation: false };
@@ -897,6 +899,7 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     return { task: task.id, trial, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
   } finally {
     cleanupAuth(authCopy);
+    rmSync(paths.temp, { recursive: true, force: true });
   }
 }
 

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { assessCoreOrder, assessExactLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalResultEligible, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
+import { assessCoreOrder, assessExactLoad, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalResultEligible, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
 
 const DRIVER = fileURLToPath(new URL("./driver.mjs", import.meta.url));
 
@@ -129,6 +129,7 @@ test("SkillRoster seam uses the real envelope and global-option ordering", () =>
   const paths = { home: "/tmp/home", state: "/tmp/state" }; const task = { prompt: "完整任务", hint: "agent hint" };
   assert.deepEqual(skillRosterScanArgs(paths, "/tmp/source"), ["--home", "/tmp/home", "--state-dir", "/tmp/state", "--json", "scan", "--source-root", "/tmp/source"]);
   assert.deepEqual(skillRosterFindArgs(paths, task), ["--home", "/tmp/home", "--state-dir", "/tmp/state", "--json", "find", "完整任务", "--hint", "agent hint"]);
+  assert.deepEqual(skillRosterFindArgs(paths, { ...task, one_call_load: true }), ["--home", "/tmp/home", "--state-dir", "/tmp/state", "--json", "find", "完整任务", "--hint", "agent hint", "--load", "--limit", "1"]);
 });
 
 test("Find audit preserves exact argument mismatch and retry classification", async () => {
@@ -160,6 +161,9 @@ test("wrapper source is allowlisted and records hashes rather than raw task or h
   const root = mkdtempSync(join(tmpdir(), "codex-find-wrapper-")); const path = join(root, "skillroster.mjs"); writeFileSync(path, source);
   const checked = spawnSync(process.execPath, ["--check", path], { encoding: "utf8" });
   assert.equal(checked.status, 0, checked.stderr);
+  writeFileSync(path, findWrapperSource(true));
+  const oneCallChecked = spawnSync(process.execPath, ["--check", path], { encoding: "utf8" });
+  assert.equal(oneCallChecked.status, 0, oneCallChecked.stderr);
 });
 
 test("post-hoc workspace audit treats every sidecar outside exact allowlist as a safety failure", () => {
@@ -216,6 +220,22 @@ test("exact target load is established from audited Codex command text", () => {
   assert.equal(assessExactLoad(transcript, path).passed, true);
   const failed = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: `cat -- '${canonical}'`, aggregated_output: "skill", exit_code: 0, status: "failed" } }); assert.equal(assessExactLoad(failed, path).passed, false);
   assert.equal(assessExactLoad(transcript, join(root, "source", "other", "SKILL.md")).passed, false);
+});
+
+test("one-call Find load proves exact content and completes route order without a filesystem read", async () => {
+  const root = mkdtempSync(join(tmpdir(), "codex-one-call-load-")); const bootstrap = join(root, "bootstrap", "SKILL.md"); const target = join(root, "target", "SKILL.md");
+  mkdirSync(join(root, "bootstrap")); mkdirSync(join(root, "target")); writeFileSync(bootstrap, "bootstrap"); writeFileSync(target, "---\nname: target\n---\ncomplete instructions\n");
+  const content = readFileSync(target, "utf8"); const contentSha = await digest(content); const command = "skillroster find '完整任务' --hint 'target helper' --load --limit 1 --json";
+  const envelope = JSON.stringify({ schema_version: 1, ok: true, command: "find", result: { ranking_strategy: "task_hint_reciprocal_rank_fusion", matches: [{ rank: 1, name: "target", paths: [target] }], loaded_skill: { selection: { rank: 1 }, content: { path: target, complete: true, text: content, byte_length: Buffer.byteLength(content), sha256: contentSha }, verification: { identity_matches_snapshot: true, entrypoint_digest_matches_snapshot: true, package_fingerprint_matches_snapshot: true, package_fingerprint_complete: true }, task_success: "not_evaluated" } } });
+  const transcript = [
+    JSON.stringify({ type: "item.started", item: { id: "find", type: "command_execution", command } }),
+    JSON.stringify({ type: "item.completed", item: { id: "find", type: "command_execution", command, aggregated_output: envelope, exit_code: 0, status: "completed" } }),
+  ].join("\n");
+  const audit = { count: 1, contract_violation: false, calls: [{ argv_shape_valid: true, envelope_valid: true, exit_code: 0, hint_count: 1, hint_nonempty: true, task_sha256: await digest("完整任务"), top1_skill: "target", top1_path_sha256: await digest(realpathSync(target)), loaded_content_complete: true, loaded_content_sha256: contentSha }] };
+  assert.equal(assessOneCallLoad(transcript, target).passed, true);
+  assert.equal(assessRouteOrder(transcript, { bootstrapPath: bootstrap, targetPath: target, findAudit: audit, expectedTask: "完整任务", expectedSkill: "target", oneCall: true }).passed, true);
+  const redundantRead = `${transcript}\n${JSON.stringify({ type: "item.started", item: { id: "read", type: "command_execution", command: `cat '${target}'` } })}\n${JSON.stringify({ type: "item.completed", item: { id: "read", type: "command_execution", command: `cat '${target}'`, aggregated_output: content, exit_code: 0, status: "completed" } })}`;
+  assert.equal(assessRouteOrder(redundantRead, { bootstrapPath: bootstrap, targetPath: target, findAudit: audit, expectedTask: "完整任务", expectedSkill: "target", oneCall: true }).passed, false);
 });
 
 test("exact target load rejects path mentions, prefixes, and non-reading commands", () => {

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -1,18 +1,39 @@
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { assessCoreOrder, assessExactLoad, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalResultEligible, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
+import { assessCoreOrder, assessExactLoad, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalResultEligible, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, setupArm, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
 
 const DRIVER = fileURLToPath(new URL("./driver.mjs", import.meta.url));
 
 const digest = async (value) => {
   const { createHash } = await import("node:crypto"); return createHash("sha256").update(value).digest("hex");
 };
+
+test("on-demand runtime state and audit stay in the sandbox temp boundary", () => {
+  const root = mkdtempSync(join(realpathSync(tmpdir()), "codex-runtime-boundary-"));
+  const repo = fileURLToPath(new URL("../../../", import.meta.url));
+  const paths = setupArm(root, {
+    expected_skill: "event-manifest",
+    workspace_files: { "handoff.psv": "fixture\n" },
+  }, "on_demand", {
+    skillsRoot: join(repo, "tests/fixtures/codex-protocol-skills"),
+    bootstrap: join(repo, "skill/skillroster/SKILL.md"),
+  });
+  try {
+    assert.equal(paths.state.startsWith(`${paths.temp}/`), true);
+    assert.equal(paths.runtimeAudit.startsWith(`${paths.temp}/`), true);
+    assert.equal(paths.audit.startsWith(`${root}/`), true);
+    assert.equal(paths.audit.startsWith(`${paths.temp}/`), false);
+  } finally {
+    rmSync(paths.temp, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("default is a non-executing plan and execution requires explicit auth", () => {
   assert.equal(parseArgs([]).execute, false);

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -25,10 +25,10 @@ test("on-demand runtime state and audit stay in the sandbox temp boundary", () =
     bootstrap: join(repo, "skill/skillroster/SKILL.md"),
   });
   try {
-    assert.equal(paths.state.startsWith(`${paths.temp}/`), true);
-    assert.equal(paths.runtimeAudit.startsWith(`${paths.temp}/`), true);
-    assert.equal(paths.audit.startsWith(`${root}/`), true);
-    assert.equal(paths.audit.startsWith(`${paths.temp}/`), false);
+    assert.equal(paths.state, join(paths.temp, "state"));
+    assert.equal(paths.runtimeAudit, join(paths.temp, "find-audit.jsonl"));
+    assert.equal(paths.audit, join(root, "find-audit.jsonl"));
+    assert.notEqual(paths.audit, join(paths.temp, "find-audit.jsonl"));
   } finally {
     rmSync(paths.temp, { recursive: true, force: true });
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

The frozen v6 Codex protocol showed that deterministic retrieval and task execution worked, but a second filesystem load left room for ordered Agent-contract failures.

## Solution

- extend `find` with `--load` so one stable JSON envelope returns the verified Top-1 `SKILL.md`
- verify roster state, approved roots, source trust, entrypoint digest, package fingerprint, UTF-8, drift, and a 128 KiB Agent transport bound
- fail closed with typed details and safe read-only retry actions where available
- keep ordinary Find compatible and keep semantic intent/task-success judgment with the Agent
- update the single Bootstrap Skill to use the canonical one-call form
- add frozen v7 harness support and redacted acceptance evidence
- document primary-source research and the deterministic/model responsibility boundary

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked --all-targets --all-features` (211 unit + 8 acceptance + 59 CLI)
- [x] `node --test tests/harness/codex-cold-routing/driver.test.mjs` (39/39)
- [x] Bootstrap and protocol fixture Skill validation
- [x] isolated real-home dogfood: success and same-name fail-closed paths
- [x] frozen Codex v7 protocol, `gpt-5.6-luna` medium: Core 3/3, On-demand 3/3, task/safety pass, decision `retain_current_design`
- [x] `git diff --check`

Closes #149
