### PR TITLE
feat: keep Bootstrap setup preview decision-complete

### DIFF
--- a/docs/acceptance/setup-preview-coldstart-v1.md
+++ b/docs/acceptance/setup-preview-coldstart-v1.md
@@ -1,0 +1,63 @@
+# Bootstrap setup preview cold start
+
+Observed on 2026-08-25 on macOS arm64. The before run used the public v1.8.27
+release binary. The after run used a debug build from branch
+`codex/issue-218-setup-bounded-summary` at base commit `43c5932`. Byte counts
+include the trailing newline emitted by the CLI. They are observations for the
+recorded temporary path lengths, not portable byte limits.
+
+## Scenario
+
+A fresh HOME exposed all eight supported Agent roots. Codex, Claude Code, and
+Pi shared one physical Skill root; the other Agents used separate roots. Each
+root contained one harmless fixture Skill. Public v1.8.27 performed Scan and
+Bootstrap Setup without Apply.
+
+## Before
+
+- `setup --json`: 5,959 bytes, 8 logical targets, 6 physical targets, 36 planned
+  operations.
+- The response omitted ordinary Plan impact, operation groups, risk, and
+  reversibility.
+- Explaining the preview required `plan --show`, which returned 87,054 bytes,
+  including 77,940 bytes of repeated Bootstrap file content.
+
+No Agent files changed, one Plan remained pending, and no Receipt existed.
+
+## Acceptance
+
+`setup --json` now projects the immutable Plan's bounded `change_summary`,
+`operation_groups`, `affected`, `diff_summary`, `impact`, `risk`,
+`reversible`, and `detail` facts. It excludes complete operations, file bodies,
+and fingerprints. An Agent can explain an ordinary Bootstrap preview from the
+Setup response alone and reserve `plan --show` for exact-detail questions.
+
+Setup remains preview-only: confirmation is required, `files_changed` is
+false, and Apply/Undo semantics are unchanged.
+
+The same isolated eight-Agent fixture returned a 6,985-byte Setup response
+with all 36 operations summarized as 12 directory creations and 24 file
+writes. It reported `filesystem_change`, `reversible: true`, and the exact
+detail command without embedding `operations`. Status showed one pending Plan,
+zero Receipts, and clear recovery. The ordinary explanation therefore needs
+one 6,985-byte response instead of Setup plus an additional 87,054-byte detail
+response.
+
+## Reproduction
+
+The isolated HOME contained the eight standard Agent roots. Codex, Claude
+Code, and Pi linked to one shared physical root; OpenCode, Hermes, Cursor,
+Gemini CLI, and GitHub Copilot used separate roots. With a fresh state
+directory, the measured command sequence was:
+
+```text
+skillroster --home HOME --state-dir STATE --json scan
+skillroster --home HOME --state-dir STATE --json setup
+skillroster --home HOME --state-dir STATE --json status
+```
+
+The CLI regression test
+`setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root`
+reconstructs the same 8/6/36 topology and verifies the bounded response,
+pending Plan, absent Receipt, Apply, and Undo. A separate legacy-summary test
+proves that an incomplete stored Bootstrap Plan is not reused.

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -160,7 +160,13 @@ official-outdated, locally modified, and unsupported states. Installation and
 official upgrades remain a normal Plan followed by Apply. A modified copy
 stops planning until the user chooses `retain-local` or `adopt-current`; the
 Agent must not choose. Unsupported targets remain unchanged and are shown as
-blocked.
+blocked. A `preview_ready` JSON result includes the same bounded impact,
+operation groups, risk, reversibility, and exact-detail pointer as the Plan
+summary. It never embeds operations, file content, or fingerprints; Agents use
+`plan --show PLAN_ID --json` only for exact-detail questions.
+An incomplete legacy Plan summary is never reused or rewritten. Setup returns a
+new decision-complete Plan ID; Status can temporarily retain both pending Plans
+as immutable audit records.
 
 ## 7. Confirmation language
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -212,7 +212,10 @@ or mutates; every write remains a normal Plan completed through Apply and
 recoverable through Undo. Repeating an unchanged setup preview on the same
 Snapshot reuses an equivalent Ready Plan instead of accumulating duplicate
 pending Plans. Terminal Plans, newer Snapshots, and changed setup inputs are
