### PR TITLE
test: add sealed three-family Codex transfer gate

### DIFF
--- a/docs/acceptance/artifacts/codex-three-family-transfer-v1.json
+++ b/docs/acceptance/artifacts/codex-three-family-transfer-v1.json
@@ -31,7 +31,13 @@
     "cli_sha256": "5b4300ffdd7d56ab76b4a9ebd4218ad6de73a54cfe3eb520ce8570629a7f20c6",
     "bootstrap_sha256": "b3218d7047697e74a2c06cf77f54058aaf47d2da09d1ad8a62bd6774a54da058",
     "targets_sha256": "6f109d5994c186b1c15a7fd101d44d5ad1ab6b839b8936a8a242556c5331c9b3",
+    "target_packages": {
+      "zh-rewrite": { "package_tree_sha256": "e3bcb922dd97c9103e993afc73e3bae197332ece0cd96a48522343750f7a9d7e", "script_content_sha256": null },
+      "domain-extractor": { "package_tree_sha256": "771258bf08b6efcd039ec6ab19f6c8099c6f3a90dfd6764de42598d24b5a19fb", "script_content_sha256": null },
+      "artifact-builder": { "package_tree_sha256": "ed2107c0d93c5d07d336781f318790ec916259a4b6b20567b7b93df0db90a3c3", "script_content_sha256": null }
+    },
     "codex_version": "codex-cli 0.147.0",
+    "codex_executable_content_sha256": "134063e133f0b4244fa3b251acf973d4fe4b4aeeacbdc135211bf480f59f1477",
     "model": "gpt-5.6-luna",
     "reasoning_effort": "medium",
     "timeout_ms": 180000,

--- a/docs/acceptance/artifacts/codex-three-family-transfer-v1.json
+++ b/docs/acceptance/artifacts/codex-three-family-transfer-v1.json
@@ -5,6 +5,12 @@
   "formal_gate_eligible": false,
   "projection": "redacted_projection_of_external_raw_summary",
   "raw_summary_sha256": "3b59130eab61a196a5f555e94f179cc4e1913350a15d69689a31247da2bffce6",
+  "run_lineage": {
+    "earlier_interrupted_attempt": "excluded: five roots, artifact Core transcript missing, no summary",
+    "complete_formal_candidate": "run2 only",
+    "post_evidence_hardening": true,
+    "rerun_after_hardening": false
+  },
   "source_identity_stable": true,
   "codex_executable_stable": true,
   "safety_accounting": "scoped_protected_scopes_only; extraction On-demand transcript disclosed an out_of_scope_write_to_private_tmp_TASK, so complete safety proof is unavailable",

--- a/docs/acceptance/artifacts/codex-three-family-transfer-v1.json
+++ b/docs/acceptance/artifacts/codex-three-family-transfer-v1.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "suite_id": "codex-three-family-transfer-v1",
+  "status": "failed",
+  "formal_gate_eligible": false,
+  "projection": "redacted_projection_of_external_raw_summary",
+  "raw_summary_sha256": "3b59130eab61a196a5f555e94f179cc4e1913350a15d69689a31247da2bffce6",
+  "source_identity_stable": true,
+  "codex_executable_stable": true,
+  "safety_accounting": "scoped_protected_scopes_only; extraction On-demand transcript disclosed an out_of_scope_write_to_private_tmp_TASK, so complete safety proof is unavailable",
+  "protocol_decision": {
+    "decision": "fix_control_task_or_oracle",
+    "required_trials_per_arm": 1,
+    "expected_runs": 6,
+    "family_count": 3,
+    "core_accepted": 2,
+    "on_demand_accepted": 1,
+    "on_demand_contract_failures": 2,
+    "overall_gate": false,
+    "family_gates": [
+      { "family": "instruction_only_rewriting", "core_accepted": 0, "on_demand_accepted": 0, "gate": "failed", "decision": "fix_control_task_or_oracle" },
+      { "family": "reference_backed_extraction", "core_accepted": 1, "on_demand_accepted": 0, "gate": "failed", "decision": "investigate_repeatable_on_demand_gap" },
+      { "family": "script_backed_artifact", "core_accepted": 1, "on_demand_accepted": 1, "gate": "passed", "decision": "retain_current_design" }
+    ]
+  },
+  "frozen": {
+    "source_commit": "3251a36660dbfa37543ba198135331864ae9e6e5",
+    "source_tree": "5a91c1e06ba386b36df78e02601ea12df67f3a2f",
+    "snapshot_digest": "c94cdd5a205e4ba24f0ff03bc314fb3212a3eba16a8ec5db2b9ec619bef8a6d2",
+    "manifest_sha256": "ffc3693e8e0f478d2c62f9200faafdf34cd13cbabcd284934218f543ab59e270",
+    "cli_sha256": "5b4300ffdd7d56ab76b4a9ebd4218ad6de73a54cfe3eb520ce8570629a7f20c6",
+    "bootstrap_sha256": "b3218d7047697e74a2c06cf77f54058aaf47d2da09d1ad8a62bd6774a54da058",
+    "targets_sha256": "6f109d5994c186b1c15a7fd101d44d5ad1ab6b839b8936a8a242556c5331c9b3",
+    "codex_version": "codex-cli 0.147.0",
+    "model": "gpt-5.6-luna",
+    "reasoning_effort": "medium",
+    "timeout_ms": 180000,
+    "driver_sha256": "2df91332990e805d05c3ff0a0530a28b745546f1c703cedcc1674734d397da3e",
+    "pair_invariants": {
+      "transfer-rewrite-001": "68a5b24f1a60bcb313d453a221b97d6395f23145f00765cb4b28708e1ca6ef63",
+      "transfer-extraction-001": "cd2bf0a5d071448a531ae0934a137f41957287e487287d1b1f3230d7fb6ec586",
+      "transfer-artifact-001": "021baeaa7e41a2601b44a7251c2b895650003be8dc4b2dba1323de176df49270"
+    }
+  },
+  "runs": [
+    { "family": "instruction_only_rewriting", "arm": "core", "surface": true, "transcript": true, "harness_valid": false, "load": false, "core_order": false, "oracle": false, "workspace": true, "protected_scopes": true, "accepted": false, "attribution": "invalid_core_control" },
+    { "family": "instruction_only_rewriting", "arm": "on_demand", "surface": true, "transcript": true, "harness_valid": true, "retrieval": true, "exact_load": true, "route_order": false, "oracle": false, "workspace": true, "protected_scopes": true, "accepted": false },
+    { "family": "reference_backed_extraction", "arm": "core", "surface": true, "transcript": true, "harness_valid": true, "load": true, "core_order": true, "oracle": true, "workspace": true, "protected_scopes": true, "accepted": true },
+    { "family": "reference_backed_extraction", "arm": "on_demand", "surface": true, "transcript": true, "harness_valid": true, "retrieval": true, "exact_load": true, "route_order": false, "oracle": true, "workspace": true, "protected_scopes": true, "out_of_scope_write": "private_tmp_TASK_disclosed_and_cleaned", "accepted": false },
+    { "family": "script_backed_artifact", "arm": "core", "surface": true, "transcript": true, "harness_valid": true, "load": true, "core_order": true, "oracle": true, "workspace": true, "protected_scopes": true, "accepted": true },
+    { "family": "script_backed_artifact", "arm": "on_demand", "surface": true, "transcript": true, "harness_valid": true, "retrieval": true, "exact_load": true, "route_order": true, "oracle": true, "workspace": true, "protected_scopes": true, "accepted": true }
+  ],
+  "auth_copies_remaining": 0,
+  "raw_evidence_committed": false
+}

--- a/docs/acceptance/artifacts/codex-three-family-transfer-v1.json
+++ b/docs/acceptance/artifacts/codex-three-family-transfer-v1.json
@@ -11,6 +11,7 @@
     "post_evidence_hardening": true,
     "rerun_after_hardening": false
   },
+  "attribution_phase": "pre_hardening_historical_run; pair attributions below are preserved and not retroactively recomputed",
   "source_identity_stable": true,
   "codex_executable_stable": true,
   "safety_accounting": "scoped_protected_scopes_only; extraction On-demand transcript disclosed an out_of_scope_write_to_private_tmp_TASK, so complete safety proof is unavailable",

--- a/docs/acceptance/codex-three-family-transfer-v1.md
+++ b/docs/acceptance/codex-three-family-transfer-v1.md
@@ -34,8 +34,26 @@ failed family signals are not treated as evidence for changing ranking.
 The redacted artifact records the frozen identities and per-arm gate facts.
 Prompts, transcripts, absolute run paths, full Skill bodies, generated output,
 and authentication are intentionally omitted. Raw evidence remains outside
-the repository. The suite was executed once after commit `3251a36`; no prompt,
-Skill, oracle, scorer, ranking, or rerun was performed after seeing results.
+the repository. The complete candidate suite was executed once from commit
+`3251a36`; no prompt, Skill, oracle, scorer, ranking, or rerun was performed
+after seeing results.
+
+## Run lineage and post-evidence hardening
+
+An earlier pre-run attempt was interrupted after five run roots had been
+created; the artifact-family Core root had no transcript and the attempt
+produced no summary. It is explicitly excluded from formal evidence. The run
+described above is the sole complete formal candidate. The README oracle and
+schema clarifications were committed before that run and were not inferred
+from any result.
+
+After capturing the failed run, this PR hardens the harness for future suites:
+the Codex `workspace-write` policy now excludes the environment temp directory
+and `/tmp`, granting only the unique run-owned temp directory needed by the
+Find audit; a command-visible redirection audit also reports writes outside
+the workspace/run temp. The OS sandbox is the actual confinement boundary,
+while the transcript audit is defense-in-depth. These changes are not applied
+retroactively and no model suite is rerun here.
 
 The result supports the deterministic fact/semantic-agent boundary for the
 script-backed family, while identifying two separate follow-ups: repair the

