### PR TITLE
refactor: remove split-state finalizers

### DIFF
--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1476,14 +1476,6 @@ impl StateStore {
         )?)
     }
 
-    pub fn mark_plan_recovery_if_applying(&self, id: &PlanId) -> StorageResult<bool> {
-        Ok(self.connection.execute(
-            "UPDATE plans SET status = 'recovery_required'
-             WHERE id = ?1 AND status = 'applying'",
-            [id.as_str()],
-        )? == 1)
-    }
-
     pub fn get_receipt(&self, id: &ReceiptId) -> StorageResult<Option<ReceiptRecord>> {
         let stored = self
             .connection
@@ -1561,26 +1553,6 @@ impl StateStore {
             .map(ReceiptId::parse)
             .transpose()
             .map_err(invalid_id)
-    }
-
-    pub fn update_receipt_status(&self, id: &ReceiptId, next: ReceiptStatus) -> StorageResult<()> {
-        if next != ReceiptStatus::Undone {
-            return Err(StorageError::InvalidData(format!(
-                "receipt {id} cannot transition to {next:?}"
-            )));
-        }
-        let next_text = enum_text(&next)?;
-        let changed = self.connection.execute(
-            "UPDATE receipts SET status = ?1, completed_at = ?2
-             WHERE id = ?3 AND status = 'applied'",
-            params![next_text, chrono::Utc::now().timestamp(), id.as_str()],
-        )?;
-        if changed != 1 {
-            return Err(StorageError::InvalidData(format!(
-                "receipt {id} cannot transition to {next:?}"
-            )));
-        }
-        Ok(())
     }
 
     pub fn recovery_required(&self) -> StorageResult<bool> {


### PR DESCRIPTION
Closes #181.

## Change

Remove the unused `mark_plan_recovery_if_applying` and `update_receipt_status` methods from `StateStore`. After #178, finalization is owned by the atomic apply, undo, and recovery transaction methods; retaining partial mutation entry points made that boundary easier to misuse.

No replacement logic was added. Schema, migrations, JSON, runtime behavior, Agent files, and Skill files are unchanged.

## Simplification receipt

- Before: two public split-state mutation methods, 28 lines, zero callers.
- After: zero symbol references; atomic finalization methods are the only persistence boundary.
- Protected contracts: Plan/Receipt transitions, Recovery/Undo, migration behavior, CLI JSON, filesystem safety.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (228 unit + 8 acceptance + 62 CLI)
- `git diff --check`
