### PR TITLE
test: prepare bounded On-demand transfer gate

### DIFF
--- a/tests/fixtures/codex-cold-routing-on-demand-transfer-v1.json
+++ b/tests/fixtures/codex-cold-routing-on-demand-transfer-v1.json
@@ -1,0 +1,150 @@
+{
+  "schema_version": 1,
+  "harness": "codex-transfer",
+  "suite_id": "codex-on-demand-transfer-gate-v1",
+  "evaluation_mode": "on_demand_transfer",
+  "formal_protocol_gate": true,
+  "trials_per_arm": 3,
+  "formal_schedule": {
+    "arm": "on_demand",
+    "model": "gpt-5.6-luna",
+    "reasoning_effort": "medium",
+    "timeout_ms": 300000,
+    "family_count": 3,
+    "trials_per_family": 3,
+    "run_count": 9
+  },
+  "stop_decision": {
+    "all_scheduled_runs_pass": "retain_current_design_and_close_129",
+    "any_run_fails": "classify_exclusive_stage_then_open_one_narrow_defect_or_end_research",
+    "post_result_tuning": "forbidden"
+  },
+  "tasks": [
+    {
+      "id": "on-demand-json-001",
+      "family": "deterministic_json_artifact",
+      "expected_skill": "event-manifest",
+      "prompt": "请把 handoff.psv 转成团队标准的事件交接清单，保存到 outputs/events.json。严格使用本机已有的团队规范，不要自行发明格式。完成后只告诉我输出路径和校验是否通过。",
+      "hint": "normalize PSV incident handoff records into team event manifest JSON",
+      "required_find_calls": 1,
+      "one_call_load": true,
+      "workspace_files": {
+        "handoff.psv": "evt-03|2026-08-23T09:30:00Z|billing|open\nevt-01|2026-08-22T14:05:00Z|identity|closed\nevt-02|2026-08-23T01:15:00Z|search|open\n"
+      },
+      "allowed_changed_paths": [
+        "outputs/events.json"
+      ],
+      "oracle": {
+        "path": "outputs/events.json",
+        "json_equals": {
+          "schema_version": 1,
+          "records": [
+            {
+              "id": "evt-01",
+              "occurred_at": "2026-08-22T14:05:00Z",
+              "owner": "identity",
+              "state": "closed"
+            },
+            {
+              "id": "evt-02",
+              "occurred_at": "2026-08-23T01:15:00Z",
+              "owner": "search",
+              "state": "open"
+            },
+            {
+              "id": "evt-03",
+              "occurred_at": "2026-08-23T09:30:00Z",
+              "owner": "billing",
+              "state": "open"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "on-demand-extraction-001",
+      "family": "reference_backed_structured_extraction",
+      "expected_skill": "domain-extractor",
+      "prompt": "请阅读 notes.txt，按随附的领域格式抽取其中明确出现的术语、定义和关系，保存为 outputs/glossary.json。只使用原文事实，保持首次出现顺序，输出严格 JSON，不要解释或额外字段。",
+      "hint": "extract exact domain terms and explicit relationships into JSON",
+      "required_find_calls": 1,
+      "one_call_load": true,
+      "workspace_files": {
+        "notes.txt": "Order Service 负责创建订单。Publish Queue 接收 Order Service 发布的异步事件。Order Service 发布事件到 Publish Queue。\n"
+      },
+      "allowed_changed_paths": [
+        "outputs/glossary.json"
+      ],
+      "oracle": {
+        "path": "outputs/glossary.json",
+        "json_equals": {
+          "terms": [
+            {
+              "id": "order-service",
+              "label": "Order Service",
+              "definition": "负责创建订单。",
+              "relations": [
+                {
+                  "type": "publishes-event",
+                  "target": "publish-queue"
+                }
+              ]
+            },
+            {
+              "id": "publish-queue",
+              "label": "Publish Queue",
+              "definition": "接收 Order Service 发布的异步事件。",
+              "relations": []
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "on-demand-multi-file-001",
+      "family": "script_backed_multi_file_artifact",
+      "expected_skill": "artifact-builder",
+      "prompt": "请根据 input.json 生成一个多文件交付物，保存到 outputs/。使用随附的程序完成转换，不要手写派生内容；完成后检查 report.json 和 README.md 都存在且内容一致，只告诉我这两个文件的路径。",
+      "hint": "build deterministic multi-file report from structured input",
+      "required_find_calls": 1,
+      "one_call_load": true,
+      "workspace_files": {
+        "input.json": "{\n  \"title\": \"Release checklist\",\n  \"items\": [\n    {\"name\": \"offline drafts\", \"status\": \"ready\"},\n    {\"name\": \"batch export\", \"status\": \"review\"}\n  ]\n}\n"
+      },
+      "allowed_changed_paths": [
+        "outputs/report.json",
+        "outputs/README.md"
+      ],
+      "oracle": {
+        "path": "outputs/report.json",
+        "json_equals": {
+          "title": "Release checklist",
+          "item_count": 2,
+          "items": [
+            {
+              "position": 1,
+              "name": "offline drafts",
+              "status": "ready"
+            },
+            {
+              "position": 2,
+              "name": "batch export",
+              "status": "review"
+            }
+          ]
+        },
+        "required_files": [
+          {
+            "path": "outputs/README.md",
+            "required_substrings": [
+              "# Release checklist",
+              "Items: 2",
+              "1. offline drafts — ready",
+              "2. batch export — review"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -11,6 +11,8 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(HERE, "../../..");
 const SYSTEM_SKILLS = ["imagegen", "openai-docs", "plugin-creator", "skill-creator", "skill-installer"];
 const DEFAULT_MANIFEST = join(REPO, "tests/fixtures/codex-cold-routing-transfer.json");
+const EVALUATION_MODES = ["paired", "on_demand_transfer"];
+const TRANSFER_STAGES = ["no_retrieval_call", "retrieval_wrong", "load_wrong", "task_execution_failed", "task_succeeded"];
 const ACTIVE_AUTH_COPIES = new Set();
 const ACTIVE_RUNTIME_DIRS = new Set();
 for (const [signal, code] of [["SIGINT", 130], ["SIGTERM", 143]]) process.once(signal, () => {
@@ -42,6 +44,7 @@ export function parseArgs(argv) {
     skillsRoot: join(homedir(), ".agents_skills"), cli: join(REPO, "target/debug/skillroster"),
     runsDir: join(tmpdir(), "skillroster-codex-transfer"), authSource: null,
     timeoutMs: 300_000, execute: false, reevaluateRoot: null, reevaluateOutput: null, summaryOutput: null,
+    armExplicit: false,
   };
   const values = new Map([
     ["--manifest", "manifest"], ["--task", "task"], ["--arm", "arm"], ["--model", "model"], ["--reasoning-effort", "reasoningEffort"],
@@ -54,6 +57,7 @@ export function parseArgs(argv) {
     const key = values.get(argv[index]); const value = argv[index + 1];
     if (!key || value === undefined) fail(`unknown or incomplete argument: ${argv[index] ?? "<missing>"}`);
     options[key] = key === "timeoutMs" ? Number(value) : ["task", "arm", "model", "reasoningEffort", "codex"].includes(key) ? value : resolve(value);
+    if (key === "arm") options.armExplicit = true;
     index += 2;
   }
   if (!["core", "on_demand", "both"].includes(options.arm)) fail("--arm must be core, on_demand, or both");
@@ -71,6 +75,8 @@ export function validateManifest(manifest) {
   const trialsPerArm = manifest.trials_per_arm ?? 1;
   if (!Number.isSafeInteger(trialsPerArm) || trialsPerArm < 1 || trialsPerArm > 10) fail("trials_per_arm must be between 1 and 10");
   if (manifest.formal_protocol_gate !== undefined && typeof manifest.formal_protocol_gate !== "boolean") fail("formal_protocol_gate must be boolean");
+  const evaluationMode = manifest.evaluation_mode ?? "paired";
+  if (!EVALUATION_MODES.includes(evaluationMode)) fail("evaluation_mode must be paired or on_demand_transfer");
   const ids = new Set();
   const families = new Set();
   for (const task of manifest.tasks) {
@@ -103,6 +109,17 @@ export function validateManifest(manifest) {
     const spec = task.oracle.architecture_spec_contract;
     if (receipt && (!spec || spec.spec_path !== receipt.spec_path || spec.components?.length !== 8 || spec.boundaries?.length !== 3 || spec.connections?.length !== 7)) fail(`${task.id} architecture spec contract is invalid`);
     for (const edge of spec?.connections ?? []) new RegExp(edge.label_regex, "u");
+  }
+  if (evaluationMode === "on_demand_transfer") {
+    if (manifest.formal_protocol_gate !== true) fail("on_demand_transfer requires formal_protocol_gate");
+    if (manifest.tasks.some((task) => task.one_call_load !== true || task.required_find_calls !== 1)) fail("on_demand_transfer requires exactly one audited one-call load per task");
+    const schedule = manifest.formal_schedule;
+    if (schedule?.arm !== "on_demand" || schedule?.family_count !== manifest.tasks.length || schedule?.trials_per_family !== trialsPerArm || schedule?.run_count !== manifest.tasks.length * trialsPerArm) fail("on_demand_transfer formal_schedule must match the manifest task and trial schedule");
+    if (typeof schedule.model !== "string" || !schedule.model.trim()
+      || !["low", "medium", "high", "xhigh"].includes(schedule.reasoning_effort)
+      || !Number.isSafeInteger(schedule.timeout_ms) || schedule.timeout_ms < 1_000 || schedule.timeout_ms > 900_000) fail("on_demand_transfer formal_schedule must freeze model, reasoning effort, and timeout");
+    const stop = manifest.stop_decision;
+    if (![stop?.all_scheduled_runs_pass, stop?.any_run_fails, stop?.post_result_tuning].every((value) => typeof value === "string" && value.trim())) fail("on_demand_transfer stop_decision must freeze all outcomes and post-result tuning");
   }
   return manifest;
 }
@@ -638,6 +655,24 @@ export function deriveArmOutcome({ arm, surface, retrieval, load, oracle, worksp
   };
 }
 
+export function deriveOnDemandTransferOutcome(inputs) {
+  const outcome = deriveArmOutcome({ ...inputs, arm: "on_demand" });
+  const { retrieval, load, oracle, routeOrder = { passed: true } } = inputs;
+  const retrievalVerified = retrieval.count === 1 && retrieval.top1_correct === true
+    && retrieval.returned_path_exact === true && retrieval.contract_violation !== true;
+  const loadVerified = retrievalVerified && load.passed === true && routeOrder.passed === true;
+  let deepestStage = "no_retrieval_call";
+  if (retrieval.count > 0) deepestStage = retrievalVerified ? "load_wrong" : "retrieval_wrong";
+  if (loadVerified) deepestStage = oracle.passed === true ? "task_succeeded" : "task_execution_failed";
+  const taskSucceededWithoutLoadedSkill = oracle.passed === true && !loadVerified;
+  return {
+    ...outcome,
+    deepest_stage: deepestStage,
+    task_succeeded_without_loaded_skill: taskSucceededWithoutLoadedSkill,
+    accepted: outcome.accepted && deepestStage === "task_succeeded" && !taskSucceededWithoutLoadedSkill,
+  };
+}
+
 export function classifyPair(core, onDemand) {
   if (!core.harness_valid || core.task !== "succeeded" || core.load !== "loaded" || core.safety !== "passed") return { attribution: "invalid_core_control", cold_routing_regression: null };
   if (!onDemand.harness_valid) return { attribution: "invalid_on_demand_harness", cold_routing_regression: null };
@@ -688,6 +723,24 @@ export function deriveProtocolDecision(results, trialsPerArm, tasks = null, pair
   else if (family_gates.some((gate) => gate.on_demand_contract_failures >= 2)) decision = "fix_bootstrap_or_cli_contract";
   else if (family_gates.length > 0 && family_gates.every((gate) => gate.gate === "passed")) decision = "retain_current_design";
   return { decision, required_trials_per_arm: trialsPerArm, expected_runs: familyIds.length * trialsPerArm * 2, family_count: familyIds.length, core_accepted: coreAccepted, on_demand_accepted: onDemandAccepted, on_demand_contract_failures: onDemandContractFailures, family_gates, overall_gate: family_gates.length > 0 && family_gates.every((gate) => gate.gate === "passed") };
+}
+
+export function deriveOnDemandTransferDecision(results, trialsPerFamily, tasks, stopDecision = null) {
+  const expectedKeys = new Set(tasks.flatMap((task) => Array.from({ length: trialsPerFamily }, (_, index) => `${task.id}#${index + 1}#on_demand`)));
+  const actualKeys = results.map((result) => `${result.task}#${result.trial}#${result.arm}`);
+  const exactSchedule = results.length === expectedKeys.size
+    && new Set(actualKeys).size === actualKeys.length
+    && actualKeys.every((key) => expectedKeys.has(key));
+  const familyGates = tasks.map((task) => {
+    const familyResults = results.filter((result) => result.family === task.family);
+    const stageCounts = Object.fromEntries(TRANSFER_STAGES.map((stage) => [stage, familyResults.filter((result) => result.outcome?.deepest_stage === stage).length]));
+    const accepted = familyResults.filter((result) => result.outcome?.accepted === true && result.outcome?.deepest_stage === "task_succeeded" && result.outcome?.task_succeeded_without_loaded_skill !== true).length;
+    return { family: task.family, task: task.id, required_trials: trialsPerFamily, run_count: familyResults.length, accepted, stage_counts: stageCounts, gate: familyResults.length === trialsPerFamily && accepted === trialsPerFamily ? "passed" : "failed" };
+  });
+  const failures = results.filter((result) => result.outcome?.accepted !== true || result.outcome?.deepest_stage !== "task_succeeded" || result.outcome?.task_succeeded_without_loaded_skill === true).map((result) => ({ family: result.family, task: result.task, trial: result.trial, deepest_stage: TRANSFER_STAGES.includes(result.outcome?.deepest_stage) ? result.outcome.deepest_stage : null, safety: result.outcome?.safety ?? null, task_succeeded_without_loaded_skill: result.outcome?.task_succeeded_without_loaded_skill === true }));
+  const overallGate = exactSchedule && familyGates.every((family) => family.gate === "passed");
+  const decision = overallGate ? stopDecision?.all_scheduled_runs_pass ?? "all_scheduled_runs_pass" : stopDecision?.any_run_fails ?? "one_or_more_scheduled_runs_failed";
+  return { decision, post_result_tuning: stopDecision?.post_result_tuning ?? null, expected_runs: expectedKeys.size, complete_schedule: exactSchedule, family_gates: familyGates, failures, overall_gate: overallGate };
 }
 
 function writeInputs(workspace, files) {
@@ -761,6 +814,23 @@ function run(command, args, options) {
 
 function canonicalPath(path) { try { return realpathSync(path); } catch { return resolve(path); } }
 function stateDigest(root) { return sha([...walk(root)].map(([path, digest]) => `${path}\0${digest}`).join("\n")); }
+
+export function assessFrozenInputIdentities(facts, options) {
+  const actual = {
+    manifest_sha256: sha(readFileSync(options.manifest)), cli_sha256: sha(readFileSync(options.cli)),
+    bootstrap_sha256: stateDigest(dirname(options.bootstrap)), targets_sha256: stateDigest(options.skillsRoot),
+    driver_sha256: sha(readFileSync(fileURLToPath(import.meta.url))), model: options.model,
+    reasoning_effort: options.reasoningEffort, timeout_ms: options.timeoutMs,
+  };
+  const expected = {
+    manifest_sha256: facts.manifest_sha256, cli_sha256: facts.cli_sha256,
+    bootstrap_sha256: facts.bootstrap_sha256, targets_sha256: facts.targets_sha256,
+    driver_sha256: facts.driver_sha256, model: facts.model,
+    reasoning_effort: facts.reasoning_effort, timeout_ms: facts.execution_contract.timeout_ms,
+  };
+  const changed = Object.keys(expected).filter((key) => JSON.stringify(actual[key]) !== JSON.stringify(expected[key]));
+  return { passed: changed.length === 0, changed, actual, expected };
+}
 
 function executableIdentity(command, env = process.env) {
   const pathEntries = (env.PATH ?? "").split(delimiter).filter(Boolean);
@@ -894,7 +964,8 @@ function freezeSuite(manifest, options) {
       execution_only_flags_unsupported_by_debug: ["ignore_user_config", "sandbox", "ephemeral"],
     },
     sandbox_policy: { workspace_write: { exclude_tmpdir_env_var: true, exclude_slash_tmp: true, add_dir: "unique_run_temp" } },
-    arm_schedule: ["core", "on_demand"], trials_per_arm: trialsPerArm,
+    ...(manifest.evaluation_mode === "on_demand_transfer" ? { evaluation_mode: manifest.evaluation_mode } : {}),
+    arm_schedule: manifest.evaluation_mode === "on_demand_transfer" ? ["on_demand"] : ["core", "on_demand"], trials_per_arm: trialsPerArm,
     family_schedule: manifest.tasks.map((task) => ({ family: task.family, task: task.id })),
   };
   const snapshotDigest = sha(`${frozenTreeDigest}\0${JSON.stringify(executionContract)}\0${JSON.stringify(sourceIdentity)}\0${JSON.stringify(codexExecutable)}\0${driverSha256}\0${parentVerifierIdentity}`);
@@ -906,7 +977,7 @@ function freezeSuite(manifest, options) {
     real_node_sha256: sha(realNode), parent_verifier_identity_sha256: parentVerifierIdentity,
     target_packages: targetPackages, trials_per_arm: trialsPerArm, pair_invariants: pairInvariants,
   };
-  return { options: { ...options, skillsRoot: targets, bootstrap: join(bootstrapRoot, basename(options.bootstrap)), cli }, facts };
+  return { options: { ...options, manifest: manifestPath, skillsRoot: targets, bootstrap: join(bootstrapRoot, basename(options.bootstrap)), cli }, facts };
 }
 
 export function codexSandboxPolicy(tempRoot) {
@@ -973,7 +1044,21 @@ export function formalResultEligible(result) {
     && result.outcome?.safety === "passed");
 }
 
-function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
+export function formalOnDemandTransferResultEligible(result) {
+  return formalResultEligible(result)
+    && result.arm === "on_demand"
+    && TRANSFER_STAGES.includes(result.outcome?.deepest_stage);
+}
+
+export function formalOnDemandTransferGateEligible({ completeSchedule, sourceIdentityStable, codexExecutableStable, frozenInputsStable, results }) {
+  return completeSchedule === true
+    && sourceIdentityStable === true
+    && codexExecutableStable === true
+    && frozenInputsStable === true
+    && results.every(formalOnDemandTransferResultEligible);
+}
+
+function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts, evaluationMode = "paired") {
   const key = trialKey(task.id, trial, trialsPerArm); const frozenPairInvariant = suiteFacts.pair_invariants?.[key]; if (!frozenPairInvariant) fail(`pair invariant was not frozen before invocation: ${key}`);
   const runPrefix = trialsPerArm === 1 ? `${task.id}-${arm}-` : `${task.id}-trial-${trial}-${arm}-`;
   const root = mkdtempSync(join(options.runsDir, runPrefix)); const paths = setupArm(root, task, arm, options);
@@ -986,7 +1071,11 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     if (!surface.passed) {
       const workspace = assessWorkspaceChanges(initialWorkspace, walk(paths.workspace), Object.keys(task.workspace_files), task.allowed_changed_paths); const protectedScopes = assessProtectedScopes(initialProtected, captureProtectedScopes(protectedPaths));
       const externalWrites = assessExternalWrites("", paths.workspace, paths.temp);
-      return { family: task.family, task: task.id, trial, arm, surface, workspace, protected_scopes: protectedScopes, external_writes: externalWrites, outcome: { harness_valid: false, safety: workspace.passed && protectedScopes.passed && externalWrites.passed ? "passed" : "failed", accepted: false }, root };
+      const safety = workspace.passed && protectedScopes.passed && externalWrites.passed ? "passed" : "failed";
+      const outcome = evaluationMode === "on_demand_transfer"
+        ? { harness_valid: false, safety, accepted: false, deepest_stage: "no_retrieval_call", task_succeeded_without_loaded_skill: false }
+        : { harness_valid: false, safety, accepted: false };
+      return { family: task.family, task: task.id, trial, arm, surface, workspace, protected_scopes: protectedScopes, external_writes: externalWrites, outcome, root };
     }
     let prepared = null;
     if (arm === "on_demand") prepared = prepareOnDemand(paths, task, options, env);
@@ -1006,7 +1095,8 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
     const coreOrder = arm === "core" ? assessCoreOrder(result.stdout, paths.targetPath) : { passed: true, audit_scope: "not_applicable" };
     const transcript = assessTranscriptIntegrity(result.stdout);
     const externalWrites = assessExternalWrites(result.stdout, paths.workspace, paths.temp);
-    const outcome = deriveArmOutcome({ arm, surface, retrieval, load, oracle, workspace, routeOrder, coreOrder, transcript, protectedScopes, externalWrites });
+    const outcomeInputs = { arm, surface, retrieval, load, oracle, workspace, routeOrder, coreOrder, transcript, protectedScopes, externalWrites };
+    const outcome = evaluationMode === "on_demand_transfer" ? deriveOnDemandTransferOutcome(outcomeInputs) : deriveArmOutcome(outcomeInputs);
     return { family: task.family, task: task.id, trial, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, external_writes: externalWrites, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
   } finally {
     cleanupAuth(authCopy);
@@ -1017,7 +1107,7 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts) {
 function dryRun(manifest, options) {
   const tasks = options.task === "all" ? manifest.tasks : manifest.tasks.filter((task) => task.id === options.task);
   if (!tasks.length) fail(`unknown task: ${options.task}`);
-  const arms = options.arm === "both" ? ["core", "on_demand"] : [options.arm];
+  const arms = manifest.evaluation_mode === "on_demand_transfer" ? ["on_demand"] : options.arm === "both" ? ["core", "on_demand"] : [options.arm];
   const trialsPerArm = manifest.trials_per_arm ?? 1;
   return { status: "planned", execute: false, suite_id: manifest.suite_id, model: options.model, reasoning_effort: options.reasoningEffort, task_count: tasks.length, trials_per_arm: trialsPerArm, arms, run_count: tasks.length * arms.length * trialsPerArm, note: "Pass --execute and an explicit --auth-source to invoke Codex." };
 }
@@ -1059,20 +1149,34 @@ export function main(argv = process.argv.slice(2)) {
   mkdirSync(options.runsDir, { recursive: true });
   if (inside(realpathSync(options.runsDir), realpathSync(REPO))) fail("--runs-dir resolves inside the repository so transcripts cannot be committed");
   validateSummaryOutput(options.summaryOutput, options.runsDir);
+  const evaluationMode = manifest.evaluation_mode ?? "paired";
+  if (evaluationMode === "on_demand_transfer" && (options.task !== "all" || (options.armExplicit && options.arm !== "on_demand"))) fail("on_demand_transfer formal gate requires the complete On-demand schedule");
+  if (evaluationMode === "on_demand_transfer" && (options.model !== manifest.formal_schedule.model || options.reasoningEffort !== manifest.formal_schedule.reasoning_effort || options.timeoutMs !== manifest.formal_schedule.timeout_ms)) fail("on_demand_transfer execution parameters must match the frozen formal schedule");
   if (!options.execute) { emitSummary(dryRun(manifest, options), options); return 0; }
-  if (manifest.formal_protocol_gate === true && (options.task !== "all" || options.arm !== "both")) fail("formal protocol gate requires the complete task and arm schedule");
+  if (manifest.formal_protocol_gate === true && evaluationMode === "paired" && (options.task !== "all" || options.arm !== "both")) fail("formal protocol gate requires the complete task and arm schedule");
   for (const path of [options.bootstrap, options.cli, options.skillsRoot, options.authSource]) if (!existsSync(path)) fail(`required path is missing: ${path}`);
   const frozen = freezeSuite(manifest, options); const runOptions = frozen.options;
   const tasks = options.task === "all" ? manifest.tasks : manifest.tasks.filter((task) => task.id === options.task); if (!tasks.length) fail(`unknown task: ${options.task}`);
-  const arms = options.arm === "both" ? ["core", "on_demand"] : [options.arm]; const results = []; const trialsPerArm = manifest.trials_per_arm ?? 1;
-  for (const task of tasks) for (let trial = 1; trial <= trialsPerArm; trial += 1) for (const arm of arms) results.push(executeArm(task, arm, trial, trialsPerArm, runOptions, frozen.facts));
-  const pairs = groupPairedResults(tasks, results, trialsPerArm);
-  const completeSchedule = tasks.length === manifest.tasks.length && arms.length === 2 && results.length === manifest.tasks.length * trialsPerArm * 2;
+  const arms = evaluationMode === "on_demand_transfer" ? ["on_demand"] : options.arm === "both" ? ["core", "on_demand"] : [options.arm]; const results = []; const trialsPerArm = manifest.trials_per_arm ?? 1;
+  for (const task of tasks) for (let trial = 1; trial <= trialsPerArm; trial += 1) for (const arm of arms) results.push(executeArm(task, arm, trial, trialsPerArm, runOptions, frozen.facts, evaluationMode));
+  const pairs = evaluationMode === "paired" ? groupPairedResults(tasks, results, trialsPerArm) : [];
+  const expectedArmCount = evaluationMode === "on_demand_transfer" ? 1 : 2;
+  const completeSchedule = tasks.length === manifest.tasks.length && arms.length === expectedArmCount && results.length === manifest.tasks.length * trialsPerArm * expectedArmCount;
   const sourceIdentityAfter = repositoryIdentity(); const sourceIdentityStable = JSON.stringify(sourceIdentityAfter) === JSON.stringify(frozen.facts.source_identity);
   const codexExecutableAfter = executableIdentity(options.codex); const codexExecutableStable = JSON.stringify(codexExecutableAfter) === JSON.stringify(frozen.facts.codex_executable);
-  const protocolDecision = manifest.formal_protocol_gate === true ? deriveProtocolDecision(results, trialsPerArm, tasks, pairs) : null;
-  const formalGateEligible = completeSchedule && sourceIdentityStable && codexExecutableStable && results.every(formalResultEligible) && pairs.every((pair) => pair.attribution !== "pair_invariant_mismatch" && pair.attribution !== "pair_incomplete");
-  const summary = { status: results.every((result) => result.outcome?.accepted) && pairs.every((pair) => pair.gate === "passed") ? "passed" : "failed", suite_id: manifest.suite_id, formal_gate_eligible: formalGateEligible, source_identity_stable: sourceIdentityStable, source_identity_after: sourceIdentityAfter, codex_executable_stable: codexExecutableStable, codex_executable_after: codexExecutableAfter, protocol_decision: protocolDecision, suite_snapshot: frozen.facts, signal_cleanup: "SIGINT/SIGTERM remove auth copies and runtime state best effort; SIGKILL cannot guarantee cleanup", results, pairs };
+  let frozenInputsAfter = null; let frozenInputsStable = true;
+  if (evaluationMode === "on_demand_transfer") {
+    const frozenInputAssessment = assessFrozenInputIdentities(frozen.facts, runOptions);
+    frozenInputsAfter = frozenInputAssessment.actual; frozenInputsStable = frozenInputAssessment.passed;
+  }
+  const protocolDecision = manifest.formal_protocol_gate !== true ? null : evaluationMode === "on_demand_transfer" ? deriveOnDemandTransferDecision(results, trialsPerArm, tasks, manifest.stop_decision) : deriveProtocolDecision(results, trialsPerArm, tasks, pairs);
+  const resultEligibility = evaluationMode === "on_demand_transfer" ? formalOnDemandTransferResultEligible : formalResultEligible;
+  const formalGateEligible = evaluationMode === "on_demand_transfer"
+    ? formalOnDemandTransferGateEligible({ completeSchedule: protocolDecision.complete_schedule, sourceIdentityStable, codexExecutableStable, frozenInputsStable, results })
+    : completeSchedule && sourceIdentityStable && codexExecutableStable && results.every(resultEligibility) && pairs.every((pair) => pair.attribution !== "pair_invariant_mismatch" && pair.attribution !== "pair_incomplete");
+  const acceptedResults = results.every((result) => result.outcome?.accepted) && pairs.every((pair) => pair.gate === "passed");
+  const statusPassed = acceptedResults && (evaluationMode !== "on_demand_transfer" || formalGateEligible);
+  const summary = { status: statusPassed ? "passed" : "failed", suite_id: manifest.suite_id, ...(evaluationMode === "on_demand_transfer" ? { evaluation_mode: evaluationMode } : {}), formal_gate_eligible: formalGateEligible, source_identity_stable: sourceIdentityStable, source_identity_after: sourceIdentityAfter, codex_executable_stable: codexExecutableStable, codex_executable_after: codexExecutableAfter, ...(evaluationMode === "on_demand_transfer" ? { frozen_inputs_stable: frozenInputsStable, frozen_inputs_after: frozenInputsAfter } : {}), protocol_decision: protocolDecision, suite_snapshot: frozen.facts, signal_cleanup: "SIGINT/SIGTERM remove auth copies and runtime state best effort; SIGKILL cannot guarantee cleanup", results, pairs };
   emitSummary(summary, options); return summary.status === "passed" ? 0 : 2;
 }
 

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { assessCoreOrder, assessExactLoad, assessExternalWrites, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, codexExecutionArgs, codexSandboxPolicy, deriveArmOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalResultEligible, groupPairedResults, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, setupArm, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
+import { assessCoreOrder, assessExactLoad, assessExternalWrites, assessFrozenInputIdentities, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, codexExecutionArgs, codexSandboxPolicy, deriveArmOutcome, deriveOnDemandTransferDecision, deriveOnDemandTransferOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalOnDemandTransferGateEligible, formalOnDemandTransferResultEligible, formalResultEligible, groupPairedResults, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, setupArm, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
 
 const DRIVER = fileURLToPath(new URL("./driver.mjs", import.meta.url));
 
@@ -115,6 +115,107 @@ test("manifest supports bounded one-or-more-task Codex protocol suites", () => {
   for (const prompt of ["use SkillRoster", "run capability search", "please Find it", "做能力检索", "load one"]) {
     assert.throws(() => validateManifest({ ...manifest, tasks: [{ ...manifest.tasks[0], prompt }] }), /must not disclose/u);
   }
+});
+
+test("legacy paired evaluation remains the default", () => {
+  const root = mkdtempSync(join(realpathSync(tmpdir()), "codex-legacy-plan-"));
+  const manifest = fileURLToPath(new URL("../../fixtures/codex-cold-routing-transfer-v2.json", import.meta.url));
+  const result = spawnSync(process.execPath, [DRIVER, "--manifest", manifest, "--runs-dir", join(root, "runs")], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const plan = JSON.parse(result.stdout);
+  assert.deepEqual(plan.arms, ["core", "on_demand"]);
+  assert.equal(plan.run_count, 6);
+});
+
+test("frozen On-demand transfer manifest rejects every partial or mixed schedule", () => {
+  const root = mkdtempSync(join(realpathSync(tmpdir()), "codex-on-demand-plan-"));
+  const manifestPath = fileURLToPath(new URL("../../fixtures/codex-cold-routing-on-demand-transfer-v1.json", import.meta.url));
+  const manifest = validateManifest(JSON.parse(readFileSync(manifestPath, "utf8")));
+  assert.equal(manifest.tasks.length, 3); assert.equal(manifest.trials_per_arm, 3);
+  const frozenArgs = ["--model", manifest.formal_schedule.model, "--reasoning-effort", manifest.formal_schedule.reasoning_effort, "--timeout-ms", String(manifest.formal_schedule.timeout_ms)];
+  const planned = spawnSync(process.execPath, [DRIVER, "--manifest", manifestPath, "--runs-dir", join(root, "complete"), ...frozenArgs], { encoding: "utf8" });
+  assert.equal(planned.status, 0, planned.stderr); assert.deepEqual(JSON.parse(planned.stdout).arms, ["on_demand"]); assert.equal(JSON.parse(planned.stdout).run_count, 9);
+  assert.equal(JSON.parse(planned.stdout).model, "gpt-5.6-luna"); assert.equal(JSON.parse(planned.stdout).reasoning_effort, "medium");
+  assert.deepEqual(manifest.tasks.map((task) => task.expected_skill), ["event-manifest", "domain-extractor", "artifact-builder"]);
+  assert.deepEqual(manifest.tasks.map((task) => task.family), ["deterministic_json_artifact", "reference_backed_structured_extraction", "script_backed_multi_file_artifact"]);
+  for (const args of [["--task", manifest.tasks[0].id], ["--arm", "core"], ["--arm", "both"]]) {
+    const partial = spawnSync(process.execPath, [DRIVER, "--manifest", manifestPath, "--runs-dir", join(root, `partial-${args.at(-1)}`), ...frozenArgs, ...args], { encoding: "utf8" });
+    assert.notEqual(partial.status, 0); assert.match(partial.stderr, /complete On-demand schedule/u);
+  }
+  assert.throws(() => validateManifest({ ...manifest, trials_per_arm: 2 }), /formal_schedule/u);
+  assert.throws(() => validateManifest({ ...manifest, tasks: manifest.tasks.slice(0, 2) }), /formal_schedule/u);
+  assert.throws(() => validateManifest({ ...manifest, stop_decision: { ...manifest.stop_decision, any_run_fails: "" } }), /stop_decision/u);
+  const wrongModel = spawnSync(process.execPath, [DRIVER, "--manifest", manifestPath, "--runs-dir", join(root, "wrong-model")], { encoding: "utf8" });
+  assert.notEqual(wrongModel.status, 0); assert.match(wrongModel.stderr, /execution parameters must match/u);
+});
+
+test("On-demand transfer emits one exclusive deepest stage and never accepts task success without load", () => {
+  const base = {
+    surface: { passed: true }, transcript: { passed: true }, workspace: { passed: true }, protectedScopes: { passed: true }, externalWrites: { passed: true }, routeOrder: { passed: true },
+  };
+  const cases = [
+    [{ count: 0 }, { passed: false }, { passed: false }, "no_retrieval_call"],
+    [{ count: 1, top1_correct: false, returned_path_exact: false }, { passed: false }, { passed: false }, "retrieval_wrong"],
+    [{ count: 1, top1_correct: true, returned_path_exact: true }, { passed: false }, { passed: false }, "load_wrong"],
+    [{ count: 1, top1_correct: true, returned_path_exact: true }, { passed: true }, { passed: false }, "task_execution_failed"],
+    [{ count: 1, top1_correct: true, returned_path_exact: true }, { passed: true }, { passed: true }, "task_succeeded"],
+  ];
+  for (const [retrieval, load, oracle, expected] of cases) {
+    const outcome = deriveOnDemandTransferOutcome({ ...base, retrieval: { contract_violation: false, ...retrieval }, load, oracle });
+    assert.equal(outcome.deepest_stage, expected);
+    assert.equal(["no_retrieval_call", "retrieval_wrong", "load_wrong", "task_execution_failed", "task_succeeded"].filter((stage) => outcome.deepest_stage === stage).length, 1);
+  }
+  const bypass = deriveOnDemandTransferOutcome({ ...base, retrieval: { count: 1, top1_correct: true, returned_path_exact: true, contract_violation: false }, load: { passed: false }, oracle: { passed: true } });
+  assert.equal(bypass.deepest_stage, "load_wrong"); assert.equal(bypass.task_succeeded_without_loaded_skill, true); assert.equal(bypass.accepted, false);
+});
+
+test("On-demand transfer aggregation requires all three complete 3-of-3 families", () => {
+  const tasks = [
+    { id: "json", family: "deterministic_json_artifact" },
+    { id: "extract", family: "reference_backed_structured_extraction" },
+    { id: "artifact", family: "script_backed_multi_file_artifact" },
+  ];
+  const passing = tasks.flatMap((task) => Array.from({ length: 3 }, (_, index) => ({ family: task.family, task: task.id, trial: index + 1, arm: "on_demand", outcome: { accepted: true, deepest_stage: "task_succeeded", safety: "passed" } })));
+  const decision = deriveOnDemandTransferDecision(passing, 3, tasks);
+  assert.equal(decision.expected_runs, 9); assert.equal(decision.complete_schedule, true); assert.equal(decision.overall_gate, true);
+  assert.ok(decision.family_gates.every((family) => family.accepted === 3 && family.stage_counts.task_succeeded === 3));
+  const partial = deriveOnDemandTransferDecision(passing.slice(0, -1), 3, tasks);
+  assert.equal(partial.complete_schedule, false); assert.equal(partial.overall_gate, false);
+  const duplicate = deriveOnDemandTransferDecision([...passing.slice(0, -1), passing[0]], 3, tasks);
+  assert.equal(duplicate.complete_schedule, false); assert.equal(duplicate.overall_gate, false);
+});
+
+test("On-demand formal evidence separates invalid safety or identity from a valid negative load result", () => {
+  const result = { arm: "on_demand", pair_invariant: "frozen-run", codex_exit_code: 0, surface: { passed: true }, transcript: { passed: true }, workspace: { passed: true }, protected_scopes: { passed: true }, outcome: { harness_valid: true, safety: "passed", accepted: true, deepest_stage: "task_succeeded", task_succeeded_without_loaded_skill: false } };
+  assert.equal(formalOnDemandTransferResultEligible(result), true);
+  const gate = (overrides = {}) => formalOnDemandTransferGateEligible({ completeSchedule: true, sourceIdentityStable: true, codexExecutableStable: true, frozenInputsStable: true, results: [result], ...overrides });
+  assert.equal(gate(), true);
+  assert.equal(gate({ completeSchedule: false }), false);
+  assert.equal(gate({ sourceIdentityStable: false }), false);
+  assert.equal(gate({ codexExecutableStable: false }), false);
+  assert.equal(gate({ frozenInputsStable: false }), false);
+  assert.equal(gate({ results: [{ ...result, outcome: { ...result.outcome, safety: "failed", accepted: false } }] }), false);
+  const validNegative = { ...result, outcome: { ...result.outcome, task: "succeeded", deepest_stage: "load_wrong", task_succeeded_without_loaded_skill: true, accepted: false } };
+  assert.equal(formalOnDemandTransferResultEligible(validNegative), true);
+  assert.equal(gate({ results: [validNegative] }), true);
+  const decision = deriveOnDemandTransferDecision([{ family: "one", task: "one", trial: 1, arm: "on_demand", outcome: validNegative.outcome }], 1, [{ id: "one", family: "one" }]);
+  assert.equal(decision.overall_gate, false); assert.equal(decision.failures[0].task_succeeded_without_loaded_skill, true);
+});
+
+test("frozen input identity compares the frozen copies and fails closed on digest drift", async () => {
+  const root = mkdtempSync(join(realpathSync(tmpdir()), "codex-frozen-inputs-")); const manifest = join(root, "manifest.json"); const cli = join(root, "skillroster"); const bootstrap = join(root, "bootstrap", "SKILL.md"); const skillsRoot = join(root, "targets");
+  mkdirSync(join(root, "bootstrap")); mkdirSync(join(skillsRoot, "target"), { recursive: true });
+  writeFileSync(manifest, "{}\n"); writeFileSync(cli, "binary-v1"); writeFileSync(bootstrap, "bootstrap-v1"); writeFileSync(join(skillsRoot, "target", "SKILL.md"), "target-v1");
+  const treeDigest = async (path) => digest([...snapshotWorkspace(path)].map(([name, value]) => `${name}\0${value}`).join("\n"));
+  const executionContract = { evaluation_mode: "on_demand_transfer", arm_schedule: ["on_demand"], timeout_ms: 300_000 };
+  const facts = { manifest_sha256: await digest(readFileSync(manifest)), cli_sha256: await digest(readFileSync(cli)), bootstrap_sha256: await treeDigest(join(root, "bootstrap")), targets_sha256: await treeDigest(skillsRoot), driver_sha256: await digest(readFileSync(DRIVER)), model: "gpt-5.6-luna", reasoning_effort: "medium", execution_contract: executionContract };
+  const options = { manifest, cli, bootstrap, skillsRoot, model: facts.model, reasoningEffort: facts.reasoning_effort, timeoutMs: executionContract.timeout_ms };
+  assert.equal(assessFrozenInputIdentities(facts, options).passed, true);
+  writeFileSync(cli, "binary-v2"); const drift = assessFrozenInputIdentities(facts, options);
+  assert.equal(drift.passed, false); assert.deepEqual(drift.changed, ["cli_sha256"]);
+  writeFileSync(cli, "binary-v1"); const timeoutDrift = assessFrozenInputIdentities(facts, { ...options, timeoutMs: 120_000 });
+  assert.equal(timeoutDrift.passed, false); assert.deepEqual(timeoutDrift.changed, ["timeout_ms"]);
+  assert.equal(formalOnDemandTransferGateEligible({ completeSchedule: true, sourceIdentityStable: true, codexExecutableStable: true, frozenInputsStable: drift.passed, results: [] }), false);
 });
 
 test("multi-family protocol aggregation counts every task pair and emits one gate per family", () => {


### PR DESCRIPTION
## Summary

- adds a backward-compatible on_demand_transfer evaluation mode to the existing Codex harness
- freezes three existing capability families with three trials each and Luna medium execution parameters
- records an exclusive deepest stage and rejects task success that bypasses verified Skill loading
- separates trustworthy negative evidence from product acceptance
- fails closed on partial schedules, identity drift, safety failures, and frozen-input drift

This is preparation only. It does not execute live Codex sessions or change SkillRoster ranking or runtime behavior.

## Verification

- node --check tests/harness/codex-cold-routing/driver.mjs
- 136/136 CI-equivalent Node harness tests
- 58/58 focused Codex harness tests after review fixes
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets --all-features
- git diff --check
- independent Spec and Standards re-review: PASS

Closes #189