--- a/docs/acceptance/codex-three-family-transfer-v1.md
+++ b/docs/acceptance/codex-three-family-transfer-v1.md
@@ -1,0 +1,47 @@
+# Codex three-family transfer gate v1
+
+Date: 2026-08-24 (Asia/Shanghai)
+
+Scope: Issue #155 under Issue #129. This is one frozen six-run Codex suite at
+`gpt-5.6-luna` with medium reasoning: one Core/On-demand pair for each of
+three previously untested Skill shapes. It is not a catalog-scale benchmark
+and does not extrapolate to other Agent harnesses.
+
+## Outcome
+
+The suite was formally bound to a clean source commit, manifest, driver,
+Bootstrap, CLI, target packages, executable, model, schedule, and pair
+invariants. All six runs completed with stable source and executable identity,
+but the overall protocol gate **failed** (`formal_gate_eligible: false`). The
+frozen decision is `fix_control_task_or_oracle`.
+
+| Capability family | Core | On-demand | Pair interpretation |
+|---|---|---|---|
+| Instruction-only Chinese rewriting | Control invalid: no complete pre-task Skill load; output oracle also missed the exact date form | Retrieved and loaded the exact target, but route contract and the same output oracle failed | `invalid_core_control` |
+| Reference-backed domain extraction | Passed load, task oracle, workspace, transcript, and scoped protected-scope checks | Retrieved Top-1 and complete exact content, task oracle passed; route contract rejected the model's shell shape, and the transcript revealed an out-of-scope `/private/tmp/TASK` write | `on_demand_specific_failure` with incomplete safety accounting |
+| Script-backed multi-file artifact | Passed, including both output files | Passed one-call retrieval/load, route order, task oracle, and both output files | `no_observed_regression` |
+
+Aggregate: Core `2/3`, On-demand `1/3`, family gates `1/3`. Retrieval and exact
+load passed for both On-demand families that reached the routing stage. The
+driver's protected-scope result is only scoped to target/exposed/auth paths:
+the extraction transcript wrote the full task to `/private/tmp/TASK` before
+Find, so the run is not a complete protected-scope safety proof. The exact
+test-created file was moved to the user's Trash after evidence capture. The
+failed family signals are not treated as evidence for changing ranking.
+
+## Evidence boundary
+
+The redacted artifact records the frozen identities and per-arm gate facts.
+Prompts, transcripts, absolute run paths, full Skill bodies, generated output,
+and authentication are intentionally omitted. Raw evidence remains outside
+the repository. The suite was executed once after commit `3251a36`; no prompt,
+Skill, oracle, scorer, ranking, or rerun was performed after seeing results.
+
+The result supports the deterministic fact/semantic-agent boundary for the
+script-backed family, while identifying two separate follow-ups: repair the
+rewrite Core control before attributing anything to routing, and investigate
+the repeated shell-shape contract and out-of-scope write observability without
+changing ranking.
+
+See the [redacted artifact](artifacts/codex-three-family-transfer-v1.json) and
+the parent [Issue #129](https://github.com/tt-a1i/skillroster/issues/129).

--- a/docs/acceptance/codex-three-family-transfer-v1.md
+++ b/docs/acceptance/codex-three-family-transfer-v1.md
@@ -53,7 +53,8 @@ and `/tmp`, granting only the unique run-owned temp directory needed by the
 Find audit; a command-visible redirection audit also reports writes outside
 the workspace/run temp. The OS sandbox is the actual confinement boundary,
 while the transcript audit is defense-in-depth. These changes are not applied
-retroactively and no model suite is rerun here.
+retroactively: the artifact's historical pair attributions are explicitly
+pre-hardening and remain unchanged. No model suite is rerun here.
 
 The result supports the deterministic fact/semantic-agent boundary for the
 script-backed family, while identifying two separate follow-ups: repair the

--- a/tests/fixtures/codex-cold-routing-transfer-v2.json
+++ b/tests/fixtures/codex-cold-routing-transfer-v2.json
@@ -9,7 +9,7 @@
       "id": "transfer-rewrite-001",
       "family": "instruction_only_rewriting",
       "expected_skill": "zh-rewrite",
-      "prompt": "请阅读 draft.md，把它改写成一段克制、自然的中文团队更新，保存到 outputs/update.md。只保留原文明确写出的发布日期、离线草稿、批量导出、内测人数和反馈人数；去掉夸张表述、问候、收尾建议和任何推断。保留所有日期、数字和事实，不要标题、列表或修改说明，正文控制在 80 到 180 个字符（含标点）。",
+      "prompt": "请阅读 draft.md，把它改写成一段克制、自然的中文团队更新，保存到 outputs/update.md。只保留原文明确写出的发布日期、离线草稿、批量导出、内测人数和反馈人数；去掉夸张表述、问候、收尾建议和任何推断。保留所有日期、数字和事实，不要标题、列表或修改说明，正文控制在 50 到 180 个字符（含标点）。",
       "hint": "Chinese restrained internal update preserving explicit facts",
       "workspace_files": {
         "draft.md": "桌面客户端将在 10 月 8 日发布，首版支持离线草稿和批量导出。内测共有 28 人，其中 19 人反馈批量导出节省了时间。此外，这是迈向卓越体验的关键里程碑，请告诉我是否需要进一步展开。\n"
@@ -19,7 +19,7 @@
       "required_find_calls": 1,
       "oracle": {
         "path": "outputs/update.md",
-        "minimum_characters": 80,
+        "minimum_characters": 50,
         "maximum_characters": 180,
         "required_substrings": ["桌面客户端", "10 月 8 日", "离线草稿", "批量导出", "28", "19"],
         "forbidden_regex": ["^#", "^\\s*[-*+]\\s", "关键里程碑", "卓越体验", "请告诉我", "进一步展开", "另外\\s*9\\s*人", "发布后"]
@@ -68,7 +68,13 @@
             { "position": 1, "name": "offline drafts", "status": "ready" },
             { "position": 2, "name": "batch export", "status": "review" }
           ]
-        }
+        },
+        "required_files": [
+          {
+            "path": "outputs/README.md",
+            "required_substrings": ["# Release checklist", "Items: 2", "1. offline drafts — ready", "2. batch export — review"]
+          }
+        ]
       }
     }
   ]