-never reused.
+never reused. A legacy Ready Plan whose stored summary lacks the current
+bounded decision fields is not equivalent: it remains immutable and auditable,
+while Setup creates one decision-complete replacement. Both can temporarily
+appear as pending; the Agent presents only the newly returned Plan ID.
 
 `find` preserves the user's original task and accepts repeatable Agent-authored
 retrieval hints. Hints let the semantic caller supply a cross-language or

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,6 +30,21 @@ use crate::scan::{self, ExplicitSkillRoot, RootKind, ScanOptions, ScanResult};
 use crate::sqlite::StateStore;
 
 const STATUS_PENDING_PLAN_LIMIT: usize = 20;
+const SETUP_PLAN_SUMMARY_FIELDS: &[&str] = &[
+    "snapshot_id",
+    "digest",
+    "change_summary",
+    "operation_groups",
+    "affected",
+    "diff_summary",
+    "impact",
+    "detail",
+    "risk",
+    "reversible",
+    "canonical_deletion_count",
+    "confirmation_required",
+    "files_changed",
+];
 /// Agent tool-result transport bound, deliberately narrower than the 2 MiB
 /// inventory parser bound. Larger Skills should disclose references on demand.
 const MAX_AGENT_LOADED_SKILL_BYTES: u64 = 128 * 1024;
