### PR TITLE
release: prepare SkillRoster v1.8.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.26"
+version = "1.8.27"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.26"
+version = "1.8.27"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "21f9e57e5af5f9cff9b3684bc48555f93020bfca"
-  version "1.8.26"
+      revision: "d1babf8c96de0436e38aaf8e9cdf168f14a33a80"
+  version "1.8.27"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.26", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.27", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.26
+SKILLROSTER_VERSION=1.8.27
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -51,7 +51,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.26 skillroster
+  --tag v1.8.27 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -82,7 +82,7 @@ skillroster scan --json
 skillroster setup --json
 ```
 
-CLI v1.8.26 bundles Bootstrap content version 1.8.23. These versions differ
+CLI v1.8.27 bundles Bootstrap content version 1.8.23. These versions differ
 intentionally: the CLI changed after the Bootstrap instructions last changed.
 In Setup JSON, `cli_version` identifies the executable and
 `bootstrap_content_version` identifies the bundled Skill package.

--- a/src/present.rs
+++ b/src/present.rs
@@ -2005,7 +2005,7 @@ mod tests {
             "setup",
             &json!({
                 "state": "modified_choice_required",
-                "cli_version": "1.8.26",
+                "cli_version": "1.8.27",
                 "bootstrap_content_version": "1.8.23",
                 "bootstrap_version": "1.8.23",
                 "detected_agents": [{"agent": "codex"}],
@@ -2029,7 +2029,7 @@ mod tests {
             "setup",
             &json!({
                 "state": "unsupported_targets",
-                "cli_version": "1.8.26",
+                "cli_version": "1.8.27",
                 "bootstrap_content_version": "1.8.23",
                 "bootstrap_version": "1.8.23",
                 "detected_agents": [{"agent": "codex"}],


### PR DESCRIPTION
## Summary

- bump the CLI/package version to 1.8.27
- update install examples and human rendering fixtures
- point the Homebrew Formula at the immutable version-bump commit
- prepare a public maintenance release containing #198 and #200

## Validation

- full local suite: 232 unit + 8 acceptance + 64 CLI
- fmt and Clippy with warnings denied
- locked release build and governance smoke
- Formula Ruby syntax and `brew style`
- `git diff --check`

Closes #201