--- a/tests/fixtures/codex-cold-routing-transfer-v2.json
+++ b/tests/fixtures/codex-cold-routing-transfer-v2.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": 1,
+  "harness": "codex-transfer",
+  "suite_id": "codex-three-family-transfer-v1",
+  "formal_protocol_gate": true,
+  "trials_per_arm": 1,
+  "tasks": [
+    {
+      "id": "transfer-rewrite-001",
+      "family": "instruction_only_rewriting",
+      "expected_skill": "zh-rewrite",
+      "prompt": "请阅读 draft.md，把它改写成一段克制、自然的中文团队更新，保存到 outputs/update.md。只保留原文明确写出的发布日期、离线草稿、批量导出、内测人数和反馈人数；去掉夸张表述、问候、收尾建议和任何推断。保留所有日期、数字和事实，不要标题、列表或修改说明，正文控制在 80 到 180 个字符（含标点）。",
+      "hint": "Chinese restrained internal update preserving explicit facts",
+      "workspace_files": {
+        "draft.md": "桌面客户端将在 10 月 8 日发布，首版支持离线草稿和批量导出。内测共有 28 人，其中 19 人反馈批量导出节省了时间。此外，这是迈向卓越体验的关键里程碑，请告诉我是否需要进一步展开。\n"
+      },
+      "allowed_changed_paths": ["outputs/update.md"],
+      "one_call_load": true,
+      "required_find_calls": 1,
+      "oracle": {
+        "path": "outputs/update.md",
+        "minimum_characters": 80,
+        "maximum_characters": 180,
+        "required_substrings": ["桌面客户端", "10 月 8 日", "离线草稿", "批量导出", "28", "19"],
+        "forbidden_regex": ["^#", "^\\s*[-*+]\\s", "关键里程碑", "卓越体验", "请告诉我", "进一步展开", "另外\\s*9\\s*人", "发布后"]
+      }
+    },
+    {
+      "id": "transfer-extraction-001",
+      "family": "reference_backed_extraction",
+      "expected_skill": "domain-extractor",
+      "prompt": "请阅读 notes.txt，按随附的领域格式抽取其中明确出现的术语、定义和关系，保存为 outputs/glossary.json。只使用原文事实，保持首次出现顺序，输出严格 JSON，不要解释或额外字段。",
+      "hint": "extract exact domain terms and explicit relationships into JSON",
+      "workspace_files": {
+        "notes.txt": "Order Service 负责创建订单。Publish Queue 接收 Order Service 发布的异步事件。Order Service 发布事件到 Publish Queue。\n"
+      },
+      "allowed_changed_paths": ["outputs/glossary.json"],
+      "one_call_load": true,
+      "required_find_calls": 1,
+      "oracle": {
+        "path": "outputs/glossary.json",
+        "json_equals": {
+          "terms": [
+            { "id": "order-service", "label": "Order Service", "definition": "负责创建订单。", "relations": [{ "type": "publishes-event", "target": "publish-queue" }] },
+            { "id": "publish-queue", "label": "Publish Queue", "definition": "接收 Order Service 发布的异步事件。", "relations": [] }
+          ]
+        }
+      }
+    },
+    {
+      "id": "transfer-artifact-001",
+      "family": "script_backed_artifact",
+      "expected_skill": "artifact-builder",
+      "prompt": "请根据 input.json 生成一个多文件交付物，保存到 outputs/。使用随附的程序完成转换，不要手写派生内容；完成后检查 report.json 和 README.md 都存在且内容一致，只告诉我这两个文件的路径。",
+      "hint": "build deterministic multi-file report from structured input",
+      "workspace_files": {
+        "input.json": "{\n  \"title\": \"Release checklist\",\n  \"items\": [\n    {\"name\": \"offline drafts\", \"status\": \"ready\"},\n    {\"name\": \"batch export\", \"status\": \"review\"}\n  ]\n}\n"
+      },
+      "allowed_changed_paths": ["outputs/report.json", "outputs/README.md"],
+      "one_call_load": true,
+      "required_find_calls": 1,
+      "oracle": {
+        "path": "outputs/report.json",
+        "json_equals": {
+          "title": "Release checklist",
+          "item_count": 2,
+          "items": [
+            { "position": 1, "name": "offline drafts", "status": "ready" },
+            { "position": 2, "name": "batch export", "status": "review" }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/codex-cold-routing-transfer.json
+++ b/tests/fixtures/codex-cold-routing-transfer.json
@@ -5,6 +5,7 @@
   "tasks": [
     {
       "id": "transfer-humanize-001",
+      "family": "chinese_style_editing",
       "expected_skill": "humanizer-zh",
       "prompt": "请把 draft.md 改成一段自然、克制的团队内部更新，保存到 outputs/update.md。只保留原文明确写出的发布日期、离线草稿、批量导出、内测总人数和反馈人数，不要补充问候、收尾建议、使用安排，也不要根据人数推导新信息；所有数字和事实都要保留，正文控制在 80 到 180 个字符（含标点），不要标题、列表或修改说明。",
       "hint": "Chinese natural internal update remove AI writing patterns preserve stated facts",
@@ -23,6 +24,7 @@
     },
     {
       "id": "transfer-architecture-001",
+      "family": "interactive_architecture_diagram",
       "expected_skill": "archify",
       "prompt": "请根据 system-overview.txt 生成一份可独立打开的交互式系统架构 HTML，保存为 outputs/order-architecture.html。唯一允许的中间规格文件是 scratch/order-architecture.spec.json，不要创建其他中间文件。页面支持明暗主题，并提供基础的组件搜索和链路追踪交互。架构保持真实而有界：使用 6–8 个组件、2–3 个信任边界、一条主要请求链和一个异步分支，不要强制加入循环、泳道或卡片布局。完成后只告诉我文件路径和校验是否通过。",
       "hint": "interactive standalone system architecture diagram trust boundaries request trace HTML",

--- a/tests/fixtures/codex-protocol-skills/artifact-builder/SKILL.md
+++ b/tests/fixtures/codex-protocol-skills/artifact-builder/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: artifact-builder
+description: Build a deterministic multi-file report from a structured input using the bundled script.
+---
+
+# Artifact builder
+
+Use the bundled `scripts/build-report.mjs` rather than hand-writing the
+derived files. Pass the supplied input path and the requested output directory
+as its two arguments. The script writes the JSON report and a short Markdown
+readme; inspect both files and report only the requested paths when finished.

--- a/tests/fixtures/codex-protocol-skills/artifact-builder/scripts/build-report.mjs
+++ b/tests/fixtures/codex-protocol-skills/artifact-builder/scripts/build-report.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const [inputArg, outputArg] = process.argv.slice(2);
+if (!inputArg || !outputArg) process.exit(64);
+const inputPath = resolve(inputArg);
+const outputDir = resolve(outputArg);
+const input = JSON.parse(readFileSync(inputPath, "utf8"));
+if (typeof input.title !== "string" || !Array.isArray(input.items)) process.exit(65);
+const items = input.items.map((item, index) => ({
+  position: index + 1,
+  name: String(item.name),
+  status: String(item.status),
+}));
+mkdirSync(outputDir, { recursive: true });
+writeFileSync(join(outputDir, "report.json"), `${JSON.stringify({ title: input.title, item_count: items.length, items }, null, 2)}\n`);
+writeFileSync(join(outputDir, "README.md"), `# ${input.title}\n\nItems: ${items.length}\n\n${items.map((item) => `${item.position}. ${item.name} — ${item.status}`).join("\n")}\n`);

--- a/tests/fixtures/codex-protocol-skills/domain-extractor/SKILL.md
+++ b/tests/fixtures/codex-protocol-skills/domain-extractor/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: domain-extractor
+description: Extract a small, exact domain glossary from notes using the package reference schema.
+---
+
+# Domain extraction
+
+Before producing the deliverable, read `references/domain-schema.md` from this
+Skill package and follow its schema exactly. Extract only terms and
+relationships supported by the supplied notes; do not invent definitions,
+owners, aliases, or dependencies. Write valid UTF-8 JSON to the requested
+output path and preserve the reference ordering rules.

--- a/tests/fixtures/codex-protocol-skills/domain-extractor/references/domain-schema.md
+++ b/tests/fixtures/codex-protocol-skills/domain-extractor/references/domain-schema.md
@@ -4,4 +4,7 @@ The output is a JSON object with one key, `terms`. Each term is an object with
 `id`, `label`, `definition`, and `relations`. Use lower-kebab IDs, copy labels
 from the notes, keep definitions to one sentence, and use an empty array when
 no relation is explicitly stated. `relations` contains objects with `type` and
-`target` only. Preserve first appearance order and emit no additional keys.
+`target` only. When the notes say “发布事件到” or “publishes an event to”, the
+relation type is exactly `publishes-event`; its target is the lower-kebab ID of
+the named destination. Preserve first appearance order and emit no additional
+keys.

--- a/tests/fixtures/codex-protocol-skills/domain-extractor/references/domain-schema.md
+++ b/tests/fixtures/codex-protocol-skills/domain-extractor/references/domain-schema.md
@@ -1,0 +1,7 @@
+# Domain glossary schema
+
+The output is a JSON object with one key, `terms`. Each term is an object with
+`id`, `label`, `definition`, and `relations`. Use lower-kebab IDs, copy labels
+from the notes, keep definitions to one sentence, and use an empty array when
+no relation is explicitly stated. `relations` contains objects with `type` and
+`target` only. Preserve first appearance order and emit no additional keys.

--- a/tests/fixtures/codex-protocol-skills/zh-rewrite/SKILL.md
+++ b/tests/fixtures/codex-protocol-skills/zh-rewrite/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: zh-rewrite
+description: Rewrite Chinese internal updates into restrained, natural prose while preserving explicit facts.
+---
+
+# Chinese rewrite
+
+Read the supplied draft before writing. Produce only the requested Chinese
+prose: remove inflated claims, generic transitions, and calls to action while
+preserving every explicit date, feature, count, and result. Never infer a
+remainder, future plan, or sentiment that the draft does not state. Keep the
+requested length and format exactly, and save the final text at the requested
+output path.

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -72,9 +72,12 @@ export function validateManifest(manifest) {
   if (!Number.isSafeInteger(trialsPerArm) || trialsPerArm < 1 || trialsPerArm > 10) fail("trials_per_arm must be between 1 and 10");
   if (manifest.formal_protocol_gate !== undefined && typeof manifest.formal_protocol_gate !== "boolean") fail("formal_protocol_gate must be boolean");
   const ids = new Set();
+  const families = new Set();
   for (const task of manifest.tasks) {
     if (!/^[a-z0-9][a-z0-9-]*$/u.test(task.id ?? "") || ids.has(task.id)) fail("task id must be unique and path-safe");
     ids.add(task.id);
+    if (!/^[a-z0-9][a-z0-9_-]*$/u.test(task.family ?? "") || families.has(task.family)) fail("family must be unique and path-safe");
+    families.add(task.family);
     if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(task.expected_skill ?? "")) fail(`${task.id} expected_skill is unsafe`);
     if (typeof task.prompt !== "string" || !task.prompt || typeof task.hint !== "string" || !task.hint.trim()) fail(`${task.id} requires prompt and hint`);
     const escapedSkill = task.expected_skill.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
@@ -590,16 +593,45 @@ export function classifyPair(core, onDemand) {
   return { attribution: regression ? "on_demand_specific_failure" : "no_observed_regression", cold_routing_regression: regression };
 }
 
-export function deriveProtocolDecision(results, trialsPerArm) {
+function resultFamily(result) { return result.family ?? "default"; }
+
+export function groupPairedResults(tasks, results, trialsPerArm) {
+  return tasks.flatMap((task) => Array.from({ length: trialsPerArm }, (_, index) => {
+    const trial = index + 1; const coreResult = results.find((result) => result.task === task.id && result.trial === trial && result.arm === "core"); const onDemandResult = results.find((result) => result.task === task.id && result.trial === trial && result.arm === "on_demand");
+    if (coreResult && onDemandResult && coreResult.pair_invariant !== onDemandResult.pair_invariant) return { family: task.family, task: task.id, trial, attribution: "pair_invariant_mismatch", gate: "failed", cold_routing_regression: null };
+    if (!coreResult || !onDemandResult) return { family: task.family, task: task.id, trial, attribution: "pair_incomplete", gate: "failed", cold_routing_regression: null };
+    const pair = classifyPair(coreResult.outcome, onDemandResult.outcome);
+    return { family: task.family, task: task.id, trial, ...pair, gate: pair.attribution === "no_observed_regression" ? "passed" : "failed" };
+  }));
+}
+
+export function deriveProtocolDecision(results, trialsPerArm, tasks = null, pairs = null) {
   const core = results.filter((result) => result.arm === "core"); const onDemand = results.filter((result) => result.arm === "on_demand");
   const coreAccepted = core.filter((result) => result.outcome?.accepted === true).length;
   const onDemandAccepted = onDemand.filter((result) => result.outcome?.accepted === true).length;
   const onDemandContractFailures = onDemand.filter((result) => result.outcome?.contract_violation === true || result.outcome?.load !== "loaded").length;
+  const familyIds = [...new Set((tasks ?? results).map((item) => item.family ?? "default"))];
+  const groupedPairs = pairs ?? [];
+  const family_gates = familyIds.map((family) => {
+    const familyResults = results.filter((result) => resultFamily(result) === family);
+    const familyCore = familyResults.filter((result) => result.arm === "core");
+    const familyOnDemand = familyResults.filter((result) => result.arm === "on_demand");
+    const familyPairs = groupedPairs.filter((pair) => pair.family === family);
+    const familyCoreAccepted = familyCore.filter((result) => result.outcome?.accepted === true).length;
+    const familyOnDemandAccepted = familyOnDemand.filter((result) => result.outcome?.accepted === true).length;
+    const familyContractFailures = familyOnDemand.filter((result) => result.outcome?.contract_violation === true || result.outcome?.load !== "loaded").length;
+    let familyDecision = "investigate_repeatable_on_demand_gap";
+    if (familyCoreAccepted < trialsPerArm) familyDecision = "fix_control_task_or_oracle";
+    else if (familyContractFailures >= 2) familyDecision = "fix_bootstrap_or_cli_contract";
+    else if (familyOnDemandAccepted === trialsPerArm
+      && (pairs ? familyPairs.length === trialsPerArm && familyPairs.every((pair) => pair.gate === "passed") : familyCore.length === trialsPerArm && familyOnDemand.length === trialsPerArm)) familyDecision = "retain_current_design";
+    return { family, required_trials_per_arm: trialsPerArm, pair_count: familyPairs.length, core_accepted: familyCoreAccepted, on_demand_accepted: familyOnDemandAccepted, on_demand_contract_failures: familyContractFailures, gate: familyDecision === "retain_current_design" ? "passed" : "failed", decision: familyDecision };
+  });
   let decision = "investigate_repeatable_on_demand_gap";
-  if (coreAccepted < trialsPerArm) decision = "fix_control_task_or_oracle";
+  if (coreAccepted < familyIds.length * trialsPerArm) decision = "fix_control_task_or_oracle";
   else if (onDemandContractFailures >= 2) decision = "fix_bootstrap_or_cli_contract";
-  else if (onDemandAccepted === trialsPerArm) decision = "retain_current_design";
-  return { decision, required_trials_per_arm: trialsPerArm, core_accepted: coreAccepted, on_demand_accepted: onDemandAccepted, on_demand_contract_failures: onDemandContractFailures };
+  else if (family_gates.length > 0 && family_gates.every((gate) => gate.gate === "passed")) decision = "retain_current_design";
+  return { decision, required_trials_per_arm: trialsPerArm, expected_runs: familyIds.length * trialsPerArm * 2, family_count: familyIds.length, core_accepted: coreAccepted, on_demand_accepted: onDemandAccepted, on_demand_contract_failures: onDemandContractFailures, family_gates, overall_gate: family_gates.length > 0 && family_gates.every((gate) => gate.gate === "passed") };
 }
 
 function writeInputs(workspace, files) {
@@ -806,6 +838,7 @@ function freezeSuite(manifest, options) {
       execution_only_flags_unsupported_by_debug: ["ignore_user_config", "sandbox", "ephemeral"],
     },
     arm_schedule: ["core", "on_demand"], trials_per_arm: trialsPerArm,
+    family_schedule: manifest.tasks.map((task) => ({ family: task.family, task: task.id })),
   };
   const snapshotDigest = sha(`${frozenTreeDigest}\0${JSON.stringify(executionContract)}\0${JSON.stringify(sourceIdentity)}\0${JSON.stringify(codexExecutable)}\0${driverSha256}\0${parentVerifierIdentity}`);
   const pairInvariants = {};
@@ -885,7 +918,7 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     const surface = preflightSurface(paths, task, arm, options, env);
     if (!surface.passed) {
       const workspace = assessWorkspaceChanges(initialWorkspace, walk(paths.workspace), Object.keys(task.workspace_files), task.allowed_changed_paths); const protectedScopes = assessProtectedScopes(initialProtected, captureProtectedScopes(protectedPaths));
-      return { task: task.id, trial, arm, surface, workspace, protected_scopes: protectedScopes, outcome: { harness_valid: false, safety: workspace.passed && protectedScopes.passed ? "passed" : "failed", accepted: false }, root };
+      return { family: task.family, task: task.id, trial, arm, surface, workspace, protected_scopes: protectedScopes, outcome: { harness_valid: false, safety: workspace.passed && protectedScopes.passed ? "passed" : "failed", accepted: false }, root };
     }
     let prepared = null;
     if (arm === "on_demand") prepared = prepareOnDemand(paths, task, options, env);
@@ -905,7 +938,7 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     const coreOrder = arm === "core" ? assessCoreOrder(result.stdout, paths.targetPath) : { passed: true, audit_scope: "not_applicable" };
     const transcript = assessTranscriptIntegrity(result.stdout);
     const outcome = deriveArmOutcome({ arm, surface, retrieval, load, oracle, workspace, routeOrder, coreOrder, transcript, protectedScopes });
-    return { task: task.id, trial, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
+    return { family: task.family, task: task.id, trial, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
   } finally {
     cleanupAuth(authCopy);
     cleanupRuntime(paths.temp);
@@ -925,9 +958,9 @@ export function reevaluateExistingRuns(suiteRoot, manifest) {
   for (const task of manifest.tasks) for (let trial = 1; trial <= trialsPerArm; trial += 1) for (const arm of ["core", "on_demand"]) {
     const prefix = trialsPerArm === 1 ? `${task.id}-${arm}-` : `${task.id}-trial-${trial}-${arm}-`;
     const matches = readdirSync(suiteRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory() && entry.name.startsWith(prefix));
-    if (matches.length !== 1) { results.push({ task: task.id, trial, arm, root: null, recomputed: false, formal_evidence_accepted: null, post_hoc_only: true, failures: [`run_root_count:${matches.length}`] }); continue; }
+    if (matches.length !== 1) { results.push({ family: task.family, task: task.id, trial, arm, root: null, recomputed: false, formal_evidence_accepted: null, post_hoc_only: true, failures: [`run_root_count:${matches.length}`] }); continue; }
     const root = join(suiteRoot, matches[0].name); const workspacePath = join(root, "workspace"); const transcriptPath = join(root, "codex-events.jsonl");
-    if (!existsSync(workspacePath) || !existsSync(transcriptPath)) { results.push({ task: task.id, trial, arm, root, recomputed: false, formal_evidence_accepted: null, post_hoc_only: true, failures: ["workspace_or_transcript_missing"] }); continue; }
+    if (!existsSync(workspacePath) || !existsSync(transcriptPath)) { results.push({ family: task.family, task: task.id, trial, arm, root, recomputed: false, formal_evidence_accepted: null, post_hoc_only: true, failures: ["workspace_or_transcript_missing"] }); continue; }
     const transcriptText = readFileSync(transcriptPath, "utf8"); const targetPath = arm === "core" ? join(root, "home", ".codex", "skills", task.expected_skill, "SKILL.md") : join(root, "source", task.expected_skill, "SKILL.md");
     const initial = new Map(Object.entries(task.workspace_files).map(([path, content]) => [path, sha(content)])); const workspace = assessWorkspaceChanges(initial, walk(workspacePath), Object.keys(task.workspace_files), task.allowed_changed_paths);
     const retrieval = arm === "on_demand" ? parseFindAudit(existsSync(join(root, "find-audit.jsonl")) ? readFileSync(join(root, "find-audit.jsonl"), "utf8") : "", { task: task.prompt, skill: task.expected_skill, path: targetPath, oneCall: task.one_call_load === true }) : { count: 0, contract_violation: false };
@@ -936,7 +969,7 @@ export function reevaluateExistingRuns(suiteRoot, manifest) {
     const routeOrder = arm === "on_demand" ? assessRouteOrder(transcriptText, { bootstrapPath: join(root, "home", ".codex", "skills", "skillroster", "SKILL.md"), targetPath, findAudit: retrieval, expectedTask: task.prompt, expectedSkill: task.expected_skill, oneCall: task.one_call_load === true }) : { passed: true, audit_scope: "not_applicable" };
     const coreOrder = arm === "core" ? assessCoreOrder(transcriptText, targetPath) : { passed: true, audit_scope: "not_applicable" };
     const oracle = evaluateOracle(workspacePath, task.oracle, { transcript: transcriptText, targetPackage: dirname(targetPath), parentVerificationAuthority: { mode: "historical_untrusted" } });
-    results.push({ task: task.id, trial, arm, root, recomputed: true, formal_evidence_accepted: null, post_hoc_only: true, recomputed_dimensions: { transcript: transcript.passed, retrieval: arm === "core" ? null : Boolean(retrieval.top1_correct && retrieval.returned_path_exact && !retrieval.contract_violation), load: load.passed, route_order: arm === "core" ? null : routeOrder.passed, core_order: arm === "core" ? coreOrder.passed : null, oracle: oracle.passed, parent_correctness: task.oracle.archify_receipt_contract ? oracle.archify_parent_verification?.passed ?? null : null, workspace: workspace.passed }, transcript, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, historical_evidence_limitations: ["post-hoc result is not a formal gate", "model-visible surface, earliest protected-scope baselines, and original suite ledger were not persisted"] });
+    results.push({ family: task.family, task: task.id, trial, arm, root, recomputed: true, formal_evidence_accepted: null, post_hoc_only: true, recomputed_dimensions: { transcript: transcript.passed, retrieval: arm === "core" ? null : Boolean(retrieval.top1_correct && retrieval.returned_path_exact && !retrieval.contract_violation), load: load.passed, route_order: arm === "core" ? null : routeOrder.passed, core_order: arm === "core" ? coreOrder.passed : null, oracle: oracle.passed, parent_correctness: task.oracle.archify_receipt_contract ? oracle.archify_parent_verification?.passed ?? null : null, workspace: workspace.passed }, transcript, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, historical_evidence_limitations: ["post-hoc result is not a formal gate", "model-visible surface, earliest protected-scope baselines, and original suite ledger were not persisted"] });
   }
   const sourceDigestAfter = stateDigest(suiteRoot); if (sourceDigestAfter !== sourceDigestBefore) fail("reevaluation changed the source run tree");
   return { status: "reevaluated", source_root: canonicalPath(suiteRoot), source_tree_sha256_before: sourceDigestBefore, source_tree_sha256_after: sourceDigestAfter, raw_runs_modified: false, formal_gate_eligible: false, results };
@@ -964,16 +997,13 @@ export function main(argv = process.argv.slice(2)) {
   const tasks = options.task === "all" ? manifest.tasks : manifest.tasks.filter((task) => task.id === options.task); if (!tasks.length) fail(`unknown task: ${options.task}`);
   const arms = options.arm === "both" ? ["core", "on_demand"] : [options.arm]; const results = []; const trialsPerArm = manifest.trials_per_arm ?? 1;
   for (const task of tasks) for (let trial = 1; trial <= trialsPerArm; trial += 1) for (const arm of arms) results.push(executeArm(task, arm, trial, trialsPerArm, runOptions, frozen.facts));
-  const pairs = tasks.flatMap((task) => Array.from({ length: trialsPerArm }, (_, index) => {
-    const trial = index + 1; const coreResult = results.find((result) => result.task === task.id && result.trial === trial && result.arm === "core"); const onDemandResult = results.find((result) => result.task === task.id && result.trial === trial && result.arm === "on_demand");
-    if (coreResult && onDemandResult && coreResult.pair_invariant !== onDemandResult.pair_invariant) return { task: task.id, trial, attribution: "pair_invariant_mismatch", cold_routing_regression: null };
-    return coreResult && onDemandResult ? { task: task.id, trial, ...classifyPair(coreResult.outcome, onDemandResult.outcome) } : { task: task.id, trial, attribution: "pair_incomplete", cold_routing_regression: null };
-  }));
+  const pairs = groupPairedResults(tasks, results, trialsPerArm);
   const completeSchedule = tasks.length === manifest.tasks.length && arms.length === 2 && results.length === manifest.tasks.length * trialsPerArm * 2;
   const sourceIdentityAfter = repositoryIdentity(); const sourceIdentityStable = JSON.stringify(sourceIdentityAfter) === JSON.stringify(frozen.facts.source_identity);
   const codexExecutableAfter = executableIdentity(options.codex); const codexExecutableStable = JSON.stringify(codexExecutableAfter) === JSON.stringify(frozen.facts.codex_executable);
+  const protocolDecision = manifest.formal_protocol_gate === true ? deriveProtocolDecision(results, trialsPerArm, tasks, pairs) : null;
   const formalGateEligible = completeSchedule && sourceIdentityStable && codexExecutableStable && results.every(formalResultEligible) && pairs.every((pair) => pair.attribution !== "pair_invariant_mismatch" && pair.attribution !== "pair_incomplete");
-  const summary = { status: results.every((result) => result.outcome?.accepted) && pairs.every((pair) => pair.attribution !== "pair_invariant_mismatch") ? "passed" : "failed", suite_id: manifest.suite_id, formal_gate_eligible: formalGateEligible, source_identity_stable: sourceIdentityStable, source_identity_after: sourceIdentityAfter, codex_executable_stable: codexExecutableStable, codex_executable_after: codexExecutableAfter, protocol_decision: manifest.formal_protocol_gate === true ? deriveProtocolDecision(results, trialsPerArm) : null, suite_snapshot: frozen.facts, signal_cleanup: "SIGINT/SIGTERM remove auth copies and runtime state best effort; SIGKILL cannot guarantee cleanup", results, pairs };
+  const summary = { status: results.every((result) => result.outcome?.accepted) && pairs.every((pair) => pair.gate === "passed") ? "passed" : "failed", suite_id: manifest.suite_id, formal_gate_eligible: formalGateEligible, source_identity_stable: sourceIdentityStable, source_identity_after: sourceIdentityAfter, codex_executable_stable: codexExecutableStable, codex_executable_after: codexExecutableAfter, protocol_decision: protocolDecision, suite_snapshot: frozen.facts, signal_cleanup: "SIGINT/SIGTERM remove auth copies and runtime state best effort; SIGKILL cannot guarantee cleanup", results, pairs };
   emitSummary(summary, options); return summary.status === "passed" ? 0 : 2;
 }
 

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -633,7 +633,8 @@ export function deriveArmOutcome({ arm, surface, retrieval, load, oracle, worksp
 
 export function classifyPair(core, onDemand) {
   if (!core.harness_valid || core.task !== "succeeded" || core.load !== "loaded" || core.safety !== "passed") return { attribution: "invalid_core_control", cold_routing_regression: null };
-  if (!onDemand.harness_valid || onDemand.safety !== "passed") return { attribution: "invalid_on_demand_harness", cold_routing_regression: null };
+  if (!onDemand.harness_valid) return { attribution: "invalid_on_demand_harness", cold_routing_regression: null };
+  if (onDemand.safety !== "passed") return { attribution: "on_demand_safety_failure", cold_routing_regression: null };
   const regression = onDemand.task !== "succeeded" || onDemand.retrieval !== "retrieved" || onDemand.load !== "loaded" || onDemand.safety !== "passed" || onDemand.contract_violation;
   return { attribution: regression ? "on_demand_specific_failure" : "no_observed_regression", cold_routing_regression: regression };
 }
@@ -665,15 +666,18 @@ export function deriveProtocolDecision(results, trialsPerArm, tasks = null, pair
     const familyCoreAccepted = familyCore.filter((result) => result.outcome?.accepted === true).length;
     const familyOnDemandAccepted = familyOnDemand.filter((result) => result.outcome?.accepted === true).length;
     const familyContractFailures = familyOnDemand.filter((result) => result.outcome?.contract_violation === true || result.outcome?.load !== "loaded").length;
+    const familySafetyInvalid = familyResults.some((result) => result.outcome?.safety !== "passed");
     let familyDecision = "investigate_repeatable_on_demand_gap";
-    if (familyCoreAccepted < trialsPerArm) familyDecision = "fix_control_task_or_oracle";
+    if (familySafetyInvalid) familyDecision = "stop_invalid_safety_evidence";
+    else if (familyCoreAccepted < trialsPerArm) familyDecision = "fix_control_task_or_oracle";
     else if (familyContractFailures >= 2) familyDecision = "fix_bootstrap_or_cli_contract";
     else if (familyOnDemandAccepted === trialsPerArm
       && (pairs ? familyPairs.length === trialsPerArm && familyPairs.every((pair) => pair.gate === "passed") : familyCore.length === trialsPerArm && familyOnDemand.length === trialsPerArm)) familyDecision = "retain_current_design";
     return { family, required_trials_per_arm: trialsPerArm, pair_count: familyPairs.length, core_accepted: familyCoreAccepted, on_demand_accepted: familyOnDemandAccepted, on_demand_contract_failures: familyContractFailures, gate: familyDecision === "retain_current_design" ? "passed" : "failed", decision: familyDecision };
   });
   let decision = "investigate_repeatable_on_demand_gap";
-  if (coreAccepted < familyIds.length * trialsPerArm) decision = "fix_control_task_or_oracle";
+  if (results.some((result) => result.outcome?.safety !== "passed")) decision = "stop_invalid_safety_evidence";
+  else if (coreAccepted < familyIds.length * trialsPerArm) decision = "fix_control_task_or_oracle";
   else if (family_gates.some((gate) => gate.on_demand_contract_failures >= 2)) decision = "fix_bootstrap_or_cli_contract";
   else if (family_gates.length > 0 && family_gates.every((gate) => gate.gate === "passed")) decision = "retain_current_design";
   return { decision, required_trials_per_arm: trialsPerArm, expected_runs: familyIds.length * trialsPerArm * 2, family_count: familyIds.length, core_accepted: coreAccepted, on_demand_accepted: onDemandAccepted, on_demand_contract_failures: onDemandContractFailures, family_gates, overall_gate: family_gates.length > 0 && family_gates.every((gate) => gate.gate === "passed") };

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -326,6 +326,27 @@ export function assessTranscriptIntegrity(jsonl) {
   return { passed: violations.length === 0, violations, turn_completed_count: turnCompleted, successful_command_count: successfulCommands, unsuccessful_command_count: unsuccessfulCommands };
 }
 
+function writeTargetAllowed(path, workspace, tempRoot) {
+  const candidate = isAbsolute(path) ? resolve(path) : resolve(workspace, path);
+  return inside(candidate, workspace) || inside(candidate, tempRoot);
+}
+
+export function assessExternalWrites(jsonl, workspace, tempRoot) {
+  const targets = []; const violations = [];
+  const commands = extractCommandEvents(jsonl).filter((event) => event.kind === "command");
+  const redirection = /(?:^|\s)(?:\d*>>?|\d*<>)[ \t]*(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/gu;
+  for (const [eventIndex, event] of commands.entries()) {
+    for (const match of event.command.matchAll(redirection)) {
+      const raw = match[1] ?? match[2] ?? match[3];
+      if (["/dev/null", "NUL", "nul"].includes(raw)) continue;
+      const target = { raw, canonical: canonicalPath(isAbsolute(raw) ? raw : join(workspace, raw)), event_index: eventIndex, command: event.command };
+      const allowed = writeTargetAllowed(raw, workspace, tempRoot); targets.push({ ...target, allowed });
+      if (!allowed) violations.push(`external_write_target:${target.canonical}`);
+    }
+  }
+  return { passed: violations.length === 0, violations: [...new Set(violations)], targets, audit_scope: "command-visible explicit redirection targets; OS sandbox is the actual write boundary" };
+}
+
 export function extractCommandTexts(jsonl) { return extractCommandEvents(jsonl).filter((event) => event.kind === "command").map((event) => event.command); }
 
 function unwrapSimpleShell(command) {
@@ -584,8 +605,8 @@ export function assessCoreOrder(transcript, targetPath) {
   return { passed: violations.length === 0, violations, audit_scope: "Core first-action full-load gate over Codex command event state machine" };
 }
 
-export function deriveArmOutcome({ arm, surface, retrieval, load, oracle, workspace, routeOrder = { passed: true }, coreOrder = { passed: true }, transcript = { passed: true }, protectedScopes = { passed: true } }) {
-  const safety = workspace.passed && protectedScopes.passed ? "passed" : "failed";
+export function deriveArmOutcome({ arm, surface, retrieval, load, oracle, workspace, routeOrder = { passed: true }, coreOrder = { passed: true }, transcript = { passed: true }, protectedScopes = { passed: true }, externalWrites = { passed: true } }) {
+  const safety = workspace.passed && protectedScopes.passed && externalWrites.passed ? "passed" : "failed";
   const harnessValid = surface.passed && transcript.passed && (arm !== "core" || coreOrder.passed);
   const retrievalStage = arm === "core" ? "core_control" : retrieval.count === 0 ? "no_retrieval" : retrieval.top1_correct ? "retrieved" : "retrieval_wrong";
   const loadStage = arm === "core" ? load.passed ? "loaded" : "load_wrong" : load.passed && retrieval.returned_path_exact ? "loaded" : "load_wrong";
@@ -602,6 +623,7 @@ export function deriveArmOutcome({ arm, surface, retrieval, load, oracle, worksp
 
 export function classifyPair(core, onDemand) {
   if (!core.harness_valid || core.task !== "succeeded" || core.load !== "loaded" || core.safety !== "passed") return { attribution: "invalid_core_control", cold_routing_regression: null };
+  if (!onDemand.harness_valid || onDemand.safety !== "passed") return { attribution: "invalid_on_demand_harness", cold_routing_regression: null };
   const regression = onDemand.task !== "succeeded" || onDemand.retrieval !== "retrieved" || onDemand.load !== "loaded" || onDemand.safety !== "passed" || onDemand.contract_violation;
   return { attribution: regression ? "on_demand_specific_failure" : "no_observed_regression", cold_routing_regression: regression };
 }
@@ -642,7 +664,7 @@ export function deriveProtocolDecision(results, trialsPerArm, tasks = null, pair
   });
   let decision = "investigate_repeatable_on_demand_gap";
   if (coreAccepted < familyIds.length * trialsPerArm) decision = "fix_control_task_or_oracle";
-  else if (onDemandContractFailures >= 2) decision = "fix_bootstrap_or_cli_contract";
+  else if (family_gates.some((gate) => gate.on_demand_contract_failures >= 2)) decision = "fix_bootstrap_or_cli_contract";
   else if (family_gates.length > 0 && family_gates.every((gate) => gate.gate === "passed")) decision = "retain_current_design";
   return { decision, required_trials_per_arm: trialsPerArm, expected_runs: familyIds.length * trialsPerArm * 2, family_count: familyIds.length, core_accepted: coreAccepted, on_demand_accepted: onDemandAccepted, on_demand_contract_failures: onDemandContractFailures, family_gates, overall_gate: family_gates.length > 0 && family_gates.every((gate) => gate.gate === "passed") };
 }
@@ -850,6 +872,7 @@ function freezeSuite(manifest, options) {
       isolated_non_repository_workspace: true,
       execution_only_flags_unsupported_by_debug: ["ignore_user_config", "sandbox", "ephemeral"],
     },
+    sandbox_policy: { workspace_write: { exclude_tmpdir_env_var: true, exclude_slash_tmp: true, add_dir: "unique_run_temp" } },
     arm_schedule: ["core", "on_demand"], trials_per_arm: trialsPerArm,
     family_schedule: manifest.tasks.map((task) => ({ family: task.family, task: task.id })),
   };
@@ -863,6 +886,15 @@ function freezeSuite(manifest, options) {
     target_packages: targetPackages, trials_per_arm: trialsPerArm, pair_invariants: pairInvariants,
   };
   return { options: { ...options, skillsRoot: targets, bootstrap: join(bootstrapRoot, basename(options.bootstrap)), cli }, facts };
+}
+
+export function codexSandboxPolicy(tempRoot) {
+  return { exclude_tmpdir_env_var: true, exclude_slash_tmp: true, add_dirs: [canonicalPath(tempRoot)] };
+}
+
+export function codexExecutionArgs(options, paths, prompt) {
+  const policy = codexSandboxPolicy(paths.temp);
+  return ["exec", "--ephemeral", "--ignore-user-config", "--sandbox", "workspace-write", "--add-dir", policy.add_dirs[0], "--skip-git-repo-check", "--json", "-c", "sandbox_workspace_write.exclude_tmpdir_env_var=true", "-c", "sandbox_workspace_write.exclude_slash_tmp=true", ...codexModelConfig(options), "-C", paths.workspace, prompt];
 }
 
 function codexModelConfig(options) { return ["-c", `model=${JSON.stringify(options.model)}`, "-c", `model_reasoning_effort=${JSON.stringify(options.reasoningEffort)}`]; }
@@ -916,7 +948,8 @@ export function formalResultEligible(result) {
     && result.transcript?.passed === true
     && result.workspace?.passed === true
     && result.protected_scopes?.passed === true
-    && result.outcome?.harness_valid === true);
+    && result.outcome?.harness_valid === true
+    && result.outcome?.safety === "passed");
 }
 
 function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
@@ -931,14 +964,15 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     const surface = preflightSurface(paths, task, arm, options, env);
     if (!surface.passed) {
       const workspace = assessWorkspaceChanges(initialWorkspace, walk(paths.workspace), Object.keys(task.workspace_files), task.allowed_changed_paths); const protectedScopes = assessProtectedScopes(initialProtected, captureProtectedScopes(protectedPaths));
-      return { family: task.family, task: task.id, trial, arm, surface, workspace, protected_scopes: protectedScopes, outcome: { harness_valid: false, safety: workspace.passed && protectedScopes.passed ? "passed" : "failed", accepted: false }, root };
+      const externalWrites = assessExternalWrites("", paths.workspace, paths.temp);
+      return { family: task.family, task: task.id, trial, arm, surface, workspace, protected_scopes: protectedScopes, external_writes: externalWrites, outcome: { harness_valid: false, safety: workspace.passed && protectedScopes.passed && externalWrites.passed ? "passed" : "failed", accepted: false }, root };
     }
     let prepared = null;
     if (arm === "on_demand") prepared = prepareOnDemand(paths, task, options, env);
     const runEnv = { ...env };
     if (prepared) Object.assign(runEnv, { SKILLROSTER_REAL_CLI: options.cli, SKILLROSTER_TEST_HOME: paths.home, SKILLROSTER_TEST_STATE: paths.state, SKILLROSTER_FIND_AUDIT: paths.runtimeAudit });
     if (prepared) runEnv.PATH = `${prepared.bin}:${process.env.PATH ?? "/usr/bin:/bin"}`;
-    const result = run(options.codex, ["exec", "--ephemeral", "--ignore-user-config", "--sandbox", "workspace-write", "--skip-git-repo-check", "--json", ...codexModelConfig(options), "-C", paths.workspace, task.prompt], { cwd: paths.workspace, env: runEnv, timeout: options.timeoutMs });
+    const result = run(options.codex, codexExecutionArgs(options, paths, task.prompt), { cwd: paths.workspace, env: runEnv, timeout: options.timeoutMs });
     const protectedScopes = assessProtectedScopes(initialProtected, captureProtectedScopes(protectedPaths));
     writeFileSync(paths.transcript, result.stdout, { mode: 0o600 });
     if (existsSync(paths.runtimeAudit)) copyFileSync(paths.runtimeAudit, paths.audit);
@@ -950,8 +984,9 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     const routeOrder = arm === "on_demand" ? assessRouteOrder(result.stdout, { bootstrapPath: join(paths.codexHome, "skills", "skillroster", "SKILL.md"), targetPath: paths.targetPath, findAudit: retrieval, expectedTask: task.prompt, expectedSkill: task.expected_skill, oneCall: task.one_call_load === true }) : { passed: true, audit_scope: "not_applicable" };
     const coreOrder = arm === "core" ? assessCoreOrder(result.stdout, paths.targetPath) : { passed: true, audit_scope: "not_applicable" };
     const transcript = assessTranscriptIntegrity(result.stdout);
-    const outcome = deriveArmOutcome({ arm, surface, retrieval, load, oracle, workspace, routeOrder, coreOrder, transcript, protectedScopes });
-    return { family: task.family, task: task.id, trial, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
+    const externalWrites = assessExternalWrites(result.stdout, paths.workspace, paths.temp);
+    const outcome = deriveArmOutcome({ arm, surface, retrieval, load, oracle, workspace, routeOrder, coreOrder, transcript, protectedScopes, externalWrites });
+    return { family: task.family, task: task.id, trial, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, external_writes: externalWrites, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
   } finally {
     cleanupAuth(authCopy);
     cleanupRuntime(paths.temp);

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -90,6 +90,12 @@ export function validateManifest(manifest) {
     if (task.allowed_changed_paths.some((path) => Object.hasOwn(task.workspace_files ?? {}, path))) fail(`${task.id} cannot mutate an input`);
     safeRelative(task.oracle?.path, `${task.id} oracle path`);
     if (!task.allowed_changed_paths.includes(task.oracle.path)) fail(`${task.id} oracle path must be allowlisted`);
+    for (const requiredFile of task.oracle.required_files ?? []) {
+      safeRelative(requiredFile?.path, `${task.id} required file path`);
+      if (!task.allowed_changed_paths.includes(requiredFile.path)) fail(`${task.id} required file path must be allowlisted`);
+      for (const value of requiredFile.required_substrings ?? []) if (typeof value !== "string" || !value) fail(`${task.id} required file substring must be non-empty`);
+      for (const value of requiredFile.required_regex ?? []) new RegExp(value, "u");
+    }
     for (const pattern of [...(task.oracle.required_regex ?? []), ...(task.oracle.forbidden_regex ?? [])]) new RegExp(pattern, "u");
     if (task.oracle?.json_equals !== undefined && (task.oracle.json_equals === null || typeof task.oracle.json_equals !== "object")) fail(`${task.id} json_equals must be an object or array`);
     const receipt = task.oracle.archify_receipt_contract;
@@ -190,6 +196,13 @@ export function evaluateOracle(workspace, oracle, evidence = {}) {
   for (const value of oracle.forbidden_substrings ?? []) if (text.includes(value)) failures.push(`forbidden_substring:${value}`);
   for (const value of oracle.required_regex ?? []) if (!new RegExp(value, "u").test(text)) failures.push(`missing_regex:${value}`);
   for (const value of oracle.forbidden_regex ?? []) if (new RegExp(value, "u").test(text)) failures.push(`forbidden_regex:${value}`);
+  for (const requiredFile of oracle.required_files ?? []) {
+    const requiredPath = noFollowWorkspaceFile(workspace, requiredFile.path);
+    if (!requiredPath) { failures.push(`required_file:unsafe_or_missing:${requiredFile.path}`); continue; }
+    const requiredText = readFileSync(requiredPath, "utf8");
+    for (const value of requiredFile.required_substrings ?? []) if (!requiredText.includes(value)) failures.push(`required_file:missing_substring:${requiredFile.path}:${value}`);
+    for (const value of requiredFile.required_regex ?? []) if (!new RegExp(value, "u").test(requiredText)) failures.push(`required_file:missing_regex:${requiredFile.path}:${value}`);
+  }
   if (oracle.json_equals !== undefined) {
     let actual; try { actual = JSON.parse(text); } catch { failures.push("json_equals:invalid_json"); }
     if (actual !== undefined && JSON.stringify(canonicalJson(actual)) !== JSON.stringify(canonicalJson(oracle.json_equals))) failures.push("json_equals:mismatch");

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -331,13 +331,23 @@ function writeTargetAllowed(path, workspace, tempRoot) {
   return inside(candidate, workspace) || inside(candidate, tempRoot);
 }
 
+function explicitWritePaths(command) {
+  const paths = []; const redirection = /(?:^|\s)(?:\d*>>?|\d*<>)[ \t]*(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/gu;
+  for (const match of command.matchAll(redirection)) paths.push(match[1] ?? match[2] ?? match[3]);
+  const tokens = simpleCommandTokens(command); if (!tokens?.length) return paths;
+  const executable = basename(tokens[0]).toLowerCase(); const args = tokens.slice(1).filter((token) => token !== "--");
+  const nonOptions = args.filter((token) => !token.startsWith("-"));
+  if (["touch", "mkdir", "tee"].includes(executable)) paths.push(...nonOptions);
+  else if (["cp", "mv", "install"].includes(executable) && nonOptions.length >= 2) paths.push(nonOptions.at(-1));
+  else if (executable === "sed" && args.includes("-i") && nonOptions.length) paths.push(nonOptions.at(-1));
+  return paths;
+}
+
 export function assessExternalWrites(jsonl, workspace, tempRoot) {
   const targets = []; const violations = [];
   const commands = extractCommandEvents(jsonl).filter((event) => event.kind === "command");
-  const redirection = /(?:^|\s)(?:\d*>>?|\d*<>)[ \t]*(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/gu;
   for (const [eventIndex, event] of commands.entries()) {
-    for (const match of event.command.matchAll(redirection)) {
-      const raw = match[1] ?? match[2] ?? match[3];
+    for (const raw of explicitWritePaths(event.command)) {
       if (["/dev/null", "NUL", "nul"].includes(raw)) continue;
       const target = { raw, canonical: canonicalPath(isAbsolute(raw) ? raw : join(workspace, raw)), event_index: eventIndex, command: event.command };
       const allowed = writeTargetAllowed(raw, workspace, tempRoot); targets.push({ ...target, allowed });

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
@@ -48,10 +48,11 @@ test("default is a non-executing plan and execution requires explicit auth", () 
 });
 
 test("Codex execution freezes temp confinement and grants only the unique run temp", () => {
-  const policy = codexSandboxPolicy("/tmp/run-temp");
-  assert.deepEqual(policy, { exclude_tmpdir_env_var: true, exclude_slash_tmp: true, add_dirs: ["/tmp/run-temp"] });
-  const args = codexExecutionArgs({ model: "gpt-5.6-luna", reasoningEffort: "medium" }, { temp: "/tmp/run-temp", workspace: "/tmp/workspace" }, "task");
-  assert.ok(args.includes("--add-dir")); assert.ok(args.includes("/tmp/run-temp"));
+  const runTemp = resolve("/tmp/run-temp");
+  const policy = codexSandboxPolicy(runTemp);
+  assert.deepEqual(policy, { exclude_tmpdir_env_var: true, exclude_slash_tmp: true, add_dirs: [runTemp] });
+  const args = codexExecutionArgs({ model: "gpt-5.6-luna", reasoningEffort: "medium" }, { temp: runTemp, workspace: resolve("/tmp/workspace") }, "task");
+  assert.ok(args.includes("--add-dir")); assert.ok(args.includes(runTemp));
   assert.ok(args.includes("sandbox_workspace_write.exclude_tmpdir_env_var=true"));
   assert.ok(args.includes("sandbox_workspace_write.exclude_slash_tmp=true"));
 });
@@ -194,9 +195,9 @@ test("external write audit rejects redirections outside workspace and run temp",
   const safe = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "printf ok > outputs/result.txt", aggregated_output: "", exit_code: 0, status: "completed" } });
   const unsafe = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "printf secret > /private/tmp/TASK", aggregated_output: "", exit_code: 0, status: "completed" } });
   assert.equal(assessExternalWrites(safe, workspace, temp).passed, true);
-  assert.match(assessExternalWrites(unsafe, workspace, temp).violations.join("\n"), /private\/tmp\/TASK/u);
+  assert.equal(assessExternalWrites(unsafe, workspace, temp).violations.includes(`external_write_target:${resolve("/private/tmp/TASK")}`), true);
   const commandWrite = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "mkdir -p /private/tmp/TASK", aggregated_output: "", exit_code: 0, status: "completed" } });
-  assert.match(assessExternalWrites(commandWrite, workspace, temp).violations.join("\n"), /private\/tmp\/TASK/u);
+  assert.equal(assessExternalWrites(commandWrite, workspace, temp).violations.includes(`external_write_target:${resolve("/private/tmp/TASK")}`), true);
 });
 
 test("prompt-input preflight permits only fixed Codex system skills plus the arm skill", () => {

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -185,6 +185,8 @@ test("external write audit rejects redirections outside workspace and run temp",
   const unsafe = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "printf secret > /private/tmp/TASK", aggregated_output: "", exit_code: 0, status: "completed" } });
   assert.equal(assessExternalWrites(safe, workspace, temp).passed, true);
   assert.match(assessExternalWrites(unsafe, workspace, temp).violations.join("\n"), /private\/tmp\/TASK/u);
+  const commandWrite = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "mkdir -p /private/tmp/TASK", aggregated_output: "", exit_code: 0, status: "completed" } });
+  assert.match(assessExternalWrites(commandWrite, workspace, temp).violations.join("\n"), /private\/tmp\/TASK/u);
 });
 
 test("prompt-input preflight permits only fixed Codex system skills plus the arm skill", () => {

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -424,6 +424,16 @@ test("JSON oracle compares structure without depending on object key order", () 
   assert.deepEqual(evaluateOracle(root, oracle).failures, ["json_equals:invalid_json"]);
 });
 
+test("JSON oracle can require a bounded companion file", () => {
+  const root = mkdtempSync(join(tmpdir(), "codex-required-file-oracle-")); mkdirSync(join(root, "outputs"));
+  writeFileSync(join(root, "outputs/report.json"), JSON.stringify({ ok: true }));
+  writeFileSync(join(root, "outputs/README.md"), "# Report\nItems: 2\n");
+  const oracle = { path: "outputs/report.json", json_equals: { ok: true }, required_files: [{ path: "outputs/README.md", required_substrings: ["# Report", "Items: 2"] }] };
+  assert.equal(evaluateOracle(root, oracle).passed, true);
+  writeFileSync(join(root, "outputs/README.md"), "# Report\n");
+  assert.deepEqual(evaluateOracle(root, oracle).failures, ["required_file:missing_substring:outputs/README.md:Items: 2"]);
+});
+
 test("Archify transcript attempts require exact shape and lifecycle order", () => {
   const root = mkdtempSync(join(tmpdir(), "codex-archify-receipts-")); const workspace = join(root, "workspace"); const target = join(root, "archify"); const spec = join(workspace, "scratch", "order.spec.json"); const artifact = join(workspace, "outputs", "order.html"); const script = join(target, "bin", "archify.mjs");
   mkdirSync(join(workspace, "scratch"), { recursive: true }); mkdirSync(join(workspace, "outputs"), { recursive: true }); mkdirSync(join(target, "bin"), { recursive: true }); writeFileSync(spec, "{\"type\":\"architecture\"}\n"); writeFileSync(artifact, "<html>static token stuffing</html>\n"); writeFileSync(script, "// frozen tool");

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { assessCoreOrder, assessExactLoad, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalResultEligible, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, setupArm, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
+import { assessCoreOrder, assessExactLoad, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalResultEligible, groupPairedResults, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, setupArm, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
 
 const DRIVER = fileURLToPath(new URL("./driver.mjs", import.meta.url));
 
@@ -91,8 +91,8 @@ test("offline reevaluation writes only outside the immutable source run tree", (
 
 test("manifest supports bounded one-or-more-task Codex protocol suites", () => {
   const manifest = { schema_version: 1, harness: "codex-transfer", tasks: [
-    { id: "a", expected_skill: "one", prompt: "p", hint: "h", workspace_files: { "in.txt": "x" }, allowed_changed_paths: ["out.md"], oracle: { path: "out.md" } },
-    { id: "b", expected_skill: "two", prompt: "p", hint: "h", workspace_files: {}, allowed_changed_paths: ["out.md"], oracle: { path: "out.md" } },
+    { id: "a", family: "family-a", expected_skill: "one", prompt: "p", hint: "h", workspace_files: { "in.txt": "x" }, allowed_changed_paths: ["out.md"], oracle: { path: "out.md" } },
+    { id: "b", family: "family-b", expected_skill: "two", prompt: "p", hint: "h", workspace_files: {}, allowed_changed_paths: ["out.md"], oracle: { path: "out.md" } },
   ] };
   assert.equal(validateManifest(manifest), manifest);
   assert.throws(() => validateManifest({ ...manifest, harness: "pi" }), /unsupported/u);
@@ -100,9 +100,39 @@ test("manifest supports bounded one-or-more-task Codex protocol suites", () => {
   assert.throws(() => validateManifest({ ...manifest, tasks: [], trials_per_arm: 3 }), /unsupported/u);
   assert.throws(() => validateManifest({ ...manifest, trials_per_arm: 0 }), /trials_per_arm/u);
   assert.throws(() => validateManifest({ ...manifest, formal_protocol_gate: "yes" }), /formal_protocol_gate/u);
+  assert.throws(() => validateManifest({ ...manifest, tasks: [{ ...manifest.tasks[0], family: "family-b" }, manifest.tasks[1]] }), /family must be unique/u);
+  assert.throws(() => validateManifest({ ...manifest, tasks: [{ ...manifest.tasks[0], family: "Family A" }, manifest.tasks[1]] }), /family must be unique/u);
   for (const prompt of ["use SkillRoster", "run capability search", "please Find it", "做能力检索", "load one"]) {
     assert.throws(() => validateManifest({ ...manifest, tasks: [{ ...manifest.tasks[0], prompt }] }), /must not disclose/u);
   }
+});
+
+test("multi-family protocol aggregation counts every task pair and emits one gate per family", () => {
+  const tasks = [{ id: "a", family: "rewrite" }, { id: "b", family: "extract" }, { id: "c", family: "artifact" }];
+  const results = tasks.flatMap((task) => [
+    { family: task.family, task: task.id, trial: 1, arm: "core", pair_invariant: `${task.id}-pair`, outcome: { accepted: true, harness_valid: true, task: "succeeded", load: "loaded", safety: "passed" } },
+    { family: task.family, task: task.id, trial: 1, arm: "on_demand", pair_invariant: `${task.id}-pair`, outcome: { accepted: true, harness_valid: true, task: "succeeded", load: "loaded", safety: "passed", retrieval: "retrieved", contract_violation: false } },
+  ]);
+  const pairs = groupPairedResults(tasks, results, 1);
+  assert.deepEqual(pairs.map((pair) => [pair.family, pair.gate]), [["rewrite", "passed"], ["extract", "passed"], ["artifact", "passed"]]);
+  const decision = deriveProtocolDecision(results, 1, tasks, pairs);
+  assert.equal(decision.expected_runs, 6);
+  assert.equal(decision.core_accepted, 3);
+  assert.equal(decision.on_demand_accepted, 3);
+  assert.equal(decision.overall_gate, true);
+  assert.deepEqual(decision.family_gates.map((gate) => gate.family), ["rewrite", "extract", "artifact"]);
+  assert.ok(decision.family_gates.every((gate) => gate.gate === "passed"));
+});
+
+test("a failed family gate cannot be hidden by passing families", () => {
+  const tasks = [{ id: "rewrite", family: "rewrite" }, { id: "extract", family: "extract" }];
+  const result = (task, family, arm, accepted) => ({ family, task, trial: 1, arm, pair_invariant: `${task}-pair`, outcome: { accepted, harness_valid: true, task: accepted ? "succeeded" : "failed", load: accepted ? "loaded" : "load_wrong", safety: "passed", retrieval: accepted ? "retrieved" : "retrieval_wrong", contract_violation: !accepted } });
+  const results = [result("rewrite", "rewrite", "core", true), result("rewrite", "rewrite", "on_demand", true), result("extract", "extract", "core", true), result("extract", "extract", "on_demand", false)];
+  const pairs = groupPairedResults(tasks, results, 1);
+  const decision = deriveProtocolDecision(results, 1, tasks, pairs);
+  assert.equal(decision.overall_gate, false);
+  assert.equal(decision.family_gates.find((gate) => gate.family === "rewrite").gate, "passed");
+  assert.equal(decision.family_gates.find((gate) => gate.family === "extract").gate, "failed");
 });
 
 test("formal eligibility requires a complete successful harness record, not a task pass", () => {
@@ -454,4 +484,13 @@ test("fixture remains readable and contains only the two previously passing fami
   const fixture = JSON.parse(readFileSync(new URL("../../fixtures/codex-cold-routing-transfer.json", import.meta.url)));
   validateManifest(fixture);
   assert.deepEqual(fixture.tasks.map((task) => task.expected_skill).sort(), ["archify", "humanizer-zh"]);
+});
+
+test("sealed transfer fixture keeps three distinct capability families and six scheduled runs", () => {
+  const fixture = JSON.parse(readFileSync(new URL("../../fixtures/codex-cold-routing-transfer-v2.json", import.meta.url)));
+  validateManifest(fixture);
+  assert.equal(fixture.formal_protocol_gate, true);
+  assert.deepEqual(fixture.tasks.map((task) => task.family), ["instruction_only_rewriting", "reference_backed_extraction", "script_backed_artifact"]);
+  assert.equal(fixture.tasks.length * 2 * fixture.trials_per_arm, 6);
+  assert.equal(new Set(fixture.tasks.map((task) => task.family)).size, 3);
 });

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -163,7 +163,7 @@ test("pair invariant is frozen from the suite snapshot and complete task input",
 });
 
 test("protocol decision applies the frozen stop conditions", () => {
-  const result = (arm, accepted, overrides = {}) => ({ arm, outcome: { accepted, load: "loaded", contract_violation: false, ...overrides } });
+  const result = (arm, accepted, overrides = {}) => ({ arm, outcome: { accepted, safety: "passed", load: "loaded", contract_violation: false, ...overrides } });
   assert.equal(deriveProtocolDecision([result("core", true), result("core", false), result("core", true)], 3).decision, "fix_control_task_or_oracle");
   const core = Array.from({ length: 3 }, () => result("core", true));
   const contractFailures = [result("on_demand", false, { load: "load_wrong" }), result("on_demand", false, { contract_violation: true }), result("on_demand", true)];
@@ -177,6 +177,16 @@ test("repeated contract failures must occur within one family", () => {
   const pairs = [{ family: "a", gate: "failed" }, { family: "b", gate: "failed" }];
   const results = [result("a", "core", true), result("a", "on_demand", false, true), result("b", "core", true), result("b", "on_demand", false, true)];
   assert.equal(deriveProtocolDecision(results, 1, tasks, pairs).decision, "investigate_repeatable_on_demand_gap");
+});
+
+test("safety-invalid evidence takes the family and global stop path", () => {
+  const result = (family, arm, safety) => ({ family, arm, outcome: { accepted: false, harness_valid: true, safety, task: "succeeded", load: "loaded", contract_violation: false } });
+  const tasks = [{ id: "safe", family: "safe" }, { id: "unsafe", family: "unsafe" }];
+  const pairs = [{ family: "safe", gate: "failed" }, { family: "unsafe", gate: "failed" }];
+  const results = [result("safe", "core", "passed"), result("safe", "on_demand", "passed"), result("unsafe", "core", "passed"), result("unsafe", "on_demand", "failed")];
+  const decision = deriveProtocolDecision(results, 1, tasks, pairs);
+  assert.equal(decision.decision, "stop_invalid_safety_evidence");
+  assert.equal(decision.family_gates.find((gate) => gate.family === "unsafe").decision, "stop_invalid_safety_evidence");
 });
 
 test("external write audit rejects redirections outside workspace and run temp", () => {
@@ -515,7 +525,7 @@ test("a failed Core control prevents cold-routing attribution", () => {
   assert.deepEqual(classifyPair({ ...good, task: "failed" }, good), { attribution: "invalid_core_control", cold_routing_regression: null });
   assert.deepEqual(classifyPair(good, { ...good, contract_violation: true }), { attribution: "on_demand_specific_failure", cold_routing_regression: true });
   assert.deepEqual(classifyPair(good, { ...good, harness_valid: false }), { attribution: "invalid_on_demand_harness", cold_routing_regression: null });
-  assert.deepEqual(classifyPair(good, { ...good, safety: "failed" }), { attribution: "invalid_on_demand_harness", cold_routing_regression: null });
+  assert.deepEqual(classifyPair(good, { ...good, safety: "failed" }), { attribution: "on_demand_safety_failure", cold_routing_regression: null });
   assert.deepEqual(classifyPair(good, good), { attribution: "no_observed_regression", cold_routing_regression: false });
 });
 

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { assessCoreOrder, assessExactLoad, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, deriveArmOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalResultEligible, groupPairedResults, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, setupArm, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
+import { assessCoreOrder, assessExactLoad, assessExternalWrites, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, codexExecutionArgs, codexSandboxPolicy, deriveArmOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalResultEligible, groupPairedResults, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, setupArm, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
 
 const DRIVER = fileURLToPath(new URL("./driver.mjs", import.meta.url));
 
@@ -45,6 +45,15 @@ test("default is a non-executing plan and execution requires explicit auth", () 
   assert.equal(parseArgs(["--reevaluate-root", "/tmp/existing-runs"]).execute, false);
   assert.throws(() => parseArgs(["--execute", "--auth-source", "/tmp/auth.json", "--reevaluate-root", "/tmp/runs"]), /mutually exclusive/u);
   assert.throws(() => main(["--runs-dir", fileURLToPath(new URL("../../../tests/transcripts", import.meta.url))]), /outside the repository/u);
+});
+
+test("Codex execution freezes temp confinement and grants only the unique run temp", () => {
+  const policy = codexSandboxPolicy("/tmp/run-temp");
+  assert.deepEqual(policy, { exclude_tmpdir_env_var: true, exclude_slash_tmp: true, add_dirs: ["/tmp/run-temp"] });
+  const args = codexExecutionArgs({ model: "gpt-5.6-luna", reasoningEffort: "medium" }, { temp: "/tmp/run-temp", workspace: "/tmp/workspace" }, "task");
+  assert.ok(args.includes("--add-dir")); assert.ok(args.includes("/tmp/run-temp"));
+  assert.ok(args.includes("sandbox_workspace_write.exclude_tmpdir_env_var=true"));
+  assert.ok(args.includes("sandbox_workspace_write.exclude_slash_tmp=true"));
 });
 
 test("summary output preserves stdout JSON in a private external file", { skip: process.platform === "win32" }, () => {
@@ -136,11 +145,11 @@ test("a failed family gate cannot be hidden by passing families", () => {
 });
 
 test("formal eligibility requires a complete successful harness record, not a task pass", () => {
-  const eligible = { pair_invariant: "frozen", codex_exit_code: 0, surface: { passed: true }, transcript: { passed: true }, workspace: { passed: true }, protected_scopes: { passed: true }, outcome: { harness_valid: true, accepted: false } };
+  const eligible = { pair_invariant: "frozen", codex_exit_code: 0, surface: { passed: true }, transcript: { passed: true }, workspace: { passed: true }, protected_scopes: { passed: true }, outcome: { harness_valid: true, safety: "passed", accepted: false } };
   assert.equal(formalResultEligible(eligible), true);
   for (const mutation of [
     { codex_exit_code: 124 }, { transcript: { passed: false } }, { surface: { passed: false } },
-    { workspace: { passed: false } }, { protected_scopes: { passed: false } }, { outcome: { harness_valid: false } },
+    { workspace: { passed: false } }, { protected_scopes: { passed: false } }, { outcome: { harness_valid: false } }, { outcome: { harness_valid: true, safety: "failed" } },
   ]) assert.equal(formalResultEligible({ ...eligible, ...mutation }), false);
 });
 
@@ -160,6 +169,22 @@ test("protocol decision applies the frozen stop conditions", () => {
   const contractFailures = [result("on_demand", false, { load: "load_wrong" }), result("on_demand", false, { contract_violation: true }), result("on_demand", true)];
   assert.equal(deriveProtocolDecision([...core, ...contractFailures], 3).decision, "fix_bootstrap_or_cli_contract");
   assert.equal(deriveProtocolDecision([...core, ...Array.from({ length: 3 }, () => result("on_demand", true))], 3).decision, "retain_current_design");
+});
+
+test("repeated contract failures must occur within one family", () => {
+  const result = (family, arm, accepted, contractViolation = false) => ({ family, arm, outcome: { accepted, harness_valid: true, safety: "passed", task: accepted ? "succeeded" : "failed", load: accepted ? "loaded" : "load_wrong", contract_violation: contractViolation } });
+  const tasks = [{ id: "a", family: "a" }, { id: "b", family: "b" }];
+  const pairs = [{ family: "a", gate: "failed" }, { family: "b", gate: "failed" }];
+  const results = [result("a", "core", true), result("a", "on_demand", false, true), result("b", "core", true), result("b", "on_demand", false, true)];
+  assert.equal(deriveProtocolDecision(results, 1, tasks, pairs).decision, "investigate_repeatable_on_demand_gap");
+});
+
+test("external write audit rejects redirections outside workspace and run temp", () => {
+  const workspace = "/tmp/workspace"; const temp = "/tmp/run-temp";
+  const safe = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "printf ok > outputs/result.txt", aggregated_output: "", exit_code: 0, status: "completed" } });
+  const unsafe = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "printf secret > /private/tmp/TASK", aggregated_output: "", exit_code: 0, status: "completed" } });
+  assert.equal(assessExternalWrites(safe, workspace, temp).passed, true);
+  assert.match(assessExternalWrites(unsafe, workspace, temp).violations.join("\n"), /private\/tmp\/TASK/u);
 });
 
 test("prompt-input preflight permits only fixed Codex system skills plus the arm skill", () => {
@@ -487,6 +512,8 @@ test("a failed Core control prevents cold-routing attribution", () => {
   const good = { harness_valid: true, task: "succeeded", safety: "passed", retrieval: "retrieved", load: "loaded", contract_violation: false };
   assert.deepEqual(classifyPair({ ...good, task: "failed" }, good), { attribution: "invalid_core_control", cold_routing_regression: null });
   assert.deepEqual(classifyPair(good, { ...good, contract_violation: true }), { attribution: "on_demand_specific_failure", cold_routing_regression: true });
+  assert.deepEqual(classifyPair(good, { ...good, harness_valid: false }), { attribution: "invalid_on_demand_harness", cold_routing_regression: null });
+  assert.deepEqual(classifyPair(good, { ...good, safety: "failed" }), { attribution: "invalid_on_demand_harness", cold_routing_regression: null });
   assert.deepEqual(classifyPair(good, good), { attribution: "no_observed_regression", cold_routing_regression: false });
 });
 


### PR DESCRIPTION
## Summary

Addresses #155 with a bounded multi-family Codex cold-routing harness extension and one redacted acceptance record.

- requires a unique, path-safe `family` per manifest task;
- aggregates `tasks × trials_per_arm` and emits explicit per-family gates plus an overall gate;
- freezes family schedule and propagates family identity through pairs/results;
- adds three distinct fixtures: instruction-only Chinese rewriting, reference-backed extraction, and script-backed multi-file artifact generation;
- adds a bounded `required_files` oracle for companion artifacts;
- records the single complete six-run sealed result without rerun or post-result prompt/Skill/oracle/ranking changes;
- hardens future runs with OS sandbox temp confinement, command-visible external-write auditing, and fail-closed safety attribution.

## Result

The suite is intentionally **failed / not formally eligible** under the Issue stop rules: Core 2/3, On-demand 1/3, family gates 1/3. The rewrite Core control did not fully load before acting; extraction On-demand passed retrieval/load/task but violated route order and disclosed an out-of-scope `/private/tmp/TASK` write not covered by the historical run's protected scopes; artifact family passed both arms. The acceptance docs explicitly mark the historical safety accounting as scoped/incomplete and record cleanup.

An earlier interrupted pre-run produced no summary and is excluded from evidence. Post-evidence safety hardening has not been applied retroactively and the model suite was not rerun.

## Verification

- `node --test tests/harness/codex-cold-routing/driver.test.mjs` (47 passed)
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (214 unit + 8 acceptance + 62 CLI passed)
- fixture dry-run confirms 6 scheduled runs

Do not merge or release from this PR; it is awaiting final independent review and parent #129 decision.
