### PR TITLE
release: prepare SkillRoster v1.8.24

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -4,6 +4,7 @@ class Skillroster < Formula
   url "https://github.com/tt-a1i/skillroster.git",
       revision: "dde059ad39d9dbe9021cef0acbeb7b428afb0268"
   version "1.8.24"
+  license "Apache-2.0"
 
   depends_on "rust" => :build
 

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "5e6c5fbb1db0886e890065c381e8163c6b55efd2"
-  version "1.8.20"
+      revision: "dde059ad39d9dbe9021cef0acbeb7b428afb0268"
+  version "1.8.24"
 
   depends_on "rust" => :build
 
@@ -12,7 +12,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.20", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.24", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.20
+SKILLROSTER_VERSION=1.8.24
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
@@ -46,7 +46,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.20 skillroster
+  --tag v1.8.24 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -60,7 +60,7 @@ clone the release tag and install the checked-in Formula:
 ```sh
 git clone https://github.com/tt-a1i/skillroster.git
 cd skillroster
-git checkout v1.8.20
+git checkout v1.8.24
 brew install --formula ./Formula/skillroster.rb
 brew test skillroster
 ```
@@ -79,6 +79,9 @@ detected bootstrap targets:
 skillroster scan --json
 skillroster setup --json
 ```
+
+CLI v1.8.24 bundles Bootstrap content version 1.8.23. These versions differ
+intentionally: the CLI changed after the Bootstrap instructions last changed.
 
 `setup` changes no files. Apply its returned Plan only after review. Exact
 official older copies are upgraded through the same reversible Plan/Receipt

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,10 +30,15 @@ install the binary from that directory (not from the current directory):
 SKILLROSTER_VERSION=1.8.24
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
+mkdir -p "$HOME/.local/bin"
 install "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}/skillroster" \
   "$HOME/.local/bin/skillroster"
+export PATH="$HOME/.local/bin:$PATH"
 skillroster --version
 ```
+
+Persist the PATH entry in the startup file for the shell that launches your
+Agent, then restart that Agent so future sessions can resolve `skillroster`.
 
 On Windows, compare `Get-FileHash .\skillroster-*.zip -Algorithm SHA256` with
 the checksum file. Extract the archive, open its versioned directory, then
@@ -54,21 +59,18 @@ installation with `skillroster --version` and `skillroster --help`.
 
 ## Homebrew
 
-The repository includes a source-building Formula. Until a public tap exists,
-clone the release tag and install the checked-in Formula:
+The public repository also acts as a source-building Homebrew tap:
 
 ```sh
-git clone https://github.com/tt-a1i/skillroster.git
-cd skillroster
-git checkout v1.8.24
-brew install --formula ./Formula/skillroster.rb
+brew tap tt-a1i/skillroster https://github.com/tt-a1i/skillroster.git
+brew install tt-a1i/skillroster/skillroster
 brew test skillroster
 ```
 
 The repository is public, so cloning the source and downloading Release
-archives do not require GitHub authentication. This is a checked-in Formula,
-not yet a published Homebrew tap. Never paste a GitHub token into the Formula
-or a command line.
+archives do not require GitHub authentication. This is a repository-backed
+custom tap, not a Homebrew/core Formula. Never paste a GitHub token into the
+Formula or a command line.
 
 ## Install or upgrade the Agent bootstrap Skill
 


### PR DESCRIPTION
## Problem

The current CLI is v1.8.24, but the latest public Release is v1.8.19 and the checked-in Formula and installation guide still point to v1.8.20. That makes current Agent dogfood and public installation non-reproducible.

Part of #125. The Issue remains open through release-candidate acceptance and public Release verification.

## Changes

- update the checked-in Formula to build immutable source commit dde059ad at v1.8.24 and declare Apache-2.0
- update GitHub archive, Cargo tag, PATH, and repository-backed Homebrew tap installation examples for v1.8.24
- document that CLI v1.8.24 intentionally bundles unchanged Bootstrap content version 1.8.23

The Bootstrap package itself is unchanged, so its content version and digest are not mechanically bumped.

## Verification

- cargo fmt --all --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features: 214 unit, 8 acceptance, 62 CLI tests passed
- ruby -c Formula/skillroster.rb
- brew style Formula/skillroster.rb
- repository tap discovery: brew tap, brew info, and brew untap passed; no package installed and temporary tap removed
- git diff --check
- Formula revision Cargo package version verified as 1.8.24
- independent Spec and correctness re-reviews: PASS, no blocker or should-fix

No real Agent or Skill files were changed.