### PR TITLE
fix: separate source-read continuation paths

### DIFF
--- a/docs/acceptance/source-read-continuation-dogfood-v1.md
+++ b/docs/acceptance/source-read-continuation-dogfood-v1.md
@@ -1,0 +1,52 @@
+# Source-read continuation dogfood v1
+
+Date: 2026-08-25
+Issue: [#211](https://github.com/tt-a1i/skillroster/issues/211)
+Baseline: `9cb8c8121a7faf428d0172a2bfc5dbe62fe81d2b`
+
+## Frozen follow-up
+
+The prior analysis identified escaping-link Finding
+`finding_000000000000a1a218cee457f81f6f79` in Report
+`report_000000000000a1a218cee457f81f5fd8`. The user then asked:
+
+> 那先看看最高优先级这个问题，具体哪些路径，为什么会有问题，下一步该怎么做？先别改。
+
+Both Luna high trials reused the same isolated state and were forbidden to
+confirm a source root, rescan, Plan, Apply, or modify Agent and Skill files.
+
+## Before
+
+The baseline Agent correctly found four targets and 16 placements, but described
+the continuation as durable `source-root confirm` followed by a Scan carrying
+temporary `--source-root` overrides. The CLI induced this by returning the
+temporary Scan template as legacy `resolution.after_confirmation` while its
+typed actions recommended durable confirmation.
+
+## After
+
+A fresh Agent used one `report --finding ... --limit 20 --json` call, reused the
+same Report, and preserved every path and safety caveat. It presented two
+exclusive choices:
+
+- `temporary_one_scan`: exact `--source-root` overrides with no permission
+  record;
+- `durable_permission`: exact confirmation followed by a plain Scan.
+
+It reported `content_trust=not_assessed`, made no trust or maliciousness claim,
+and stopped at the user's confirmation boundary. `files_changed=false`; no
+state, Agent, Skill, or repository file changed. This is a qualitative Agent
+behavior receipt, not a deterministic model benchmark.
+
+Review also exercised replay from a command carrying temporary `--source-root`
+context. Durable continuation strips those overrides while retaining the same
+home, state, and discovery roots. A page with 11 distinct targets returns 11
+matching confirmation actions, so the typed action set does not silently drop
+targets shown on that bounded page.
+
+## Decision
+
+Keep the legacy decision and `after_confirmation` fields for compatibility, but
+make their legacy/temporary semantics explicit. New callers use the canonical
+decision code, complete target count, truncation marker, page target set, and
+exclusive permission paths. No new subsystem is justified.

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -110,6 +110,11 @@ read-only `view_source_confirmation_finding` action when available. The
 opened escaping-link Finding remains the only surface that offers exact
 confirmation-gated source-root actions. Never execute a confirmation-gated
 Core-protection template or source-link change on the user's behalf.
+Its additive `permission_paths` are mutually exclusive: durable confirmation
+continues with a plain Scan, while temporary `--source-root` overrides belong
+to a one-Scan alternative that creates no permission record. The legacy
+`confirm_trusted_source_roots` value is an opaque decision alias, not a content
+trust assessment.
 
 ## 5. Ready Plan response
 
@@ -277,10 +282,12 @@ The Agent distinguishes “not observed” from “unused,” names missing cove
 
 The Agent leaves an escaping link unread, shows its target, and asks whether
 the source is intentional. After confirmation it records an exact local read
-permission with `source-root confirm`, then rescans without increasing any
-Agent's default exposure. The decision does not endorse content or authorize a
-Plan; unconfirmed, revoked, or identity-drifted sources remain excluded. The
-temporary `--source-root` flag remains available for one Scan. Drift detection
+permission with `source-root confirm`, then follows the returned plain Scan
+action without adding the confirmed path as `--source-root`. Alternatively, it
+can skip durable confirmation and use temporary `--source-root` flags for one
+Scan. These paths are never combined. Neither decision endorses content or
+authorizes a Plan; unconfirmed, revoked, or identity-drifted sources remain
+excluded. Drift detection
 uses bounded identity and entrypoint-binding checks around discovery and
 content consumption; it detects accidental or persistent changes, not a
 malicious same-user ABA race completed entirely between checkpoints.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -183,6 +183,18 @@ separate security hardening. The persisted object epoch is conservative:
 platform metadata changes that could indicate object reuse may require an
 explicit revoke and reconfirm rather than silently retaining read access.
 
+The escaping-link Finding keeps legacy resolution fields for schema
+compatibility and adds the canonical `decision_code` plus two explicitly
+exclusive `permission_paths`. The durable path runs `source-root confirm` and
+continues with a plain Scan; the temporary path skips confirmation persistence
+and uses repeatable exact `--source-root` overrides for one Scan. The resolution
+reports the complete unique observed-target count, a bounded target list, and a
+truncation flag independently of the current placement page. When that list is
+truncated, `page_observed_link_targets` and the page's typed confirmation
+actions make the remaining exact targets retrievable through ordinary Finding
+pagination. The legacy `confirm_trusted_source_roots` value never means that
+content trust was assessed.
+
 `setup` detects supported Agents and returns a preview for installing or
 upgrading the single bootstrap Skill. Exact official older copies are eligible
 for automatic planning. Unknown content is treated as a local modification and

--- a/skill/skillroster/references/governance.md
+++ b/skill/skillroster/references/governance.md
@@ -64,17 +64,26 @@ points to a SkillRoster-owned JSON detail file; validate its schema before
 using the complete identities and argv. Do not inspect or trust targets
 independently, synthesize broader parents, or submit a partial Plan.
 
-For an escaping Skill link, show the observed target and obtain confirmation
-before running
-`skillroster source-root confirm --finding FINDING_ID --path ABSOLUTE_PATH --json`.
-This records factual read access for that exact canonical directory and stable
-filesystem identity only. It does not endorse content, raise Evidence quality,
-or authorize Plan/Apply. Then rescan. Use `source-root inspect --json` to audit
-active, revoked, or drifted permissions and `source-root revoke ID --json` to
-revoke one. The temporary repeatable `--source-root` option remains a one-scan
-alternative. Treat its drift facts as bounded accidental/persistent-drift
-evidence, not proof against a malicious same-user ABA race. Never infer a
-parent, sibling, descendant, alias, or wildcard.
+For an escaping Skill link, show the observed target, obtain confirmation, and
+choose exactly one typed `permission_paths` continuation:
+
+- `durable_permission`: run
+  `skillroster source-root confirm --finding FINDING_ID --path ABSOLUTE_PATH --json`,
+  then follow its plain Scan action. Do not add the confirmed path as a
+  `--source-root` override.
+- `temporary_one_scan`: skip `source-root confirm` and run one Scan with the
+  repeatable exact `--source-root` option. This creates no durable permission.
+
+Both paths grant factual read access only. They do not assess or endorse
+content, raise Evidence quality, or authorize Plan/Apply. Treat the legacy
+`confirm_trusted_source_roots` decision as an opaque compatibility alias; use
+`decision_code` and `decision_semantics` for meaning. Use `source-root inspect
+--json` to audit active, revoked, or drifted durable permissions and
+`source-root revoke ID --json` to revoke one. Treat drift facts as bounded
+accidental/persistent-drift evidence, not proof against a malicious same-user
+ABA race. When `observed_link_targets_truncated` is true, follow Finding pages;
+each page's exact confirmation actions cover its `page_observed_link_targets`.
+Never infer a parent, sibling, descendant, alias, or wildcard.
 
 ## Present
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,6 +39,7 @@ const MAX_AGENT_LOADED_SKILL_BYTES: u64 = 128 * 1024;
 #[derive(Clone, Debug, Default)]
 pub struct ActionContext {
     argv: Vec<String>,
+    argv_without_source_roots: Vec<String>,
 }
 
 impl ActionContext {
@@ -63,13 +64,17 @@ impl ActionContext {
         for root in &cli.roots {
             argv.extend(["--root".to_owned(), root.clone()]);
         }
+        let argv_without_source_roots = argv.clone();
         for source_root in &cli.source_roots {
             argv.extend([
                 "--source-root".to_owned(),
                 action_path(source_root, "--source-root")?,
             ]);
         }
-        Ok(Self { argv })
+        Ok(Self {
+            argv,
+            argv_without_source_roots,
+        })
     }
 
     fn apply(&self, actions: &mut [SuggestedAction]) {
@@ -77,9 +82,16 @@ impl ActionContext {
             return;
         }
         for action in actions {
+            let context = if action.action == "scan"
+                && action.reason_code == "source_root_permission_recorded"
+            {
+                &self.argv_without_source_roots
+            } else {
+                &self.argv
+            };
             let insertion =
                 usize::from(action.argv.first().is_some_and(|arg| arg == "skillroster"));
-            action.argv.splice(insertion..insertion, self.argv.clone());
+            action.argv.splice(insertion..insertion, context.clone());
         }
     }
 
@@ -88,17 +100,7 @@ impl ActionContext {
     }
 
     fn apply_json_argv(&self, argv: &mut Value) {
-        let Some(values) = argv.as_array_mut() else {
-            return;
-        };
-        if self.argv.is_empty() {
-            return;
-        }
-        let insertion = usize::from(values.first().and_then(Value::as_str) == Some("skillroster"));
-        values.splice(
-            insertion..insertion,
-            self.argv.iter().cloned().map(Value::String),
-        );
+        apply_json_argv_context(argv, &self.argv);
     }
 
     fn apply_result(&self, command: &str, result: &mut Value) {
@@ -113,15 +115,37 @@ impl ActionContext {
                 }
             }
             "report" => {
-                if let Some(argv) =
-                    result.pointer_mut("/resolution/after_confirmation/argv_template")
-                {
-                    self.apply_json_argv(argv);
+                for pointer in [
+                    "/resolution/after_confirmation/argv_template",
+                    "/resolution/permission_paths/temporary_one_scan/argv_template",
+                ] {
+                    if let Some(argv) = result.pointer_mut(pointer) {
+                        self.apply_json_argv(argv);
+                    }
+                }
+                if let Some(argv) = result.pointer_mut(
+                    "/resolution/permission_paths/durable_permission/next/argv_template",
+                ) {
+                    apply_json_argv_context(argv, &self.argv_without_source_roots);
                 }
             }
             _ => {}
         }
     }
+}
+
+fn apply_json_argv_context(argv: &mut Value, context: &[String]) {
+    let Some(values) = argv.as_array_mut() else {
+        return;
+    };
+    if context.is_empty() {
+        return;
+    }
+    let insertion = usize::from(values.first().and_then(Value::as_str) == Some("skillroster"));
+    values.splice(
+        insertion..insertion,
+        context.iter().cloned().map(Value::String),
+    );
 }
 
 fn action_path(path: &Path, option: &str) -> Result<String> {
@@ -2494,6 +2518,7 @@ enum ReportRequest<'a> {
 
 const DEFAULT_FINDING_DETAIL_LIMIT: usize = 5;
 const DEFAULT_REPORT_PAGE_LIMIT: usize = 20;
+const SOURCE_READ_CONTINUATION_TARGET_LIMIT: usize = 10;
 
 const fn finding_page_limit(full: bool, explicit: Option<usize>) -> usize {
     match explicit {
@@ -2576,6 +2601,17 @@ fn report_command(
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
+            let affected_placement_id_set = affected_placement_ids
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<BTreeSet<_>>();
+            let observed_link_targets = scan
+                .placements
+                .iter()
+                .filter(|placement| affected_placement_id_set.contains(placement.id.as_str()))
+                .filter_map(|placement| placement.link_target.as_ref())
+                .map(|path| path.display().to_string())
+                .collect::<BTreeSet<_>>();
             let ordered_evidence = if stored.title == "Five-stage usage evidence" {
                 let mut evidence = store.finding_evidence(&id)?;
                 for record in &mut evidence {
@@ -2716,7 +2752,7 @@ fn report_command(
                     }
                 }),
             );
-            add_finding_resolution(object);
+            add_finding_resolution(object, &observed_link_targets);
             object.insert(
                 "detail".into(),
                 json!({
@@ -2855,13 +2891,22 @@ fn report_supports_source_confirmation_kind(report: &ReportRecord) -> bool {
         })
 }
 
-fn add_finding_resolution(object: &mut serde_json::Map<String, Value>) {
+fn add_finding_resolution(
+    object: &mut serde_json::Map<String, Value>,
+    complete_observed_link_targets: &BTreeSet<String>,
+) {
     if object.get("kind").and_then(Value::as_str)
         != Some(crate::source_policy::ESCAPING_LINK_FINDING_KIND)
     {
         return;
     }
-    let observed_link_targets = object
+    let observed_link_target_count = complete_observed_link_targets.len();
+    let observed_link_targets = complete_observed_link_targets
+        .iter()
+        .take(SOURCE_READ_CONTINUATION_TARGET_LIMIT)
+        .cloned()
+        .collect::<Vec<_>>();
+    let page_observed_link_targets = object
         .get("placements")
         .and_then(Value::as_array)
         .into_iter()
@@ -2873,15 +2918,51 @@ fn add_finding_resolution(object: &mut serde_json::Map<String, Value>) {
         "resolution".into(),
         json!({
             "decision": "confirm_trusted_source_roots",
+            "decision_code": "source_read_permission_required",
             "decision_semantics": "confirm_exact_local_read_permission",
+            "legacy_decision_alias": true,
             "permission_scope": "exact_local_read_only",
+            "content_trust": "not_assessed",
             "content_endorsed": false,
             "evidence_quality_changed": false,
             "governance_authorized": false,
             "plan_apply_authorized": false,
             "automatic_change_supported": false,
+            "observed_link_target_count": observed_link_target_count,
             "observed_link_targets": observed_link_targets,
+            "observed_link_targets_truncated": observed_link_target_count
+                > SOURCE_READ_CONTINUATION_TARGET_LIMIT,
+            "page_observed_link_targets": page_observed_link_targets,
+            "permission_paths": {
+                "exclusive": true,
+                "durable_permission": {
+                    "action": "confirm_source_root_read_permission",
+                    "persists": true,
+                    "requires_confirmation": true,
+                    "next": {
+                        "action": "scan",
+                        "confirmed_source_root_option_required": false,
+                        "argv_template": ["skillroster", "scan", "--json"]
+                    }
+                },
+                "temporary_one_scan": {
+                    "action": "scan_with_source_root_override",
+                    "persists": false,
+                    "requires_confirmation": true,
+                    "repeatable_option": "--source-root",
+                    "value": "observed canonical source directory",
+                    "argv_template": [
+                        "skillroster",
+                        "--source-root",
+                        "<observed-canonical-source-directory>",
+                        "scan",
+                        "--json"
+                    ]
+                }
+            },
             "after_confirmation": {
+                "legacy_compatibility": true,
+                "permission_path": "temporary_one_scan",
                 "repeatable_option": "--source-root",
                 "value": "absolute canonical source directory",
                 "argv_template": [
@@ -3445,12 +3526,18 @@ fn report_actions(result: &Value, request: ReportRequest<'_>) -> Vec<SuggestedAc
                 }
             }
             if requires_trust_decision {
-                for path in result["resolution"]["observed_link_targets"]
+                let targets = if result["resolution"]["observed_link_targets_truncated"].as_bool()
+                    == Some(true)
+                {
+                    &result["resolution"]["page_observed_link_targets"]
+                } else {
+                    &result["resolution"]["observed_link_targets"]
+                };
+                for path in targets
                     .as_array()
                     .into_iter()
                     .flatten()
                     .filter_map(Value::as_str)
-                    .take(10)
                 {
                     actions.push(action(
                         "confirm_source_root_read_permission",
@@ -11531,6 +11618,7 @@ mod recovery_tests {
             &blocked,
             &ActionContext {
                 argv: action_argv_prefix.clone(),
+                argv_without_source_roots: action_argv_prefix.clone(),
             },
         ))
         .unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7998,7 +7998,157 @@ fn find_rejects_a_skill_symlink_that_now_escapes_approved_roots() {
 
 #[cfg(unix)]
 #[test]
-fn escaping_link_finding_requests_trust_confirmation_instead_of_a_plan() {
+fn escaping_link_resolution_separates_durable_and_temporary_read_paths() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    fs::create_dir_all(&root).unwrap();
+    let mut sources = Vec::new();
+    for index in 0..11 {
+        let source = temp.path().join(format!("source-{index}"));
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join("SKILL.md"),
+            format!("---\nname: external-{index}\ndescription: fixture\n---\n"),
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&source, root.join(format!("external-{index}"))).unwrap();
+        sources.push(source);
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let report = json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Skill links escape an approved root")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+
+    let detail = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "--source-root",
+                sources[0].to_str().unwrap(),
+                "report",
+                "--finding",
+                finding_id,
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let resolution = &detail["result"]["resolution"];
+    assert_eq!(detail["result"]["page"]["returned"]["items"], 5);
+    assert_eq!(
+        detail["result"]["page"]["totals"]["affected_placements"],
+        11
+    );
+    assert_eq!(
+        resolution["decision_code"],
+        "source_read_permission_required"
+    );
+    assert_eq!(resolution["content_trust"], "not_assessed");
+    assert_eq!(resolution["observed_link_target_count"], 11);
+    assert_eq!(
+        resolution["observed_link_targets"]
+            .as_array()
+            .unwrap()
+            .len(),
+        10
+    );
+    assert_eq!(resolution["observed_link_targets_truncated"], true);
+    assert_eq!(
+        resolution["page_observed_link_targets"]
+            .as_array()
+            .unwrap()
+            .len(),
+        5
+    );
+    assert_eq!(resolution["permission_paths"]["exclusive"], true);
+    assert_eq!(
+        resolution["permission_paths"]["durable_permission"]["next"]["confirmed_source_root_option_required"],
+        false
+    );
+    let durable_argv =
+        resolution["permission_paths"]["durable_permission"]["next"]["argv_template"]
+            .as_array()
+            .unwrap();
+    assert!(!durable_argv.iter().any(|arg| arg == "--source-root"));
+    assert_eq!(
+        resolution["permission_paths"]["temporary_one_scan"]["persists"],
+        false
+    );
+    assert!(
+        resolution["permission_paths"]["temporary_one_scan"]["argv_template"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|arg| arg == "--source-root")
+    );
+    let confirm_actions = detail["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|action| action["action"] == "confirm_source_root_read_permission")
+        .count();
+    assert_eq!(confirm_actions, 5);
+
+    let expanded_detail = json_output(&run(
+        &[
+            &common[..],
+            &["report", "--finding", finding_id, "--limit", "11"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(
+        expanded_detail["result"]["resolution"]["page_observed_link_targets"]
+            .as_array()
+            .unwrap()
+            .len(),
+        11
+    );
+    assert_eq!(
+        expanded_detail["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|action| action["action"] == "confirm_source_root_read_permission")
+            .count(),
+        11
+    );
+
+    let temporary_scan = json_output(&run(
+        &[
+            &common[..],
+            &["--source-root", sources[0].to_str().unwrap(), "scan"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(
+        temporary_scan["result"]["source_root_policy"]["permissions"]
+            .as_array()
+            .unwrap()
+            .len(),
+        0
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn escaping_link_finding_requests_exact_read_permission_instead_of_a_plan() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
     let state = temp.path().join("state");
@@ -8034,7 +8184,17 @@ fn escaping_link_finding_requests_trust_confirmation_instead_of_a_plan() {
         .unwrap();
 
     let detail = json_output(&run(
-        &[&common[..], &["report", "--finding", finding_id]].concat(),
+        &[
+            &common[..],
+            &[
+                "--source-root",
+                source.to_str().unwrap(),
+                "report",
+                "--finding",
+                finding_id,
+            ],
+        ]
+        .concat(),
         None,
     ));
     assert_eq!(
@@ -8124,6 +8284,19 @@ fn escaping_link_finding_requests_trust_confirmation_instead_of_a_plan() {
     assert_eq!(confirmed["result"]["plan_apply_authorized"], false);
     assert_eq!(confirmed["result"]["files_changed"], false);
     assert_eq!(confirmed["result"]["state_files_changed"], true);
+    let next_scan = confirmed["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|action| action["action"] == "scan")
+        .unwrap();
+    assert!(
+        !next_scan["argv"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|arg| arg == "--source-root")
+    );
     let mut permission_id = confirmed["result"]["permission"]["permission_id"]
         .as_str()
         .unwrap()


### PR DESCRIPTION
## Summary

- separate durable source-root confirmation from temporary one-scan overrides
- preserve legacy fields while adding a canonical exclusive permission contract
- report complete unique target counts, bounded target previews, and page-complete typed actions
- update Bootstrap guidance and record before/after Agent dogfood evidence

## Validation

- `cargo test --locked --all-targets --all-features` (237 unit + 8 acceptance + 65 CLI)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- Bootstrap Skill validation
- independent Standards and Spec re-reviews: PASS

Closes #211