### PR TITLE
fix: make recovery state convergence atomic

### DIFF
--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -76,8 +76,9 @@ Progress must describe real stages or measured counts. It must not display 100% 
 Success, cancellation, interruption, timeout, and compensated failure all end with a final summary. Cursor state is restored on every exit path. A partial result states what completed, what did not, and whether any files changed.
 
 Commands that create or reconcile persisted state are serialized behind one
-exclusive state lock. True read and detail commands may run together behind the
-shared lock. A lock conflict returns typed `write_locked` with
+exclusive state lock. First initialization and schema migration use the same
+exclusive boundary. True read and detail commands may run together behind the
+shared lock once the current schema exists. A lock conflict returns typed `write_locked` with
 `retryable: true`; an Agent waits for the active local command to finish and
 retries with a bound instead of polling in a tight loop.
 

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -75,6 +75,12 @@ Progress must describe real stages or measured counts. It must not display 100% 
 
 Success, cancellation, interruption, timeout, and compensated failure all end with a final summary. Cursor state is restored on every exit path. A partial result states what completed, what did not, and whether any files changed.
 
+Commands that create or reconcile persisted state are serialized behind one
+exclusive state lock. True read and detail commands may run together behind the
+shared lock. A lock conflict returns typed `write_locked` with
+`retryable: true`; an Agent waits for the active local command to finish and
+retries with a bound instead of polling in a tight loop.
+
 ## 6. Command experiences
 
 ### `status`

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -24,7 +24,7 @@ tests/
   fixtures/         synthetic Agent homes and session samples
 ```
 
-Adapters discover and normalize Agent-specific facts. They do not implement eight separate mutation systems. All writes pass through `change`, and only one Apply or Undo may hold the process-level write lock at a time. Do not add an ORM, repository trait, Tokio runtime, generic plugin interface, vector database, virtual filesystem, or TUI. A private filesystem seam inside `change` is allowed for fault-injection tests.
+Adapters discover and normalize Agent-specific facts. They do not implement eight separate mutation systems. All Agent and Library filesystem writes pass through `change`. Commands that create or reconcile persisted state hold the exclusive process-level state lock; true read and detail commands share the read lock. A typed, retryable `write_locked` response means another local command must finish before a bounded retry. Do not add an ORM, repository trait, Tokio runtime, generic plugin interface, vector database, virtual filesystem, or TUI. A private filesystem seam inside `change` is allowed for fault-injection tests.
 
 ## Persistence model
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -24,7 +24,7 @@ tests/
   fixtures/         synthetic Agent homes and session samples
 ```
 
-Adapters discover and normalize Agent-specific facts. They do not implement eight separate mutation systems. All Agent and Library filesystem writes pass through `change`. Commands that create or reconcile persisted state hold the exclusive process-level state lock; true read and detail commands share the read lock. A typed, retryable `write_locked` response means another local command must finish before a bounded retry. Do not add an ORM, repository trait, Tokio runtime, generic plugin interface, vector database, virtual filesystem, or TUI. A private filesystem seam inside `change` is allowed for fault-injection tests.
+Adapters discover and normalize Agent-specific facts. They do not implement eight separate mutation systems. All Agent and Library filesystem writes pass through `change`. Commands that create or reconcile persisted state hold the exclusive process-level state lock; true read and detail commands share the read lock once the current SQLite schema exists. First initialization and migration also require the exclusive lock. A typed, retryable `write_locked` response means another local command must finish before a bounded retry. Do not add an ORM, repository trait, Tokio runtime, generic plugin interface, vector database, virtual filesystem, or TUI. A private filesystem seam inside `change` is allowed for fault-injection tests.
 
 ## Persistence model
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -168,7 +168,9 @@ pub fn run(cli: Cli) -> Result<Output> {
         .with_context(|| format!("cannot create {}", state_dir.display()))?;
     // Shared guards let Agent read/analysis commands run concurrently while
     // still excluding lifecycle deletion and filesystem mutations on Windows.
-    let _state_lock = if command_requires_exclusive_state_lock(cli.command.as_ref()) {
+    let requires_exclusive_state_lock = command_requires_exclusive_state_lock(cli.command.as_ref())
+        || StateStore::requires_migration(&database_path)?;
+    let _state_lock = if requires_exclusive_state_lock {
         change::StateLock::acquire_exclusive(&state_dir)?
     } else {
         change::StateLock::acquire_shared(&state_dir)?

--- a/src/app.rs
+++ b/src/app.rs
@@ -2092,7 +2092,7 @@ fn lifecycle_recovery_command(store: &StateStore, state_dir: &Path) -> Result<Va
         "imported_receipt_ids": imported,
         "import_errors": import_errors,
         "automatic_resolution_available": false,
-        "resolution_note": "Orphan journals with an existing immutable Plan are imported as recovery_required, never guessed successful. Inspect exact paths before repair.",
+        "resolution_note": "Orphan journals with an existing immutable Plan are imported as recovery_required, never guessed successful. Apply recovery transitions an applying Plan; Undo recovery preserves its terminal Plan. Inspect exact paths before repair.",
         "state_changed": state_changed,
         "files_changed": false,
     }))

