### PR TITLE
test: parse quoted Find punctuation safely

### DIFF
--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -373,14 +373,15 @@ function simpleCommandTokens(command) {
     if (char === "`" || (char === "$" && value[index + 1] === "(")) return null;
     if (quote) {
       if (char === quote) quote = null;
-      else if (quote === '"' && char === "\\") { index += 1; if (index >= value.length) return null; token += value[index]; }
+      else if (quote === '"' && char === "\\") { index += 1; if (index >= value.length || /[\r\n]/u.test(value[index])) return null; token += value[index]; }
       else token += char;
       continue;
     }
     if (char === "'" || char === '"') { quote = char; continue; }
     if (/[|;&<>]/u.test(char)) return null;
+    if (/[\r\n]/u.test(char)) return null;
     if (/\s/u.test(char)) { if (token) { tokens.push(token); token = ""; } continue; }
-    if (char === "\\") { index += 1; if (index >= value.length) return null; token += value[index]; continue; }
+    if (char === "\\") { index += 1; if (index >= value.length || /[\r\n]/u.test(value[index])) return null; token += value[index]; continue; }
     token += char;
   }
   if (quote) return null;

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -367,12 +367,18 @@ function unwrapSimpleShell(command) {
 
 function simpleCommandTokens(command) {
   const value = unwrapSimpleShell(command);
-  if (/[|;&<>`]|\$\(/u.test(value)) return null;
   const tokens = []; let token = ""; let quote = null;
   for (let index = 0; index < value.length; index += 1) {
     const char = value[index];
-    if (quote) { if (char === quote) quote = null; else token += char; continue; }
+    if (char === "`" || (char === "$" && value[index + 1] === "(")) return null;
+    if (quote) {
+      if (char === quote) quote = null;
+      else if (quote === '"' && char === "\\") { index += 1; if (index >= value.length) return null; token += value[index]; }
+      else token += char;
+      continue;
+    }
     if (char === "'" || char === '"') { quote = char; continue; }
+    if (/[|;&<>]/u.test(char)) return null;
     if (/\s/u.test(char)) { if (token) { tokens.push(token); token = ""; } continue; }
     if (char === "\\") { index += 1; if (index >= value.length) return null; token += value[index]; continue; }
     token += char;

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -389,6 +389,12 @@ test("on-demand route order permits metadata-authorized Find followed by exact t
   const directFind = [event("skillroster find '完整任务' --hint 'agent hint' --json"), event(`cat '${realpathSync(target)}'`, "target")].join("\n");
   const directAssessment = assessRouteOrder(directFind, { bootstrapPath: bootstrap, targetPath: target, findAudit, expectedTask: "完整任务", expectedSkill: "sample" });
   assert.equal(directAssessment.passed, true); assert.equal(directAssessment.bootstrap_loaded, false);
+  const quotedPunctuation = [event("skillroster find '完整任务' --hint 'literal ; & | < > punctuation' --json"), event(`cat '${realpathSync(target)}'`, "target")].join("\n");
+  assert.equal(assessRouteOrder(quotedPunctuation, { bootstrapPath: bootstrap, targetPath: target, findAudit, expectedTask: "完整任务", expectedSkill: "sample" }).passed, true);
+  for (const unsafeHint of ["'agent $(echo unsafe)'", "'agent `echo unsafe`'"]) {
+    const unsafeExpansion = [event("skillroster find '完整任务' --hint " + unsafeHint + " --json"), event(`cat '${realpathSync(target)}'`, "target")].join("\n");
+    assert.match(assessRouteOrder(unsafeExpansion, { bootstrapPath: bootstrap, targetPath: target, findAudit, expectedTask: "完整任务", expectedSkill: "sample" }).violations.join(","), /find_shell_shape_invalid/u);
+  }
   const unsafePrefix = [event(`printf task > /tmp/TASK && skillroster find '完整任务' --hint 'agent hint' --json`), event(`cat '${realpathSync(target)}'`, "target")].join("\n");
   assert.match(assessRouteOrder(unsafePrefix, { bootstrapPath: bootstrap, targetPath: target, findAudit, expectedTask: "完整任务", expectedSkill: "sample" }).violations.join(","), /find_shell_shape_invalid/u);
   const assignment = [event(`TASK='完整任务'; skillroster find "$TASK" --hint 'agent hint' --json`), event(`cat '${realpathSync(target)}'`, "target")].join("\n");

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -395,6 +395,12 @@ test("on-demand route order permits metadata-authorized Find followed by exact t
     const unsafeExpansion = [event("skillroster find '完整任务' --hint " + unsafeHint + " --json"), event(`cat '${realpathSync(target)}'`, "target")].join("\n");
     assert.match(assessRouteOrder(unsafeExpansion, { bootstrapPath: bootstrap, targetPath: target, findAudit, expectedTask: "完整任务", expectedSkill: "sample" }).violations.join(","), /find_shell_shape_invalid/u);
   }
+  const quotedNewline = [event("skillroster find '完整任务' --hint 'agent\nnewline' --json"), event(`cat '${realpathSync(target)}'`, "target")].join("\n");
+  assert.equal(assessRouteOrder(quotedNewline, { bootstrapPath: bootstrap, targetPath: target, findAudit, expectedTask: "完整任务", expectedSkill: "sample" }).passed, true);
+  for (const unsafeNewline of ["skillroster find '完整任务' --hint 'agent' --json\ntouch /private/tmp/TASK", "/bin/zsh -lc \"skillroster find '完整任务' --hint 'agent' --json\nrm -rf /\"", "skillroster find '完整任务' --hint agent\\\ntouch --json"]) {
+    const transcript = [event(unsafeNewline), event(`cat '${realpathSync(target)}'`, "target")].join("\n");
+    assert.match(assessRouteOrder(transcript, { bootstrapPath: bootstrap, targetPath: target, findAudit, expectedTask: "完整任务", expectedSkill: "sample" }).violations.join(","), /find_shell_shape_invalid/u);
+  }
   const unsafePrefix = [event(`printf task > /tmp/TASK && skillroster find '完整任务' --hint 'agent hint' --json`), event(`cat '${realpathSync(target)}'`, "target")].join("\n");
   assert.match(assessRouteOrder(unsafePrefix, { bootstrapPath: bootstrap, targetPath: target, findAudit, expectedTask: "完整任务", expectedSkill: "sample" }).violations.join(","), /find_shell_shape_invalid/u);
   const assignment = [event(`TASK='完整任务'; skillroster find "$TASK" --hint 'agent hint' --json`), event(`cat '${realpathSync(target)}'`, "target")].join("\n");


### PR DESCRIPTION
Closes #157.

Updates the deterministic Codex scorer so shell control characters inside quoted Find arguments remain literal, while unquoted operators, command substitution, and backticks still fail closed. The existing extraction compound command remains invalid. Adds focused route-order regressions only; no Agent suite was rerun and no historical evidence was rewritten.

Verification: `node --test tests/harness/codex-cold-routing/driver.test.mjs` (47/47), `git diff --check`.