### PR TITLE
release: prepare SkillRoster v1.8.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.25"
+version = "1.8.26"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.25"
+version = "1.8.26"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "f8d98f2c2cea117d1f651f5393763aa8244edf8b"
-  version "1.8.25"
+      revision: "21f9e57e5af5f9cff9b3684bc48555f93020bfca"
+  version "1.8.26"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.25", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.26", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.25
+SKILLROSTER_VERSION=1.8.26
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -51,7 +51,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.25 skillroster
+  --tag v1.8.26 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -82,7 +82,7 @@ skillroster scan --json
 skillroster setup --json
 ```
 
-CLI v1.8.25 bundles Bootstrap content version 1.8.23. These versions differ
+CLI v1.8.26 bundles Bootstrap content version 1.8.23. These versions differ
 intentionally: the CLI changed after the Bootstrap instructions last changed.
 In Setup JSON, `cli_version` identifies the executable and
 `bootstrap_content_version` identifies the bundled Skill package.

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,7 +18,9 @@ other user data.
 4. Download all four workflow artifacts and verify every adjacent `.sha256`
    file. The workflow smoke-tests `skillroster --version` and a fixture-backed
    Plan/Apply/Undo cycle on each operating system, then runs the Linux archive
-   inside checksum-pinned Ubuntu WSL. Review all five successful jobs.
+   inside checksum-pinned Ubuntu WSL. Unix packaging also runs the staged
+   archive binary through the synthetic retained-ID collision regression before
+   the archive is created. Review all five successful jobs.
 
 Candidate artifacts expire after 14 days. The workflow token has only
 `contents: read`; checkout credentials are not persisted.

--- a/scripts/release/package-unix.sh
+++ b/scripts/release/package-unix.sh
@@ -33,6 +33,10 @@ if [[ -e "$stage" || -L "$stage" || -e "$archive" || -L "$archive" || -e "$check
   exit 1
 fi
 
+cleanup_stage() {
+  if [[ -e "$stage" || -L "$stage" ]]; then rm -rf -- "$stage"; fi
+}
+trap cleanup_stage EXIT
 mkdir -p "$stage"
 install -m 0755 "target/${target}/release/skillroster" "$stage/skillroster"
 cp README.md "$stage/README.md"
@@ -40,6 +44,7 @@ cp LICENSE "$stage/LICENSE"
 scripts/release/smoke.sh "$stage/skillroster"
 tar -C "$dist_root" -czf "$archive" "$name"
 rm -rf "$stage"
+trap - EXIT
 
 if ! tar -xOf "$archive" "$name/LICENSE" | cmp - LICENSE; then
   echo "release archive does not contain the repository LICENSE" >&2

--- a/scripts/release/package-unix.sh
+++ b/scripts/release/package-unix.sh
@@ -37,6 +37,7 @@ mkdir -p "$stage"
 install -m 0755 "target/${target}/release/skillroster" "$stage/skillroster"
 cp README.md "$stage/README.md"
 cp LICENSE "$stage/LICENSE"
+scripts/release/smoke.sh "$stage/skillroster"
 tar -C "$dist_root" -czf "$archive" "$name"
 rm -rf "$stage"
 

--- a/scripts/release/smoke.sh
+++ b/scripts/release/smoke.sh
@@ -56,4 +56,67 @@ status="$(run_json status)"
   exit 1
 }
 
+# Keep this fixture synthetic and local: it recreates the retained-ID collision
+# reported by real-home dogfood without reading or copying any user data.
+source_root="$fixture/external-source"
+linked_skill="$home_root/.claude/skills/retained-external"
+entrypoint="$linked_skill/SKILL.md"
+mkdir -p "$source_root"
+mkdir -p "$(dirname "$linked_skill")"
+cat > "$source_root/SKILL.md" <<'EOF'
+---
+name: retained-external
+description: release smoke fixture
+---
+EOF
+ln -s "$source_root" "$linked_skill"
+if command -v sha256sum >/dev/null 2>&1; then
+  skill_digest="$(printf 'unreadable-link:%s' "$entrypoint" | sha256sum | awk '{print $1}')"
+else
+  skill_digest="$(printf 'unreadable-link:%s' "$entrypoint" | shasum -a 256 | awk '{print $1}')"
+fi
+skill_id="skill_${skill_digest}"
+python3 - "$state_root/skillroster.db" "$skill_id" "$linked_skill" <<'PY'
+import sqlite3
+import sys
+
+database, skill_id, linked_skill = sys.argv[1:]
+connection = sqlite3.connect(database)
+connection.execute(
+    """INSERT INTO skills
+       (id, identity_key, name, description, declared_source, declared_revision,
+        content_digest, digest_version, governance_state, canonical_path)
+       VALUES (?, ?, ?, NULL, NULL, NULL, ?, 1, 'managed', ?)""",
+    (skill_id, "content:retained-strong-identity", "retained-external",
+     "retained-package-digest", linked_skill),
+)
+connection.commit()
+connection.close()
+PY
+
+collision_scan="$(run_json scan)"
+[[ "$collision_scan" == *'"skill_count":1'* ]] || {
+  echo "retained-ID collision scan did not preserve the fixture Skill" >&2
+  exit 1
+}
+python3 - "$state_root/skillroster.db" "$skill_id" <<'PY'
+import sqlite3
+import sys
+
+database, skill_id = sys.argv[1:]
+connection = sqlite3.connect(database)
+row = connection.execute(
+    "SELECT COUNT(*), identity_key, governance_state FROM skills WHERE id = ?",
+    (skill_id,),
+).fetchone()
+connection.close()
+assert row == (1, "content:retained-strong-identity", "managed"), row
+PY
+
+repeat_scan="$(run_json scan)"
+[[ "$repeat_scan" == *'"skill_count":1'* ]] || {
+  echo "repeated retained-ID collision scan did not remain stable" >&2
+  exit 1
+}
+
 echo "release governance smoke passed"

--- a/src/present.rs
+++ b/src/present.rs
@@ -2005,7 +2005,7 @@ mod tests {
             "setup",
             &json!({
                 "state": "modified_choice_required",
-                "cli_version": "1.8.25",
+                "cli_version": "1.8.26",
                 "bootstrap_content_version": "1.8.23",
                 "bootstrap_version": "1.8.23",
                 "detected_agents": [{"agent": "codex"}],
@@ -2029,7 +2029,7 @@ mod tests {
             "setup",
             &json!({
                 "state": "unsupported_targets",
-                "cli_version": "1.8.25",
+                "cli_version": "1.8.26",
                 "bootstrap_content_version": "1.8.23",
                 "bootstrap_version": "1.8.23",
                 "detected_agents": [{"agent": "codex"}],


### PR DESCRIPTION
## Summary
- bump the CLI/package version to 1.8.26 while keeping Bootstrap content at 1.8.23
- update the repository Formula and immutable installation references
- exercise staged Unix package binaries against a synthetic retained-ID collision fixture
- clean failed staging directories without weakening existing artifact overwrite protection

## Why
Real-home dogfood showed the installed public v1.8.25 binary deterministically fails Scan with `UNIQUE constraint failed: skills.id`. Current main already contains the retained-identity fix and succeeds against the same state, but still identified itself as 1.8.25.

## Verification
- `cargo test --locked --all-targets --all-features` (230 unit + 8 acceptance + 64 CLI)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- normal governance smoke
- staged macOS package retained-ID collision smoke
- `bash -n`, `ruby -c`, `brew style`, `git diff --check`
- independent Spec and Safety reviews: no blocker or should-fix

This PR only prepares the release. Tagging, publication, artifact verification, installation, and real-home read-only dogfood remain separate gates after merge.

Part of #195