### PR TITLE
test: make transfer evidence classifications exact

### DIFF
--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -348,9 +348,10 @@ function writeTargetAllowed(path, workspace, tempRoot) {
   return inside(candidate, workspace) || inside(candidate, tempRoot);
 }
 
+function writeTargetStatic(path) { return !/(?:^~|[$`*?\[\]{}])/u.test(path); }
+
 function explicitWritePaths(command) {
-  const paths = []; const redirection = /(?:^|\s)(?:\d*>>?|\d*<>)[ \t]*(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/gu;
-  for (const match of command.matchAll(redirection)) paths.push(match[1] ?? match[2] ?? match[3]);
+  const paths = [...redirectionTargets(command)];
   const tokens = simpleCommandTokens(command); if (!tokens?.length) return paths;
   const executable = basename(tokens[0]).toLowerCase(); const args = tokens.slice(1).filter((token) => token !== "--");
   const nonOptions = args.filter((token) => !token.startsWith("-"));
@@ -364,8 +365,13 @@ export function assessExternalWrites(jsonl, workspace, tempRoot) {
   const targets = []; const violations = [];
   const commands = extractCommandEvents(jsonl).filter((event) => event.kind === "command");
   for (const [eventIndex, event] of commands.entries()) {
+    if (unsupportedShellWrapperWrite(event.command)) violations.push("unresolved_shell_wrapper_write");
     for (const raw of explicitWritePaths(event.command)) {
       if (["/dev/null", "NUL", "nul"].includes(raw)) continue;
+      if (!writeTargetStatic(raw)) {
+        targets.push({ raw, canonical: null, event_index: eventIndex, command: event.command, allowed: false });
+        violations.push("unresolved_write_target"); continue;
+      }
       const target = { raw, canonical: canonicalPath(isAbsolute(raw) ? raw : join(workspace, raw)), event_index: eventIndex, command: event.command };
       const allowed = writeTargetAllowed(raw, workspace, tempRoot); targets.push({ ...target, allowed });
       if (!allowed) violations.push(`external_write_target:${target.canonical}`);
@@ -378,8 +384,63 @@ export function extractCommandTexts(jsonl) { return extractCommandEvents(jsonl).
 
 function unwrapSimpleShell(command) {
   const trimmed = command.trim();
-  const match = trimmed.match(/^\S*(?:ba|z)?sh\s+-l?c\s+(['"])([\s\S]*)\1$/u);
+  const match = simpleShellWrapper(trimmed);
   return match ? match[2] : trimmed;
+}
+
+function simpleShellWrapper(command) { return command.match(/^\S*(?:ba|z)?sh\s+-l?c\s+(['"])([\s\S]*)\1$/u); }
+
+function unsupportedShellWrapperWrite(command) {
+  const trimmed = command.trim();
+  return !simpleShellWrapper(trimmed)
+    && /(?:^|\s)\S*(?:ba|z)?sh(?=\s)/u.test(trimmed)
+    && /(?:^|\s)-[A-Za-z]*c[A-Za-z]*(?:\s|$)/u.test(trimmed)
+    && trimmed.includes(">");
+}
+
+function redirectionTargets(command) {
+  const trimmed = command.trim(); const wrapper = simpleShellWrapper(trimmed);
+  const value = wrapper?.[1] === '"'
+    ? wrapper[2].replace(/\\(["\\$`])/gu, "$1").replace(/\\\r?\n/gu, "")
+    : wrapper?.[2] ?? trimmed;
+  const paths = []; let quote = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (quote) {
+      if (char === quote) quote = null;
+      else if (quote === '"' && char === "\\") index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"') { quote = char; continue; }
+    if (char === "\\") { index += 1; continue; }
+    if (char !== ">") continue;
+    let cursor = index + 1;
+    if (value[cursor] === ">") cursor += 1;
+    if (value[cursor] === "|" || value[cursor] === "!") cursor += 1;
+    while (/[ \t]/u.test(value[cursor] ?? "")) cursor += 1;
+    if (value[cursor] === "&") {
+      cursor += 1;
+      while (/[ \t]/u.test(value[cursor] ?? "")) cursor += 1;
+      if (/\d/u.test(value[cursor] ?? "") || value[cursor] === "-") continue;
+    }
+    let target = ""; let targetQuote = null;
+    for (; cursor < value.length; cursor += 1) {
+      const targetChar = value[cursor];
+      if (targetQuote) {
+        if (targetChar === targetQuote) targetQuote = null;
+        else if (targetQuote === '"' && targetChar === "\\") { cursor += 1; if (cursor < value.length) target += value[cursor]; }
+        else target += targetChar;
+        continue;
+      }
+      if (targetChar === "'" || targetChar === '"') { targetQuote = targetChar; continue; }
+      if (targetChar === "\\") { cursor += 1; if (cursor < value.length) target += value[cursor]; continue; }
+      if (/\s/u.test(targetChar) || /[;&|<>]/u.test(targetChar)) break;
+      target += targetChar;
+    }
+    if (target) paths.push(target);
+    index = Math.max(index, cursor - 1);
+  }
+  return paths;
 }
 
 function simpleCommandTokens(command) {
@@ -664,12 +725,14 @@ export function deriveOnDemandTransferOutcome(inputs) {
   let deepestStage = "no_retrieval_call";
   if (retrieval.count > 0) deepestStage = retrievalVerified ? "load_wrong" : "retrieval_wrong";
   if (loadVerified) deepestStage = oracle.passed === true ? "task_succeeded" : "task_execution_failed";
-  const taskSucceededWithoutLoadedSkill = oracle.passed === true && !loadVerified;
+  const taskSucceededWithoutVerifiedSkillBytes = oracle.passed === true && load.passed !== true;
+  const taskSucceededWithoutAcceptedOneCallLoadContract = oracle.passed === true && !loadVerified;
   return {
     ...outcome,
     deepest_stage: deepestStage,
-    task_succeeded_without_loaded_skill: taskSucceededWithoutLoadedSkill,
-    accepted: outcome.accepted && deepestStage === "task_succeeded" && !taskSucceededWithoutLoadedSkill,
+    task_succeeded_without_verified_skill_bytes: taskSucceededWithoutVerifiedSkillBytes,
+    task_succeeded_without_accepted_one_call_load_contract: taskSucceededWithoutAcceptedOneCallLoadContract,
+    accepted: outcome.accepted && deepestStage === "task_succeeded" && !taskSucceededWithoutAcceptedOneCallLoadContract,
   };
 }
 
@@ -734,10 +797,10 @@ export function deriveOnDemandTransferDecision(results, trialsPerFamily, tasks, 
   const familyGates = tasks.map((task) => {
     const familyResults = results.filter((result) => result.family === task.family);
     const stageCounts = Object.fromEntries(TRANSFER_STAGES.map((stage) => [stage, familyResults.filter((result) => result.outcome?.deepest_stage === stage).length]));
-    const accepted = familyResults.filter((result) => result.outcome?.accepted === true && result.outcome?.deepest_stage === "task_succeeded" && result.outcome?.task_succeeded_without_loaded_skill !== true).length;
+    const accepted = familyResults.filter((result) => transferEvidenceFieldsValid(result.outcome) && result.outcome?.accepted === true && result.outcome?.deepest_stage === "task_succeeded" && result.outcome.task_succeeded_without_accepted_one_call_load_contract === false).length;
     return { family: task.family, task: task.id, required_trials: trialsPerFamily, run_count: familyResults.length, accepted, stage_counts: stageCounts, gate: familyResults.length === trialsPerFamily && accepted === trialsPerFamily ? "passed" : "failed" };
   });
-  const failures = results.filter((result) => result.outcome?.accepted !== true || result.outcome?.deepest_stage !== "task_succeeded" || result.outcome?.task_succeeded_without_loaded_skill === true).map((result) => ({ family: result.family, task: result.task, trial: result.trial, deepest_stage: TRANSFER_STAGES.includes(result.outcome?.deepest_stage) ? result.outcome.deepest_stage : null, safety: result.outcome?.safety ?? null, task_succeeded_without_loaded_skill: result.outcome?.task_succeeded_without_loaded_skill === true }));
+  const failures = results.filter((result) => !transferEvidenceFieldsValid(result.outcome) || result.outcome?.accepted !== true || result.outcome?.deepest_stage !== "task_succeeded" || result.outcome.task_succeeded_without_accepted_one_call_load_contract === true).map((result) => ({ family: result.family, task: result.task, trial: result.trial, deepest_stage: TRANSFER_STAGES.includes(result.outcome?.deepest_stage) ? result.outcome.deepest_stage : null, safety: result.outcome?.safety ?? null, task_succeeded_without_verified_skill_bytes: result.outcome?.task_succeeded_without_verified_skill_bytes === true, task_succeeded_without_accepted_one_call_load_contract: result.outcome?.task_succeeded_without_accepted_one_call_load_contract === true }));
   const overallGate = exactSchedule && familyGates.every((family) => family.gate === "passed");
   const decision = overallGate ? stopDecision?.all_scheduled_runs_pass ?? "all_scheduled_runs_pass" : stopDecision?.any_run_fails ?? "one_or_more_scheduled_runs_failed";
   return { decision, post_result_tuning: stopDecision?.post_result_tuning ?? null, expected_runs: expectedKeys.size, complete_schedule: exactSchedule, family_gates: familyGates, failures, overall_gate: overallGate };
@@ -1047,7 +1110,16 @@ export function formalResultEligible(result) {
 export function formalOnDemandTransferResultEligible(result) {
   return formalResultEligible(result)
     && result.arm === "on_demand"
-    && TRANSFER_STAGES.includes(result.outcome?.deepest_stage);
+    && TRANSFER_STAGES.includes(result.outcome?.deepest_stage)
+    && transferEvidenceFieldsValid(result.outcome);
+}
+
+function transferEvidenceFieldsValid(outcome) {
+  return typeof outcome?.task_succeeded_without_verified_skill_bytes === "boolean"
+    && typeof outcome?.task_succeeded_without_accepted_one_call_load_contract === "boolean"
+    && !(outcome.task_succeeded_without_verified_skill_bytes && !outcome.task_succeeded_without_accepted_one_call_load_contract)
+    && !(outcome.deepest_stage === "task_succeeded" && outcome.task_succeeded_without_accepted_one_call_load_contract)
+    && !(outcome.accepted === true && (outcome.deepest_stage !== "task_succeeded" || outcome.task_succeeded_without_verified_skill_bytes));
 }
 
 export function formalOnDemandTransferGateEligible({ completeSchedule, sourceIdentityStable, codexExecutableStable, frozenInputsStable, results }) {
@@ -1073,7 +1145,7 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts, evaluat
       const externalWrites = assessExternalWrites("", paths.workspace, paths.temp);
       const safety = workspace.passed && protectedScopes.passed && externalWrites.passed ? "passed" : "failed";
       const outcome = evaluationMode === "on_demand_transfer"
-        ? { harness_valid: false, safety, accepted: false, deepest_stage: "no_retrieval_call", task_succeeded_without_loaded_skill: false }
+        ? { harness_valid: false, safety, accepted: false, deepest_stage: "no_retrieval_call", task_succeeded_without_verified_skill_bytes: false, task_succeeded_without_accepted_one_call_load_contract: false }
         : { harness_valid: false, safety, accepted: false };
       return { family: task.family, task: task.id, trial, arm, surface, workspace, protected_scopes: protectedScopes, external_writes: externalWrites, outcome, root };
     }

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -166,7 +166,9 @@ test("On-demand transfer emits one exclusive deepest stage and never accepts tas
     assert.equal(["no_retrieval_call", "retrieval_wrong", "load_wrong", "task_execution_failed", "task_succeeded"].filter((stage) => outcome.deepest_stage === stage).length, 1);
   }
   const bypass = deriveOnDemandTransferOutcome({ ...base, retrieval: { count: 1, top1_correct: true, returned_path_exact: true, contract_violation: false }, load: { passed: false }, oracle: { passed: true } });
-  assert.equal(bypass.deepest_stage, "load_wrong"); assert.equal(bypass.task_succeeded_without_loaded_skill, true); assert.equal(bypass.accepted, false);
+  assert.equal(bypass.deepest_stage, "load_wrong"); assert.equal(bypass.task_succeeded_without_verified_skill_bytes, true); assert.equal(bypass.task_succeeded_without_accepted_one_call_load_contract, true); assert.equal(bypass.accepted, false);
+  const recovered = deriveOnDemandTransferOutcome({ ...base, retrieval: { count: 2, top1_correct: true, returned_path_exact: true, contract_violation: true }, load: { passed: true }, oracle: { passed: true } });
+  assert.equal(recovered.deepest_stage, "retrieval_wrong"); assert.equal(recovered.task_succeeded_without_verified_skill_bytes, false); assert.equal(recovered.task_succeeded_without_accepted_one_call_load_contract, true); assert.equal(recovered.accepted, false);
 });
 
 test("On-demand transfer aggregation requires all three complete 3-of-3 families", () => {
@@ -175,7 +177,7 @@ test("On-demand transfer aggregation requires all three complete 3-of-3 families
     { id: "extract", family: "reference_backed_structured_extraction" },
     { id: "artifact", family: "script_backed_multi_file_artifact" },
   ];
-  const passing = tasks.flatMap((task) => Array.from({ length: 3 }, (_, index) => ({ family: task.family, task: task.id, trial: index + 1, arm: "on_demand", outcome: { accepted: true, deepest_stage: "task_succeeded", safety: "passed" } })));
+  const passing = tasks.flatMap((task) => Array.from({ length: 3 }, (_, index) => ({ family: task.family, task: task.id, trial: index + 1, arm: "on_demand", outcome: { accepted: true, deepest_stage: "task_succeeded", safety: "passed", task_succeeded_without_verified_skill_bytes: false, task_succeeded_without_accepted_one_call_load_contract: false } })));
   const decision = deriveOnDemandTransferDecision(passing, 3, tasks);
   assert.equal(decision.expected_runs, 9); assert.equal(decision.complete_schedule, true); assert.equal(decision.overall_gate, true);
   assert.ok(decision.family_gates.every((family) => family.accepted === 3 && family.stage_counts.task_succeeded === 3));
@@ -183,10 +185,13 @@ test("On-demand transfer aggregation requires all three complete 3-of-3 families
   assert.equal(partial.complete_schedule, false); assert.equal(partial.overall_gate, false);
   const duplicate = deriveOnDemandTransferDecision([...passing.slice(0, -1), passing[0]], 3, tasks);
   assert.equal(duplicate.complete_schedule, false); assert.equal(duplicate.overall_gate, false);
+  const legacy = structuredClone(passing); legacy[0].outcome = { accepted: true, deepest_stage: "task_succeeded", safety: "passed", task_succeeded_without_loaded_skill: false };
+  const legacyDecision = deriveOnDemandTransferDecision(legacy, 3, tasks);
+  assert.equal(legacyDecision.overall_gate, false); assert.equal(legacyDecision.failures.length, 1);
 });
 
 test("On-demand formal evidence separates invalid safety or identity from a valid negative load result", () => {
-  const result = { arm: "on_demand", pair_invariant: "frozen-run", codex_exit_code: 0, surface: { passed: true }, transcript: { passed: true }, workspace: { passed: true }, protected_scopes: { passed: true }, outcome: { harness_valid: true, safety: "passed", accepted: true, deepest_stage: "task_succeeded", task_succeeded_without_loaded_skill: false } };
+  const result = { arm: "on_demand", pair_invariant: "frozen-run", codex_exit_code: 0, surface: { passed: true }, transcript: { passed: true }, workspace: { passed: true }, protected_scopes: { passed: true }, outcome: { harness_valid: true, safety: "passed", accepted: true, deepest_stage: "task_succeeded", task_succeeded_without_verified_skill_bytes: false, task_succeeded_without_accepted_one_call_load_contract: false } };
   assert.equal(formalOnDemandTransferResultEligible(result), true);
   const gate = (overrides = {}) => formalOnDemandTransferGateEligible({ completeSchedule: true, sourceIdentityStable: true, codexExecutableStable: true, frozenInputsStable: true, results: [result], ...overrides });
   assert.equal(gate(), true);
@@ -195,11 +200,15 @@ test("On-demand formal evidence separates invalid safety or identity from a vali
   assert.equal(gate({ codexExecutableStable: false }), false);
   assert.equal(gate({ frozenInputsStable: false }), false);
   assert.equal(gate({ results: [{ ...result, outcome: { ...result.outcome, safety: "failed", accepted: false } }] }), false);
-  const validNegative = { ...result, outcome: { ...result.outcome, task: "succeeded", deepest_stage: "load_wrong", task_succeeded_without_loaded_skill: true, accepted: false } };
+  assert.equal(gate({ results: [{ ...result, outcome: { ...result.outcome, task_succeeded_without_verified_skill_bytes: undefined } }] }), false);
+  assert.equal(gate({ results: [{ ...result, outcome: { ...result.outcome, task_succeeded_without_verified_skill_bytes: true } }] }), false);
+  assert.equal(gate({ results: [{ ...result, outcome: { ...result.outcome, task_succeeded_without_accepted_one_call_load_contract: true } }] }), false);
+  assert.equal(gate({ results: [{ ...result, outcome: { ...result.outcome, accepted: false, task_succeeded_without_accepted_one_call_load_contract: true } }] }), false);
+  const validNegative = { ...result, outcome: { ...result.outcome, task: "succeeded", deepest_stage: "load_wrong", task_succeeded_without_verified_skill_bytes: true, task_succeeded_without_accepted_one_call_load_contract: true, accepted: false } };
   assert.equal(formalOnDemandTransferResultEligible(validNegative), true);
   assert.equal(gate({ results: [validNegative] }), true);
   const decision = deriveOnDemandTransferDecision([{ family: "one", task: "one", trial: 1, arm: "on_demand", outcome: validNegative.outcome }], 1, [{ id: "one", family: "one" }]);
-  assert.equal(decision.overall_gate, false); assert.equal(decision.failures[0].task_succeeded_without_loaded_skill, true);
+  assert.equal(decision.overall_gate, false); assert.equal(decision.failures[0].task_succeeded_without_verified_skill_bytes, true); assert.equal(decision.failures[0].task_succeeded_without_accepted_one_call_load_contract, true);
 });
 
 test("frozen input identity compares the frozen copies and fails closed on digest drift", async () => {
@@ -299,6 +308,51 @@ test("external write audit rejects redirections outside workspace and run temp",
   assert.equal(assessExternalWrites(unsafe, workspace, temp).violations.includes(`external_write_target:${resolve("/private/tmp/TASK")}`), true);
   const commandWrite = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "mkdir -p /private/tmp/TASK", aggregated_output: "", exit_code: 0, status: "completed" } });
   assert.equal(assessExternalWrites(commandWrite, workspace, temp).violations.includes(`external_write_target:${resolve("/private/tmp/TASK")}`), true);
+});
+
+test("external write audit strips shell wrapper quotes from null-sink redirections", () => {
+  const workspace = "/tmp/workspace"; const temp = "/tmp/run-temp";
+  const commandEvent = (command) => JSON.stringify({ type: "item.completed", item: { type: "command_execution", command, aggregated_output: "", exit_code: 0, status: "completed" } });
+  const issue191Shape = commandEvent('/bin/zsh -lc "rg --files -g \'build-report.mjs\' -g \'package.json\' /approved/source 2>/dev/null"');
+  const nullSink = assessExternalWrites(issue191Shape, workspace, temp);
+  assert.equal(nullSink.passed, true); assert.deepEqual(nullSink.violations, []); assert.deepEqual(nullSink.targets, []);
+
+  const quotedExternal = assessExternalWrites(commandEvent('/bin/zsh -lc "printf secret > /private/tmp/TASK"'), workspace, temp);
+  assert.equal(quotedExternal.passed, false); assert.equal(quotedExternal.violations.includes(`external_write_target:${resolve("/private/tmp/TASK")}`), true);
+  const singleQuotedWrapper = assessExternalWrites(commandEvent("/bin/zsh -lc 'printf secret 2>/private/tmp/TASK'"), workspace, temp);
+  assert.equal(singleQuotedWrapper.passed, false); assert.equal(singleQuotedWrapper.violations.includes(`external_write_target:${resolve("/private/tmp/TASK")}`), true);
+  const quotedTarget = assessExternalWrites(commandEvent("printf secret > '/private/tmp/TASK'"), workspace, temp);
+  assert.equal(quotedTarget.passed, false); assert.equal(quotedTarget.violations.includes(`external_write_target:${resolve("/private/tmp/TASK")}`), true);
+  const arbitraryDevice = assessExternalWrites(commandEvent('/bin/zsh -lc "printf secret > /dev/tty"'), workspace, temp);
+  assert.equal(arbitraryDevice.passed, false); assert.equal(arbitraryDevice.violations.includes(`external_write_target:${resolve("/dev/tty")}`), true);
+  for (const command of [
+    '/bin/zsh -lc "printf secret>/private/tmp/TASK"',
+    '/bin/zsh -lc "printf secret &>/private/tmp/TASK"',
+    '/bin/zsh -lc "printf secret > \\"/private/tmp/TASK\\""',
+    '/bin/zsh -lc "printf secret >| /private/tmp/TASK"',
+    '/bin/zsh -lc "printf secret >! /private/tmp/TASK"',
+    '/bin/zsh -lc "printf secret >& /private/tmp/TASK"',
+  ]) {
+    const external = assessExternalWrites(commandEvent(command), workspace, temp);
+    assert.equal(external.passed, false, command); assert.equal(external.violations.includes(`external_write_target:${resolve("/private/tmp/TASK")}`), true, command);
+  }
+  for (const target of ["$OUTSIDE", "${OUTSIDE}", "$(resolve-target)", "~/TASK", "*.log", "{one,two}.log"]) {
+    const dynamic = assessExternalWrites(commandEvent(`/bin/zsh -lc "printf secret > ${target}"`), workspace, temp);
+    assert.equal(dynamic.passed, false, target); assert.equal(dynamic.violations.includes("unresolved_write_target"), true, target);
+  }
+  for (const command of [
+    'env FOO=bar /bin/zsh -lc "printf secret > /private/tmp/TASK"',
+    '/usr/bin/env -i /bin/zsh -lc "printf secret > /private/tmp/TASK"',
+    'command /bin/zsh -lc "printf secret > /private/tmp/TASK"',
+    '/bin/zsh --login -c "printf secret > /private/tmp/TASK"',
+    '/bin/zsh -l -c "printf secret > /private/tmp/TASK"',
+    '/bin/zsh -ic "printf secret > /private/tmp/TASK"',
+    '/bin/zsh -ilc "printf secret > /private/tmp/TASK"',
+    '/bin/bash --login -c "printf secret > /private/tmp/TASK"',
+  ]) {
+    const unsupportedWrapper = assessExternalWrites(commandEvent(command), workspace, temp);
+    assert.equal(unsupportedWrapper.passed, false, command); assert.equal(unsupportedWrapper.violations.includes("unresolved_shell_wrapper_write"), true, command);
+  }
 });
 
 test("prompt-input preflight permits only fixed Codex system skills plus the arm skill", () => {


### PR DESCRIPTION
## Summary
- parse supported shell redirections without retaining wrapper quote syntax
- fail closed for external, dynamic, device, and unsupported wrapper write targets
- split verified Skill bytes from the accepted one-call load contract
- reject legacy, missing, and contradictory transfer evidence fields during formal eligibility and aggregation

## Verification
- `node --check tests/harness/codex-cold-routing/driver.mjs`
- `node --test tests/harness/codex-cold-routing/driver.test.mjs` (59/59)
- `node --test tests/harness/pi-cold-routing/*.test.mjs tests/harness/codex-cold-routing/*.test.mjs tests/harness/byte-ledger/*.test.mjs` (137/137)
- `git diff --check`
- independent Spec and Safety reviews: no blocker or should-fix

No model run, historical artifact rewrite, or product runtime change.

Closes #193