@@ -7647,7 +7662,11 @@ fn prepare_plan(
             &input,
             reuse_identity.as_ref(),
         )? {
-            if let Some(summary) = existing.input.get("summary") {
+            if let Some(summary) = existing.input.get("summary").filter(|summary| {
+                SETUP_PLAN_SUMMARY_FIELDS
+                    .iter()
+                    .all(|field| summary.get(*field).is_some())
+            }) {
                 return Ok(summary.clone());
             }
         }
@@ -8534,7 +8553,11 @@ fn setup_command_with_manifests<'a>(
     result["plan_id"] = plan["plan_id"].clone();
     result["state"] = json!("preview_ready");
     result["operation_count"] = json!(operation_count);
-    result["confirmation_required"] = json!(true);
+    for &field in SETUP_PLAN_SUMMARY_FIELDS {
+        if let Some(value) = plan.get(field) {
+            result[field] = value.clone();
+        }
+    }
     Ok(result)
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3203,7 +3203,11 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
     let shared = home.join(".agents_skills");
     let opencode = home.join(".config/opencode/skills");
     let hermes = home.join(".hermes/skills");
-    for root in [&shared, &opencode, &hermes] {
+    let cursor = home.join(".cursor/skills");
+    let gemini = home.join(".gemini/skills");
+    let copilot = home.join(".copilot/skills");
+    let physical_roots = [&shared, &opencode, &hermes, &cursor, &gemini, &copilot];
+    for root in physical_roots {
         fs::create_dir_all(root).unwrap();
     }
     for (parent, link) in [
@@ -3227,28 +3231,66 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
     assert_eq!(setup["result"]["state"], "preview_ready");
     assert_eq!(
         setup["result"]["detected_agents"].as_array().unwrap().len(),
-        5
+        8
     );
-    assert_eq!(setup["result"]["targets"].as_array().unwrap().len(), 5);
-    assert_eq!(setup["result"]["missing_count"], 5);
-    assert_eq!(setup["result"]["physical_target_count"], 3);
-    assert_eq!(setup["result"]["operation_count"], 18);
+    assert_eq!(setup["result"]["targets"].as_array().unwrap().len(), 8);
+    assert_eq!(setup["result"]["missing_count"], 8);
+    assert_eq!(setup["result"]["physical_target_count"], 6);
+    assert_eq!(setup["result"]["operation_count"], 36);
 
     let plan_id = setup["result"]["plan_id"].as_str().unwrap();
     let detail = json_output(&run(
         &[&common[..], &["plan", "--show", plan_id]].concat(),
         None,
     ));
+    for field in [
+        "snapshot_id",
+        "digest",
+        "change_summary",
+        "operation_groups",
+        "affected",
+        "diff_summary",
+        "impact",
+        "risk",
+        "reversible",
+        "canonical_deletion_count",
+        "confirmation_required",
+        "files_changed",
+    ] {
+        assert_eq!(setup["result"][field], detail["result"][field], "{field}");
+    }
+    assert_eq!(setup["result"]["detail"]["available"], true);
+    assert_eq!(
+        setup["result"]["detail"]["command"],
+        json!(["plan", "--show", plan_id, "--json"])
+    );
+    assert_eq!(setup["result"]["change_summary"]["operation_count"], 36);
+    assert_eq!(setup["result"]["operation_groups"]["create_directory"], 12);
+    assert_eq!(setup["result"]["operation_groups"]["write_file"], 24);
+    assert_eq!(setup["result"]["risk"], "filesystem_change");
+    assert_eq!(setup["result"]["reversible"], true);
+    assert_eq!(setup["result"]["confirmation_required"], true);
+    assert_eq!(setup["result"]["files_changed"], false);
+    assert!(setup["result"].get("operations").is_none());
+    let setup_json = serde_json::to_string(&setup).unwrap();
+    assert!(!setup_json.contains("\"content\":"));
+    assert!(!setup_json.contains("expected_fingerprint"));
+    assert!(serde_json::to_vec(&setup).unwrap().len() < serde_json::to_vec(&detail).unwrap().len());
     let operations = detail["result"]["operations"].as_array().unwrap();
-    assert_eq!(operations.len(), 18);
+    assert_eq!(operations.len(), 36);
     let unique_targets = operations
         .iter()
         .map(|operation| operation["target"].as_str().unwrap())
         .collect::<std::collections::BTreeSet<_>>();
-    assert_eq!(unique_targets.len(), 18);
+    assert_eq!(unique_targets.len(), 36);
+
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["pending_plan_count"], 1);
+    assert!(status["result"]["last_receipt"].is_null());
+    assert_eq!(status["result"]["recovery_state"], "clear");
 
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
-    for root in [&shared, &opencode, &hermes] {
+    for root in physical_roots {
         assert!(root.join("skillroster/SKILL.md").is_file());
         assert!(root.join("skillroster/references/routing.md").is_file());
         assert!(root.join("skillroster/references/governance.md").is_file());
@@ -3257,7 +3299,7 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
     let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
     let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
     assert_eq!(undone["result"]["verification"], "passed");
-    for root in [&shared, &opencode, &hermes] {
+    for root in physical_roots {
         assert!(!root.join("skillroster").exists());
     }
 }
@@ -3423,6 +3465,59 @@ fn setup_reuse_and_status_actionability_follow_snapshot_lifecycle() {
             .unwrap();
         assert_eq!(retained_lifecycle["status"], lifecycle_status);
     }
+}
+
+#[test]
+fn setup_does_not_reuse_an_incomplete_legacy_plan_summary() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    fs::create_dir_all(&root).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let first = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    let first_plan_id = first["result"]["plan_id"].as_str().unwrap();
+
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let immutable: String = database
+        .query_row(
+            "SELECT immutable_json FROM plans WHERE id = ?1",
+            [first_plan_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut legacy: Value = serde_json::from_str(&immutable).unwrap();
+    let summary = legacy["input"]["summary"].as_object_mut().unwrap();
+    summary.remove("operation_groups");
+    summary.remove("affected");
+    database
+        .execute(
+            "UPDATE plans SET immutable_json = ?1 WHERE id = ?2",
+            rusqlite::params![legacy.to_string(), first_plan_id],
+        )
+        .unwrap();
+    drop(database);
+
+    let retry = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(retry["result"]["state"], "preview_ready");
+    assert_ne!(retry["result"]["plan_id"], first["result"]["plan_id"]);
+    assert_eq!(retry["result"]["operation_groups"]["create_directory"], 2);
+    assert_eq!(retry["result"]["operation_groups"]["write_file"], 4);
+    assert!(retry["result"]["affected"].is_object());
+    assert_eq!(retry["result"]["confirmation_required"], true);
+    assert_eq!(retry["result"]["files_changed"], false);
+    assert!(!root.join("skillroster").exists());
+
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["pending_plan_count"], 2);
+    assert!(status["result"]["last_receipt"].is_null());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- project the immutable bounded Plan summary into `setup --json` through one explicit allowlist
- keep complete operations, file content, and fingerprints behind `plan --show`
- avoid reusing incomplete legacy Plan summaries while preserving them as immutable audit records
- cover the real 8-Agent / 6-physical-root / 36-operation cold-start topology and Apply/Undo

Closes #218

## Product evidence

Public v1.8.27 required a 5,959-byte Setup response plus an 87,054-byte Plan detail response to explain an ordinary Bootstrap preview. The same isolated topology now needs one observed 6,985-byte Setup response with operation groups, risk, reversibility, confirmation, and exact-detail pointer. Setup remains no-change and returns no embedded operations.

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (239 unit + 8 acceptance + 67 CLI)
- `git diff --check`
- two independent Luna high reviews: no blocker / should-fix
- focused simplify-codebase pass: retained the compatibility alias, centralized only the production allowlist/reuse contract, and added no new command/schema/state

No Release is included.