### PR TITLE
fix: canonicalize coverage Agent IDs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1492,6 +1492,14 @@ fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> 
 
 fn lifecycle_export_command(store: &StateStore, state_dir: &Path, output: &Path) -> Result<Value> {
     let source_confirmation_details = read_source_confirmation_details(state_dir)?;
+    let mut data = store.export_lifecycle()?;
+    if let Some(evidence) = data["evidence"].as_array_mut() {
+        for record in evidence {
+            if record["kind"].as_str() == Some("coverage") {
+                normalize_legacy_coverage_agent(&mut record["details"]);
+            }
+        }
+    }
     let export = json!({
         "schema_version": 2,
         "generated_at": Utc::now().timestamp(),
@@ -1510,7 +1518,7 @@ fn lifecycle_export_command(store: &StateStore, state_dir: &Path, output: &Path)
             "observations_additive": false,
             "legacy_monthly_combinable": false,
         },
-        "data": store.export_lifecycle()?,
+        "data": data,
         "evidence_exclusions": store.evidence_exclusions()?,
         "source_confirmation_details": source_confirmation_details,
         "source_root_permissions": crate::source_policy::policy_export_value(store)?,
@@ -2238,12 +2246,8 @@ fn scan_command(
     let coverage = result
         .coverage
         .iter()
-        .map(|coverage| {
-            let mut value = json!(coverage);
-            value["agent"] = json!(coverage.agent.id());
-            value
-        })
-        .collect::<Vec<_>>();
+        .map(session_coverage_details)
+        .collect::<Result<Vec<_>>>()?;
     let warnings = compact_scan_warnings(result.warnings);
     Ok((
         json!({
@@ -2332,6 +2336,28 @@ fn usage_finding_evidence_priority(evidence: &EvidenceRecord) -> u8 {
         (EvidenceQuality::Observed, true) => 2,
         (_, false) => 3,
         (_, true) => 4,
+    }
+}
+
+fn session_coverage_details(coverage: &scan::SessionCoverage) -> Result<Value> {
+    let mut details = serde_json::to_value(coverage)?;
+    details["agent"] = json!(coverage.agent.id());
+    Ok(details)
+}
+
+fn normalize_legacy_coverage_agent(details: &mut Value) {
+    let Some(agent) = details.get_mut("agent") else {
+        return;
+    };
+    let canonical = match agent.as_str() {
+        Some("claude_code") => Some(AgentKind::ClaudeCode.id()),
+        Some("open_code") => Some(AgentKind::OpenCode.id()),
+        Some("gemini_cli") => Some(AgentKind::GeminiCli.id()),
+        Some("git_hub_copilot") => Some(AgentKind::GitHubCopilot.id()),
+        _ => None,
+    };
+    if let Some(canonical) = canonical {
+        *agent = json!(canonical);
     }
 }
 
@@ -2439,6 +2465,11 @@ fn report_command(
                 .unwrap_or_default();
             let ordered_evidence = if stored.title == "Five-stage usage evidence" {
                 let mut evidence = store.finding_evidence(&id)?;
+                for record in &mut evidence {
+                    if record.kind == EvidenceKind::Coverage {
+                        normalize_legacy_coverage_agent(&mut record.details);
+                    }
+                }
                 evidence.sort_by(|left, right| {
                     usage_finding_evidence_priority(left)
                         .cmp(&usage_finding_evidence_priority(right))
@@ -2519,7 +2550,7 @@ fn report_command(
                 })
                 .collect::<Vec<_>>();
             placements.sort_by(|left, right| left["id"].as_str().cmp(&right["id"].as_str()));
-            let evidence = if ordered_evidence.is_empty() {
+            let mut evidence = if ordered_evidence.is_empty() {
                 paged_evidence_ids
                     .iter()
                     .map(|id| store.get_evidence(id))
@@ -2534,6 +2565,11 @@ fn report_command(
                     .take(limit)
                     .collect()
             };
+            for record in &mut evidence {
+                if record.kind == EvidenceKind::Coverage {
+                    normalize_legacy_coverage_agent(&mut record.details);
+                }
+            }
             let total = affected_skill_ids
                 .len()
                 .max(affected_placement_ids.len())
@@ -8324,7 +8360,7 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
             agent_id.as_str(),
             None,
             None,
-            serde_json::to_value(coverage)?,
+            session_coverage_details(coverage)?,
             observed_at,
         )?;
     }

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+use rusqlite::Connection;
 use serde::Deserialize;
 use serde_json::Value;
 use skillroster::harness::{AgentKind, known_agent_roots};
@@ -497,6 +498,51 @@ fn usage_finding_names_skills_and_uses_public_agent_ids() {
     copy_tree(&Path::new(FIXTURES).join("agents/home"), &home);
 
     cli_json(&home, &state, &["scan"], None);
+    let expected_agents = BTreeSet::from([
+        "codex",
+        "claude-code",
+        "pi",
+        "opencode",
+        "hermes",
+        "cursor",
+        "gemini-cli",
+        "github-copilot",
+    ]);
+    let connection = Connection::open(state.join("skillroster.db")).unwrap();
+    let persisted_agents = {
+        let mut statement = connection
+            .prepare(
+                "SELECT json_extract(details_json, '$.agent') FROM evidence WHERE kind = 'coverage'",
+            )
+            .unwrap();
+        statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    assert_eq!(persisted_agents.len(), 8);
+    assert_eq!(
+        persisted_agents
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        expected_agents
+    );
+    for (canonical, legacy) in [
+        ("claude-code", "claude_code"),
+        ("opencode", "open_code"),
+        ("gemini-cli", "gemini_cli"),
+        ("github-copilot", "git_hub_copilot"),
+    ] {
+        connection
+            .execute(
+                "UPDATE evidence SET details_json = replace(details_json, ?1, ?2) WHERE kind = 'coverage'",
+                [format!("\"{canonical}\""), format!("\"{legacy}\"")],
+            )
+            .unwrap();
+    }
+    drop(connection);
     let report = cli_json(
         &home,
         &state,
@@ -529,6 +575,18 @@ fn usage_finding_names_skills_and_uses_public_agent_ids() {
         })
         .expect("compact Claude Code Loaded evidence");
     assert_eq!(compact_claude["facts"]["skill_name"], "claude-code-fixture");
+    let compact_coverage_agents = compact["result"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|item| item["kind"] == "coverage")
+        .map(|item| item["facts"]["agent"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(compact_coverage_agents.len(), 8);
+    assert_eq!(
+        compact_coverage_agents.into_iter().collect::<BTreeSet<_>>(),
+        expected_agents
+    );
     let overview = &compact["result"]["usage_overview"];
     assert!(
         compact["suggested_actions"]
@@ -583,6 +641,16 @@ fn usage_finding_names_skills_and_uses_public_agent_ids() {
         .expect("full Claude Code Loaded evidence");
     assert_eq!(full_claude["details"]["skill_name"], "claude-code-fixture");
     let full_evidence = full["result"]["evidence"].as_array().unwrap();
+    let full_coverage_agents = full_evidence
+        .iter()
+        .filter(|evidence| evidence["kind"] == "coverage")
+        .map(|evidence| evidence["details"]["agent"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(full_coverage_agents.len(), 8);
+    assert_eq!(
+        full_coverage_agents.into_iter().collect::<BTreeSet<_>>(),
+        expected_agents
+    );
     let first_observed_activity = full_evidence
         .iter()
         .position(|evidence| {
@@ -610,6 +678,34 @@ fn usage_finding_names_skills_and_uses_public_agent_ids() {
     assert_eq!(
         compact["result"]["usage_overview"],
         full["result"]["usage_overview"]
+    );
+
+    let export_path = temp.path().join("lifecycle-export.json");
+    cli_json(
+        &home,
+        &state,
+        &[
+            "lifecycle",
+            "export",
+            "--output",
+            export_path.to_str().unwrap(),
+        ],
+        None,
+    );
+    let export: Value = serde_json::from_slice(&fs::read(export_path).unwrap()).unwrap();
+    let exported_coverage_agents = export["data"]["evidence"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|evidence| evidence["kind"] == "coverage")
+        .map(|evidence| evidence["details"]["agent"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(exported_coverage_agents.len(), 8);
+    assert_eq!(
+        exported_coverage_agents
+            .into_iter()
+            .collect::<BTreeSet<_>>(),
+        expected_agents
     );
 }
 


### PR DESCRIPTION
Closes #203.

## What changed

- serialize new Session Coverage Evidence with the existing canonical public Agent IDs
- normalize the four historical enum spellings before public Finding ordering/pagination and in compact/full output
- normalize the same legacy values in `lifecycle export` without rewriting the database or requiring a rescan
- keep Scan payload compatibility and all sampling/reliability semantics unchanged
- extend the eight-Agent acceptance flow to prove canonical persistence plus compact/full/export legacy-read compatibility

## Real dogfood

- current v1.8.27 state reproduced internal `claude_code`, `open_code`, `gemini_cli`, and `git_hub_copilot` in stored Coverage Evidence
- the patched binary read that unchanged legacy database and returned all eight canonical IDs without a rescan
- an isolated real-home Scan persisted all eight canonical IDs and reported `files_changed=false`

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (232 unit + 8 acceptance + 64 CLI)
- `git diff --check`

## Simplification audit

The public coverage serializer is one shared helper for Scan output and Evidence persistence. One end-to-end acceptance flow proves the database, legacy read compatibility, compact/full detail, and lifecycle export rather than duplicating helper-level tests. A global serde rename was rejected because stored Scan payloads retain a compatibility contract; a database migration was rejected because read-boundary normalization removes the inconsistency without adding schema/state machinery.