### PR TITLE
fix: distinguish CLI and Bootstrap content versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.24"
+version = "1.8.25"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.24"
+version = "1.8.25"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,6 +84,11 @@ skillroster setup --json
 
 CLI v1.8.24 bundles Bootstrap content version 1.8.23. These versions differ
 intentionally: the CLI changed after the Bootstrap instructions last changed.
+In Setup JSON, `cli_version` identifies the executable and
+`bootstrap_content_version` identifies the bundled Skill package.
+`bootstrap_version` remains a compatibility alias for
+`bootstrap_content_version`; a current target's `installed_version` also
+refers to Bootstrap content, not the executable.
 
 `setup` changes no files. Apply its returned Plan only after review. Exact
 official older copies are upgraded through the same reversible Plan/Receipt

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
-use crate::bootstrap::PACKAGE_FILES as BOOTSTRAP_PACKAGE_FILES;
+use crate::bootstrap::{PACKAGE_FILES as BOOTSTRAP_PACKAGE_FILES, content_version};
 use crate::change::{
     self, ChangeReceipt, Operation, OperationPolicy, PrepareContext, PreparedPlan,
 };
@@ -7532,6 +7532,8 @@ fn setup_command_with_manifests<'a>(
     modified_choice: Option<ModifiedBootstrapChoice>,
     legacy_complete_packages: &'a [BootstrapPackageManifest<'a>],
 ) -> Result<Value> {
+    let bootstrap_content_version = content_version()
+        .context("bundled Bootstrap Skill is missing metadata.bootstrap-version")?;
     let Some(snapshot) = store.latest_completed_scan()? else {
         return Ok(json!({
             "detected_agents": [],
@@ -7539,7 +7541,9 @@ fn setup_command_with_manifests<'a>(
             "plan_id": Value::Null,
             "state": "scan_required",
             "bootstrap_skill": "skillroster",
-            "bootstrap_version": env!("CARGO_PKG_VERSION"),
+            "cli_version": env!("CARGO_PKG_VERSION"),
+            "bootstrap_content_version": bootstrap_content_version,
+            "bootstrap_version": bootstrap_content_version,
             "missing_count": 0,
             "current_count": 0,
             "outdated_count": 0,
@@ -7696,7 +7700,7 @@ fn setup_command_with_manifests<'a>(
                 "physical_target": physical_entrypoint,
                 "status": package_status,
                 "installed_version": if package_status == "current" {
-                    Some(env!("CARGO_PKG_VERSION"))
+                    Some(bootstrap_content_version)
                 } else if package_status == "official_outdated" {
                     legacy_version
                 } else {
@@ -7714,7 +7718,9 @@ fn setup_command_with_manifests<'a>(
         "detected_agents": detected,
         "targets": targets,
         "bootstrap_skill": "skillroster",
-        "bootstrap_version": env!("CARGO_PKG_VERSION"),
+        "cli_version": env!("CARGO_PKG_VERSION"),
+        "bootstrap_content_version": bootstrap_content_version,
+        "bootstrap_version": bootstrap_content_version,
         "missing_count": missing_count,
         "current_count": current_count,
         "outdated_count": outdated_count,

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -25,6 +25,69 @@ pub(crate) const PACKAGE_FILES: [PackageFile; 4] = [
     },
 ];
 
+pub(crate) fn content_version() -> Option<&'static str> {
+    let content = PACKAGE_FILES
+        .iter()
+        .find(|file| file.relative_path == "SKILL.md")?
+        .content;
+    parse_content_version(content)
+}
+
+fn parse_content_version(content: &str) -> Option<&str> {
+    let mut lines = content.lines();
+    if lines.next()? != "---" {
+        return None;
+    }
+
+    let mut in_metadata = false;
+    let mut metadata_child_indentation = None;
+    let mut version = None;
+    for line in lines {
+        if line == "---" {
+            return version;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indentation = line.len().saturating_sub(line.trim_start().len());
+        if indentation == 0 {
+            in_metadata = trimmed == "metadata:";
+            metadata_child_indentation = None;
+            continue;
+        }
+        if !in_metadata {
+            continue;
+        }
+        let child_indentation = *metadata_child_indentation.get_or_insert(indentation);
+        if indentation != child_indentation {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        if key.trim() != "bootstrap-version" || version.is_some() {
+            continue;
+        }
+        version = parse_version_scalar(value.trim());
+    }
+    None
+}
+
+fn parse_version_scalar(value: &str) -> Option<&str> {
+    let value = match value.as_bytes() {
+        [b'"', .., b'"'] | [b'\'', .., b'\''] => &value[1..value.len() - 1],
+        _ => value,
+    };
+    let mut parts = value.split('.');
+    let valid = (0..3).all(|_| {
+        parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+    }) && parts.next().is_none();
+    valid.then_some(value)
+}
+
 pub(crate) fn is_managed_target(relative_to_skill_root: &Path) -> bool {
     let Ok(relative_to_package) = relative_to_skill_root.strip_prefix("skillroster") else {
         return false;
@@ -32,4 +95,46 @@ pub(crate) fn is_managed_target(relative_to_skill_root: &Path) -> bool {
     PACKAGE_FILES
         .iter()
         .any(|file| relative_to_package == Path::new(file.relative_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{content_version, parse_content_version};
+
+    #[test]
+    fn content_version_comes_from_the_bundled_skill_frontmatter() {
+        assert_eq!(content_version(), Some("1.8.23"));
+    }
+
+    #[test]
+    fn content_version_requires_closed_leading_frontmatter_and_metadata_parent() {
+        assert_eq!(
+            parse_content_version(
+                "---\r\nname: fixture\r\nmetadata:\r\n  bootstrap-version: '1.8.23'\r\n---\r\nBody"
+            ),
+            Some("1.8.23")
+        );
+        assert_eq!(
+            parse_content_version("# preface\n---\nmetadata:\n  bootstrap-version: 1.8.23\n---"),
+            None
+        );
+        assert_eq!(
+            parse_content_version("---\nmetadata:\n  bootstrap-version: 1.8.23"),
+            None
+        );
+        assert_eq!(
+            parse_content_version(
+                "---\nother:\n  bootstrap-version: 9.9.9\nmetadata:\n  nested:\n    bootstrap-version: 8.8.8\n---\nBody\n---\nbootstrap-version: 7.7.7"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn content_version_rejects_non_version_scalars() {
+        for value in ["", "1.8", "1.8.23-beta", "1.8.23 # comment", "\"1.8.23"] {
+            let content = format!("---\nmetadata:\n  bootstrap-version: {value}\n---\n");
+            assert_eq!(parse_content_version(&content), None, "value: {value}");
+        }
+    }
 }

--- a/src/present.rs
+++ b/src/present.rs
@@ -1504,7 +1504,12 @@ fn mutation(value: &Value, lines: &mut Vec<String>) {
 
 fn setup(value: &Value, lines: &mut Vec<String>, width: usize) {
     fact(lines, "State", text(value, "state"));
-    fact(lines, "Bootstrap version", text(value, "bootstrap_version"));
+    fact(lines, "CLI version", text(value, "cli_version"));
+    fact(
+        lines,
+        "Bootstrap content",
+        text(value, "bootstrap_content_version"),
+    );
     fact(
         lines,
         "Detected Agents",
@@ -1978,7 +1983,9 @@ mod tests {
             "setup",
             &json!({
                 "state": "modified_choice_required",
-                "bootstrap_version": "1.5.0",
+                "cli_version": "1.8.25",
+                "bootstrap_content_version": "1.8.23",
+                "bootstrap_version": "1.8.23",
                 "detected_agents": [{"agent": "codex"}],
                 "current_count": 0,
                 "missing_count": 0,
@@ -2000,7 +2007,9 @@ mod tests {
             "setup",
             &json!({
                 "state": "unsupported_targets",
-                "bootstrap_version": "1.5.0",
+                "cli_version": "1.8.25",
+                "bootstrap_content_version": "1.8.23",
+                "bootstrap_version": "1.8.23",
                 "detected_agents": [{"agent": "codex"}],
                 "current_count": 0,
                 "missing_count": 0,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -42,6 +42,12 @@ fn json_output(output: &std::process::Output) -> Value {
     serde_json::from_slice(&output.stdout).unwrap()
 }
 
+fn assert_setup_versions(output: &Value) {
+    assert_eq!(output["result"]["cli_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(output["result"]["bootstrap_content_version"], "1.8.23");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.23");
+}
+
 fn context_action_argv(home: &Path, state: &Path, tail: &[&str]) -> Value {
     let mut argv = vec![
         "skillroster".to_owned(),
@@ -2309,6 +2315,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
 
     let blocked = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_eq!(blocked["result"]["state"], "modified_choice_required");
+    assert_setup_versions(&blocked);
     assert_eq!(blocked["result"]["modified_count"], 1);
     assert!(blocked["result"]["plan_id"].is_null());
     assert_eq!(blocked["result"]["targets"][0]["status"], "modified");
@@ -2354,6 +2361,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
         None,
     ));
     assert_eq!(upgrade["result"]["state"], "preview_ready");
+    assert_setup_versions(&upgrade);
     assert_eq!(upgrade["result"]["replace_count"], 1);
     assert_eq!(upgrade["result"]["modified_count"], 1);
     assert_eq!(upgrade["suggested_actions"].as_array().unwrap().len(), 1);
@@ -2395,9 +2403,10 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_eq!(current["result"]["state"], "up_to_date");
     assert!(current["result"]["plan_id"].is_null());
+    assert_setup_versions(&current);
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        env!("CARGO_PKG_VERSION")
+        "1.8.23"
     );
 
     let undone = json_output(&run(
@@ -2735,6 +2744,7 @@ fn setup_rejects_a_symlinked_managed_reference() {
         None,
     ));
     assert_eq!(result["result"]["state"], "unsupported_targets");
+    assert_setup_versions(&result);
     assert_eq!(result["result"]["unsupported_count"], 1);
     assert!(result["result"]["plan_id"].is_null());
     assert!(
@@ -2996,10 +3006,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     ));
 
     assert_eq!(output["result"]["state"], "scan_required");
-    assert_eq!(
-        output["result"]["bootstrap_version"],
-        env!("CARGO_PKG_VERSION")
-    );
+    assert_setup_versions(&output);
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],


### PR DESCRIPTION
## Summary

- report the executable version and bundled Bootstrap content version as distinct Setup facts
- keep `bootstrap_version` as a documented compatibility alias for content and report current installed content accurately
- parse the version from the bundled Skill frontmatter with fail-closed structural checks
- cover scan, preview, current, modified, and unsupported Setup states

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (217 unit + 8 acceptance + 62 CLI)
- read-only real-state Setup preview: CLI 1.8.25 / Bootstrap content 1.8.23 / files_changed false
- independent Spec review: PASS
- independent Correctness review: PASS, no blocker or should-fix

Closes #171