### PR TITLE
improve: compact Finding detail by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ skillroster --source-root /absolute/confirmed/source scan --json
 skillroster report --json
 skillroster report --findings --limit 20 --json
 skillroster report --findings --category usage --json
-skillroster report --finding <finding-id> --limit 20 --json
+skillroster report --finding <finding-id> --json       # 5-row compact first view
 skillroster report --finding <finding-id> --full --json
 skillroster report --full --json
 skillroster find "database migration" --json

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -106,9 +106,10 @@ Finding summaries plus `page.next_offset`; it never suggests planning before a
 Finding is selected. `report --full --json` is the explicit exhaustive
 diagnostic export and never the bootstrap workflow default.
 
-`report --finding ID --json` returns at most 20 compact Evidence items. Each
-item combines its stable Evidence ID, subject, path, quality, and decision facts
-without repeating affected-ID, placement, and full Evidence collections.
+`report --finding ID --json` defaults to five compact Evidence items. An
+explicit `--limit` may request 1–100 rows. Each item combines its stable
+Evidence ID, subject, path, quality, and decision facts without repeating
+affected-ID, placement, and full Evidence collections.
 `report --finding ID --full --json` explicitly returns those complete paged
 records. `page.next_offset` is the only pagination cursor; callers request
 another page only when the decision still lacks relevant evidence. Counts and

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -158,8 +158,9 @@ skillroster setup [--modified-choice retain-local|adopt-current] [--json]
 Finding lists and full Finding records default to 20 rows per page. Compact
 `report --finding <id>` detail defaults to five rows so an Agent receives the
 decision and action chain without spending context on a large first page.