--- a/src/app.rs
+++ b/src/app.rs
@@ -168,12 +168,16 @@ pub fn run(cli: Cli) -> Result<Output> {
         .with_context(|| format!("cannot create {}", state_dir.display()))?;
     // Shared guards let Agent read/analysis commands run concurrently while
     // still excluding lifecycle deletion and filesystem mutations on Windows.
-    let requires_exclusive_state_lock = command_requires_exclusive_state_lock(cli.command.as_ref())
-        || StateStore::requires_migration(&database_path)?;
-    let _state_lock = if requires_exclusive_state_lock {
+    let _state_lock = if command_requires_exclusive_state_lock(cli.command.as_ref()) {
         change::StateLock::acquire_exclusive(&state_dir)?
     } else {
-        change::StateLock::acquire_shared(&state_dir)?
+        let shared = change::StateLock::acquire_shared(&state_dir)?;
+        if StateStore::requires_migration(&database_path)? {
+            drop(shared);
+            change::StateLock::acquire_exclusive(&state_dir)?
+        } else {
+            shared
+        }
     };
     let store = StateStore::open(&database_path)?;
 
@@ -8931,6 +8935,46 @@ mod recovery_tests {
         ] {
             assert!(!exclusive(args), "expected shared lock for {args:?}");
         }
+    }
+
+    #[test]
+    fn fresh_read_command_upgrades_to_exclusive_before_initializing_state() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let state = temp.path().join("state");
+        std::fs::create_dir_all(&state).unwrap();
+        let shared = change::StateLock::acquire_shared(&state).unwrap();
+        let cli = Cli::try_parse_from([
+            "skillroster",
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--json",
+            "status",
+        ])
+        .unwrap();
+
+        let error = match run(cli) {
+            Ok(_) => panic!("fresh read unexpectedly initialized under a shared lock"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("write_locked"));
+        assert!(!state.join("skillroster.db").exists());
+
+        drop(shared);
+        let retry = Cli::try_parse_from([
+            "skillroster",
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--json",
+            "status",
+        ])
+        .unwrap();
+        assert!(run(retry).is_ok());
+        assert!(state.join("skillroster.db").is_file());
     }
 
     fn placement_with_scope(

--- a/src/app.rs
+++ b/src/app.rs
@@ -1991,8 +1991,15 @@ fn remove_recovery_artifacts(state_dir: &Path) -> Result<u64> {
 fn lifecycle_recovery_command(store: &StateStore, state_dir: &Path) -> Result<Value> {
     let mut imported = Vec::new();
     let mut import_errors = Vec::new();
+    let mut state_changed = false;
     for mut journal in change::journals(state_dir)? {
         let receipt_id = ReceiptId::parse(journal.id.clone())?;
+        if store
+            .get_receipt(&receipt_id)?
+            .is_some_and(|receipt| receipt.status != ReceiptStatus::RecoveryRequired)
+        {
+            continue;
+        }
         let plan_id = match PlanId::parse(journal.plan_id.clone()) {
             Ok(id) => id,
             Err(error) => {
@@ -2049,8 +2056,9 @@ fn lifecycle_recovery_command(store: &StateStore, state_dir: &Path) -> Result<Va
             }),
         )?;
         match store.save_recovery_receipt(&plan_id, &imported_receipt) {
-            Ok(inserted) => {
-                if inserted {
+            Ok(outcome) => {
+                state_changed |= outcome.inserted || outcome.plan_transitioned;
+                if outcome.inserted {
                     imported.push(receipt_id);
                 }
             }
@@ -2085,7 +2093,7 @@ fn lifecycle_recovery_command(store: &StateStore, state_dir: &Path) -> Result<Va
         "import_errors": import_errors,
         "automatic_resolution_available": false,
         "resolution_note": "Orphan journals with an existing immutable Plan are imported as recovery_required, never guessed successful. Inspect exact paths before repair.",
-        "state_changed": !imported.is_empty(),
+        "state_changed": state_changed,
         "files_changed": false,
     }))
 }
@@ -10416,6 +10424,7 @@ mod recovery_tests {
 
         let result = lifecycle_recovery_command(&store, &state_dir).unwrap();
         assert_eq!(result["imported_receipt_ids"][0], receipt.id);
+        assert_eq!(result["state_changed"], true);
         let imported = store
             .get_receipt(&ReceiptId::parse(receipt.id).unwrap())
             .unwrap()
@@ -10425,6 +10434,103 @@ mod recovery_tests {
             store.get_plan(&plan.id).unwrap().unwrap().status,
             PlanStatus::RecoveryRequired
         );
+
+        let repeated = lifecycle_recovery_command(&store, &state_dir).unwrap();
+        assert_eq!(repeated["imported_receipt_ids"], json!([]));
+        assert_eq!(repeated["import_errors"], json!([]));
+        assert_eq!(repeated["state_changed"], false);
+    }
+
+    #[test]
+    fn lifecycle_recovery_imports_a_reverse_journal_without_changing_the_plan() {
+        let temp = TempDir::new().unwrap();
+        let state_dir = temp.path().join("state");
+        std::fs::create_dir_all(state_dir.join("receipts")).unwrap();
+        let store = StateStore::open_in_memory().unwrap();
+        let scan = ScanRun {
+            id: ScanId::new(),
+            started_at: 1,
+            completed_at: Some(2),
+            status: ScanStatus::Completed,
+            coverage_notes: vec![],
+        };
+        store.save_scan(&scan).unwrap();
+        let prepared = PreparedPlan {
+            id: PlanId::new().to_string(),
+            scan_id: scan.id.to_string(),
+            evidence_ids: vec![],
+            digest: "sha256:test".to_owned(),
+            operations: vec![],
+            roster_changes: vec![],
+            source_updates: vec![],
+            library_changes: vec![],
+            approved_roots: vec![temp.path().to_path_buf()],
+            state_dir: state_dir.clone(),
+        };
+        let plan = PlanRecord {
+            id: PlanId::parse(prepared.id.clone()).unwrap(),
+            scan_id: scan.id,
+            report_id: None,
+            created_at: 3,
+            status: PlanStatus::Ready,
+            input: json!({
+                "prepared": prepared,
+                "roster_before": [],
+                "library_before": [],
+            }),
+            fingerprint: "sha256:test".to_owned(),
+            operations: vec![],
+        };
+        store.save_plan(&plan).unwrap();
+        store
+            .update_plan_status(&plan.id, PlanStatus::Applying)
+            .unwrap();
+        let original = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: None,
+            created_at: 4,
+            completed_at: Some(5),
+            status: ReceiptStatus::Applied,
+            verification: json!({}),
+            operation_results: vec![],
+        };
+        store
+            .save_apply_receipt(&plan.id, PlanStatus::Applied, &original)
+            .unwrap();
+        let reverse = ChangeReceipt {
+            id: ReceiptId::new().to_string(),
+            plan_id: plan.id.to_string(),
+            status: change::ReceiptStatus::Undone,
+            changed_paths: vec![temp.path().join("agent-skill")],
+            compensations: vec![],
+            approved_roots: vec![temp.path().to_path_buf()],
+            state_dir: state_dir.clone(),
+            error: None,
+            reverses_receipt_id: Some(original.id.to_string()),
+            operation_results: vec![],
+        };
+        std::fs::write(
+            state_dir
+                .join("receipts")
+                .join(format!("{}.json", reverse.id)),
+            serde_json::to_vec(&reverse).unwrap(),
+        )
+        .unwrap();
+
+        let result = lifecycle_recovery_command(&store, &state_dir).unwrap();
+        assert_eq!(result["imported_receipt_ids"][0], reverse.id);
+        assert_eq!(result["import_errors"], json!([]));
+        assert_eq!(result["state_changed"], true);
+        assert_eq!(
+            store.get_plan(&plan.id).unwrap().unwrap().status,
+            PlanStatus::Applied
+        );
+
+        let repeated = lifecycle_recovery_command(&store, &state_dir).unwrap();
+        assert_eq!(repeated["imported_receipt_ids"], json!([]));
+        assert_eq!(repeated["import_errors"], json!([]));
+        assert_eq!(repeated["state_changed"], false);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -582,16 +582,23 @@ pub fn run(cli: Cli) -> Result<Output> {
 }
 
 fn command_requires_exclusive_state_lock(command: Option<&Command>) -> bool {
-    matches!(
-        command,
-        Some(Command::Apply(_) | Command::Undo(_) | Command::Setup(_))
-            | Some(Command::SourceRoot(crate::cli::SourceRootArgs {
-                command: SourceRootCommand::Confirm(_) | SourceRootCommand::Revoke(_),
-            }))
-            | Some(Command::Lifecycle(crate::cli::LifecycleArgs {
-                command: LifecycleCommand::Purge(_),
-            }))
-    )
+    match command {
+        Some(Command::Scan | Command::Apply(_) | Command::Undo(_) | Command::Setup(_)) => true,
+        Some(Command::Report(args)) => args.finding.is_none(),
+        Some(Command::Plan(args)) => args.show.is_none(),
+        Some(Command::SourceRoot(args)) => matches!(
+            &args.command,
+            SourceRootCommand::Confirm(_) | SourceRootCommand::Revoke(_)
+        ),
+        Some(Command::Lifecycle(args)) => matches!(
+            &args.command,
+            LifecycleCommand::Exclude(_)
+                | LifecycleCommand::Purge(_)
+                | LifecycleCommand::Recovery
+                | LifecycleCommand::Delete(_)
+        ),
+        Some(Command::Find(_) | Command::Status) | None => false,
+    }
 }
 
 pub fn error_json(command: &str, error: &(dyn std::error::Error + 'static)) -> String {
@@ -1986,9 +1993,6 @@ fn lifecycle_recovery_command(store: &StateStore, state_dir: &Path) -> Result<Va
     let mut import_errors = Vec::new();
     for mut journal in change::journals(state_dir)? {
         let receipt_id = ReceiptId::parse(journal.id.clone())?;
-        if store.receipt_exists(&receipt_id)? {
-            continue;
-        }
         let plan_id = match PlanId::parse(journal.plan_id.clone()) {
             Ok(id) => id,
             Err(error) => {
@@ -2044,10 +2048,11 @@ fn lifecycle_recovery_command(store: &StateStore, state_dir: &Path) -> Result<Va
                 "after": prepared.library_changes,
             }),
         )?;
-        match store.save_receipt(&imported_receipt) {
-            Ok(()) => {
-                store.mark_plan_recovery_if_applying(&plan_id)?;
-                imported.push(receipt_id);
+        match store.save_recovery_receipt(&plan_id, &imported_receipt) {
+            Ok(inserted) => {
+                if inserted {
+                    imported.push(receipt_id);
+                }
             }
             Err(error) => import_errors.push(json!({
                 "receipt_id": journal.id,
@@ -8869,7 +8874,54 @@ fn action(
 #[allow(clippy::items_after_test_module)]
 mod recovery_tests {
     use super::*;
+    use clap::Parser;
     use tempfile::TempDir;
+
+    #[test]
+    fn command_lock_mode_matches_state_production_boundary() {
+        fn exclusive(args: &[&str]) -> bool {
+            let cli =
+                Cli::try_parse_from(std::iter::once("skillroster").chain(args.iter().copied()))
+                    .unwrap();
+            command_requires_exclusive_state_lock(cli.command.as_ref())
+        }
+
+        for args in [
+            &["scan"][..],
+            &["report"][..],
+            &["plan"][..],
+            &["apply", "plan_1"][..],
+            &["undo", "receipt_1"][..],
+            &["setup"][..],
+            &[
+                "source-root",
+                "confirm",
+                "--finding",
+                "finding_1",
+                "--path",
+                "/tmp",
+            ][..],
+            &["source-root", "revoke", "permission_1"][..],
+            &["lifecycle", "exclude", "codex"][..],
+            &["lifecycle", "purge", "--raw-days", "180"][..],
+            &["lifecycle", "recovery"][..],
+            &["lifecycle", "delete", "--confirm", "DELETE-LOCAL-STATE"][..],
+        ] {
+            assert!(exclusive(args), "expected exclusive lock for {args:?}");
+        }
+        for args in [
+            &[][..],
+            &["status"][..],
+            &["find", "review a pull request"][..],
+            &["report", "--finding", "finding_1"][..],
+            &["plan", "--show", "plan_1"][..],
+            &["source-root", "inspect"][..],
+            &["lifecycle", "inspect"][..],
+            &["lifecycle", "export", "--output", "/tmp/export.json"][..],
+        ] {
+            assert!(!exclusive(args), "expected shared lock for {args:?}");
+        }
+    }
 
     fn placement_with_scope(
         id: &str,

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1354,6 +1354,63 @@ impl StateStore {
         Ok(())
     }
 
+    /// Imports a filesystem recovery Receipt and transitions its Applying Plan
+    /// in one transaction. An already-imported recovery Receipt is accepted so
+    /// older split states can converge on retry.
+    pub fn save_recovery_receipt(
+        &self,
+        plan: &PlanId,
+        receipt: &ReceiptRecord,
+    ) -> StorageResult<bool> {
+        if receipt.plan_id != *plan || receipt.status != ReceiptStatus::RecoveryRequired {
+            return Err(StorageError::InvalidData(
+                "Recovery receipt does not match the recovery Plan".to_owned(),
+            ));
+        }
+        let transaction = self.connection.unchecked_transaction()?;
+        let existing = transaction
+            .query_row(
+                "SELECT plan_id, status FROM receipts WHERE id = ?1",
+                [receipt.id.as_str()],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?;
+        let inserted = match existing {
+            Some((existing_plan, existing_status)) => {
+                if existing_plan != plan.as_str() || existing_status != "recovery_required" {
+                    return Err(StorageError::InvalidData(format!(
+                        "recovery receipt {} conflicts with retained state",
+                        receipt.id
+                    )));
+                }
+                false
+            }
+            None => {
+                save_receipt_transaction(&transaction, receipt)?;
+                true
+            }
+        };
+        transaction.execute(
+            "UPDATE plans SET status = 'recovery_required'
+             WHERE id = ?1 AND status = 'applying'",
+            [plan.as_str()],
+        )?;
+        let plan_status = transaction
+            .query_row(
+                "SELECT status FROM plans WHERE id = ?1",
+                [plan.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        if plan_status.as_deref() != Some("recovery_required") {
+            return Err(StorageError::InvalidData(format!(
+                "plan {plan} is not recoverable from its current state"
+            )));
+        }
+        transaction.commit()?;
+        Ok(inserted)
+    }
+
     pub fn receipt_exists(&self, id: &ReceiptId) -> StorageResult<bool> {
         Ok(self.connection.query_row(
             "SELECT EXISTS(SELECT 1 FROM receipts WHERE id = ?1)",
@@ -2772,6 +2829,90 @@ mod tests {
                 .save_apply_receipt(&plan.id, PlanStatus::Applied, &receipt)
                 .is_err()
         );
+        assert!(!store.receipt_exists(&receipt.id).unwrap());
+        assert_eq!(
+            store.get_plan(&plan.id).unwrap().unwrap().status,
+            PlanStatus::Applying
+        );
+    }
+
+    #[test]
+    fn recovery_receipt_atomically_converges_new_and_legacy_split_state() {
+        let store = StateStore::open_in_memory().unwrap();
+        let scan = scan();
+        store.save_scan(&scan).unwrap();
+        let plan = PlanRecord {
+            id: PlanId::new(),
+            scan_id: scan.id,
+            report_id: None,
+            created_at: 30,
+            status: PlanStatus::Ready,
+            input: serde_json::json!({}),
+            fingerprint: "plan-sha256".to_owned(),
+            operations: vec![],
+        };
+        store.save_plan(&plan).unwrap();
+        store
+            .update_plan_status(&plan.id, PlanStatus::Applying)
+            .unwrap();
+        let receipt = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: None,
+            created_at: 31,
+            completed_at: Some(32),
+            status: ReceiptStatus::RecoveryRequired,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+
+        store.save_receipt(&receipt).unwrap();
+        assert!(!store.save_recovery_receipt(&plan.id, &receipt).unwrap());
+        assert_eq!(
+            store.get_plan(&plan.id).unwrap().unwrap().status,
+            PlanStatus::RecoveryRequired
+        );
+    }
+
+    #[test]
+    fn failed_recovery_finalization_retains_neither_receipt_nor_plan_transition() {
+        let store = StateStore::open_in_memory().unwrap();
+        let scan = scan();
+        store.save_scan(&scan).unwrap();
+        let plan = PlanRecord {
+            id: PlanId::new(),
+            scan_id: scan.id,
+            report_id: None,
+            created_at: 30,
+            status: PlanStatus::Ready,
+            input: serde_json::json!({}),
+            fingerprint: "plan-sha256".to_owned(),
+            operations: vec![],
+        };
+        store.save_plan(&plan).unwrap();
+        store
+            .update_plan_status(&plan.id, PlanStatus::Applying)
+            .unwrap();
+        store
+            .connection
+            .execute_batch(
+                "CREATE TRIGGER fail_recovery_transition BEFORE UPDATE OF status ON plans
+                 WHEN NEW.status = 'recovery_required'
+                 BEGIN SELECT RAISE(FAIL, 'injected recovery failure'); END;",
+            )
+            .unwrap();
+        let receipt = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: None,
+            created_at: 31,
+            completed_at: Some(32),
+            status: ReceiptStatus::RecoveryRequired,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+
+        assert!(store.save_recovery_receipt(&plan.id, &receipt).is_err());
         assert!(!store.receipt_exists(&receipt.id).unwrap());
         assert_eq!(
             store.get_plan(&plan.id).unwrap().unwrap().status,

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -39,6 +39,12 @@ pub struct PlanReceiptPurgeCounts {
     pub receipts: u64,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RecoveryReceiptSaveOutcome {
+    pub inserted: bool,
+    pub plan_transitioned: bool,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SourceBaseline {
     pub source: String,
@@ -1361,7 +1367,7 @@ impl StateStore {
         &self,
         plan: &PlanId,
         receipt: &ReceiptRecord,
-    ) -> StorageResult<bool> {
+    ) -> StorageResult<RecoveryReceiptSaveOutcome> {
         if receipt.plan_id != *plan || receipt.status != ReceiptStatus::RecoveryRequired {
             return Err(StorageError::InvalidData(
                 "Recovery receipt does not match the recovery Plan".to_owned(),
@@ -1390,11 +1396,34 @@ impl StateStore {
                 true
             }
         };
-        transaction.execute(
-            "UPDATE plans SET status = 'recovery_required'
-             WHERE id = ?1 AND status = 'applying'",
-            [plan.as_str()],
-        )?;
+        let is_reverse = receipt.reverses_receipt_id.is_some();
+        if let Some(original_id) = &receipt.reverses_receipt_id {
+            let original = transaction
+                .query_row(
+                    "SELECT plan_id, status FROM receipts WHERE id = ?1",
+                    [original_id.as_str()],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()?;
+            if original.as_ref().map(|(original_plan, original_status)| {
+                (original_plan.as_str(), original_status.as_str())
+            }) != Some((plan.as_str(), "applied"))
+            {
+                return Err(StorageError::InvalidData(format!(
+                    "recovery receipt {} does not reverse an applied Receipt from Plan {plan}",
+                    receipt.id
+                )));
+            }
+        }
+        let plan_transitioned = if is_reverse {
+            false
+        } else {
+            transaction.execute(
+                "UPDATE plans SET status = 'recovery_required'
+                 WHERE id = ?1 AND status = 'applying'",
+                [plan.as_str()],
+            )? == 1
+        };
         let plan_status = transaction
             .query_row(
                 "SELECT status FROM plans WHERE id = ?1",
@@ -1402,13 +1431,24 @@ impl StateStore {
                 |row| row.get::<_, String>(0),
             )
             .optional()?;
-        if plan_status.as_deref() != Some("recovery_required") {
+        let valid_plan_status = if is_reverse {
+            matches!(
+                plan_status.as_deref(),
+                Some("applied" | "failed_rolled_back")
+            )
+        } else {
+            plan_status.as_deref() == Some("recovery_required")
+        };
+        if !valid_plan_status {
             return Err(StorageError::InvalidData(format!(
                 "plan {plan} is not recoverable from its current state"
             )));
         }
         transaction.commit()?;
-        Ok(inserted)
+        Ok(RecoveryReceiptSaveOutcome {
+            inserted,
+            plan_transitioned,
+        })
     }
 
     pub fn receipt_exists(&self, id: &ReceiptId) -> StorageResult<bool> {
@@ -2867,7 +2907,13 @@ mod tests {
         };
 
         store.save_receipt(&receipt).unwrap();
-        assert!(!store.save_recovery_receipt(&plan.id, &receipt).unwrap());
+        assert_eq!(
+            store.save_recovery_receipt(&plan.id, &receipt).unwrap(),
+            RecoveryReceiptSaveOutcome {
+                inserted: false,
+                plan_transitioned: true,
+            }
+        );
         assert_eq!(
             store.get_plan(&plan.id).unwrap().unwrap().status,
             PlanStatus::RecoveryRequired
@@ -2917,6 +2963,69 @@ mod tests {
         assert_eq!(
             store.get_plan(&plan.id).unwrap().unwrap().status,
             PlanStatus::Applying
+        );
+    }
+
+    #[test]
+    fn reverse_recovery_receipt_preserves_applied_plan_and_is_idempotent() {
+        let store = StateStore::open_in_memory().unwrap();
+        let scan = scan();
+        store.save_scan(&scan).unwrap();
+        let plan = PlanRecord {
+            id: PlanId::new(),
+            scan_id: scan.id,
+            report_id: None,
+            created_at: 30,
+            status: PlanStatus::Ready,
+            input: serde_json::json!({}),
+            fingerprint: "plan-sha256".to_owned(),
+            operations: vec![],
+        };
+        store.save_plan(&plan).unwrap();
+        store
+            .update_plan_status(&plan.id, PlanStatus::Applying)
+            .unwrap();
+        let original = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: None,
+            created_at: 31,
+            completed_at: Some(32),
+            status: ReceiptStatus::Applied,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+        store
+            .save_apply_receipt(&plan.id, PlanStatus::Applied, &original)
+            .unwrap();
+        let recovery = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: Some(original.id.clone()),
+            created_at: 33,
+            completed_at: Some(34),
+            status: ReceiptStatus::RecoveryRequired,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+
+        assert_eq!(
+            store.save_recovery_receipt(&plan.id, &recovery).unwrap(),
+            RecoveryReceiptSaveOutcome {
+                inserted: true,
+                plan_transitioned: false,
+            }
+        );
+        assert_eq!(
+            store.get_plan(&plan.id).unwrap().unwrap().status,
+            PlanStatus::Applied
+        );
+        assert_eq!(
+            store.save_recovery_receipt(&plan.id, &recovery).unwrap(),
+            RecoveryReceiptSaveOutcome {
+                inserted: false,
+                plan_transitioned: false,
+            }
         );
     }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, Transaction, params};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
@@ -145,6 +145,15 @@ pub struct StateStore {
 }
 
 impl StateStore {
+    pub fn requires_migration(path: impl AsRef<Path>) -> StorageResult<bool> {
+        if !path.as_ref().exists() {
+            return Ok(true);
+        }
+        let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let version: i64 = connection.pragma_query_value(None, "user_version", |row| row.get(0))?;
+        Ok(version != SCHEMA_VERSION)
+    }
+
     /// Opens a SQLite savepoint around normalized Snapshot persistence. The
     /// initial `running` row is intentionally written before this boundary so
     /// a failed attempt can be retained as `failed` after rollback.
@@ -1377,14 +1386,24 @@ impl StateStore {
         let transaction = self.connection.unchecked_transaction()?;
         let existing = transaction
             .query_row(
-                "SELECT plan_id, status FROM receipts WHERE id = ?1",
+                "SELECT plan_id, status, reverses_receipt_id FROM receipts WHERE id = ?1",
                 [receipt.id.as_str()],
-                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
+                },
             )
             .optional()?;
         let inserted = match existing {
-            Some((existing_plan, existing_status)) => {
-                if existing_plan != plan.as_str() || existing_status != "recovery_required" {
+            Some((existing_plan, existing_status, existing_reverse)) => {
+                let expected_reverse = receipt.reverses_receipt_id.as_ref().map(ReceiptId::as_str);
+                if existing_plan != plan.as_str()
+                    || existing_status != "recovery_required"
+                    || existing_reverse.as_deref() != expected_reverse
+                {
                     return Err(StorageError::InvalidData(format!(
                         "recovery receipt {} conflicts with retained state",
                         receipt.id
@@ -1433,10 +1452,7 @@ impl StateStore {
             )
             .optional()?;
         let valid_plan_status = if is_reverse {
-            matches!(
-                plan_status.as_deref(),
-                Some("applied" | "failed_rolled_back")
-            )
+            plan_status.as_deref() == Some("applied")
         } else {
             plan_status.as_deref() == Some("recovery_required")
         };
@@ -2520,6 +2536,21 @@ mod tests {
     }
 
     #[test]
+    fn migration_requirement_detects_missing_old_and_current_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("skillroster.db");
+        assert!(StateStore::requires_migration(&path).unwrap());
+
+        let connection = Connection::open(&path).unwrap();
+        connection.pragma_update(None, "user_version", 9).unwrap();
+        drop(connection);
+        assert!(StateStore::requires_migration(&path).unwrap());
+
+        drop(StateStore::open(&path).unwrap());
+        assert!(!StateStore::requires_migration(&path).unwrap());
+    }
+
+    #[test]
     fn migration_preserves_distinct_v8_observations_without_combining_legacy_totals() {
         let mut connection = Connection::open_in_memory().unwrap();
         connection
@@ -3027,6 +3058,119 @@ mod tests {
                 inserted: false,
                 plan_transitioned: false,
             }
+        );
+    }
+
+    #[test]
+    fn reverse_recovery_receipt_rejects_a_rolled_back_plan() {
+        let store = StateStore::open_in_memory().unwrap();
+        let scan = scan();
+        store.save_scan(&scan).unwrap();
+        let plan = PlanRecord {
+            id: PlanId::new(),
+            scan_id: scan.id,
+            report_id: None,
+            created_at: 30,
+            status: PlanStatus::Ready,
+            input: serde_json::json!({}),
+            fingerprint: "plan-sha256".to_owned(),
+            operations: vec![],
+        };
+        store.save_plan(&plan).unwrap();
+        store
+            .update_plan_status(&plan.id, PlanStatus::Applying)
+            .unwrap();
+        store
+            .update_plan_status(&plan.id, PlanStatus::FailedRolledBack)
+            .unwrap();
+        let original = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: None,
+            created_at: 31,
+            completed_at: Some(32),
+            status: ReceiptStatus::Applied,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+        store.save_receipt(&original).unwrap();
+        let recovery = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: Some(original.id),
+            created_at: 33,
+            completed_at: Some(34),
+            status: ReceiptStatus::RecoveryRequired,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+
+        assert!(store.save_recovery_receipt(&plan.id, &recovery).is_err());
+        assert!(!store.receipt_exists(&recovery.id).unwrap());
+        assert_eq!(
+            store.get_plan(&plan.id).unwrap().unwrap().status,
+            PlanStatus::FailedRolledBack
+        );
+    }
+
+    #[test]
+    fn recovery_receipt_rejects_a_changed_reverse_identity() {
+        let store = StateStore::open_in_memory().unwrap();
+        let scan = scan();
+        store.save_scan(&scan).unwrap();
+        let plan = PlanRecord {
+            id: PlanId::new(),
+            scan_id: scan.id,
+            report_id: None,
+            created_at: 30,
+            status: PlanStatus::Ready,
+            input: serde_json::json!({}),
+            fingerprint: "plan-sha256".to_owned(),
+            operations: vec![],
+        };
+        store.save_plan(&plan).unwrap();
+        store
+            .update_plan_status(&plan.id, PlanStatus::Applying)
+            .unwrap();
+        let original = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: None,
+            created_at: 31,
+            completed_at: Some(32),
+            status: ReceiptStatus::Applied,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+        store.save_receipt(&original).unwrap();
+        let retained = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: None,
+            created_at: 33,
+            completed_at: Some(34),
+            status: ReceiptStatus::RecoveryRequired,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+        store.save_receipt(&retained).unwrap();
+        let conflicting = ReceiptRecord {
+            reverses_receipt_id: Some(original.id),
+            ..retained
+        };
+
+        assert!(store.save_recovery_receipt(&plan.id, &conflicting).is_err());
+        assert_eq!(
+            store
+                .get_receipt(&conflicting.id)
+                .unwrap()
+                .unwrap()
+                .reverses_receipt_id,
+            None
+        );
+        assert_eq!(
+            store.get_plan(&plan.id).unwrap().unwrap().status,
+            PlanStatus::Applying
         );
     }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1360,9 +1360,10 @@ impl StateStore {
         Ok(())
     }
 
-    /// Imports a filesystem recovery Receipt and transitions its Applying Plan
-    /// in one transaction. An already-imported recovery Receipt is accepted so
-    /// older split states can converge on retry.
+    /// Imports a filesystem recovery Receipt in one transaction. Apply recovery
+    /// transitions its Applying Plan; a verified reverse Undo keeps the terminal
+    /// Plan unchanged. An already-imported recovery Receipt is accepted so older
+    /// split states can converge on retry.
     pub fn save_recovery_receipt(
         &self,
         plan: &PlanId,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2022,11 +2022,25 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
     FileExt::try_lock_shared(&shared_lock).unwrap();
     let concurrent_status = run(&[&common[..], &["status"]].concat(), None);
     assert!(concurrent_status.status.success());
-    let blocked_purge = run(
-        &[&common[..], &["lifecycle", "purge", "--raw-days", "180"]].concat(),
-        None,
-    );
-    assert!(!blocked_purge.status.success());
+    let concurrent_plan_detail = run(&[&common[..], &["plan", "--show", plan_id]].concat(), None);
+    assert!(concurrent_plan_detail.status.success());
+    for (args, input) in [
+        (&["scan"][..], None),
+        (&["report"][..], None),
+        (&["plan"][..], Some("{}")),
+        (&["lifecycle", "exclude", "codex"][..], None),
+        (&["lifecycle", "purge", "--raw-days", "180"][..], None),
+        (&["lifecycle", "recovery"][..], None),
+    ] {
+        let blocked = run(&[&common[..], args].concat(), input);
+        assert!(
+            !blocked.status.success(),
+            "command was not locked: {args:?}"
+        );
+        let blocked: Value = serde_json::from_slice(&blocked.stdout).unwrap();
+        assert_eq!(blocked["error"]["code"], "write_locked");
+        assert_eq!(blocked["error"]["retryable"], true);
+    }
     FileExt::unlock(&shared_lock).unwrap();
     drop(shared_lock);
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2044,6 +2044,15 @@ fn public_cli_scans_reports_plans_applies_and_undoes() {
     FileExt::unlock(&shared_lock).unwrap();
     drop(shared_lock);
 
+    let clean_recovery = json_output(&run(
+        &[&common[..], &["lifecycle", "recovery"]].concat(),
+        None,
+    ));
+    assert_eq!(clean_recovery["result"]["recovery_state"], "clear");
+    assert_eq!(clean_recovery["result"]["imported_receipt_ids"], json!([]));
+    assert_eq!(clean_recovery["result"]["import_errors"], json!([]));
+    assert_eq!(clean_recovery["result"]["state_changed"], false);
+
     let write_lock = OpenOptions::new()
         .read(true)
         .write(true)


### PR DESCRIPTION
Closes #178.

## Problem

Recovery imported a filesystem Receipt and transitioned its Plan in two independent SQLite writes. A crash or busy error between them left `Receipt=recovery_required` with `Plan=applying`; the next Recovery skipped the existing Receipt and could never repair the Plan.

Several commands that produce persistent state also held a shared command lock, allowing higher-level Scan/Report/Plan/Exclude/Recovery interleavings even though individual SQLite statements were safe.

## Changes

- Add one SQLite transaction that inserts or validates a Recovery Receipt and converges its Plan to `recovery_required`.
- Make retries repair legacy split state idempotently; preserve terminal Applied/Undone journals; and import a verified reverse Undo recovery journal without changing its Applied Plan. Conflicting or non-recoverable retained state fails closed.
- Use the exclusive state lock for Scan, Report generation, Plan preparation, evidence exclusion, and Recovery.
- Preserve shared locks for true read paths: home, Status, Find, Report finding drilldown, Plan show, SourceRoot inspect, and Lifecycle inspect/export.
- Add failure injection, legacy-state repair, lock-matrix, and real CLI external-lock regressions.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (228 unit + 8 acceptance + 62 CLI)
- `git diff --check`

No Agent or Skill file contract, JSON schema, journal/compensation rule, or stored schema changed.



