### PR TITLE
release: prepare SkillRoster v1.8.25

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "dde059ad39d9dbe9021cef0acbeb7b428afb0268"
-  version "1.8.24"
+      revision: "f8d98f2c2cea117d1f651f5393763aa8244edf8b"
+  version "1.8.25"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.24", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.25", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.24
+SKILLROSTER_VERSION=1.8.25
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -51,7 +51,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.24 skillroster
+  --tag v1.8.25 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -82,7 +82,7 @@ skillroster scan --json
 skillroster setup --json
 ```
 
-CLI v1.8.24 bundles Bootstrap content version 1.8.23. These versions differ
+CLI v1.8.25 bundles Bootstrap content version 1.8.23. These versions differ
 intentionally: the CLI changed after the Bootstrap instructions last changed.
 In Setup JSON, `cli_version` identifies the executable and
 `bootstrap_content_version` identifies the bundled Skill package.


### PR DESCRIPTION
## Summary

- update the repository-backed Homebrew Formula to 1.8.25 at immutable source commit f8d98f2
- update Release archive and Cargo tag installation examples to v1.8.25
- preserve bundled Bootstrap content version 1.8.23

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (217 unit + 8 acceptance + 62 CLI)
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- independent Spec and Correctness review: PASS

Part of #175