-Explicit `--limit` values always win; `page` totals and continuation actions
-remain the authoritative path to omitted rows.
+Explicit `--limit` values always win on paged Finding lists and detail;
+`page` totals and continuation actions remain the authoritative path to
+omitted rows. Top-level `report --full` remains an unpaged exhaustive export.
 
 `source-root confirm` persists one exact local read permission bound to a
 current completed escaping-link Finding, its observed canonical directory, and

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -155,6 +155,12 @@ skillroster source-root revoke <permission-id> [--json]
 skillroster setup [--modified-choice retain-local|adopt-current] [--json]
 ```
 
+Finding lists and full Finding records default to 20 rows per page. Compact
+`report --finding <id>` detail defaults to five rows so an Agent receives the
+decision and action chain without spending context on a large first page.
+Explicit `--limit` values always win; `page` totals and continuation actions
+remain the authoritative path to omitted rows.
+
 `source-root confirm` persists one exact local read permission bound to a
 current completed escaping-link Finding, its observed canonical directory, and
 the directory's stable filesystem identity. Scan freezes active permissions

--- a/src/app.rs
+++ b/src/app.rs
@@ -2356,6 +2356,14 @@ enum ReportRequest<'a> {
 const DEFAULT_FINDING_DETAIL_LIMIT: usize = 5;
 const DEFAULT_REPORT_PAGE_LIMIT: usize = 20;
 
+const fn finding_page_limit(full: bool, explicit: Option<usize>) -> usize {
+    match explicit {
+        Some(limit) => limit,
+        None if full => DEFAULT_REPORT_PAGE_LIMIT,
+        None => DEFAULT_FINDING_DETAIL_LIMIT,
+    }
+}
+
 fn report_command(
     store: &StateStore,
     state_dir: &Path,
@@ -2368,11 +2376,7 @@ fn report_command(
         offset,
     } = request
     {
-        let limit = limit.unwrap_or(if full {
-            DEFAULT_REPORT_PAGE_LIMIT
-        } else {
-            DEFAULT_FINDING_DETAIL_LIMIT
-        });
+        let limit = finding_page_limit(full, limit);
         let id = FindingId::parse(id.to_string())?;
         let stored = store
             .get_finding(&id)?
@@ -3237,11 +3241,7 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
             limit,
             offset,
         } => {
-            let page_limit = limit.unwrap_or(if full {
-                DEFAULT_REPORT_PAGE_LIMIT
-            } else {
-                DEFAULT_FINDING_DETAIL_LIMIT
-            });
+            let page_limit = finding_page_limit(full, limit);
             let requires_trust_decision =
                 result["resolution"]["decision"].as_str() == Some("confirm_trusted_source_roots");
             let requires_variant_decision =

--- a/src/app.rs
+++ b/src/app.rs
@@ -367,11 +367,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                 ReportRequest::Finding {
                     id,
                     full: args.full,
-                    limit: args.limit.map(usize::from).unwrap_or(if args.full {
-                        DEFAULT_REPORT_PAGE_LIMIT
-                    } else {
-                        DEFAULT_FINDING_DETAIL_LIMIT
-                    }),
+                    limit: args.limit.map(usize::from),
                     offset: usize::try_from(args.offset)?,
                 }
             } else if args.full {
@@ -2351,7 +2347,7 @@ enum ReportRequest<'a> {
     Finding {
         id: &'a str,
         full: bool,
-        limit: usize,
+        limit: Option<usize>,
         offset: usize,
     },
     Exhaustive,
@@ -2372,6 +2368,11 @@ fn report_command(
         offset,
     } = request
     {
+        let limit = limit.unwrap_or(if full {
+            DEFAULT_REPORT_PAGE_LIMIT
+        } else {
+            DEFAULT_FINDING_DETAIL_LIMIT
+        });
         let id = FindingId::parse(id.to_string())?;
         let stored = store
             .get_finding(&id)?
@@ -3163,13 +3164,14 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
             let returned = findings.map_or(0, |findings| findings.len() as u64);
             let mut actions = Vec::new();
             if total > returned {
+                let limit = DEFAULT_REPORT_PAGE_LIMIT.to_string();
                 actions.push(action(
                     "list_findings",
                     &[
                         "report",
                         "--findings",
                         "--limit",
-                        "20",
+                        &limit,
                         "--offset",
                         "0",
                         "--json",
@@ -3235,6 +3237,11 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
             limit,
             offset,
         } => {
+            let page_limit = limit.unwrap_or(if full {
+                DEFAULT_REPORT_PAGE_LIMIT
+            } else {
+                DEFAULT_FINDING_DETAIL_LIMIT
+            });
             let requires_trust_decision =
                 result["resolution"]["decision"].as_str() == Some("confirm_trusted_source_roots");
             let requires_variant_decision =
@@ -3248,7 +3255,7 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
                 }
                 argv.extend([
                     "--limit".to_owned(),
-                    limit.to_string(),
+                    page_limit.to_string(),
                     "--offset".to_owned(),
                     next_offset.to_string(),
                     "--json".to_owned(),
@@ -3314,21 +3321,23 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
                 }
             }
             if !full {
-                let limit = limit.to_string();
-                let offset = offset.to_string();
+                let mut argv = vec![
+                    "report".to_owned(),
+                    "--finding".to_owned(),
+                    id.to_owned(),
+                    "--full".to_owned(),
+                ];
+                if let Some(limit) = limit {
+                    argv.extend(["--limit".to_owned(), limit.to_string()]);
+                }
+                if offset != 0 {
+                    argv.extend(["--offset".to_owned(), offset.to_string()]);
+                }
+                argv.push("--json".to_owned());
+                let argv = argv.iter().map(String::as_str).collect::<Vec<_>>();
                 actions.push(action(
                     "show_full_finding",
-                    &[
-                        "report",
-                        "--finding",
-                        id,
-                        "--full",
-                        "--limit",
-                        &limit,
-                        "--offset",
-                        &offset,
-                        "--json",
-                    ],
+                    &argv,
                     false,
                     false,
                     "finding_full_detail_available",

--- a/src/app.rs
+++ b/src/app.rs
@@ -367,7 +367,11 @@ pub fn run(cli: Cli) -> Result<Output> {
                 ReportRequest::Finding {
                     id,
                     full: args.full,
-                    limit: usize::from(args.limit),
+                    limit: args.limit.map(usize::from).unwrap_or(if args.full {
+                        DEFAULT_REPORT_PAGE_LIMIT
+                    } else {
+                        DEFAULT_FINDING_DETAIL_LIMIT
+                    }),
                     offset: usize::try_from(args.offset)?,
                 }
             } else if args.full {
@@ -378,7 +382,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                 ReportRequest::Findings {
                     category: args.category,
                     severity: args.severity,
-                    limit: usize::from(args.limit),
+                    limit: args.limit.map_or(DEFAULT_REPORT_PAGE_LIMIT, usize::from),
                     offset: usize::try_from(args.offset)?,
                 }
             } else {
@@ -2352,6 +2356,9 @@ enum ReportRequest<'a> {
     },
     Exhaustive,
 }
+
+const DEFAULT_FINDING_DETAIL_LIMIT: usize = 5;
+const DEFAULT_REPORT_PAGE_LIMIT: usize = 20;
 
 fn report_command(
     store: &StateStore,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -139,9 +139,9 @@ pub struct ReportArgs {
     #[arg(long, value_enum, requires = "findings")]
     pub severity: Option<ReportSeverity>,
 
-    /// Maximum Finding summaries or detail rows returned.
-    #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u16).range(1..=100))]
-    pub limit: u16,
+    /// Maximum rows returned. Defaults to 5 for compact detail and 20 otherwise.
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..=100))]
+    pub limit: Option<u16>,
 
     /// Zero-based offset for Finding list or detail pagination.
     #[arg(long, default_value_t = 0)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -297,6 +297,28 @@ fn semantic_overlap_detail_is_decision_complete_for_agent_comparison() {
             .iter()
             .all(|action| action["action"] != "plan")
     );
+    let compact_full_action = compact["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|action| action["action"] == "show_full_finding")
+        .unwrap();
+    assert_eq!(
+        compact_full_action["argv"],
+        context_action_argv(
+            &home,
+            &state,
+            &[
+                "report",
+                "--finding",
+                finding_id,
+                "--full",
+                "--limit",
+                "1",
+                "--json",
+            ]
+        )
+    );
     let full = json_output(&run(
         &[
             &common[..],
@@ -857,10 +879,21 @@ fn finding_drilldown_is_bounded_and_pageable() {
         second["result"]["items"][0]["evidence_id"]
     );
 
-    let full_output = run(
-        &[&common[..], &["report", "--finding", finding_id, "--full"]].concat(),
-        None,
+    let full_action = first["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|action| action["action"] == "show_full_finding")
+        .unwrap();
+    assert_eq!(
+        full_action["argv"],
+        context_action_argv(
+            &home,
+            &state,
+            &["report", "--finding", finding_id, "--full", "--json"]
+        )
     );
+    let full_output = run_suggested_action(full_action);
     let full = json_output(&full_output);
     assert_eq!(full["result"]["detail"]["mode"], "full");
     assert_eq!(full["result"]["page"]["limit"], 20);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -144,6 +144,10 @@ fn report_help_names_the_safe_default_and_explicit_exhaustive_export() {
     );
     assert!(help.contains("--full"), "{help}");
     assert!(help.contains("exhaustive report"), "{help}");
+    assert!(
+        help.contains("Defaults to 5 for compact detail and 20 otherwise"),
+        "{help}"
+    );
 }
 
 #[test]
@@ -800,9 +804,9 @@ fn finding_drilldown_is_bounded_and_pageable() {
     assert!(first_output.stdout.len() < 20_000);
     let first = json_output(&first_output);
     assert_eq!(first["result"]["page"]["offset"], 0);
-    assert_eq!(first["result"]["page"]["limit"], 20);
-    assert_eq!(first["result"]["page"]["next_offset"], 20);
-    assert_eq!(first["result"]["items"].as_array().unwrap().len(), 20);
+    assert_eq!(first["result"]["page"]["limit"], 5);
+    assert_eq!(first["result"]["page"]["next_offset"], 5);
+    assert_eq!(first["result"]["items"].as_array().unwrap().len(), 5);
     assert_eq!(first["result"]["detail"]["mode"], "compact");
     assert!(first["result"].get("placements").is_none());
     assert!(first["result"].get("affected_placement_ids").is_none());
@@ -821,9 +825,9 @@ fn finding_drilldown_is_bounded_and_pageable() {
                 "--finding",
                 finding_id,
                 "--limit",
-                "20",
+                "5",
                 "--offset",
-                "20",
+                "5",
                 "--json",
             ]
         )
@@ -846,6 +850,8 @@ fn finding_drilldown_is_bounded_and_pageable() {
         None,
     ));
     assert_eq!(second["result"]["page"]["offset"], 20);
+    assert_eq!(second["result"]["page"]["limit"], 20);
+    assert_eq!(second["result"]["items"].as_array().unwrap().len(), 20);
     assert_ne!(
         first["result"]["items"][0]["evidence_id"],
         second["result"]["items"][0]["evidence_id"]
@@ -857,6 +863,7 @@ fn finding_drilldown_is_bounded_and_pageable() {
     );
     let full = json_output(&full_output);
     assert_eq!(full["result"]["detail"]["mode"], "full");
+    assert_eq!(full["result"]["page"]["limit"], 20);
     assert!(full["result"]["placements"].is_array());
     assert!(full["result"]["evidence"].is_array());
     assert!(full["result"]["affected_placement_ids"].is_array());


### PR DESCRIPTION
## Summary

- default compact `report --finding <id>` detail to five rows
- keep Finding lists and full Finding records at the existing 20-row default
- preserve explicit `--limit`, complete totals, pagination, full retrieval, and typed actions
- document and test the split defaults

## Real-home dogfood

- escaping-link detail: 15,649 B -> 7,532 B (-52%), 5/16 items with exact confirm actions retained
- large-Roster detail: 22,896 B -> 14,942 B (-35%), 5/479 items with planning prerequisite retained
- both retain complete totals, `next_offset`, paging/full actions, and zero mutation

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
- `git diff --check`

Closes #199
