### PR TITLE
test: add byte-level read-only dogfood ledger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,10 @@ jobs:
           node --check tests/harness/pi-cold-routing/bounds.mjs
           node --check tests/harness/pi-cold-routing/runner.mjs
           node --check tests/harness/codex-cold-routing/driver.mjs
+          node --check tests/harness/byte-ledger/ledger.mjs
+          node --check scripts/byte-ledger.mjs
           node --experimental-strip-types --check tests/harness/pi-cold-routing/gate.ts
-          node --test tests/harness/pi-cold-routing/*.test.mjs tests/harness/codex-cold-routing/*.test.mjs
+          node --test tests/harness/pi-cold-routing/*.test.mjs tests/harness/codex-cold-routing/*.test.mjs tests/harness/byte-ledger/*.test.mjs
 
   portability:
     name: ${{ matrix.name }}
@@ -139,8 +141,10 @@ jobs:
           node --check tests/harness/pi-cold-routing/bounds.mjs
           node --check tests/harness/pi-cold-routing/runner.mjs
           node --check tests/harness/codex-cold-routing/driver.mjs
+          node --check tests/harness/byte-ledger/ledger.mjs
+          node --check scripts/byte-ledger.mjs
           node --experimental-strip-types --check tests/harness/pi-cold-routing/gate.ts
-          node --test tests/harness/pi-cold-routing/*.test.mjs tests/harness/codex-cold-routing/*.test.mjs
+          node --test tests/harness/pi-cold-routing/*.test.mjs tests/harness/codex-cold-routing/*.test.mjs tests/harness/byte-ledger/*.test.mjs
 
   gate:
     name: CI gate

--- a/docs/acceptance/artifacts/real-agent-dogfood-issue-165.json
+++ b/docs/acceptance/artifacts/real-agent-dogfood-issue-165.json
@@ -10,7 +10,14 @@
   "execution": {
     "sequence": ["ledger_before", "scan", "report", "find", "find", "status", "ledger_after", "compare"],
     "state_isolated": true,
+    "estate_assumption": "quiescent",
+    "directory_race_guarantee": "drift_detecting_not_adversarial_concurrent_capability",
     "raw_evidence": "external_isolated_directory_not_committed",
+    "evidence_bundle": {
+      "record_count": 10,
+      "bundle_sha256": "2c1a2e48245dce1f256ef030a178c1932c541f8be3617afae6e93bfaac716c71",
+      "exploratory_attempts_included": false
+    },
     "mutations_allowed": false,
     "product_network_used": false
   },
@@ -54,6 +61,7 @@
   },
   "decision": {
     "approved_scoped_estate_byte_stable": true,
+    "concurrent_hostile_directory_race_proven": false,
     "all_home_files_unchanged": false,
     "semantic_or_routing_claim": false,
     "governance_authorized": false

--- a/docs/acceptance/artifacts/real-agent-dogfood-issue-165.json
+++ b/docs/acceptance/artifacts/real-agent-dogfood-issue-165.json
@@ -15,7 +15,7 @@
     "raw_evidence": "external_isolated_directory_not_committed",
     "evidence_bundle": {
       "record_count": 10,
-      "bundle_sha256": "2c1a2e48245dce1f256ef030a178c1932c541f8be3617afae6e93bfaac716c71",
+      "bundle_sha256": "eb965d82044f24351f4817e07be17809ffcdfac2cd2bf76a2a08d229c9de0346",
       "exploratory_attempts_included": false
     },
     "mutations_allowed": false,

--- a/docs/acceptance/artifacts/real-agent-dogfood-issue-165.json
+++ b/docs/acceptance/artifacts/real-agent-dogfood-issue-165.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "suite_id": "real-agent-dogfood-issue-165",
+  "issue": 165,
+  "status": "completed_read_only_byte_ledger",
+  "source": {
+    "commit": "26a60ee6b76a9cb3c76e0d71b2f76e1bf2281b4e",
+    "binary_version": "skillroster 1.8.24"
+  },
+  "execution": {
+    "sequence": ["ledger_before", "scan", "report", "find", "find", "status", "ledger_after", "compare"],
+    "state_isolated": true,
+    "raw_evidence": "external_isolated_directory_not_committed",
+    "mutations_allowed": false,
+    "product_network_used": false
+  },
+  "scope": {
+    "scan_skill_roots_included": 21,
+    "canonical_non_symlink_roots_ledgered": 18,
+    "symlink_root_aliases_refused": 3,
+    "explicit_config_paths": 4,
+    "regular_file_content_hashed": true,
+    "directory_structure_recorded": true,
+    "symlink_targets_followed": false
+  },
+  "ledger": {
+    "before_digest": "db32a5511ea6658cfe3236ff3328869b0dccf9aa0ffeb4340414c516c2eab2d2",
+    "after_digest": "db32a5511ea6658cfe3236ff3328869b0dccf9aa0ffeb4340414c516c2eab2d2",
+    "equal": true,
+    "added_records": 0,
+    "removed_records": 0,
+    "changed_records": 0,
+    "record_count": 3944,
+    "regular_file_count": 2797,
+    "directory_count": 1140,
+    "symlink_count": 7,
+    "regular_file_bytes": 70262720,
+    "external_target_count": 7,
+    "external_target_bytes": "out_of_scope_and_not_hashed"
+  },
+  "cli": {
+    "scan": {"independent_skills": 251, "placements": 887, "files_changed": false},
+    "report": {"finding_count": 177, "default_exposure": 521, "observed_use_agents": 3},
+    "coverage": {"limited_agents": 5, "missing_agents": 3, "complete_agents": 0},
+    "status": {"files_changed": false, "recovery_state": "clear", "journal_issues": 0, "pending_plan_count": 0},
+    "commands_mutating_real_estate": false
+  },
+  "privacy": {
+    "absolute_paths": false,
+    "file_names": false,
+    "file_contents": false,
+    "credentials": false,
+    "raw_session_text": false
+  },
+  "decision": {
+    "approved_scoped_estate_byte_stable": true,
+    "all_home_files_unchanged": false,
+    "semantic_or_routing_claim": false,
+    "governance_authorized": false
+  }
+}

--- a/docs/acceptance/real-agent-dogfood-issue-165.md
+++ b/docs/acceptance/real-agent-dogfood-issue-165.md
@@ -24,7 +24,7 @@ provide an adversarial concurrent-directory guarantee.
 - State and evidence were isolated; no Apply, Setup, Undo, Plan persistence,
   delete, purge, roster/config/Skill mutation, or external-target read ran.
 - Frozen evidence bundle: 10 JSON records, bundle digest
-  `2c1a2e48245dce1f256ef030a178c1932c541f8be3617afae6e93bfaac716c71`.
+  `eb965d82044f24351f4817e07be17809ffcdfac2cd2bf76a2a08d229c9de0346`.
   Earlier exploratory captures and failed invocations are excluded from this
   acceptance bundle and are not used for its claims.
 

--- a/docs/acceptance/real-agent-dogfood-issue-165.md
+++ b/docs/acceptance/real-agent-dogfood-issue-165.md
@@ -1,0 +1,54 @@
+# Byte-level zero-change ledger — Issue #165
+
+Date: 2026-08-24 (Asia/Shanghai)
+
+This addendum strengthens the read-only real-agent dogfood from Issue #163. It
+uses the independent Node standard-library ledger helper in
+`tests/harness/byte-ledger/ledger.mjs`; raw ledgers and command output remain
+outside the repository. The public artifact contains only aggregates,
+digests, and boundary statements.
+
+## Run and scope
+
+- Candidate: `skillroster 1.8.24`, source `26a60ee6b76a9cb3c76e0d71b2f76e1bf2281b4e`
+- Sequence: before ledger → read-only Scan → Report → two Find queries →
+  Status → after ledger → redacted comparison
+- Approved scope: 18 canonical non-symlink Skill roots derived from the 21
+  Scan-included Skill roots; three Agent roots were symlink aliases of the
+  shared root and were refused as roots by the helper's fail-closed policy.
+- Explicit configuration inputs: four regular files supplied in a separate
+  newline-delimited list
+- State and evidence were isolated; no Apply, Setup, Undo, Plan persistence,
+  delete, purge, roster/config/Skill mutation, or external-target read ran.
+
+## Byte-ledger result
+
+Before and after both contain 3,944 records: 2,797 regular files, 1,140
+directories, and 7 symlinks. Regular-file bytes total 70,262,720. The before
+and after ledger digest is the same (`db32a5511ea6658cfe3236ff3328869b0dccf9aa0ffeb4340414c516c2eab2d2`),
+with zero added, removed, or changed records. The four explicit configuration
+files also match by content digest.
+
+Seven symlinks resolve outside the approved root set. Their link identity and
+target spelling were recorded, but their targets were not followed, read, or
+hashed. Those target bytes are explicitly out of scope.
+
+## CLI evidence
+
+The read-only flow reported 251 independent Skills, 887 placements, 521
+default exposures, and 177 Findings. Observed usage covered three Agents, but
+coverage remained incomplete (five limited roots and three missing roots), so
+absence is still unknown rather than “never used”. Final Status reported
+`files_changed=false`, recovery `clear`, zero journal issues, and zero pending
+Plans.
+
+## Acceptance boundary
+
+The approved Skill/config estate covered by this ledger was byte-stable across
+the flow. This does not prove that every file in Home, dynamic sessions/logs,
+caches, repository files, isolated state, or external symlink targets was
+unchanged. It also does not add semantic intent quality, routing superiority,
+or a governance authorization claim.
+
+The redacted machine record is
+[`real-agent-dogfood-issue-165.json`](artifacts/real-agent-dogfood-issue-165.json).

--- a/docs/acceptance/real-agent-dogfood-issue-165.md
+++ b/docs/acceptance/real-agent-dogfood-issue-165.md
@@ -6,7 +6,10 @@ This addendum strengthens the read-only real-agent dogfood from Issue #163. It
 uses the independent Node standard-library ledger helper in
 `tests/harness/byte-ledger/ledger.mjs`; raw ledgers and command output remain
 outside the repository. The public artifact contains only aggregates,
-digests, and boundary statements.
+digests, and boundary statements. The run assumes a quiescent estate: the
+helper detects observed path drift and refuses unsafe inputs, but Node's
+cross-platform standard library has no `openat/readdir(fd)` capability to
+provide an adversarial concurrent-directory guarantee.
 
 ## Run and scope
 
@@ -20,6 +23,10 @@ digests, and boundary statements.
   newline-delimited list
 - State and evidence were isolated; no Apply, Setup, Undo, Plan persistence,
   delete, purge, roster/config/Skill mutation, or external-target read ran.
+- Frozen evidence bundle: 10 JSON records, bundle digest
+  `2c1a2e48245dce1f256ef030a178c1932c541f8be3617afae6e93bfaac716c71`.
+  Earlier exploratory captures and failed invocations are excluded from this
+  acceptance bundle and are not used for its claims.
 
 ## Byte-ledger result
 
@@ -44,11 +51,12 @@ Plans.
 
 ## Acceptance boundary
 
-The approved Skill/config estate covered by this ledger was byte-stable across
-the flow. This does not prove that every file in Home, dynamic sessions/logs,
+The approved Skill/config estate covered by this quiescent run was byte-stable
+across the flow. This does not prove that every file in Home, dynamic sessions/logs,
 caches, repository files, isolated state, or external symlink targets was
-unchanged. It also does not add semantic intent quality, routing superiority,
-or a governance authorization claim.
+unchanged, nor does it claim byte stability against a concurrent hostile
+directory rename/symlink race. It also does not add semantic intent quality,
+routing superiority, or a governance authorization claim.
 
 The redacted machine record is
 [`real-agent-dogfood-issue-165.json`](artifacts/real-agent-dogfood-issue-165.json).

--- a/scripts/byte-ledger.mjs
+++ b/scripts/byte-ledger.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { runCli } from "../tests/harness/byte-ledger/ledger.mjs";
+
+runCli(process.argv.slice(2)).catch((error) => {
+  process.stderr.write(`${error.code ?? "error"}: ${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tests/harness/byte-ledger/ledger.mjs
+++ b/tests/harness/byte-ledger/ledger.mjs
@@ -31,6 +31,22 @@ const canonical = (path) => {
   try { return realpathSync.native(absolute); } catch { return absolute; }
 };
 
+const canonicalSafePath = (path, label) => {
+  let current = resolve(path); const missing = [];
+  while (true) {
+    let mode;
+    try { mode = lstatSync(current); }
+    catch (error) {
+      if (error.code !== "ENOENT") fail("unreadable_scope", `${label} cannot be inspected`);
+      const parent = dirname(current); if (parent === current) fail("unreadable_scope", `${label} cannot be inspected`);
+      missing.unshift(current.slice(parent.length + (parent.endsWith(sep) ? 0 : 1))); current = parent; continue;
+    }
+    if (mode.isSymbolicLink()) fail("unsafe_scope", `${label} has a symlink ancestor`);
+    let real; try { real = realpathSync.native(current); } catch { fail("unreadable_scope", `${label} cannot be resolved`); }
+    return resolve(real, ...missing);
+  }
+};
+
 const isWithin = (child, parent) => {
   const relation = relative(parent, child);
   return relation === "" || (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation));
@@ -112,9 +128,9 @@ export const validateScope = ({ approvedRoots, configPaths = [], evidenceDir, re
   for (const [input, label] of [[evidenceInput, "evidence directory"], [repositoryInput, "repository directory"], [stateInput, "state directory"]]) {
     try { if (lstatSync(input).isSymbolicLink()) fail("unsafe_scope", `${label} must not be a symlink`); } catch (error) { if (error instanceof LedgerError) throw error; }
   }
-  const evidence = canonical(evidenceInput);
-  const repository = canonical(repositoryInput);
-  const state = canonical(stateInput);
+  const evidence = canonicalSafePath(evidenceInput, "evidence directory");
+  const repository = canonicalSafePath(repositoryInput, "repository directory");
+  const state = canonicalSafePath(stateInput, "state directory");
   if (overlapsForbidden(evidence, [home, repository, state]) || overlapsForbidden(repository, [state])) fail("unsafe_scope", "evidence, repository, and state directories overlap");
   const forbidden = [evidence, repository, state]
     .filter((entry) => entry !== undefined && entry !== null)
@@ -310,13 +326,18 @@ export const redactedComparison = (before, after) => {
   };
 };
 
-export const writeRawLedger = (ledger, outputPath, evidenceDir) => {
+export const writeRawLedger = (ledger, outputPath, evidenceDir, boundaries = {}) => {
   validateLedger(ledger);
   const output = requireAbsolute(outputPath, "ledger output");
   const lexicalEvidence = requireAbsolute(evidenceDir, "evidence directory");
+  const boundaryPaths = [boundaries.homeDir, boundaries.repositoryDir, boundaries.stateDir].filter(Boolean).map((path) => canonicalSafePath(requireAbsolute(path, "boundary directory"), "boundary directory"));
+  if (boundaryPaths.length !== 3) fail("invalid_scope", "raw ledger boundaries are required");
+  const initialEvidence = canonicalSafePath(lexicalEvidence, "evidence directory");
+  if (overlapsForbidden(initialEvidence, boundaryPaths)) fail("unsafe_output", "evidence directory overlaps a forbidden boundary");
   if (!isWithin(output, lexicalEvidence) || output === lexicalEvidence) fail("unsafe_output", "raw ledger must be written inside evidence directory");
   try { mkdirSync(lexicalEvidence, { recursive: true }); } catch { fail("write_failed", "evidence directory could not be created"); }
-  const evidence = canonical(lexicalEvidence);
+  const evidence = canonicalSafePath(lexicalEvidence, "evidence directory");
+  if (evidence !== initialEvidence || overlapsForbidden(evidence, boundaryPaths)) fail("unsafe_output", "evidence directory drifted into a forbidden boundary");
   const safeOutput = resolve(evidence, relative(lexicalEvidence, output));
   if (dirname(safeOutput) !== evidence || !isWithin(canonical(dirname(safeOutput)), evidence)) fail("unsafe_output", "raw ledger must be directly inside evidence directory");
   let descriptor;
@@ -338,6 +359,13 @@ const readListArg = (path, label) => {
   finally { if (opened !== undefined) closeSync(opened.descriptor); }
   return parsePathList(text, label);
 };
+const readJsonArg = (path, label) => {
+  const absolute = requireAbsolute(path, `${label} file`); let opened; let text;
+  try { opened = openNoFollow(absolute); text = readFileSync(opened.descriptor, "utf8"); const current = lstatSync(absolute); if (!sameIdentity(opened.opened, current) || current.isSymbolicLink()) fail("input_drift", `${label} file changed while it was read`); }
+  catch (error) { if (error instanceof LedgerError) throw error; fail("unreadable_input", `${label} file cannot be read`); }
+  finally { if (opened !== undefined) closeSync(opened.descriptor); }
+  try { return JSON.parse(text); } catch { fail("invalid_ledger", `${label} JSON is invalid`); }
+};
 const argValue = (args, flag) => {
   const index = args.indexOf(flag);
   if (index < 0) return undefined;
@@ -353,11 +381,11 @@ const cli = async (args) => {
     const repositoryDir = argValue(args, "--repository-dir"); const stateDir = argValue(args, "--state-dir"); const homeDir = argValue(args, "--home-dir");
     if (!rootsFile || !evidenceDir || !output || !repositoryDir || !stateDir || !homeDir) fail("invalid_args", "capture requires explicit roots, evidence, output, repository, state, and home paths");
     const ledger = await collectLedger({ approvedRoots: readListArg(rootsFile, "approved root list"), configPaths: configFile ? readListArg(configFile, "config path list") : [], evidenceDir, repositoryDir, stateDir, homeDir });
-    writeRawLedger(ledger, output, evidenceDir);
+    writeRawLedger(ledger, output, evidenceDir, { repositoryDir, stateDir, homeDir });
     process.stdout.write(`${JSON.stringify({ format: ledger.format, aggregate: ledger.aggregate, ledger_sha256: ledgerDigest(ledger) })}\n`);
   } else if (mode === "compare") {
-    const before = JSON.parse(readFileSync(requireAbsolute(argValue(args, "--before"), "before ledger"), "utf8"));
-    const after = JSON.parse(readFileSync(requireAbsolute(argValue(args, "--after"), "after ledger"), "utf8"));
+    const before = readJsonArg(argValue(args, "--before"), "before ledger");
+    const after = readJsonArg(argValue(args, "--after"), "after ledger");
     process.stdout.write(`${JSON.stringify(redactedComparison(before, after))}\n`);
   } else fail("invalid_args", "command must be capture or compare");
 };

--- a/tests/harness/byte-ledger/ledger.mjs
+++ b/tests/harness/byte-ledger/ledger.mjs
@@ -1,0 +1,272 @@
+import { createHash } from "node:crypto";
+import {
+  constants,
+  createReadStream,
+  closeSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  realpathSync,
+  writeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+export class LedgerError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "LedgerError";
+    this.code = code;
+  }
+}
+
+const fail = (code, message) => { throw new LedgerError(code, message); };
+
+const canonical = (path) => {
+  const absolute = resolve(path);
+  try { return realpathSync.native(absolute); } catch { return absolute; }
+};
+
+const isWithin = (child, parent) => {
+  const relation = relative(parent, child);
+  return relation === "" || (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation));
+};
+
+const requireAbsolute = (value, label) => {
+  if (typeof value !== "string" || value.trim() === "") fail("empty_scope", `${label} must be a non-empty path`);
+  if (!isAbsolute(value)) fail("relative_scope", `${label} must be absolute`);
+  return resolve(value);
+};
+
+const uniquePaths = (paths, label) => {
+  const inputs = paths.map((path) => requireAbsolute(path, label));
+  const normalized = inputs.map((path) => canonical(path));
+  for (let index = 0; index < normalized.length; index += 1) {
+    for (let other = index + 1; other < normalized.length; other += 1) {
+      if (isWithin(normalized[index], normalized[other]) || isWithin(normalized[other], normalized[index])) {
+        fail("conflicting_scope", `${label} entries overlap`);
+      }
+    }
+  }
+  return normalized;
+};
+
+const overlapsForbidden = (scope, forbidden) => forbidden.some((entry) => isWithin(scope, entry) || isWithin(entry, scope));
+
+const modeKind = (mode) => {
+  if (mode.isFile()) return "file";
+  if (mode.isDirectory()) return "directory";
+  if (mode.isSymbolicLink()) return "symlink";
+  return "special";
+};
+
+export const parsePathList = (text, label = "path list") => {
+  if (typeof text !== "string") fail("invalid_list", `${label} must be text`);
+  return text.split(/\r?\n/u).map((line) => line.trim()).filter((line) => line !== "");
+};
+
+export const validateScope = ({ approvedRoots, configPaths = [], evidenceDir, repositoryDir, stateDir, homeDir = homedir() }) => {
+  if (!Array.isArray(approvedRoots) || approvedRoots.length === 0) fail("empty_scope", "at least one approved root is required");
+  if (!Array.isArray(configPaths)) fail("invalid_scope", "config paths must be an array");
+  const rootInputs = approvedRoots.map((path) => requireAbsolute(path, "approved root"));
+  const configInputs = configPaths.map((path) => requireAbsolute(path, "config path"));
+  for (const [inputs, label] of [[rootInputs, "approved root"], [configInputs, "config path"]]) {
+    for (const input of inputs) {
+      let mode;
+      try { mode = lstatSync(input); } catch { fail("unreadable_scope", `${label} cannot be inspected`); }
+      if (mode.isSymbolicLink()) fail("unsafe_scope", `${label} must not be a symlink`);
+    }
+  }
+  const roots = uniquePaths(rootInputs, "approved root");
+  const configs = uniquePaths(configInputs, "config path");
+  const home = canonical(requireAbsolute(homeDir, "home directory"));
+  const forbidden = [evidenceDir, repositoryDir, stateDir]
+    .filter((entry) => entry !== undefined && entry !== null)
+    .map((entry) => canonical(requireAbsolute(entry, "forbidden scope")));
+  for (const root of roots) {
+    if (root === resolve(sep)) fail("unsafe_scope", "filesystem root is not an approved scope");
+    if (root === home || isWithin(home, root) || overlapsForbidden(root, forbidden)) fail("unsafe_scope", "approved root overlaps a forbidden scope");
+    let mode;
+    try { mode = lstatSync(root); } catch { fail("unreadable_scope", "approved root cannot be inspected"); }
+    if (!mode.isDirectory() || mode.isSymbolicLink()) fail("unsafe_scope", "approved root must be a real directory");
+  }
+  for (const config of configs) {
+    if (config === home || overlapsForbidden(config, forbidden)) fail("unsafe_scope", "config path overlaps a forbidden scope");
+    let mode;
+    try { mode = lstatSync(config); } catch { fail("unreadable_scope", "config path cannot be inspected"); }
+    if (!mode.isFile() || mode.isSymbolicLink()) fail("unsafe_config", "config path must be a regular file");
+  }
+  return { roots, configs, forbidden };
+};
+
+const hashFile = async (path) => {
+  const hash = createHash("sha256");
+  let descriptor;
+  try {
+    // O_NOFOLLOW (where provided) and a descriptor-bound read close the
+    // lstat-to-read gap: a replacement symlink is never opened and hashed.
+    const noFollow = constants.O_NOFOLLOW ?? 0;
+    descriptor = openSync(path, constants.O_RDONLY | noFollow);
+    const opened = fstatSync(descriptor);
+    const current = lstatSync(path);
+    if (!opened.isFile() || current.isSymbolicLink() || (opened.ino !== 0 && current.ino !== 0 && (opened.ino !== current.ino || opened.dev !== current.dev))) fail("file_drift", "regular file changed while it was being opened");
+    for await (const chunk of createReadStream(null, { fd: descriptor, autoClose: false })) hash.update(chunk);
+  } catch (error) {
+    if (error instanceof LedgerError) throw error;
+    fail("unreadable_file", "regular file cannot be read");
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+  return hash.digest("hex");
+};
+
+const relativeIdentity = (root, entry, rootIndex) => {
+  const child = relative(root, entry).split(sep).join("/");
+  return `root-${rootIndex}/${child}`;
+};
+
+const targetScope = (entry, spelling, roots) => {
+  const target = resolve(dirname(entry), spelling);
+  const index = roots.findIndex((root) => isWithin(target, root));
+  return index < 0 ? "external_target_not_hashed" : `approved_root_${index}`;
+};
+
+const walkRoot = async (root, rootIndex, roots, records) => {
+  records.push({ id: `root-${rootIndex}`, kind: "directory" });
+  const visit = async (directory) => {
+    let entries;
+    try { entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name)); }
+    catch { fail("unreadable_directory", "directory cannot be read"); }
+    for (const entry of entries) {
+      const absolute = resolve(directory, entry.name);
+      const id = relativeIdentity(root, absolute, rootIndex);
+      let mode;
+      try { mode = lstatSync(absolute); } catch { fail("unreadable_entry", "entry cannot be inspected"); }
+      const kind = modeKind(mode);
+      if (kind === "file") {
+        records.push({ id, kind, size: mode.size, sha256: await hashFile(absolute) });
+      } else if (kind === "directory") {
+        records.push({ id, kind });
+        await visit(absolute);
+      } else if (kind === "symlink") {
+        let spelling;
+        try { spelling = readlinkSync(absolute); } catch { fail("unreadable_symlink", "symlink target spelling cannot be read"); }
+        records.push({ id, kind, target_spelling: spelling, target_scope: targetScope(absolute, spelling, roots) });
+      } else {
+        fail("special_file", "special files are outside the safe ledger format");
+      }
+    }
+  };
+  await visit(root);
+};
+
+const aggregate = (records) => records.reduce((result, record) => {
+  result.record_count += 1;
+  result[`${record.kind}_count`] += 1;
+  if (record.kind === "file") { result.regular_file_bytes += record.size; }
+  if (record.target_scope === "external_target_not_hashed") result.external_target_count += 1;
+  return result;
+}, { record_count: 0, file_count: 0, directory_count: 0, symlink_count: 0, special_count: 0, regular_file_bytes: 0, external_target_count: 0 });
+
+export const collectLedger = async (scope) => {
+  const validated = validateScope(scope);
+  const records = [];
+  for (const [index, root] of validated.roots.entries()) await walkRoot(root, index, validated.roots, records);
+  for (const [index, config] of validated.configs.entries()) {
+    let mode;
+    try { mode = lstatSync(config); } catch { fail("unreadable_file", "config path cannot be read"); }
+    if (!mode.isFile() || mode.isSymbolicLink()) fail("unsafe_config", "config path changed to a non-regular file");
+    records.push({ id: `config-${index}`, kind: "file", size: mode.size, sha256: await hashFile(config) });
+  }
+  records.sort((left, right) => left.id.localeCompare(right.id));
+  return {
+    schema_version: 1,
+    format: "skillroster-byte-ledger",
+    scope: { approved_root_count: validated.roots.length, config_path_count: validated.configs.length },
+    aggregate: aggregate(records),
+    records,
+  };
+};
+
+const stableJson = (value) => JSON.stringify(value);
+export const ledgerDigest = (ledger) => createHash("sha256").update(stableJson(ledger)).digest("hex");
+
+export const compareLedgers = (before, after) => {
+  const beforeById = new Map(before.records.map((record) => [record.id, stableJson(record)]));
+  const afterById = new Map(after.records.map((record) => [record.id, stableJson(record)]));
+  let added = 0; let removed = 0; let changed = 0;
+  for (const id of beforeById.keys()) {
+    if (!afterById.has(id)) removed += 1;
+    else if (beforeById.get(id) !== afterById.get(id)) changed += 1;
+  }
+  for (const id of afterById.keys()) if (!beforeById.has(id)) added += 1;
+  return { equal: added === 0 && removed === 0 && changed === 0, added, removed, changed, before_digest: ledgerDigest(before), after_digest: ledgerDigest(after) };
+};
+
+export const redactedComparison = (before, after) => {
+  const comparison = compareLedgers(before, after);
+  return {
+    schema_version: 1,
+    format: "skillroster-byte-ledger-redacted-comparison",
+    before: { digest: comparison.before_digest, aggregate: before.aggregate },
+    after: { digest: comparison.after_digest, aggregate: after.aggregate },
+    comparison: { equal: comparison.equal, added_records: comparison.added, removed_records: comparison.removed, changed_records: comparison.changed },
+    external_target_bytes: "out_of_scope_and_not_hashed",
+    privacy: { absolute_paths: false, file_names: false, file_contents: false },
+  };
+};
+
+export const writeRawLedger = (ledger, outputPath, evidenceDir) => {
+  const output = requireAbsolute(outputPath, "ledger output");
+  const lexicalEvidence = requireAbsolute(evidenceDir, "evidence directory");
+  if (!isWithin(output, lexicalEvidence) || output === lexicalEvidence) fail("unsafe_output", "raw ledger must be written inside evidence directory");
+  try { mkdirSync(lexicalEvidence, { recursive: true }); } catch { fail("write_failed", "evidence directory could not be created"); }
+  const evidence = canonical(lexicalEvidence);
+  const safeOutput = resolve(evidence, relative(lexicalEvidence, output));
+  if (!isWithin(canonical(dirname(safeOutput)), evidence)) fail("unsafe_output", "raw ledger parent escapes evidence directory");
+  let descriptor;
+  try { descriptor = openSync(safeOutput, "wx", 0o600); writeSync(descriptor, `${JSON.stringify(ledger, null, 2)}\n`); }
+  catch { fail("write_failed", "raw ledger could not be written exclusively"); }
+  finally { if (descriptor !== undefined) closeSync(descriptor); }
+  return safeOutput;
+};
+
+const readListArg = (path, label) => {
+  const absolute = requireAbsolute(path, `${label} file`);
+  let mode; let text;
+  try { mode = lstatSync(absolute); if (!mode.isFile() || mode.isSymbolicLink()) fail("unsafe_input", `${label} file must be a regular file`); text = readFileSync(absolute, "utf8"); }
+  catch (error) { if (error instanceof LedgerError) throw error; fail("unreadable_input", `${label} file cannot be read`); }
+  return parsePathList(text, label);
+};
+const argValue = (args, flag) => {
+  const index = args.indexOf(flag);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) fail("invalid_args", `${flag} requires a value`);
+  return value;
+};
+
+const cli = async (args) => {
+  const mode = args[0];
+  if (mode === "capture") {
+    const rootsFile = argValue(args, "--roots-file"); const configFile = argValue(args, "--config-file"); const evidenceDir = argValue(args, "--evidence-dir"); const output = argValue(args, "--output");
+    if (!rootsFile || !evidenceDir || !output) fail("invalid_args", "capture requires --roots-file, --evidence-dir, and --output");
+    const ledger = await collectLedger({ approvedRoots: readListArg(rootsFile, "approved root list"), configPaths: configFile ? readListArg(configFile, "config path list") : [], evidenceDir, repositoryDir: argValue(args, "--repository-dir"), stateDir: argValue(args, "--state-dir"), homeDir: argValue(args, "--home-dir") ?? homedir() });
+    writeRawLedger(ledger, output, evidenceDir);
+    process.stdout.write(`${JSON.stringify({ format: ledger.format, aggregate: ledger.aggregate, ledger_sha256: ledgerDigest(ledger) })}\n`);
+  } else if (mode === "compare") {
+    const before = JSON.parse(readFileSync(requireAbsolute(argValue(args, "--before"), "before ledger"), "utf8"));
+    const after = JSON.parse(readFileSync(requireAbsolute(argValue(args, "--after"), "after ledger"), "utf8"));
+    process.stdout.write(`${JSON.stringify(redactedComparison(before, after))}\n`);
+  } else fail("invalid_args", "command must be capture or compare");
+};
+
+export { cli as runCli };
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  cli(process.argv.slice(2)).catch((error) => { process.stderr.write(`${error.code ?? "error"}: ${error.message}\n`); process.exitCode = 1; });
+}

--- a/tests/harness/byte-ledger/ledger.mjs
+++ b/tests/harness/byte-ledger/ledger.mjs
@@ -14,7 +14,7 @@ import {
   writeSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { dirname, isAbsolute, parse, relative, resolve, sep } from "node:path";
 
 export class LedgerError extends Error {
   constructor(code, message) {
@@ -39,7 +39,10 @@ const isWithin = (child, parent) => {
 const requireAbsolute = (value, label) => {
   if (typeof value !== "string" || value.trim() === "") fail("empty_scope", `${label} must be a non-empty path`);
   if (!isAbsolute(value)) fail("relative_scope", `${label} must be absolute`);
-  return resolve(value);
+  if (value.split(/[\\/]+/u).some((segment) => segment === "." || segment === "..")) fail("path_traversal", `${label} contains traversal`);
+  const absolute = resolve(value);
+  if (parse(absolute).root === absolute) fail("unsafe_scope", `${label} must not be a filesystem root`);
+  return absolute;
 };
 
 const uniquePaths = (paths, label) => {
@@ -64,6 +67,24 @@ const modeKind = (mode) => {
   return "special";
 };
 
+const sameIdentity = (opened, current) => opened.ino === 0 || current.ino === 0 || (opened.ino === current.ino && opened.dev === current.dev);
+const openNoFollow = (path, directory = false) => {
+  const flags = constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0) | (directory ? (constants.O_DIRECTORY ?? 0) : 0);
+  const descriptor = openSync(path, flags);
+  const opened = fstatSync(descriptor);
+  const current = lstatSync(path);
+  if (!sameIdentity(opened, current) || (directory ? !opened.isDirectory() || current.isSymbolicLink() : !opened.isFile() || current.isSymbolicLink())) {
+    closeSync(descriptor); fail("file_drift", "path changed while it was being opened");
+  }
+  return { descriptor, opened };
+};
+
+const assertDirectoryStable = (path, opened) => {
+  let current;
+  try { current = lstatSync(path); } catch { fail("directory_drift", "directory changed while it was being read"); }
+  if (current.isSymbolicLink() || !current.isDirectory() || !sameIdentity(opened, current)) fail("directory_drift", "directory changed while it was being read");
+};
+
 export const parsePathList = (text, label = "path list") => {
   if (typeof text !== "string") fail("invalid_list", `${label} must be text`);
   return text.split(/\r?\n/u).map((line) => line.trim()).filter((line) => line !== "");
@@ -83,12 +104,23 @@ export const validateScope = ({ approvedRoots, configPaths = [], evidenceDir, re
   }
   const roots = uniquePaths(rootInputs, "approved root");
   const configs = uniquePaths(configInputs, "config path");
+  if (!evidenceDir || !repositoryDir || !stateDir || !homeDir) fail("invalid_scope", "evidence, repository, state, and home directories are required");
   const home = canonical(requireAbsolute(homeDir, "home directory"));
-  const forbidden = [evidenceDir, repositoryDir, stateDir]
+  const evidenceInput = requireAbsolute(evidenceDir, "evidence directory");
+  const repositoryInput = requireAbsolute(repositoryDir, "repository directory");
+  const stateInput = requireAbsolute(stateDir, "state directory");
+  for (const [input, label] of [[evidenceInput, "evidence directory"], [repositoryInput, "repository directory"], [stateInput, "state directory"]]) {
+    try { if (lstatSync(input).isSymbolicLink()) fail("unsafe_scope", `${label} must not be a symlink`); } catch (error) { if (error instanceof LedgerError) throw error; }
+  }
+  const evidence = canonical(evidenceInput);
+  const repository = canonical(repositoryInput);
+  const state = canonical(stateInput);
+  if (overlapsForbidden(evidence, [home, repository, state]) || overlapsForbidden(repository, [state])) fail("unsafe_scope", "evidence, repository, and state directories overlap");
+  const forbidden = [evidence, repository, state]
     .filter((entry) => entry !== undefined && entry !== null)
-    .map((entry) => canonical(requireAbsolute(entry, "forbidden scope")));
+    .map((entry) => canonical(entry));
   for (const root of roots) {
-    if (root === resolve(sep)) fail("unsafe_scope", "filesystem root is not an approved scope");
+    if (parse(root).root === root) fail("unsafe_scope", "filesystem root is not an approved scope");
     if (root === home || isWithin(home, root) || overlapsForbidden(root, forbidden)) fail("unsafe_scope", "approved root overlaps a forbidden scope");
     let mode;
     try { mode = lstatSync(root); } catch { fail("unreadable_scope", "approved root cannot be inspected"); }
@@ -106,14 +138,13 @@ export const validateScope = ({ approvedRoots, configPaths = [], evidenceDir, re
 const hashFile = async (path) => {
   const hash = createHash("sha256");
   let descriptor;
+  let size;
   try {
     // O_NOFOLLOW (where provided) and a descriptor-bound read close the
     // lstat-to-read gap: a replacement symlink is never opened and hashed.
-    const noFollow = constants.O_NOFOLLOW ?? 0;
-    descriptor = openSync(path, constants.O_RDONLY | noFollow);
-    const opened = fstatSync(descriptor);
-    const current = lstatSync(path);
-    if (!opened.isFile() || current.isSymbolicLink() || (opened.ino !== 0 && current.ino !== 0 && (opened.ino !== current.ino || opened.dev !== current.dev))) fail("file_drift", "regular file changed while it was being opened");
+    const opened = openNoFollow(path);
+    descriptor = opened.descriptor;
+    size = opened.opened.size;
     for await (const chunk of createReadStream(null, { fd: descriptor, autoClose: false })) hash.update(chunk);
   } catch (error) {
     if (error instanceof LedgerError) throw error;
@@ -121,7 +152,7 @@ const hashFile = async (path) => {
   } finally {
     if (descriptor !== undefined) closeSync(descriptor);
   }
-  return hash.digest("hex");
+  return { size, sha256: hash.digest("hex") };
 };
 
 const relativeIdentity = (root, entry, rootIndex) => {
@@ -132,33 +163,54 @@ const relativeIdentity = (root, entry, rootIndex) => {
 const targetScope = (entry, spelling, roots) => {
   const target = resolve(dirname(entry), spelling);
   const index = roots.findIndex((root) => isWithin(target, root));
-  return index < 0 ? "external_target_not_hashed" : `approved_root_${index}`;
+  if (index < 0) return "external_target_not_hashed";
+  const root = roots[index];
+  const components = relative(root, target).split(sep).filter(Boolean);
+  let current = root;
+  for (const component of components) {
+    current = resolve(current, component);
+    let mode;
+    try { mode = lstatSync(current); } catch { return "external_target_not_hashed"; }
+    if (mode.isSymbolicLink() || (!mode.isDirectory() && !mode.isFile())) return "external_target_not_hashed";
+  }
+  return `approved_root_${index}`;
 };
 
 const walkRoot = async (root, rootIndex, roots, records) => {
   records.push({ id: `root-${rootIndex}`, kind: "directory" });
   const visit = async (directory) => {
+    let descriptor;
+    let opened;
     let entries;
-    try { entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name)); }
-    catch { fail("unreadable_directory", "directory cannot be read"); }
-    for (const entry of entries) {
-      const absolute = resolve(directory, entry.name);
-      const id = relativeIdentity(root, absolute, rootIndex);
-      let mode;
-      try { mode = lstatSync(absolute); } catch { fail("unreadable_entry", "entry cannot be inspected"); }
-      const kind = modeKind(mode);
-      if (kind === "file") {
-        records.push({ id, kind, size: mode.size, sha256: await hashFile(absolute) });
-      } else if (kind === "directory") {
-        records.push({ id, kind });
-        await visit(absolute);
-      } else if (kind === "symlink") {
-        let spelling;
-        try { spelling = readlinkSync(absolute); } catch { fail("unreadable_symlink", "symlink target spelling cannot be read"); }
-        records.push({ id, kind, target_spelling: spelling, target_scope: targetScope(absolute, spelling, roots) });
-      } else {
-        fail("special_file", "special files are outside the safe ledger format");
+    try {
+      opened = openNoFollow(directory, true); descriptor = opened.descriptor;
+      try { entries = readdirSync(directory, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name)); }
+      catch { fail("unreadable_directory", "directory cannot be read"); }
+      assertDirectoryStable(directory, opened.opened);
+      for (const entry of entries) {
+        assertDirectoryStable(directory, opened.opened);
+        const absolute = resolve(directory, entry.name);
+        const id = relativeIdentity(root, absolute, rootIndex);
+        let mode;
+        try { mode = lstatSync(absolute); } catch { fail("unreadable_entry", "entry cannot be inspected"); }
+        const kind = modeKind(mode);
+        if (kind === "file") {
+          const hashed = await hashFile(absolute);
+          records.push({ id, kind, size: hashed.size, sha256: hashed.sha256 });
+        } else if (kind === "directory") {
+          records.push({ id, kind });
+          await visit(absolute);
+        } else if (kind === "symlink") {
+          let spelling;
+          try { spelling = readlinkSync(absolute); } catch { fail("unreadable_symlink", "symlink target spelling cannot be read"); }
+          records.push({ id, kind, target_spelling: spelling, target_scope: targetScope(absolute, spelling, roots) });
+        } else {
+          fail("special_file", "special files are outside the safe ledger format");
+        }
       }
+      assertDirectoryStable(directory, opened.opened);
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
     }
   };
   await visit(root);
@@ -172,6 +224,41 @@ const aggregate = (records) => records.reduce((result, record) => {
   return result;
 }, { record_count: 0, file_count: 0, directory_count: 0, symlink_count: 0, special_count: 0, regular_file_bytes: 0, external_target_count: 0 });
 
+const exactKeys = (value, keys, label) => {
+  if (!value || typeof value !== "object" || Array.isArray(value) || Object.keys(value).sort().join("\0") !== [...keys].sort().join("\0")) fail("invalid_ledger", `${label} has an invalid shape`);
+};
+const integer = (value, label) => { if (!Number.isSafeInteger(value) || value < 0) fail("invalid_ledger", `${label} must be a non-negative integer`); };
+const digest = (value, label) => { if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) fail("invalid_ledger", `${label} must be a SHA-256 digest`); };
+
+export const validateLedger = (ledger, label = "ledger") => {
+  exactKeys(ledger, ["schema_version", "format", "scope", "aggregate", "records"], label);
+  if (ledger.schema_version !== 1 || ledger.format !== "skillroster-byte-ledger") fail("invalid_ledger", `${label} has an unsupported format`);
+  exactKeys(ledger.scope, ["approved_root_count", "config_path_count"], `${label} scope`);
+  integer(ledger.scope.approved_root_count, `${label} root count`); integer(ledger.scope.config_path_count, `${label} config count`);
+  if (!Array.isArray(ledger.records) || ledger.records.length === 0) fail("invalid_ledger", `${label} records are required`);
+  const ids = new Set(); let rootCount = 0; let configCount = 0;
+  for (const record of ledger.records) {
+    if (!record || typeof record.id !== "string" || !(/^(?:root-\d+(?:\/[^/]+)+|root-\d+|config-\d+)$/u.test(record.id)) || record.id.startsWith("/") || record.id.split("/").some((segment) => segment === ".." || segment === ".") || ids.has(record.id)) fail("invalid_ledger", `${label} contains an invalid or duplicate identity`);
+    ids.add(record.id);
+    if (/^root-\d+$/u.test(record.id)) rootCount += 1;
+    if (/^config-\d+$/u.test(record.id)) configCount += 1;
+    if (record.kind === "file") {
+      exactKeys(record, ["id", "kind", "size", "sha256"], `${label} file`); integer(record.size, `${label} file size`); digest(record.sha256, `${label} file digest`);
+    } else if (record.kind === "directory") {
+      exactKeys(record, ["id", "kind"], `${label} directory`);
+    } else if (record.kind === "symlink") {
+      exactKeys(record, ["id", "kind", "target_scope", "target_spelling"], `${label} symlink`);
+      if (typeof record.target_spelling !== "string" || record.target_spelling.length === 0 || record.target_spelling.includes("\0")) fail("invalid_ledger", `${label} symlink spelling is invalid`);
+      if (record.target_scope !== "external_target_not_hashed" && (!/^approved_root_\d+$/u.test(record.target_scope) || Number(record.target_scope.slice("approved_root_".length)) >= ledger.scope.approved_root_count)) fail("invalid_ledger", `${label} symlink scope is invalid`);
+    } else fail("invalid_ledger", `${label} contains an unknown record kind`);
+  }
+  if (rootCount !== ledger.scope.approved_root_count || configCount !== ledger.scope.config_path_count) fail("invalid_ledger", `${label} scope counts do not match records`);
+  exactKeys(ledger.aggregate, ["record_count", "file_count", "directory_count", "symlink_count", "special_count", "regular_file_bytes", "external_target_count"], `${label} aggregate`);
+  const expected = aggregate(ledger.records);
+  if (JSON.stringify(expected) !== JSON.stringify(ledger.aggregate)) fail("invalid_ledger", `${label} aggregate does not match records`);
+  return ledger;
+};
+
 export const collectLedger = async (scope) => {
   const validated = validateScope(scope);
   const records = [];
@@ -180,7 +267,8 @@ export const collectLedger = async (scope) => {
     let mode;
     try { mode = lstatSync(config); } catch { fail("unreadable_file", "config path cannot be read"); }
     if (!mode.isFile() || mode.isSymbolicLink()) fail("unsafe_config", "config path changed to a non-regular file");
-    records.push({ id: `config-${index}`, kind: "file", size: mode.size, sha256: await hashFile(config) });
+    const hashed = await hashFile(config);
+    records.push({ id: `config-${index}`, kind: "file", size: hashed.size, sha256: hashed.sha256 });
   }
   records.sort((left, right) => left.id.localeCompare(right.id));
   return {
@@ -193,9 +281,11 @@ export const collectLedger = async (scope) => {
 };
 
 const stableJson = (value) => JSON.stringify(value);
-export const ledgerDigest = (ledger) => createHash("sha256").update(stableJson(ledger)).digest("hex");
+export const ledgerDigest = (ledger) => { validateLedger(ledger); return createHash("sha256").update(stableJson(ledger)).digest("hex"); };
 
 export const compareLedgers = (before, after) => {
+  validateLedger(before, "before ledger"); validateLedger(after, "after ledger");
+  if (JSON.stringify(before.scope) !== JSON.stringify(after.scope)) fail("scope_mismatch", "ledger scopes do not match");
   const beforeById = new Map(before.records.map((record) => [record.id, stableJson(record)]));
   const afterById = new Map(after.records.map((record) => [record.id, stableJson(record)]));
   let added = 0; let removed = 0; let changed = 0;
@@ -221,13 +311,14 @@ export const redactedComparison = (before, after) => {
 };
 
 export const writeRawLedger = (ledger, outputPath, evidenceDir) => {
+  validateLedger(ledger);
   const output = requireAbsolute(outputPath, "ledger output");
   const lexicalEvidence = requireAbsolute(evidenceDir, "evidence directory");
   if (!isWithin(output, lexicalEvidence) || output === lexicalEvidence) fail("unsafe_output", "raw ledger must be written inside evidence directory");
   try { mkdirSync(lexicalEvidence, { recursive: true }); } catch { fail("write_failed", "evidence directory could not be created"); }
   const evidence = canonical(lexicalEvidence);
   const safeOutput = resolve(evidence, relative(lexicalEvidence, output));
-  if (!isWithin(canonical(dirname(safeOutput)), evidence)) fail("unsafe_output", "raw ledger parent escapes evidence directory");
+  if (dirname(safeOutput) !== evidence || !isWithin(canonical(dirname(safeOutput)), evidence)) fail("unsafe_output", "raw ledger must be directly inside evidence directory");
   let descriptor;
   try { descriptor = openSync(safeOutput, "wx", 0o600); writeSync(descriptor, `${JSON.stringify(ledger, null, 2)}\n`); }
   catch { fail("write_failed", "raw ledger could not be written exclusively"); }
@@ -237,9 +328,14 @@ export const writeRawLedger = (ledger, outputPath, evidenceDir) => {
 
 const readListArg = (path, label) => {
   const absolute = requireAbsolute(path, `${label} file`);
-  let mode; let text;
-  try { mode = lstatSync(absolute); if (!mode.isFile() || mode.isSymbolicLink()) fail("unsafe_input", `${label} file must be a regular file`); text = readFileSync(absolute, "utf8"); }
-  catch (error) { if (error instanceof LedgerError) throw error; fail("unreadable_input", `${label} file cannot be read`); }
+  let opened; let text;
+  try {
+    opened = openNoFollow(absolute);
+    text = readFileSync(opened.descriptor, "utf8");
+    const current = lstatSync(absolute);
+    if (!sameIdentity(opened.opened, current) || current.isSymbolicLink()) fail("input_drift", `${label} file changed while it was read`);
+  } catch (error) { if (error instanceof LedgerError) throw error; fail("unreadable_input", `${label} file cannot be read`); }
+  finally { if (opened !== undefined) closeSync(opened.descriptor); }
   return parsePathList(text, label);
 };
 const argValue = (args, flag) => {
@@ -254,8 +350,9 @@ const cli = async (args) => {
   const mode = args[0];
   if (mode === "capture") {
     const rootsFile = argValue(args, "--roots-file"); const configFile = argValue(args, "--config-file"); const evidenceDir = argValue(args, "--evidence-dir"); const output = argValue(args, "--output");
-    if (!rootsFile || !evidenceDir || !output) fail("invalid_args", "capture requires --roots-file, --evidence-dir, and --output");
-    const ledger = await collectLedger({ approvedRoots: readListArg(rootsFile, "approved root list"), configPaths: configFile ? readListArg(configFile, "config path list") : [], evidenceDir, repositoryDir: argValue(args, "--repository-dir"), stateDir: argValue(args, "--state-dir"), homeDir: argValue(args, "--home-dir") ?? homedir() });
+    const repositoryDir = argValue(args, "--repository-dir"); const stateDir = argValue(args, "--state-dir"); const homeDir = argValue(args, "--home-dir");
+    if (!rootsFile || !evidenceDir || !output || !repositoryDir || !stateDir || !homeDir) fail("invalid_args", "capture requires explicit roots, evidence, output, repository, state, and home paths");
+    const ledger = await collectLedger({ approvedRoots: readListArg(rootsFile, "approved root list"), configPaths: configFile ? readListArg(configFile, "config path list") : [], evidenceDir, repositoryDir, stateDir, homeDir });
     writeRawLedger(ledger, output, evidenceDir);
     process.stdout.write(`${JSON.stringify({ format: ledger.format, aggregate: ledger.aggregate, ledger_sha256: ledgerDigest(ledger) })}\n`);
   } else if (mode === "compare") {

--- a/tests/harness/byte-ledger/ledger.test.mjs
+++ b/tests/harness/byte-ledger/ledger.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -23,7 +24,7 @@ test("symlink retargeting changes identity but never hashes its target", { skip:
   const root = tempRoot(); const inside = join(root, "inside.txt"); const outside = join(dirname(root), "outside-secret.txt"); writeFileSync(inside, "inside"); writeFileSync(outside, "secret"); symlinkSync("inside.txt", join(root, "link"));
   const before = await collectLedger(scope(root)); rmSync(join(root, "link")); symlinkSync(outside, join(root, "link")); const after = await collectLedger(scope(root));
   const linkBefore = before.records.find((record) => record.kind === "symlink"); const linkAfter = after.records.find((record) => record.kind === "symlink");
-  assert.equal(linkBefore.target_scope, "approved_root_0"); assert.equal(linkAfter.target_scope, "external_target_not_hashed"); assert.equal(compareLedgers(before, after).changed, 1); assert.equal(after.records.some((record) => record.sha256 === "secret"), false); rmSync(outside, { force: true }); rmSync(root, { recursive: true, force: true });
+  const outsideDigest = createHash("sha256").update("secret").digest("hex"); assert.equal(linkBefore.target_scope, "approved_root_0"); assert.equal(linkAfter.target_scope, "external_target_not_hashed"); assert.equal(compareLedgers(before, after).changed, 1); assert.equal(after.records.some((record) => record.sha256 === outsideDigest), false); rmSync(outside, { force: true }); rmSync(root, { recursive: true, force: true });
 });
 
 test("external symlink targets are explicitly out of scope even when unreadable", { skip: process.platform === "win32" }, async () => {

--- a/tests/harness/byte-ledger/ledger.test.mjs
+++ b/tests/harness/byte-ledger/ledger.test.mjs
@@ -38,7 +38,15 @@ test("external symlink targets are explicitly out of scope even when unreadable"
 });
 
 test("unsafe scopes fail closed", () => {
-  const root = tempRoot(); const common = scope(root); mkdirSync(join(root, "subhome")); const filesystemRoot = process.platform === "win32" ? parse(root).root : "/"; assert.throws(() => validateScope({ ...common, approvedRoots: [] }), (error) => error instanceof LedgerError && error.code === "empty_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [filesystemRoot] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root, root] }), (error) => error instanceof LedgerError && error.code === "conflicting_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], repositoryDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], homeDir: join(root, "subhome") }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: join(dirname(root), "evidence"), homeDir: dirname(root) }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); rmSync(root, { recursive: true, force: true });
+  const root = tempRoot(); const common = scope(root); mkdirSync(join(root, "subhome")); const filesystemRoot = process.platform === "win32" ? parse(root).root : "/"; const expectError = (name, options, code) => assert.throws(() => validateScope(options), (error) => error instanceof LedgerError && error.code === code, name);
+  expectError("empty approved roots", { ...common, approvedRoots: [] }, "empty_scope");
+  expectError("filesystem root", { ...common, approvedRoots: [filesystemRoot] }, "unsafe_scope");
+  expectError("duplicate approved root", { ...common, approvedRoots: [root, root] }, "conflicting_scope");
+  expectError("evidence overlaps root", { ...common, approvedRoots: [root], evidenceDir: root }, "unsafe_scope");
+  expectError("repository overlaps root", { ...common, approvedRoots: [root], repositoryDir: root }, "unsafe_scope");
+  expectError("root contains home", { ...common, approvedRoots: [root], homeDir: join(root, "subhome") }, "unsafe_scope");
+  expectError("evidence is inside home", { ...common, approvedRoots: [root], evidenceDir: join(dirname(root), "evidence"), homeDir: dirname(root) }, "unsafe_scope");
+  rmSync(root, { recursive: true, force: true });
 });
 
 test("special files fail closed", { skip: process.platform === "win32" }, async () => {
@@ -51,7 +59,7 @@ test("config files are explicit and privacy-safe redaction contains no path, nam
 });
 
 test("raw output is exclusive and confined to the isolated evidence directory", async () => {
-  const root = tempRoot(); const evidence = `${root}-evidence`; const ledger = await collectLedger(scope(root, { evidenceDir: evidence })); const output = join(evidence, "before.json"); const written = writeRawLedger(ledger, output, evidence); assert.equal(JSON.parse(readFileSync(written)).format, "skillroster-byte-ledger"); assert.throws(() => writeRawLedger(ledger, output, evidence), (error) => error instanceof LedgerError && error.code === "write_failed"); assert.throws(() => writeRawLedger(ledger, join(root, "escape.json"), evidence), (error) => error instanceof LedgerError && error.code === "unsafe_output"); rmSync(root, { recursive: true, force: true }); rmSync(evidence, { recursive: true, force: true });
+  const root = tempRoot(); const evidence = `${root}-evidence`; const boundaries = scope(root, { evidenceDir: evidence }); const ledger = await collectLedger(boundaries); const output = join(evidence, "before.json"); const written = writeRawLedger(ledger, output, evidence, boundaries); assert.equal(JSON.parse(readFileSync(written)).format, "skillroster-byte-ledger"); assert.throws(() => writeRawLedger(ledger, output, evidence, boundaries), (error) => error instanceof LedgerError && error.code === "write_failed"); assert.throws(() => writeRawLedger(ledger, join(root, "escape.json"), evidence, boundaries), (error) => error instanceof LedgerError && error.code === "unsafe_output"); if (process.platform !== "win32") { const after = join(evidence, "after.json"); writeRawLedger(ledger, after, evidence, boundaries); const beforeLink = join(evidence, "before-link.json"); symlinkSync(written, beforeLink); const script = fileURLToPath(new URL("../../../scripts/byte-ledger.mjs", import.meta.url)); const comparison = spawnSync(process.execPath, [script, "compare", "--before", beforeLink, "--after", after], { encoding: "utf8" }); assert.notEqual(comparison.status, 0); rmSync(beforeLink, { force: true }); } rmSync(root, { recursive: true, force: true }); rmSync(evidence, { recursive: true, force: true });
 });
 
 test("config identity and symlink inputs are validated before canonicalization", { skip: process.platform === "win32" }, async () => {
@@ -60,6 +68,11 @@ test("config identity and symlink inputs are validated before canonicalization",
   const rootAlias = `${root}-alias`; symlinkSync(root, rootAlias, "dir"); assert.throws(() => validateScope({ ...common, approvedRoots: [rootAlias] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope");
   const configAlias = `${config}-alias`; symlinkSync(config, configAlias); assert.throws(() => validateScope({ ...common, configPaths: [configAlias] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope");
   rmSync(root, { recursive: true, force: true }); rmSync(rootAlias, { force: true }); rmSync(dirname(config), { recursive: true, force: true });
+});
+
+test("missing evidence under a symlinked ancestor fails before mkdir", { skip: process.platform === "win32" }, () => {
+  const root = tempRoot(); const repository = `${root}-repository`; mkdirSync(repository); const alias = `${root}-repository-alias`; symlinkSync(repository, alias, "dir"); const evidence = join(alias, "evidence");
+  assert.throws(() => validateScope({ ...scope(root), evidenceDir: evidence, repositoryDir: repository }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); rmSync(root, { recursive: true, force: true }); rmSync(repository, { recursive: true, force: true }); rmSync(alias, { force: true });
 });
 
 test("CLI fails closed for unsafe list inputs and missing flag values", () => {

--- a/tests/harness/byte-ledger/ledger.test.mjs
+++ b/tests/harness/byte-ledger/ledger.test.mjs
@@ -3,7 +3,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, parse, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -38,7 +38,7 @@ test("external symlink targets are explicitly out of scope even when unreadable"
 });
 
 test("unsafe scopes fail closed", () => {
-  const root = tempRoot(); const common = scope(root); mkdirSync(join(root, "subhome")); assert.throws(() => validateScope({ ...common, approvedRoots: [] }), (error) => error instanceof LedgerError && error.code === "empty_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: ["/"] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root, root] }), (error) => error instanceof LedgerError && error.code === "conflicting_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], repositoryDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], homeDir: join(root, "subhome") }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: join(dirname(root), "evidence"), homeDir: dirname(root) }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); rmSync(root, { recursive: true, force: true });
+  const root = tempRoot(); const common = scope(root); mkdirSync(join(root, "subhome")); const filesystemRoot = process.platform === "win32" ? parse(root).root : "/"; assert.throws(() => validateScope({ ...common, approvedRoots: [] }), (error) => error instanceof LedgerError && error.code === "empty_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [filesystemRoot] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root, root] }), (error) => error instanceof LedgerError && error.code === "conflicting_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], repositoryDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], homeDir: join(root, "subhome") }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: join(dirname(root), "evidence"), homeDir: dirname(root) }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); rmSync(root, { recursive: true, force: true });
 });
 
 test("special files fail closed", { skip: process.platform === "win32" }, async () => {

--- a/tests/harness/byte-ledger/ledger.test.mjs
+++ b/tests/harness/byte-ledger/ledger.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { collectLedger, compareLedgers, LedgerError, redactedComparison, validateScope, writeRawLedger } from "./ledger.mjs";
+
+const tempRoot = () => mkdtempSync(join(resolve(tmpdir()), "skillroster-byte-ledger-"));
+const scope = (root, extras = {}) => ({ approvedRoots: [root], configPaths: extras.configPaths ?? [], evidenceDir: extras.evidenceDir ?? join(dirname(root), "evidence"), repositoryDir: extras.repositoryDir ?? join(dirname(root), "repo"), stateDir: extras.stateDir ?? join(dirname(root), "state"), homeDir: extras.homeDir ?? join(dirname(root), "home") });
+
+test("same-size content changes are detected without relying on mtime", async () => {
+  const root = tempRoot(); const file = join(root, "skill", "SKILL.md"); mkdirSync(dirname(file), { recursive: true }); writeFileSync(file, "AAAA");
+  const before = await collectLedger(scope(root)); const originalMtime = (await import("node:fs")).statSync(file).mtime;
+  writeFileSync(file, "BBBB"); utimesSync(file, originalMtime, originalMtime);
+  const after = await collectLedger(scope(root)); const comparison = compareLedgers(before, after);
+  assert.equal(comparison.equal, false); assert.equal(comparison.changed, 1); assert.notEqual(before.records.find((record) => record.kind === "file").sha256, after.records.find((record) => record.kind === "file").sha256); rmSync(root, { recursive: true, force: true });
+});
+
+test("symlink retargeting changes identity but never hashes its target", { skip: process.platform === "win32" }, async () => {
+  const root = tempRoot(); const inside = join(root, "inside.txt"); const outside = join(dirname(root), "outside-secret.txt"); writeFileSync(inside, "inside"); writeFileSync(outside, "secret"); symlinkSync("inside.txt", join(root, "link"));
+  const before = await collectLedger(scope(root)); rmSync(join(root, "link")); symlinkSync(outside, join(root, "link")); const after = await collectLedger(scope(root));
+  const linkBefore = before.records.find((record) => record.kind === "symlink"); const linkAfter = after.records.find((record) => record.kind === "symlink");
+  assert.equal(linkBefore.target_scope, "approved_root_0"); assert.equal(linkAfter.target_scope, "external_target_not_hashed"); assert.equal(compareLedgers(before, after).changed, 1); assert.equal(after.records.some((record) => record.sha256 === "secret"), false); rmSync(outside, { force: true }); rmSync(root, { recursive: true, force: true });
+});
+
+test("external symlink targets are explicitly out of scope even when unreadable", { skip: process.platform === "win32" }, async () => {
+  const root = tempRoot(); const target = join(root, "link"); symlinkSync("/path/that/does/not/exist", target); const ledger = await collectLedger(scope(root)); const link = ledger.records.find((record) => record.kind === "symlink");
+  assert.equal(link.target_scope, "external_target_not_hashed"); assert.equal(ledger.aggregate.external_target_count, 1); rmSync(root, { recursive: true, force: true });
+});
+
+test("unsafe scopes fail closed", () => {
+  const root = tempRoot(); const common = scope(root); mkdirSync(join(root, "subhome")); assert.throws(() => validateScope({ ...common, approvedRoots: [] }), (error) => error instanceof LedgerError && error.code === "empty_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: ["/"] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root, root] }), (error) => error instanceof LedgerError && error.code === "conflicting_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], repositoryDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], homeDir: join(root, "subhome") }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); rmSync(root, { recursive: true, force: true });
+});
+
+test("special files fail closed", { skip: process.platform === "win32" }, async () => {
+  const root = tempRoot(); const special = join(root, "pipe"); execFileSync("mkfifo", [special]); await assert.rejects(() => collectLedger(scope(root)), (error) => error instanceof LedgerError && error.code === "special_file"); rmSync(root, { recursive: true, force: true });
+});
+
+test("config files are explicit and privacy-safe redaction contains no path, name, or content", async () => {
+  const root = tempRoot(); const config = join(dirname(root), "agent-config.json"); writeFileSync(config, '{"private":"value"}'); const before = await collectLedger(scope(root, { configPaths: [config] })); const after = await collectLedger(scope(root, { configPaths: [config] })); const redacted = redactedComparison(before, after);
+  const serialized = JSON.stringify(redacted); assert.equal(redacted.comparison.equal, true); assert.equal(serialized.includes(config), false); assert.equal(serialized.includes("agent-config.json"), false); assert.equal(serialized.includes("private"), false); assert.equal(redacted.privacy.absolute_paths, false); rmSync(config, { force: true }); rmSync(root, { recursive: true, force: true });
+});
+
+test("raw output is exclusive and confined to the isolated evidence directory", async () => {
+  const root = tempRoot(); const evidence = `${root}-evidence`; const ledger = await collectLedger(scope(root, { evidenceDir: evidence })); const output = join(evidence, "before.json"); const written = writeRawLedger(ledger, output, evidence); assert.equal(JSON.parse(readFileSync(written)).format, "skillroster-byte-ledger"); assert.throws(() => writeRawLedger(ledger, output, evidence), (error) => error instanceof LedgerError && error.code === "write_failed"); assert.throws(() => writeRawLedger(ledger, join(root, "escape.json"), evidence), (error) => error instanceof LedgerError && error.code === "unsafe_output"); rmSync(root, { recursive: true, force: true }); rmSync(evidence, { recursive: true, force: true });
+});
+
+test("config identity and symlink inputs are validated before canonicalization", { skip: process.platform === "win32" }, async () => {
+  const root = tempRoot(); const config = join(`${root}-config`, "settings.json"); mkdirSync(dirname(config), { recursive: true }); writeFileSync(config, "{}"); const common = scope(root, { configPaths: [config] });
+  assert.throws(() => validateScope({ ...common, configPaths: [config, config] }), (error) => error instanceof LedgerError && error.code === "conflicting_scope");
+  const rootAlias = `${root}-alias`; symlinkSync(root, rootAlias, "dir"); assert.throws(() => validateScope({ ...common, approvedRoots: [rootAlias] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope");
+  const configAlias = `${config}-alias`; symlinkSync(config, configAlias); assert.throws(() => validateScope({ ...common, configPaths: [configAlias] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope");
+  rmSync(root, { recursive: true, force: true }); rmSync(rootAlias, { force: true }); rmSync(dirname(config), { recursive: true, force: true });
+});
+
+test("CLI fails closed for unsafe list inputs and missing flag values", () => {
+  const script = fileURLToPath(new URL("../../../scripts/byte-ledger.mjs", import.meta.url));
+  const missing = spawnSync(process.execPath, [script, "capture", "--roots-file"], { encoding: "utf8" });
+  assert.notEqual(missing.status, 0); assert.match(missing.stderr, /requires a value/u);
+  const unreadable = spawnSync(process.execPath, [script, "capture", "--roots-file", "/path/does/not/exist", "--evidence-dir", "/tmp/evidence", "--output", "/tmp/evidence/x.json"], { encoding: "utf8" });
+  assert.notEqual(unreadable.status, 0); assert.match(unreadable.stderr, /unreadable_input/u);
+});

--- a/tests/harness/byte-ledger/ledger.test.mjs
+++ b/tests/harness/byte-ledger/ledger.test.mjs
@@ -7,7 +7,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { collectLedger, compareLedgers, LedgerError, redactedComparison, validateScope, writeRawLedger } from "./ledger.mjs";
+import { collectLedger, compareLedgers, LedgerError, redactedComparison, validateLedger, validateScope, writeRawLedger } from "./ledger.mjs";
 
 const tempRoot = () => mkdtempSync(join(resolve(tmpdir()), "skillroster-byte-ledger-"));
 const scope = (root, extras = {}) => ({ approvedRoots: [root], configPaths: extras.configPaths ?? [], evidenceDir: extras.evidenceDir ?? join(dirname(root), "evidence"), repositoryDir: extras.repositoryDir ?? join(dirname(root), "repo"), stateDir: extras.stateDir ?? join(dirname(root), "state"), homeDir: extras.homeDir ?? join(dirname(root), "home") });
@@ -27,13 +27,18 @@ test("symlink retargeting changes identity but never hashes its target", { skip:
   const outsideDigest = createHash("sha256").update("secret").digest("hex"); assert.equal(linkBefore.target_scope, "approved_root_0"); assert.equal(linkAfter.target_scope, "external_target_not_hashed"); assert.equal(compareLedgers(before, after).changed, 1); assert.equal(after.records.some((record) => record.sha256 === outsideDigest), false); rmSync(outside, { force: true }); rmSync(root, { recursive: true, force: true });
 });
 
+test("symlink target classification is conservative for indirect external links", { skip: process.platform === "win32" }, async () => {
+  const root = tempRoot(); const outside = `${root}-outside`; mkdirSync(outside); writeFileSync(join(outside, "secret"), "secret"); symlinkSync(outside, join(root, "alias"), "dir"); symlinkSync("alias/secret", join(root, "indirect")); const ledger = await collectLedger(scope(root));
+  assert.equal(ledger.records.find((record) => record.id === "root-0/indirect").target_scope, "external_target_not_hashed"); rmSync(root, { recursive: true, force: true }); rmSync(outside, { recursive: true, force: true });
+});
+
 test("external symlink targets are explicitly out of scope even when unreadable", { skip: process.platform === "win32" }, async () => {
   const root = tempRoot(); const target = join(root, "link"); symlinkSync("/path/that/does/not/exist", target); const ledger = await collectLedger(scope(root)); const link = ledger.records.find((record) => record.kind === "symlink");
   assert.equal(link.target_scope, "external_target_not_hashed"); assert.equal(ledger.aggregate.external_target_count, 1); rmSync(root, { recursive: true, force: true });
 });
 
 test("unsafe scopes fail closed", () => {
-  const root = tempRoot(); const common = scope(root); mkdirSync(join(root, "subhome")); assert.throws(() => validateScope({ ...common, approvedRoots: [] }), (error) => error instanceof LedgerError && error.code === "empty_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: ["/"] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root, root] }), (error) => error instanceof LedgerError && error.code === "conflicting_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], repositoryDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], homeDir: join(root, "subhome") }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); rmSync(root, { recursive: true, force: true });
+  const root = tempRoot(); const common = scope(root); mkdirSync(join(root, "subhome")); assert.throws(() => validateScope({ ...common, approvedRoots: [] }), (error) => error instanceof LedgerError && error.code === "empty_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: ["/"] }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root, root] }), (error) => error instanceof LedgerError && error.code === "conflicting_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], repositoryDir: root }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], homeDir: join(root, "subhome") }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); assert.throws(() => validateScope({ ...common, approvedRoots: [root], evidenceDir: join(dirname(root), "evidence"), homeDir: dirname(root) }), (error) => error instanceof LedgerError && error.code === "unsafe_scope"); rmSync(root, { recursive: true, force: true });
 });
 
 test("special files fail closed", { skip: process.platform === "win32" }, async () => {
@@ -61,6 +66,17 @@ test("CLI fails closed for unsafe list inputs and missing flag values", () => {
   const script = fileURLToPath(new URL("../../../scripts/byte-ledger.mjs", import.meta.url));
   const missing = spawnSync(process.execPath, [script, "capture", "--roots-file"], { encoding: "utf8" });
   assert.notEqual(missing.status, 0); assert.match(missing.stderr, /requires a value/u);
-  const unreadable = spawnSync(process.execPath, [script, "capture", "--roots-file", "/path/does/not/exist", "--evidence-dir", "/tmp/evidence", "--output", "/tmp/evidence/x.json"], { encoding: "utf8" });
+  const unreadable = spawnSync(process.execPath, [script, "capture", "--roots-file", "/path/does/not/exist", "--evidence-dir", "/tmp/evidence", "--output", "/tmp/evidence/x.json", "--repository-dir", "/tmp/repo", "--state-dir", "/tmp/state", "--home-dir", "/tmp/home"], { encoding: "utf8" });
   assert.notEqual(unreadable.status, 0); assert.match(unreadable.stderr, /unreadable_input/u);
+  const incomplete = spawnSync(process.execPath, [script, "capture", "--roots-file", "/tmp/roots.txt", "--evidence-dir", "/tmp/evidence", "--output", "/tmp/evidence/x.json"], { encoding: "utf8" });
+  assert.notEqual(incomplete.status, 0); assert.match(incomplete.stderr, /explicit roots/u);
+});
+
+test("compare validates schema, identities, scope, and aggregates before redaction", async () => {
+  const root = tempRoot(); const ledger = await collectLedger(scope(root));
+  assert.throws(() => validateLedger({ ...ledger, aggregate: { ...ledger.aggregate, file_count: ledger.aggregate.file_count + 1 } }), (error) => error instanceof LedgerError && error.code === "invalid_ledger");
+  assert.throws(() => validateLedger({ ...ledger, records: [{ ...ledger.records[0], id: "../private" }, ...ledger.records.slice(1)] }), (error) => error instanceof LedgerError && error.code === "invalid_ledger");
+  assert.throws(() => compareLedgers(ledger, { ...ledger, scope: { ...ledger.scope, config_path_count: 1 } }), (error) => error instanceof LedgerError && error.code === "invalid_ledger");
+  const redacted = redactedComparison(ledger, ledger); assert.deepEqual(Object.keys(redacted).sort(), ["after", "before", "comparison", "external_target_bytes", "format", "privacy", "schema_version"]); assert.equal(JSON.stringify(redacted).includes(root), false);
+  rmSync(root, { recursive: true, force: true });
 });


### PR DESCRIPTION
Closes #165

## Summary
- add a small Node standard-library byte ledger with explicit roots/config inputs
- hash regular files from a no-follow descriptor-bound read, record directory structure, and record symlink spelling without reading/hash external targets
- fail closed for unsafe scopes, textual traversal, symlink roots/configs/ancestors, special/unreadable files, conflicting inputs, malformed ledgers, and raw-output escapes
- add focused tests, CI coverage, and a redacted Issue #165 real-agent read-only acceptance addendum

## Acceptance boundary
The selected frozen run is a quiescent-estate evidence run: before ledger -> read-only Scan -> Report -> two Find queries -> Status -> after ledger -> strict compare. Node standard library has no cross-platform openat/readdir(fd) capability, so directory traversal is drift-detecting under this quiescent assumption, not an adversarial concurrent directory rename/symlink guarantee. Regular-file final reads and list-input reads use no-follow descriptor-bound opens. Evidence boundaries reject symlink ancestors and are rechecked before raw write. The docs/artifact state this boundary explicitly.

Frozen evidence bundle: 10 JSON records, SHA-256 `eb965d82044f24351f4817e07be17809ffcdfac2cd2bf76a2a08d229c9de0346`. Earlier exploratory captures, failed invocations, and pre-fix runs are excluded from this acceptance claim.

Observed frozen result: before/after ledger digests equal with 0 added/removed/changed records; 3,944 records (2,797 files, 1,140 directories, 7 symlinks), 7 external targets explicitly not hashed; CLI 251 Skills, 887 placements, 177 Findings, files_changed=false, recovery clear, zero pending Plans. Three scan roots were symlink aliases and were refused as roots; canonical shared root was used. This is not an all-Home unchanged claim.

## Checks
- `node --test tests/harness/byte-ledger/ledger.test.mjs` (12 local tests)
- `node --check tests/harness/byte-ledger/ledger.mjs`
- `node --check scripts/byte-ledger.mjs`
- `git diff --check`
- artifact JSON parse
- GitHub CI Linux, Windows, macOS arm64/x64

Raw ledgers remain outside the repository. No Rust product, Bootstrap, routing, Agent, Skill, config, or roster files were changed. PR remains open for independent Spec/Correctness/Privacy review; do not merge in this task.