### PR TITLE
docs: bound Agent governance impact claims

### DIFF
--- a/docs/acceptance/agent-governance-natural-language-v1.md
+++ b/docs/acceptance/agent-governance-natural-language-v1.md
@@ -1,0 +1,52 @@
+# Natural-language Agent governance dogfood v1
+
+Date: 2026-08-25
+Issue: [#209](https://github.com/tt-a1i/skillroster/issues/209)
+
+## Frozen task
+
+> 帮我分析这台电脑当前安装的 Agent Skills：主要有什么问题，哪些确实有证据，哪些不能下结论，并给出治理优先级。先只读，不要改任何 Skill 或 Agent 配置。结果要一眼能看懂，不要把一堆命令和原始 JSON 扔给我。
+
+Each Luna high trial scanned `/Users/tushaokun` with a separate temporary state
+directory. Trials could read the Bootstrap and governance reference only when
+assigned to the Bootstrap arm. No trial could Plan, Apply, confirm a source
+root, or mutate Agent and Skill files.
+
+## Evidence
+
+| Trial | Bootstrap | SkillRoster calls | Result |
+| --- | --- | ---: | --- |
+| A | no | 9 | Safe facts, but paged Findings, full detail, and three unrelated Find calls |
+| B | old | 7 | Clear summary, but inferred `9 - 3 = 6` removable placements without a Plan |
+| C | first correction | 7 | Unsupported reduction closed; unnecessary help, drills, and enumeration remained |
+| D | final correction | 2 | Scan and bounded Report only; no unsupported impact claim |
+
+This table is a qualitative behavior ledger, not a deterministic model test.
+Trials A–C preserve the observed failure progression; only Trial D is the
+accepted run and is bound to the Snapshot and Report below. The baseline source
+revision was `fd01ea7418dcc83d07d593735239c85821f55aa8`.
+
+All four trials agreed on 251 independent Skills, 887 placements, 521 default
+exposure placements, and three Agents with positive usage observations. Trial D
+also preserved the three selected Findings, every Finding rollup, session and
+root coverage limitations, and the read-only boundary. It correctly described
+the exact-duplicate Finding as current affected scale and deferred canonical
+ownership, before/after impact, and mutation to a later decision and validated
+Plan.
+
+Trial D wrote only its isolated database and captured JSON under
+`/tmp/skillroster-agent-dogfood-d`. It changed no repository, Agent, or Skill
+file. Snapshot `scan_000000000000982418cee44ffe47ac88` and Report
+`report_000000000000a1a218cee457f81f5fd8` identify the accepted run.
+Its receipt records `files_changed=false`. It did not inspect or confirm any
+source root: exact targets remained unretrieved, the sole next action was a
+read-only drill into the high-severity Finding, and exact source-root permission
+remained a later explicit user decision rather than a trust claim.
+
+## Decision
+
+The failure was an Agent instruction boundary, not evidence for a new Rust
+analysis subsystem. Keep the CLI contract unchanged. Finding counts describe
+current scale; only a validated Plan may state proposed before/after impact,
+and only a Receipt may state observed mutation impact. Initial diagnosis is
+complete at the bounded Report unless one exact primary-decision fact is absent.

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -1,6 +1,9 @@
 # Agent Experience Specification
 
-SkillRoster is primarily used through an Agent conversation. The CLI is the deterministic local engine; the bootstrap Skill tells the Agent how to gather facts, prepare a complete Plan, present it clearly, obtain one user confirmation, and execute it safely.
+SkillRoster is primarily used through an Agent conversation. The CLI is the
+deterministic local engine; the bootstrap Skill tells the Agent how to gather
+facts and, when the user requests a concrete change proposal, prepare a complete
+Plan, present it clearly, obtain one user confirmation, and execute it safely.
 
 ## 1. Primary promise
 
@@ -17,6 +20,10 @@ In the same Agent turn, when evidence is sufficient, the Agent should:
 5. present the validated Plan and one primary action: **应用这份方案**.
 
 Plan generation is read-only, so it should not require a separate user round trip. Apply always requires confirmation after the Plan is visible.
+
+An analysis-only request ends at the bounded Report. The Agent may recommend a
+next decision, but it prepares a Plan only when the user asks for a concrete
+proposal or accepts that recommendation.
 
 ## 2. One-confirmation Apply
 
@@ -42,7 +49,8 @@ The Agent selects one primary action from current state:
 | Not initialized | Explain local setup targets | 安装 SkillRoster |
 | No Snapshot | Run Scan automatically | 查看检查结果 |
 | Healthy, no useful change | Say no governance is needed | 保持现状 |
-| Findings, sufficient Evidence | Prepare and show a Plan | 应用这份方案 |
+| Findings, analysis requested | Show priorities and boundaries | 深挖最高优先级问题 |
+| Findings, change proposal requested and Evidence sufficient | Prepare and show a Plan | 应用这份方案 |
 | Findings, insufficient Evidence | Explain the exact unknown | 补充信息 or 保持现状 |
 | Plan blocked or stale | Explain the blocker | 重新扫描并生成方案 |
 | Applied | Show verification and Receipt | 完成 |
@@ -60,7 +68,10 @@ The initial response should fit roughly one conversation viewport. It contains:
 1. **One-sentence diagnosis** with only evidence-backed numbers.
 2. **Four core metrics:** independent Skills, placements, default exposure, and observed-use coverage. Usage coverage names sampled, complete, limited, missing-root, and inaccessible Agent counts separately.
 3. **Top three Findings:** fact, impact, and Evidence quality.
-4. **Proposed change:** current → proposed counts and affected Agents.
+4. **Impact:** current affected scale for Finding-only diagnosis; current →
+   proposed counts and affected Agents only from a validated Plan. Preserve each
+   field's unit: source, placement, exposure, relink, and deletion counts are
+   not interchangeable.
 5. **Safety boundary:** read-only so far, canonical deletion count, reversibility, and uncertainty. For semantic Roster Plans, include forced, target-Agent, cross-Agent, and stable-fallback Core counts plus the bounded named Core preview and its reasons. Cross-Agent selections name the Agent that supplied exact-identity evidence and are described as used elsewhere, not as target-Agent usage. Fallback- or cross-Agent-dominated selection remains a review-required proposal.
 6. **One primary action:** the exact phrase the user can reply with.
 
@@ -176,7 +187,8 @@ The single `skillroster` bootstrap Skill must instruct every supported Agent to:
   high-ranked hint evidence must outrank weak overlap that only appears in both
   lexical channels;
 - treat `suggested_actions` as typed options, not authorization;
-- automatically prepare a read-only Plan when evidence is sufficient;
+- prepare a read-only Plan when evidence is sufficient and the user requested a
+  concrete change proposal or accepted a recommendation;
 - show the complete Plan impact before Apply;
 - require one explicit user confirmation for Apply or Undo;
 - never use `--force`, `--yes`, hidden shell writes, or direct filesystem substitutes;
@@ -241,7 +253,10 @@ The Agent decides wording and information order from these fields. The CLI must 
 
 ### Disorder found
 
-The Agent discovers 100+ Skills, creates a Plan in the same read-only turn, makes the largest problems obvious, and offers one Apply action.
+When the user asks for a concrete proposal, the Agent discovers 100+ Skills,
+creates a Plan in the same read-only turn, makes the largest problems obvious,
+and offers one Apply action. An analysis-only request stops at the bounded
+Report and offers one follow-up decision instead.
 
 ### Healthy setup
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -328,12 +328,15 @@ at 60, 80, and 120 columns without printing session paths.
 
 The normative conversation flow, one-confirmation Apply behavior, state-dependent primary action, and bootstrap Skill rules live in [agent-experience-spec.md](agent-experience-spec.md).
 
-The bootstrap Skill instructs an Agent to prepare a complete read-only Plan when Evidence is sufficient, then present:
+When the user requested a concrete change proposal and Evidence is sufficient,
+the bootstrap Skill instructs an Agent to prepare a complete read-only Plan,
+then present:
 
 1. a one-sentence diagnosis;
 2. independent Skill count, placement count, default exposure, and observed-use count;
 3. the three most important Findings plus compact rollups that state the complete scale of every Finding group without loading the exhaustive report;
-4. prioritized recommendations with expected measurable impact;
+4. prioritized recommendations with current affected scale; measurable
+   before/after impact only when a validated Plan provides it;
 5. uncertainties, evidence quality, and safety risks;
 6. one primary next action and whether confirmation is required.
 

--- a/docs/research/skillroster-agent-first-governance-evidence-2026-08-25.md
+++ b/docs/research/skillroster-agent-first-governance-evidence-2026-08-25.md
@@ -205,6 +205,22 @@ SkillRoster 不应把自己定义成“替模型决定用户意图的总路由�
 4. 将 `scan → report → plan → one confirmation → apply → receipt → undo` 视为状态链：每个状态都记录输入快照和输出，不用自然语言“已完成”替代文件 hash、变更清单和回滚证据。
 5. 结论只在同一 snapshot、harness、模型、任务集和方法下比较；跨供应商数字仅作方向性背景，最终阈值由 SkillRoster 自己的 paired eval 决定。
 
+## 七、自然语言治理 dogfood 的新增验证
+
+Issue #209 的四轮 Luna dogfood 把上述边界落到一个真实用户请求。无
+Bootstrap 的 Agent 能找到相同结构事实，但执行了 9 次 CLI 调用；修订后的
+Bootstrap 最终只用 Scan 和 bounded Report，仍保留四项核心指标、Top 3、
+完整 rollups 和覆盖限制。详细证据见
+[Natural-language Agent governance dogfood v1](../acceptance/agent-governance-natural-language-v1.md)。
+
+本轮同时验证了一个反例：Agent 曾把 9 个 placements 和 3 个物理来源推导为
+“可减少 6 个 placements”。这不是工具事实，也没有 Plan 支持。ReAct 的原始
+工作支持 observation-grounded 的行动循环，但不把观察后的自由推断变成确定性
+事实；Anthropic 的可信 Agent 原则同样强调 transparency、human control 和在
+高风险动作前请求介入。因此 Finding 只陈述当前影响规模，Plan 才能陈述拟议的
+before/after，Receipt 才能陈述实际变更结果。该结果支持收紧 Bootstrap，不支持
+增加一个新的 Rust 语义分析子系统。
+
 ## 来源索引
 
 - OpenAI：[Build skills](https://developers.openai.com/codex/skills/)、[Function calling](https://developers.openai.com/api/docs/guides/function-calling)、[Model guidance](https://developers.openai.com/api/docs/guides/latest-model)。
@@ -212,5 +228,6 @@ SkillRoster 不应把自己定义成“替模型决定用户意图的总路由�
 - Skills 论文：[SkillsBench v4](https://arxiv.org/abs/2602.12670)、[How Well Do Agentic Skills Work in the Wild](https://arxiv.org/abs/2604.04323)、[SWE-Skills-Bench](https://arxiv.org/abs/2603.15401)。
 - 候选深度论文：[How Many Tools Should an LLM Agent See?](https://arxiv.org/abs/2605.24660)。
 - 安全论文：[Agent Skills in the Wild](https://arxiv.org/abs/2601.10338)。
+- Agent 决策边界：[ReAct](https://arxiv.org/abs/2210.03629)、[Anthropic Trustworthy agents](https://www.anthropic.com/research/trustworthy-agents)。
 
 上述论文是特定实验条件下的原始研究或预印本；除官方文档描述的 Codex 机制外，所有性能数字都应被视为方向性证据，不能直接当作 SkillRoster 的验收结果。

--- a/skill/skillroster/references/governance.md
+++ b/skill/skillroster/references/governance.md
@@ -9,6 +9,13 @@ by one category or severity, only when enumeration is needed. Follow
 `page.next_offset` while that decision remains open. Reserve `report --full`
 for deliberate exhaustive export.
 
+The initial diagnosis is complete when the bounded Report supplies the four
+core metrics, selected Findings, complete rollups, coverage, and a primary next
+action. Stop there. If one exact fact required to explain that primary action is
+absent, make one `report --finding` call for it. Help, status, Finding
+enumeration, other Finding drills, and full detail belong to a later user
+question; they are not initial-diagnosis checks.
+
 Usage evidence is five-stage and conservative. Read `session_coverage` before
 describing it. `sampled_agents` support bounded observed events;
 `complete_agents` alone support a complete observable-session denominator;
@@ -75,9 +82,13 @@ Show one bounded viewport with a one-sentence diagnosis and exactly these four
 core metrics: independent Skill count, placement count, default exposure, and
 observed-use count. Show the three highest-priority Findings plus compact
 rollups for the complete scale of every Finding group. Prioritize
-recommendations and state their expected measurable impact. Include
-uncertainties, evidence quality, safety risks, and whether confirmation is
-required. Name one primary next action. For a proposed change, include its
+recommendations and keep each typed count's field meaning and unit. A Finding
+describes current affected scale: canonical candidates, physical sources,
+logical placements, default exposure, and relinks are distinct facts. Do not
+derive deletion or reduction counts from them. State measurable before/after
+impact only from a validated Plan, and actual impact only from its Receipt.
+Include uncertainties, evidence quality, safety risks, and whether confirmation
+is required. Name one primary next action. For a proposed change, include its
 measurable before/after impact, `change_summary`, operation groups, affected
 facts, uncertainty, reversibility, canonical deletion count, and Plan ID. Use
 `plan --show PLAN_ID --json` only when an exact operation, path, selection, or


### PR DESCRIPTION
## Summary

- keep Finding affected counts separate from Plan and Receipt impact
- stop analysis-only governance at the bounded Report, with at most one exact Finding drill
- distinguish analysis requests from concrete change-proposal requests across the Agent contract
- record the real-home A/B/C/D Luna dogfood and consolidate its research into the existing evidence document

Closes #209

## Evidence

- baseline Agent: 7 SkillRoster calls and an unsupported `9 - 3 = 6` placement-reduction inference
- final fresh Agent: 2 SkillRoster calls (`scan`, `report`), all four metrics and complete rollups preserved, no unsupported impact claim, `files_changed=false`
- no Rust analysis subsystem added
- focused simplify audit removed the duplicate research document and retained one canonical evidence source

## Validation

- `uv run --with pyyaml python /Users/tushaokun/.agents_skills/.system/skill-creator/scripts/quick_validate.py skill/skillroster`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo test --locked bootstrap` (7 unit + 4 CLI)
- `cargo test --locked --all-targets --all-features` (237 unit + 8 acceptance + 64 CLI)
- independent Standards review: no blocker / should-fix
- independent Spec review: no blocker / should-fix
