### PR TITLE
fix: keep stable placements in the latest Snapshot graph

### DIFF
--- a/docs/acceptance/temporary-source-rescan-dogfood-v1.md
+++ b/docs/acceptance/temporary-source-rescan-dogfood-v1.md
@@ -1,0 +1,55 @@
+# Temporary source rescan dogfood v1
+
+Date: 2026-08-25
+Issue: [#213](https://github.com/tt-a1i/skillroster/issues/213)
+Baseline: `85f092f6cea732714263d57b04ff50a3fa2ae408`
+
+## Frozen request
+
+After inspecting one escaping-link Finding, the user selected temporary access
+to its four exact observed source directories and asked the Agent to rescan,
+reanalyze the issue, and make no changes.
+
+The Luna high trial used isolated state
+`/tmp/skillroster-agent-dogfood-e.kS1sVs`. It could use only SkillRoster CLI
+facts, could not confirm durable permissions, and could not Plan or Apply.
+
+## Agent behavior
+
+The Agent ran a temporary Scan and bounded Report, correctly kept durable
+permission count at zero, and did not describe readable content as trusted. The
+old high Finding no longer appeared because the same links were readable for
+that Scan. The Agent conservatively called this unverified resolution rather
+than a content or governance endorsement. No Agent, Skill, or repository file
+changed.
+
+## Fact-layer defect
+
+The new immutable payload correctly contained 890 placements, including all 16
+previously unread stable Agent placements with `link_status=valid`. The SQLite
+normalized graph attached only three newly discovered physical placements to
+the new Snapshot. Stable rows remained attached to the old `scan_id` because
+their upsert refreshed only fingerprint, link target, and exposure.
+
+This divergence was invisible in the top-level placement and exposure totals,
+so aggregate equality was not sufficient evidence. It could also retain an old
+Skill identity after content changed.
+
+## Decision
+
+Keep stable placement IDs and immutable payload history. Treat the normalized
+table as the current projection: a repeated placement moves to the latest Scan
+and refreshes all association and fact columns. A core regression compares the
+latest payload placement ID set with the normalized latest-Snapshot ID set.
+Historical-Finding continuity remains a separate Agent-experience question; it
+does not widen this projection fix.
+
+## After fix
+
+The fixed binary rescanned the same real isolated inventory as Snapshot
+`scan_0000000000009e4a18cee958ea9c6ee0`. Its immutable payload and normalized
+latest-Snapshot projection both contained 890 placement IDs, with zero IDs
+present on only one side. All 16 placements from the old escaping-link Finding
+were attached to the latest Snapshot; 13 remained default exposed. Temporary
+read permissions remained unpersisted and no Agent, Skill, or repository file
+was changed.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -56,6 +56,14 @@ Use this placement test for every capability: local truth, stable identity, repr
 
 A read-only Scan discovers Skill roots, `SKILL.md` entry points, source metadata, links, configuration exposure, and supported local session sources. It normalizes paths without following links outside approved roots silently.
 
+The immutable Scan payload is the historical Snapshot record. SQLite's
+normalized placement table is the current projection: when a stable placement
+is observed again, the same placement ID moves to the latest Snapshot and every
+current Skill, Agent, root, path, kind, link, fingerprint, and exposure fact is
+refreshed. The latest payload placement IDs and normalized latest-Snapshot
+placement IDs must be identical; historical graphs remain available in their
+immutable payloads rather than stale projection rows.
+
 Skill-root discovery and package fingerprints carry explicit completeness facts. A configured root whose depth limit was reached remains Included but is marked discovery-incomplete, making structural coverage unreliable. Each placement fingerprint is `complete`, `bounded`, `unreadable`, or `unknown`; payloads created before this contract default to `unknown`. Only a complete package fingerprint may support an exact-duplicate Finding or any Library/Roster Plan that relies on exact content. Bounded or unreadable packages remain inventory facts and require a new complete Scan before governance. Apply repeats this check so a Ready Plan created by an older binary cannot bypass the boundary.
 
 Scan records two deliberately separate hashes in one bounded traversal. The complete package fingerprint covers every retained package file, including `.gitignore`, and remains the only hash used for drift checks, exact load, Plan, Apply, Receipt, Undo, and recovery. The versioned routing content identity excludes only the package-root `.gitignore`; it is used for unsourced logical identity and same-name variant grouping because source-control metadata is not Agent Skills payload. `SKILL.md`, scripts, references, assets, and symlink targets remain identity-bearing. A legacy Snapshot without the current content-identity algorithm must be rescanned; the CLI never backfills or infers equality from old package fingerprints.

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -710,8 +710,11 @@ impl StateStore {
                 (id, scan_id, skill_id, agent_id, root_id, path, kind, symlink_target,
                  fingerprint, exposed)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
-             ON CONFLICT(id) DO UPDATE SET fingerprint = excluded.fingerprint,
-                 symlink_target = excluded.symlink_target, exposed = excluded.exposed",
+             ON CONFLICT(id) DO UPDATE SET scan_id = excluded.scan_id,
+                 skill_id = excluded.skill_id, agent_id = excluded.agent_id,
+                 root_id = excluded.root_id, path = excluded.path, kind = excluded.kind,
+                 symlink_target = excluded.symlink_target,
+                 fingerprint = excluded.fingerprint, exposed = excluded.exposed",
             params![
                 placement.id.as_str(),
                 placement.scan_id.as_str(),
@@ -3318,6 +3321,122 @@ mod tests {
             })
             .unwrap();
         assert_eq!(store.latest_completed_scan().unwrap().unwrap().id, scan.id);
+    }
+
+    #[test]
+    fn stable_placement_moves_to_the_latest_scan_graph() {
+        let store = StateStore::open_in_memory().unwrap();
+        let agent = AgentRecord {
+            id: AgentId::new(),
+            kind: AgentKind::Codex,
+            display_name: "Codex".to_owned(),
+        };
+        store.save_agent(&agent).unwrap();
+        let placement_id = PlacementId::new();
+
+        let first_scan = scan();
+        store.save_scan(&first_scan).unwrap();
+        let first_root = RootRecord {
+            id: RootId::new(),
+            scan_id: first_scan.id.clone(),
+            agent_id: Some(agent.id.clone()),
+            path: "/tmp/skills-a".to_owned(),
+            kind: "skills".to_owned(),
+            status: RootStatus::Included,
+            explicit: false,
+            detail: None,
+        };
+        store.save_root(&first_root).unwrap();
+        let first_skill_record = SkillRecord {
+            id: SkillId::new(),
+            identity_key: "sha256:first".to_owned(),
+            name: "example".to_owned(),
+            description: None,
+            declared_source: None,
+            declared_revision: None,
+            content_digest: "sha256:first".to_owned(),
+            digest_version: 1,
+            governance_state: GovernanceState::Observed,
+            canonical_path: None,
+        };
+        let first_skill = store.save_skill(&first_skill_record).unwrap();
+        let first_placement = PlacementRecord {
+            id: placement_id.clone(),
+            scan_id: first_scan.id,
+            skill_id: first_skill,
+            agent_id: Some(agent.id.clone()),
+            root_id: first_root.id.clone(),
+            path: "/tmp/skills-a/example".to_owned(),
+            kind: PlacementKind::Directory,
+            symlink_target: None,
+            fingerprint: "first".to_owned(),
+            exposed: false,
+        };
+        store.save_placement(&first_placement).unwrap();
+
+        let second_scan = scan();
+        store.save_scan(&second_scan).unwrap();
+        let second_root = RootRecord {
+            id: RootId::new(),
+            scan_id: second_scan.id.clone(),
+            path: "/tmp/skills-b".to_owned(),
+            explicit: true,
+            ..first_root
+        };
+        store.save_root(&second_root).unwrap();
+        let second_skill = store
+            .save_skill(&SkillRecord {
+                id: SkillId::new(),
+                identity_key: "sha256:second".to_owned(),
+                content_digest: "sha256:second".to_owned(),
+                ..first_skill_record
+            })
+            .unwrap();
+        store
+            .save_placement(&PlacementRecord {
+                scan_id: second_scan.id.clone(),
+                skill_id: second_skill.clone(),
+                root_id: second_root.id.clone(),
+                path: "/tmp/skills-b/example".to_owned(),
+                kind: PlacementKind::Symlink,
+                symlink_target: Some("/tmp/source/example".to_owned()),
+                fingerprint: "second".to_owned(),
+                exposed: true,
+                ..first_placement
+            })
+            .unwrap();
+
+        let stored = store
+            .connection
+            .query_row(
+                "SELECT scan_id, skill_id, agent_id, root_id, path, kind,
+                        symlink_target, fingerprint, exposed
+                 FROM placements WHERE id = ?1",
+                [placement_id.as_str()],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, Option<String>>(6)?,
+                        row.get::<_, String>(7)?,
+                        row.get::<_, bool>(8)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(stored.0, second_scan.id.as_str());
+        assert_eq!(stored.1, second_skill.as_str());
+        assert_eq!(stored.2.as_deref(), Some(agent.id.as_str()));
+        assert_eq!(stored.3, second_root.id.as_str());
+        assert_eq!(stored.4, "/tmp/skills-b/example");
+        assert_eq!(stored.5, "symlink");
+        assert_eq!(stored.6.as_deref(), Some("/tmp/source/example"));
+        assert_eq!(stored.7, "second");
+        assert!(stored.8);
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::fs::{FileTimes, OpenOptions};
 use std::io::Write;
@@ -8023,7 +8024,8 @@ fn escaping_link_resolution_separates_durable_and_temporary_read_paths() {
         state.to_str().unwrap(),
         "--json",
     ];
-    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let initial_scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let initial_snapshot = initial_scan["result"]["snapshot_id"].as_str().unwrap();
     let report = json_output(&run(&[&common[..], &["report"]].concat(), None));
     let finding_id = report["result"]["findings"]
         .as_array()
@@ -8144,6 +8146,71 @@ fn escaping_link_resolution_separates_durable_and_temporary_read_paths() {
             .len(),
         0
     );
+    let temporary_snapshot = temporary_scan["result"]["snapshot_id"].as_str().unwrap();
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let load_payload = |snapshot| {
+        database
+            .query_row(
+                "SELECT payload_json FROM scan_payloads WHERE scan_id = ?1",
+                [snapshot],
+                |row| row.get::<_, String>(0),
+            )
+            .map(|payload| serde_json::from_str::<Value>(&payload).unwrap())
+            .unwrap()
+    };
+    let initial_payload = load_payload(initial_snapshot);
+    let payload = load_payload(temporary_snapshot);
+    let initial_placements = initial_payload["placements"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|placement| {
+            (
+                placement["id"].as_str().unwrap(),
+                placement["default_exposed"].as_bool().unwrap(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(initial_placements.len(), 11);
+    let payload_placement_ids = payload["placements"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|placement| placement["id"].as_str().unwrap())
+        .collect::<BTreeSet<_>>();
+    assert!(
+        initial_placements
+            .keys()
+            .all(|id| payload_placement_ids.contains(id))
+    );
+    let mut statement = database
+        .prepare("SELECT id, exposed FROM placements WHERE scan_id = ?1")
+        .unwrap();
+    let stored_placements = statement
+        .query_map([temporary_snapshot], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, bool>(1)?))
+        })
+        .unwrap()
+        .collect::<Result<BTreeMap<_, _>, _>>()
+        .unwrap();
+    assert!(initial_placements.iter().all(|(id, exposed)| {
+        stored_placements
+            .get(*id)
+            .is_some_and(|stored| stored == exposed)
+    }));
+    assert_eq!(
+        stored_placements.keys().cloned().collect::<BTreeSet<_>>(),
+        payload_placement_ids
+            .into_iter()
+            .map(str::to_owned)
+            .collect::<BTreeSet<_>>()
+    );
+    let foreign_key_violations: u64 = database
+        .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(foreign_key_violations, 0);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- refresh every current placement projection field when a stable placement is reobserved
- preserve stable IDs and immutable historical Scan payloads
- assert baseline placement retention, exposure stability, payload/projection ID equality, and foreign-key integrity
- record the real temporary-source rescan dogfood evidence

## Validation

- `cargo test --locked --all-targets --all-features` (238 unit + 8 acceptance + 65 CLI)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- real isolated rescan: payload 890, normalized 890, bidirectional ID difference 0
- independent Standards and Spec re-reviews: PASS

Closes #213