### PR TITLE
fix: preserve retained Skill identity on unreadable scans

### DIFF
--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -566,6 +566,24 @@ impl StateStore {
             )?;
             return SkillId::parse(id).map_err(invalid_id);
         }
+        if let Some(existing_identity) = self
+            .connection
+            .query_row(
+                "SELECT identity_key FROM skills WHERE id = ?1",
+                [skill.id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+        {
+            let expected_weak_identity = format!("incomplete-snapshot-skill:{}", skill.id.as_str());
+            if skill.identity_key == expected_weak_identity {
+                return Ok(skill.id.clone());
+            }
+            return Err(StorageError::InvalidData(format!(
+                "Skill {} conflicts with retained identity {existing_identity}",
+                skill.id
+            )));
+        }
         self.connection.execute(
             "INSERT INTO skills
                 (id, identity_key, name, description, declared_source, declared_revision,
@@ -2657,6 +2675,13 @@ mod tests {
             store.skill_governance_state(&stable).unwrap(),
             Some(GovernanceState::Managed)
         );
+
+        let conflicting = SkillRecord {
+            id: stable,
+            identity_key: "content:different-strong-identity".to_owned(),
+            ..skill
+        };
+        assert!(store.save_skill(&conflicting).is_err());
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7863,6 +7863,71 @@ fn escaping_link_finding_requests_trust_confirmation_instead_of_a_plan() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn unreadable_link_scan_preserves_a_retained_skill_identity() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".claude/skills");
+    let source = temp.path().join("external-source");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(&source).unwrap();
+    fs::write(
+        source.join("SKILL.md"),
+        "---\nname: retained-external\ndescription: fixture\n---\n",
+    )
+    .unwrap();
+    let linked = root.join("retained-external");
+    std::os::unix::fs::symlink(&source, &linked).unwrap();
+    let entrypoint = linked.join("SKILL.md");
+    let skill_id = format!(
+        "skill_{:x}",
+        Sha256::digest(format!("unreadable-link:{}", entrypoint.display()).as_bytes())
+    );
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["status"]].concat(), None));
+    let connection = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    connection
+        .execute(
+            "INSERT INTO skills
+                (id, identity_key, name, description, declared_source, declared_revision,
+                 content_digest, digest_version, governance_state, canonical_path)
+             VALUES (?1, ?2, ?3, NULL, NULL, NULL, ?4, 1, 'managed', ?5)",
+            rusqlite::params![
+                skill_id,
+                "content:retained-strong-identity",
+                "retained-external",
+                "retained-package-digest",
+                linked.to_string_lossy(),
+            ],
+        )
+        .unwrap();
+    drop(connection);
+
+    let first = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    assert_eq!(first["result"]["skill_count"], 1);
+    let second = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    assert_eq!(second["result"]["skill_count"], 1);
+
+    let connection = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let retained: (String, String) = connection
+        .query_row(
+            "SELECT identity_key, governance_state FROM skills WHERE id = ?1",
+            [&skill_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(retained.0, "content:retained-strong-identity");
+    assert_eq!(retained.1, "managed");
+}
+
 #[test]
 fn report_distinguishes_inaccessible_and_missing_session_roots() {
     let temp = TempDir::new().unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7916,6 +7916,42 @@ fn unreadable_link_scan_preserves_a_retained_skill_identity() {
     let second = json_output(&run(&[&common[..], &["scan"]].concat(), None));
     assert_eq!(second["result"]["skill_count"], 1);
 
+    let report = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Skill links escape an approved root")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let detail = json_output(&run(
+        &[&common[..], &["report", "--finding", finding_id]].concat(),
+        None,
+    ));
+    assert_eq!(detail["result"]["severity"], "high");
+    assert!(
+        detail["result"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["facts"]["link_target"] == json!(source))
+    );
+
+    let load = run(
+        &[&common[..], &["find", "retained-external", "--load"]].concat(),
+        None,
+    );
+    assert!(!load.status.success());
+    let load: Value = serde_json::from_slice(&load.stdout).unwrap();
+    assert_eq!(
+        load["error"]["details"]["reason"],
+        "untrusted_external_source"
+    );
+
     let connection = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
     let retained: (String, String) = connection
         .query_row(


### PR DESCRIPTION
Closes #183.

## Real failure

Dogfooding current `main` against the retained local state failed every Scan with `UNIQUE constraint failed: skills.id`. The same machine scanned successfully into a fresh state (251 Skills / 887 placements), proving this was retained-state compatibility rather than discovery failure.

The retained database had strong `content:` identities for deterministic Skill IDs that are now observed only through escaping links. Current persistence assigned the weaker `incomplete-snapshot-skill:<id>` identity, missed the retained identity-key lookup, then tried to insert the already-retained ID.

## Fix

- If a Skill ID already exists, reuse it only when the incoming identity is the exact weak `incomplete-snapshot-skill:<same-id>` form.
- Preserve the retained identity, metadata, and governance state.
- Keep any different strong identity conflict fail-closed with an explicit storage error.
- Continue persisting the current unsafe placement and layout Finding; no unsafe content is read.

## Diagnosis and verification

- Added a CLI regression that seeds a retained managed identity, scans an escaping link, repeats the Scan, proves identity/governance preservation, verifies the High layout Finding, and confirms `--load` remains blocked as `untrusted_external_source`. It failed before the fix with the same unique constraint.
- Added a strong-identity conflict negative assertion.
- Original retained home: two consecutive Scans PASS, 251 Skills / 887 placements / 8 Agents, `files_changed=false`.
- Report on the resulting Snapshot PASS, 177 Findings; the 16 escaping links remain the top High Finding.
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (228 unit + 8 acceptance + 63 CLI)
- `git diff --check`

No Agent or Skill files, schema, migration, JSON schema, trust rule, or mutation scope changed.

## Follow-up boundary

#185 separately investigates whether retained semantic evidence should produce bounded diagnostic-only unavailable matches. It is not restored to routing or loading in this PR.
