### PR TITLE
feat: add bounded Scan summary for Agent workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The agent then calls the `skillroster` CLI and returns an evidence-backed plan f
 ## Workflow
 
 ```bash
-skillroster scan --json
-skillroster --source-root /absolute/confirmed/source scan --json
+skillroster scan --summary --json
+skillroster --source-root /absolute/confirmed/source scan --summary --json
 skillroster report --json
 skillroster report --findings --limit 20 --json
 skillroster report --findings --category usage --json

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,7 +78,7 @@ After installing a new CLI version, refresh the local Snapshot and inspect all
 detected bootstrap targets:
 
 ```sh
-skillroster scan --json
+skillroster scan --summary --json
 skillroster setup --json
 ```
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -151,7 +151,7 @@ SkillRoster records source, revision, and content hash when available. A source-
 The first complete command surface is:
 
 ```bash
-skillroster scan [--json]
+skillroster scan [--summary] [--json]
 skillroster report [--summary | --full | --findings [--category <category>] [--severity <severity>] | --finding <id> [--full]] [--limit <n>] [--offset <n>] [--json]
 skillroster find <task> [--hint <text>]... [--limit <n>] [--load] [--variant-skill-id <skill-id>] [--json]
 skillroster plan --stdin [--json]
@@ -320,6 +320,15 @@ All JSON responses use a versioned envelope:
 ```
 
 IDs for Agents, Scans, reports, Skills, placements, Evidence, Findings, Plans, operations, and Receipts are opaque and stable within the local state store. Names and paths are never write-operation identities. Errors carry a stable code, human-readable message, retryability, and relevant IDs or paths. In JSON mode stdout contains exactly one JSON document and never an interactive prompt, progress bar, ANSI sequence, or log line. Terminal output is a polished human interface; Agents consume JSON rather than scraping styled text. The normative human-output, accessibility, progress, confirmation, and responsive-layout requirements live in [cli-ux-spec.md](cli-ux-spec.md).
+
+`scan --summary --json` persists the same complete immutable Snapshot as a full
+Scan but returns a bounded Agent continuation view: Snapshot and inventory
+counts, exact root totals, at most ten actionable root issues with exact
+total/truncation facts, aggregate and per-Agent typed session-coverage limits,
+source-root policy counts, and the ordinary Report action. Existing
+`scan --json` remains the complete diagnostic projection. Agent-generated Scan
+actions and the Bootstrap governance workflow use the Summary view; neither
+view changes Agent or Skill files.
 
 Selector-free `report --json` returns the bounded three-Finding Summary view;
 `--summary` is an explicit alias. The exhaustive diagnostic report requires

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -325,10 +325,17 @@ IDs for Agents, Scans, reports, Skills, placements, Evidence, Findings, Plans, o
 Scan but returns a bounded Agent continuation view: Snapshot and inventory
 counts, exact root totals, at most ten actionable root issues with exact
 total/truncation facts, aggregate and per-Agent typed session-coverage limits,
-source-root policy counts, and the ordinary Report action. Existing
+their supported next steps, and mutually exclusive `reliable`,
+`sampled_limited`, `missing`, `inaccessible`, `excluded`, or `legacy_unknown`
+states; source-root policy counts; and the ordinary Report action. Existing
 `scan --json` remains the complete diagnostic projection. Agent-generated Scan
 actions and the Bootstrap governance workflow use the Summary view; neither
 view changes Agent or Skill files.
+
+To avoid repeating identical typed facts, Summary groups Coverage limitations
+and supported next steps by their affected Agent IDs. Every group remains an
+explicit Agent-to-fact mapping; callers do not infer one Agent's boundary from
+another Agent's state.
 
 Selector-free `report --json` returns the bounded three-Finding Summary view;
 `--summary` is an explicit alias. The exhaustive diagnostic report requires

--- a/skill/skillroster/references/governance.md
+++ b/skill/skillroster/references/governance.md
@@ -2,7 +2,9 @@
 
 ## Inspect
 
-Run `skillroster scan --json`, then the bounded `skillroster report --json`.
+Run `skillroster scan --summary --json`, then the bounded
+`skillroster report --json`. Use full `scan --json` only for deliberate root or
+coverage diagnostics.
 Use `finding_rollups` for complete group scale and the selected findings for the
 first decisions. Use `report --findings --limit 20 --json`, optionally narrowed
 by one category or severity, only when enumeration is needed. Follow

--- a/src/app.rs
+++ b/src/app.rs
@@ -2376,32 +2376,60 @@ fn scan_summary_value(id: &ScanId, agents_checked: usize, result: &ScanResult) -
     let mut coverage_limitations =
         BTreeMap::<scan::SessionCoverageLimitation, BTreeSet<String>>::new();
     let mut coverage_next_steps = BTreeMap::<Vec<String>, BTreeSet<String>>::new();
-    for coverage in &result.coverage {
-        let details = session_coverage_details(coverage)?;
-        let limitations = coverage.limitations.as_deref().unwrap_or_default();
-        let supported_next_steps = details["actionability"]["supported_next_steps"]
-            .as_array()
-            .ok_or_else(|| anyhow!("session Coverage actionability must contain an array"))?
+    let mut excluded_agent_count = 0;
+    for agent in AgentKind::ALL {
+        if let Some(coverage) = result
+            .coverage
             .iter()
-            .map(|step| {
-                step.as_str()
-                    .map(str::to_owned)
-                    .ok_or_else(|| anyhow!("session Coverage next step must be a string"))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        for limitation in limitations {
-            coverage_limitations
-                .entry(limitation.clone())
+            .find(|coverage| coverage.agent == agent)
+        {
+            let details = session_coverage_details(coverage)?;
+            let supported_next_steps = details["actionability"]["supported_next_steps"]
+                .as_array()
+                .ok_or_else(|| anyhow!("session Coverage actionability must contain an array"))?
+                .iter()
+                .map(|step| {
+                    step.as_str()
+                        .map(str::to_owned)
+                        .ok_or_else(|| anyhow!("session Coverage next step must be a string"))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            for limitation in coverage.limitations.as_deref().unwrap_or_default() {
+                coverage_limitations
+                    .entry(limitation.clone())
+                    .or_default()
+                    .insert(agent.id().to_owned());
+            }
+            coverage_next_steps
+                .entry(supported_next_steps)
                 .or_default()
-                .insert(coverage.agent.id().to_owned());
+                .insert(agent.id().to_owned());
+            coverage_agents.push(json!({
+                "agent": agent.id(),
+                "state": summary_coverage_state(coverage),
+            }));
+            continue;
         }
+
+        let excluded = result.roots.iter().any(|root| {
+            root.agent == Some(agent)
+                && root.kind == scan::RootKind::Sessions
+                && root.status == scan::RootStatus::Excluded
+        });
+        if !excluded {
+            return Err(anyhow!(
+                "Scan summary has neither Coverage nor an excluded session root for {}",
+                agent.id()
+            ));
+        }
+        excluded_agent_count += 1;
         coverage_next_steps
-            .entry(supported_next_steps)
+            .entry(vec!["do_not_infer_usage_for_excluded_agent".to_owned()])
             .or_default()
-            .insert(coverage.agent.id().to_owned());
+            .insert(agent.id().to_owned());
         coverage_agents.push(json!({
-            "agent": coverage.agent.id(),
-            "state": summary_coverage_state(coverage),
+            "agent": agent.id(),
+            "state": "excluded",
         }));
     }
     let coverage_limitations = coverage_limitations
@@ -2455,13 +2483,14 @@ fn scan_summary_value(id: &ScanId, agents_checked: usize, result: &ScanResult) -
             "items": root_issue_items,
         },
         "session_coverage": {
-            "supported_agents": result.coverage.len(),
+            "supported_agents": AgentKind::ALL.len(),
             "roots_present_agents": metrics.agents_with_session_roots,
             "sampled_agents": metrics.agents_with_sampled_session_data,
             "complete_agents": metrics.agents_with_reliable_session_denominator,
             "limited_agents": metrics.agents_with_limited_session_data,
             "missing_root_agents": metrics.agents_missing_session_roots,
             "inaccessible_agents": metrics.agents_with_inaccessible_session_roots,
+            "excluded_agents": excluded_agent_count,
             "inference_boundary": {
                 "unused_claim_supported": false,
                 "automatic_governance_supported": false,

--- a/src/app.rs
+++ b/src/app.rs
@@ -236,7 +236,7 @@ pub fn run(cli: Cli) -> Result<Output> {
             } else if result["latest_snapshot_id"].is_null() {
                 vec![action(
                     "scan",
-                    &["scan", "--json"],
+                    &["scan", "--summary", "--json"],
                     false,
                     false,
                     "snapshot_required",
@@ -302,7 +302,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                     vec![],
                     vec![action(
                         "scan",
-                        &["scan", "--json"],
+                        &["scan", "--summary", "--json"],
                         false,
                         false,
                         "source_root_permission_recorded",
@@ -372,7 +372,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                     vec![],
                     vec![action(
                         "scan",
-                        &["scan", "--json"],
+                        &["scan", "--summary", "--json"],
                         false,
                         false,
                         "source_root_permission_revoked",
@@ -380,13 +380,14 @@ pub fn run(cli: Cli) -> Result<Output> {
                 )
             }
         },
-        Some(Command::Scan) => {
+        Some(Command::Scan(args)) => {
             let (result, warnings) = scan_command(
                 &store,
                 &home,
                 &state_dir,
                 parse_explicit_roots(&cli.roots)?,
                 parse_source_roots(&cli.source_roots)?,
+                args.summary,
             )?;
             (
                 "scan",
@@ -581,7 +582,7 @@ pub fn run(cli: Cli) -> Result<Output> {
             if result["state"].as_str() == Some("scan_required") {
                 actions.push(action(
                     "scan",
-                    &["scan", "--json"],
+                    &["scan", "--summary", "--json"],
                     false,
                     false,
                     "setup_requires_snapshot",
@@ -628,7 +629,7 @@ pub fn run(cli: Cli) -> Result<Output> {
 
 fn command_requires_exclusive_state_lock(command: Option<&Command>) -> bool {
     match command {
-        Some(Command::Scan | Command::Apply(_) | Command::Undo(_) | Command::Setup(_)) => true,
+        Some(Command::Scan(_) | Command::Apply(_) | Command::Undo(_) | Command::Setup(_)) => true,
         Some(Command::Report(args)) => args.finding.is_none(),
         Some(Command::Plan(args)) => args.show.is_none(),
         Some(Command::SourceRoot(args)) => matches!(
@@ -678,7 +679,7 @@ pub fn error_json_with_context(
         );
         envelope.suggested_actions = vec![action(
             "refresh_snapshot_content_identity",
-            &["scan", "--json"],
+            &["scan", "--summary", "--json"],
             false,
             false,
             "content_identity_rescan_required",
@@ -2157,6 +2158,7 @@ fn scan_command(
     state_dir: &Path,
     explicit: Vec<ExplicitSkillRoot>,
     source_roots: Vec<PathBuf>,
+    summary: bool,
 ) -> Result<(Value, Vec<String>)> {
     let started = Utc::now().timestamp();
     let id = ScanId::new();
@@ -2273,24 +2275,26 @@ fn scan_command(
         .filter_map(|root| root.agent)
         .collect::<std::collections::BTreeSet<_>>()
         .len();
-    let roots = result
-        .roots
-        .iter()
-        .map(|root| {
-            let mut value = json!(root);
-            value["agent"] = json!(root.agent.map(AgentKind::id));
-            value
-        })
-        .collect::<Vec<_>>();
-    let coverage = result
-        .coverage
-        .iter()
-        .map(session_coverage_details)
-        .collect::<Result<Vec<_>>>()?;
-    let warnings = compact_scan_warnings(result.warnings);
-    Ok((
+    let warnings = compact_scan_warnings(result.warnings.clone());
+    let public_result = if summary {
+        scan_summary_value(&id, agents_checked, &result)?
+    } else {
+        let roots = result
+            .roots
+            .iter()
+            .map(|root| {
+                let mut value = json!(root);
+                value["agent"] = json!(root.agent.map(AgentKind::id));
+                value
+            })
+            .collect::<Vec<_>>();
+        let coverage = result
+            .coverage
+            .iter()
+            .map(session_coverage_details)
+            .collect::<Result<Vec<_>>>()?;
         json!({
-            "snapshot_id": id,
+            "snapshot_id": &id,
             "agents_checked": agents_checked,
             "skill_count": result.skills.len(),
             "placement_count": result.placements.len(),
@@ -2304,9 +2308,150 @@ fn scan_command(
                 "permissions": result.source_root_policy,
             },
             "files_changed": false
-        }),
-        warnings,
-    ))
+        })
+    };
+    Ok((public_result, warnings))
+}
+
+const SCAN_SUMMARY_ROOT_ISSUE_LIMIT: usize = 10;
+
+fn scan_summary_value(id: &ScanId, agents_checked: usize, result: &ScanResult) -> Result<Value> {
+    let root_kinds = [scan::RootKind::Skills, scan::RootKind::Sessions];
+    let root_statuses = [
+        scan::RootStatus::Included,
+        scan::RootStatus::Missing,
+        scan::RootStatus::Inaccessible,
+        scan::RootStatus::Excluded,
+    ];
+    let mut root_counts = Vec::new();
+    for kind in root_kinds {
+        for status in root_statuses {
+            let count = result
+                .roots
+                .iter()
+                .filter(|root| root.kind == kind && root.status == status)
+                .count();
+            if count > 0 {
+                root_counts.push(json!({
+                    "kind": kind,
+                    "status": status,
+                    "count": count,
+                }));
+            }
+        }
+    }
+
+    let root_issues = result
+        .roots
+        .iter()
+        .filter(|root| {
+            root.status != scan::RootStatus::Included
+                || (root.kind == scan::RootKind::Skills && !root.discovery_complete)
+        })
+        .collect::<Vec<_>>();
+    let root_issue_items = root_issues
+        .iter()
+        .take(SCAN_SUMMARY_ROOT_ISSUE_LIMIT)
+        .map(|root| {
+            json!({
+                "agent": root.agent.map(AgentKind::id),
+                "kind": root.kind,
+                "path": root.path,
+                "status": root.status,
+                "explicit": root.explicit,
+                "discovery_complete": root.discovery_complete,
+                "detail": root.detail,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let metrics = crate::query::primary_metrics(result);
+    let mut coverage_agents = Vec::new();
+    let mut coverage_next_steps = BTreeSet::new();
+    for coverage in &result.coverage {
+        let details = session_coverage_details(coverage)?;
+        let limitation_codes = coverage
+            .limitations
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|limitation| serde_json::to_value(limitation.code))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        if let Some(steps) = details["actionability"]["supported_next_steps"].as_array() {
+            coverage_next_steps.extend(steps.iter().filter_map(Value::as_str).map(str::to_owned));
+        }
+        coverage_agents.push(json!({
+            "agent": coverage.agent.id(),
+            "limitation_state": details["limitation_state"],
+            "limitations_recorded": coverage.limitations.is_some(),
+            "limitation_codes": limitation_codes,
+            "denominator_reliable": details["denominator_reliable"],
+        }));
+    }
+
+    let source_states = [
+        crate::source_policy::SourceRootState::Active,
+        crate::source_policy::SourceRootState::Missing,
+        crate::source_policy::SourceRootState::Inaccessible,
+        crate::source_policy::SourceRootState::Replaced,
+        crate::source_policy::SourceRootState::Retargeted,
+    ];
+    let source_state_counts = source_states
+        .into_iter()
+        .filter_map(|state| {
+            let count = result
+                .source_root_policy
+                .iter()
+                .filter(|fact| fact.state == state)
+                .count();
+            (count > 0).then(|| json!({"state": state, "count": count}))
+        })
+        .collect::<Vec<_>>();
+    let source_issue_count = result
+        .source_root_policy
+        .iter()
+        .filter(|fact| fact.state != crate::source_policy::SourceRootState::Active)
+        .count();
+
+    Ok(json!({
+        "view": "summary",
+        "snapshot_id": id,
+        "agents_checked": agents_checked,
+        "skill_count": result.skills.len(),
+        "placement_count": result.placements.len(),
+        "root_counts": root_counts,
+        "root_issues": {
+            "total": root_issues.len(),
+            "returned": root_issue_items.len(),
+            "truncated": root_issue_items.len() < root_issues.len(),
+            "items": root_issue_items,
+        },
+        "session_coverage": {
+            "supported_agents": result.coverage.len(),
+            "roots_present_agents": metrics.agents_with_session_roots,
+            "sampled_agents": metrics.agents_with_sampled_session_data,
+            "complete_agents": metrics.agents_with_reliable_session_denominator,
+            "limited_agents": metrics.agents_with_limited_session_data,
+            "missing_root_agents": metrics.agents_missing_session_roots,
+            "inaccessible_agents": metrics.agents_with_inaccessible_session_roots,
+            "inference_boundary": {
+                "unused_claim_supported": false,
+                "automatic_governance_supported": false,
+            },
+            "supported_next_steps": coverage_next_steps,
+            "agents": coverage_agents,
+        },
+        "source_root_policy": {
+            "scope": "exact_local_read_only",
+            "permission_count": result.source_root_policy.len(),
+            "issue_count": source_issue_count,
+            "state_counts": source_state_counts,
+            "content_endorsed": false,
+            "evidence_quality_changed": false,
+            "governance_authorized": false,
+        },
+        "files_changed": false,
+    }))
 }
 
 /// Merge policy observations conservatively across a Scan. Once a permission
@@ -5313,7 +5458,7 @@ fn bind_variant_findings(
         let (reference, suggested) = if variant_drifted {
             let suggested = action(
                 "refresh_drifted_snapshot",
-                &["scan", "--json"],
+                &["scan", "--summary", "--json"],
                 false,
                 false,
                 "routable_variant_drift_detected",
@@ -11304,7 +11449,7 @@ mod recovery_tests {
             std::fs::write(package.join(relative_path), content).unwrap();
         }
         let store = StateStore::open(state.join("skillroster.db")).unwrap();
-        scan_command(&store, &home, &state, Vec::new(), Vec::new()).unwrap();
+        scan_command(&store, &home, &state, Vec::new(), Vec::new(), false).unwrap();
 
         std::fs::write(package.join(current[1].0), &current[1].2).unwrap();
         let mixed = setup_command_with_manifests(&store, &home, &state, None, &manifests).unwrap();

--- a/src/app.rs
+++ b/src/app.rs
@@ -706,7 +706,7 @@ pub fn error_json_with_context(
                 argv.push("--source-root");
                 argv.push(path.as_str());
             }
-            argv.extend(["scan", "--json"]);
+            argv.extend(["scan", "--summary", "--json"]);
             envelope.suggested_actions = vec![action(
                 "scan_with_confirmed_source_roots",
                 &argv,
@@ -742,7 +742,9 @@ pub fn error_json_with_context(
             | "legacy_snapshot_requires_rescan"
             | "eligible_placement_missing"
             | "entrypoint_content_drift"
-            | "package_identity_drift" => Some(("refresh_snapshot", vec!["scan", "--json"])),
+            | "package_identity_drift" => {
+                Some(("refresh_snapshot", vec!["scan", "--summary", "--json"]))
+            }
             _ => None,
         };
         if let Some((name, argv)) = safe_retry {
@@ -1746,7 +1748,7 @@ fn lifecycle_delete_command(database_path: &Path, state_dir: &Path) -> Result<Va
         "removed_receipt_journals": removed_journals,
         "removed_recovery_directories": removed_recovery_directories,
         "removed_source_confirmation_details": removed_source_confirmation_details,
-        "rebuild_command": "skillroster scan --json",
+        "rebuild_command": "skillroster scan --summary --json",
         "agent_files_changed": false,
         "library_files_changed": false,
         "files_changed": files_changed,
@@ -1876,7 +1878,7 @@ fn recognized_source_confirmation_detail(detail: &Value) -> bool {
         .collect::<Vec<_>>();
         let action_context_argv = match schema_version {
             1 => Vec::new(),
-            2 => detail["action_context_argv"]
+            2 | 3 => detail["action_context_argv"]
                 .as_array()?
                 .iter()
                 .map(Value::as_str)
@@ -1889,14 +1891,18 @@ fn recognized_source_confirmation_detail(detail: &Value) -> bool {
         for root in &source_roots {
             expected_argv.extend(["--source-root", *root]);
         }
-        expected_argv.extend(["scan", "--json"]);
+        match schema_version {
+            1 | 2 => expected_argv.extend(["scan", "--json"]),
+            3 => expected_argv.extend(["scan", "--summary", "--json"]),
+            _ => return None,
+        }
         let argv = detail["after_confirmation"]["argv"]
             .as_array()?
             .iter()
             .map(Value::as_str)
             .collect::<Option<Vec<_>>>()?;
         Some(
-            matches!(schema_version, 1 | 2)
+            matches!(schema_version, 1..=3)
                 && detail["reason"] == "trusted_canonical_sources_required"
                 && detail["decision"] == "confirm_trusted_source_roots"
                 && (1..=crate::roster_recommendation::MAX_CORE_BUDGET as u64)
@@ -2367,27 +2373,49 @@ fn scan_summary_value(id: &ScanId, agents_checked: usize, result: &ScanResult) -
 
     let metrics = crate::query::primary_metrics(result);
     let mut coverage_agents = Vec::new();
-    let mut coverage_next_steps = BTreeSet::new();
+    let mut coverage_limitations =
+        BTreeMap::<scan::SessionCoverageLimitation, BTreeSet<String>>::new();
+    let mut coverage_next_steps = BTreeMap::<Vec<String>, BTreeSet<String>>::new();
     for coverage in &result.coverage {
         let details = session_coverage_details(coverage)?;
-        let limitation_codes = coverage
-            .limitations
-            .as_deref()
-            .unwrap_or_default()
+        let limitations = coverage.limitations.as_deref().unwrap_or_default();
+        let supported_next_steps = details["actionability"]["supported_next_steps"]
+            .as_array()
+            .ok_or_else(|| anyhow!("session Coverage actionability must contain an array"))?
             .iter()
-            .map(|limitation| serde_json::to_value(limitation.code))
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        if let Some(steps) = details["actionability"]["supported_next_steps"].as_array() {
-            coverage_next_steps.extend(steps.iter().filter_map(Value::as_str).map(str::to_owned));
+            .map(|step| {
+                step.as_str()
+                    .map(str::to_owned)
+                    .ok_or_else(|| anyhow!("session Coverage next step must be a string"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        for limitation in limitations {
+            coverage_limitations
+                .entry(limitation.clone())
+                .or_default()
+                .insert(coverage.agent.id().to_owned());
         }
+        coverage_next_steps
+            .entry(supported_next_steps)
+            .or_default()
+            .insert(coverage.agent.id().to_owned());
         coverage_agents.push(json!({
             "agent": coverage.agent.id(),
-            "limitation_state": details["limitation_state"],
-            "limitations_recorded": coverage.limitations.is_some(),
-            "limitation_codes": limitation_codes,
-            "denominator_reliable": details["denominator_reliable"],
+            "state": summary_coverage_state(coverage),
         }));
     }
+    let coverage_limitations = coverage_limitations
+        .into_iter()
+        .map(|(limitation, agents)| -> Result<Value> {
+            let mut fact = serde_json::to_value(limitation)?;
+            fact["agents"] = json!(agents);
+            Ok(fact)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let coverage_next_steps = coverage_next_steps
+        .into_iter()
+        .map(|(steps, agents)| json!({"agents": agents, "steps": steps}))
+        .collect::<Vec<_>>();
 
     let source_states = [
         crate::source_policy::SourceRootState::Active,
@@ -2438,8 +2466,9 @@ fn scan_summary_value(id: &ScanId, agents_checked: usize, result: &ScanResult) -
                 "unused_claim_supported": false,
                 "automatic_governance_supported": false,
             },
-            "supported_next_steps": coverage_next_steps,
             "agents": coverage_agents,
+            "limitation_groups": coverage_limitations,
+            "next_step_groups": coverage_next_steps,
         },
         "source_root_policy": {
             "scope": "exact_local_read_only",
@@ -2452,6 +2481,22 @@ fn scan_summary_value(id: &ScanId, agents_checked: usize, result: &ScanResult) -
         },
         "files_changed": false,
     }))
+}
+
+fn summary_coverage_state(coverage: &scan::SessionCoverage) -> &'static str {
+    if coverage.limitations.is_none() {
+        "legacy_unknown"
+    } else if coverage.roots_inaccessible > 0 {
+        "inaccessible"
+    } else if coverage.roots_missing > 0 {
+        "missing"
+    } else if coverage.denominator_is_reliable() {
+        "reliable"
+    } else if coverage.roots_present > 0 {
+        "sampled_limited"
+    } else {
+        "excluded"
+    }
 }
 
 /// Merge policy observations conservatively across a Scan. Once a permission
@@ -3114,7 +3159,7 @@ fn add_finding_resolution(
                     "next": {
                         "action": "scan",
                         "confirmed_source_root_option_required": false,
-                        "argv_template": ["skillroster", "scan", "--json"]
+                        "argv_template": ["skillroster", "scan", "--summary", "--json"]
                     }
                 },
                 "temporary_one_scan": {
@@ -3128,6 +3173,7 @@ fn add_finding_resolution(
                         "--source-root",
                         "<observed-canonical-source-directory>",
                         "scan",
+                        "--summary",
                         "--json"
                     ]
                 }
@@ -3142,6 +3188,7 @@ fn add_finding_resolution(
                     "--source-root",
                     "<confirmed-canonical-source-directory>",
                     "scan",
+                    "--summary",
                     "--json"
                 ]
             }
@@ -8490,7 +8537,7 @@ fn setup_command_with_manifests<'a>(
             "physical_target_count": 0,
             "canonical_deletion_count": 0,
             "files_changed": false,
-            "next": "skillroster scan --json"
+            "next": "skillroster scan --summary --json"
         }));
     };
     let current_package = current_bootstrap_package();
@@ -12122,7 +12169,7 @@ mod recovery_tests {
             .as_str()
             .unwrap();
         let complete: Value = serde_json::from_slice(&std::fs::read(detail_path).unwrap()).unwrap();
-        assert_eq!(complete["schema_version"], 2);
+        assert_eq!(complete["schema_version"], 3);
         assert_eq!(complete["action_context_argv"], json!(action_argv_prefix));
         assert_eq!(complete["source_roots"], json!(expected_roots));
         let complete_argv = complete["after_confirmation"]["argv"]
@@ -12134,6 +12181,10 @@ mod recovery_tests {
         assert_eq!(
             complete_argv[1..=action_argv_prefix.len()],
             action_argv_prefix
+        );
+        assert_eq!(
+            &complete_argv[complete_argv.len() - 3..],
+            ["scan", "--summary", "--json"]
         );
         for root in &expected_roots {
             assert!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ pub struct Cli {
 impl Cli {
     pub fn command_name(&self) -> &'static str {
         match &self.command {
-            Some(Command::Scan) => "scan",
+            Some(Command::Scan(_)) => "scan",
             Some(Command::Report(_)) => "report",
             Some(Command::Find(_)) => "find",
             Some(Command::Plan(_)) => "plan",
@@ -55,7 +55,7 @@ impl Cli {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Discover Skills and persist an immutable Snapshot.
-    Scan,
+    Scan(ScanArgs),
     /// Analyze the latest Snapshot or drill into one Finding. Defaults to the bounded Summary view.
     Report(ReportArgs),
     /// Rank locally known Skills for a task without activating them.
@@ -74,6 +74,13 @@ pub enum Command {
     Setup(SetupArgs),
     /// Confirm, inspect, or revoke exact local source-root read permissions.
     SourceRoot(SourceRootArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct ScanArgs {
+    /// Return the bounded Agent continuation view while persisting the complete Snapshot.
+    #[arg(long)]
+    pub summary: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -337,8 +337,8 @@ impl RetrievalQuery {
     }
 }
 
-pub fn build_report(scan: &ScanResult) -> Report {
-    let metrics = PrimaryMetrics {
+pub(crate) fn primary_metrics(scan: &ScanResult) -> PrimaryMetrics {
+    PrimaryMetrics {
         independent_skills: scan.skills.len(),
         placements: scan.placements.len(),
         default_exposure: scan
@@ -381,7 +381,11 @@ pub fn build_report(scan: &ScanResult) -> Report {
             .iter()
             .filter(|coverage| coverage.roots_inaccessible > 0)
             .count(),
-    };
+    }
+}
+
+pub fn build_report(scan: &ScanResult) -> Report {
+    let metrics = primary_metrics(scan);
     let mut findings = Vec::new();
     inventory_findings(scan, &mut findings);
     layout_findings(scan, &mut findings);

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde_json::{Value, json};
 
 const SOURCE_CONFIRMATION_JSON_LIMIT: usize = 10;
-const SOURCE_CONFIRMATION_SCHEMA_VERSION: u32 = 2;
+const SOURCE_CONFIRMATION_SCHEMA_VERSION: u32 = 3;
 
 use crate::change::{self, LibraryChangeAction, RosterChange};
 use crate::harness::AgentKind;
@@ -398,6 +398,7 @@ fn scan_with_source_roots_argv(
         argv.push(root.clone());
     }
     argv.push("scan".into());
+    argv.push("--summary".into());
     argv.push("--json".into());
     argv
 }
@@ -2355,7 +2356,7 @@ mod tests {
             "atomic publication must not leave a temporary artifact"
         );
         let complete: Value = serde_json::from_slice(&fs::read(detail_path).unwrap()).unwrap();
-        assert_eq!(complete["schema_version"], 2);
+        assert_eq!(complete["schema_version"], 3);
         assert_eq!(complete["action_context_argv"], json!([]));
         assert_eq!(complete["blocked_changes"].as_array().unwrap().len(), 11);
         assert_eq!(complete["source_roots"], json!(expected_roots));
@@ -2369,6 +2370,7 @@ mod tests {
             .iter()
             .filter_map(Value::as_str)
             .collect::<Vec<_>>();
+        assert_eq!(&argv[argv.len() - 3..], ["scan", "--summary", "--json"]);
         for root in &expected_roots {
             let root = root.display().to_string();
             assert!(

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -361,7 +361,7 @@ pub enum SessionCoverageLimitationSource {
     SessionJsonl,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct SessionCoverageLimitation {
     pub code: SessionCoverageLimitationCode,
     pub scope: SessionCoverageScope,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -140,13 +140,40 @@ fn scan_summary_preserves_report_facts_and_bounds_agent_context() {
     let home = temp.path().join("home");
     let full_state = temp.path().join("full-state");
     let summary_state = temp.path().join("summary-state");
-    let skill = home.join(".codex/skills/example");
-    fs::create_dir_all(&skill).unwrap();
-    fs::write(
-        skill.join("SKILL.md"),
-        "---\nname: example\ndescription: Example task helper\n---\n",
-    )
-    .unwrap();
+    let agent_roots = [
+        (".codex/skills", ".codex/sessions"),
+        (".claude/skills", ".claude/projects"),
+        (".pi/agent/skills", ".pi/agent/sessions"),
+        (
+            ".config/opencode/skills",
+            ".local/share/opencode/storage/session",
+        ),
+        (".hermes/skills", ".hermes/sessions"),
+        (".cursor/skills", ".cursor/projects"),
+        (".gemini/skills", ".gemini/tmp"),
+        (".copilot/skills", ".copilot/session-state"),
+    ];
+    for (agent_index, (skill_root, session_root)) in agent_roots.iter().enumerate() {
+        for skill_index in 0..8 {
+            let name = format!("fixture-{agent_index}-{skill_index}");
+            let skill = home.join(skill_root).join(&name);
+            fs::create_dir_all(&skill).unwrap();
+            fs::write(
+                skill.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: Representative task helper\n---\n"),
+            )
+            .unwrap();
+        }
+        if agent_index < 7 {
+            let sessions = home.join(session_root);
+            fs::create_dir_all(&sessions).unwrap();
+            fs::write(
+                sessions.join("representative.jsonl"),
+                "{\"type\":\"message\",\"content\":\"bounded fixture\"}\n",
+            )
+            .unwrap();
+        }
+    }
 
     let scan_args = |state: &Path, summary: bool| {
         let mut args = vec![
@@ -198,12 +225,61 @@ fn scan_summary_preserves_report_facts_and_bounds_agent_context() {
         summary["result"]["session_coverage"]["inference_boundary"]["automatic_governance_supported"],
         false
     );
+    assert_eq!(summary["result"]["skill_count"], 64);
+    assert_eq!(summary["result"]["placement_count"], 64);
+    assert_eq!(
+        summary["result"]["session_coverage"]["agents"]
+            .as_array()
+            .unwrap()
+            .len(),
+        8
+    );
     assert!(
-        summary["result"]["session_coverage"]["supported_next_steps"]
+        summary["result"]["session_coverage"]["agents"]
             .as_array()
             .unwrap()
             .iter()
-            .all(Value::is_string)
+            .all(|agent| agent["state"].is_string())
+    );
+    let missing_coverage = summary["result"]["session_coverage"]["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|agent| agent["state"] == "missing")
+        .unwrap();
+    assert_eq!(missing_coverage["agent"], "github-copilot");
+    let missing_limitation = summary["result"]["session_coverage"]["limitation_groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|limitation| limitation["code"] == "root_missing")
+        .unwrap();
+    assert!(
+        missing_limitation["agents"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("github-copilot"))
+    );
+    for field in ["scope", "count_kind", "observed", "unit", "source"] {
+        assert!(
+            missing_limitation.get(field).is_some(),
+            "typed limitation field {field}"
+        );
+    }
+    assert!(missing_limitation.get("limit").is_some());
+    assert!(
+        summary["result"]["session_coverage"]["next_step_groups"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|group| group["agents"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("github-copilot"))
+                && group["steps"]
+                    .as_array()
+                    .unwrap()
+                    .contains(&json!("verify_session_root_before_rescan")))
     );
     assert!(
         summary_output.stdout.len() * 100 <= full_output.stdout.len() * 40,
@@ -234,21 +310,34 @@ fn scan_summary_preserves_report_facts_and_bounds_agent_context() {
         ],
         None,
     ));
-    for field in [
-        "skill_count",
-        "placement_count",
-        "default_exposure",
-        "observed_use_agent_count",
-        "primary_metrics",
-        "session_coverage",
-        "category_counts",
-        "finding_rollups",
-    ] {
-        assert_eq!(
-            summary_report["result"][field], full_report["result"][field],
-            "report field {field}"
-        );
+    let full_payload: String = rusqlite::Connection::open(full_state.join("skillroster.db"))
+        .unwrap()
+        .query_row("SELECT payload_json FROM scan_payloads", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    let summary_payload: String = rusqlite::Connection::open(summary_state.join("skillroster.db"))
+        .unwrap()
+        .query_row("SELECT payload_json FROM scan_payloads", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(summary_payload, full_payload);
+
+    let mut full_report_result = full_report["result"].clone();
+    let mut summary_report_result = summary_report["result"].clone();
+    for result in [&mut full_report_result, &mut summary_report_result] {
+        result.as_object_mut().unwrap().remove("report_id");
+        result.as_object_mut().unwrap().remove("snapshot_id");
+        for finding in result["findings"].as_array_mut().unwrap() {
+            finding.as_object_mut().unwrap().remove("id");
+            finding
+                .as_object_mut()
+                .unwrap()
+                .remove("primary_evidence_id");
+        }
     }
+    assert_eq!(summary_report_result, full_report_result);
 }
 
 #[test]
@@ -8052,8 +8141,8 @@ fn find_rejects_content_drift_and_requests_rescan() {
     );
     let retry_argv = loaded["suggested_actions"][0]["argv"].as_array().unwrap();
     assert_eq!(
-        &retry_argv[retry_argv.len() - 2..],
-        &[json!("scan"), json!("--json")]
+        &retry_argv[retry_argv.len() - 3..],
+        &[json!("scan"), json!("--summary"), json!("--json")]
     );
     assert!(loaded["error"]["details"].get("content").is_none());
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -135,6 +135,123 @@ fn suggested_action_argv_replays_the_same_discovery_context() {
 }
 
 #[test]
+fn scan_summary_preserves_report_facts_and_bounds_agent_context() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let full_state = temp.path().join("full-state");
+    let summary_state = temp.path().join("summary-state");
+    let skill = home.join(".codex/skills/example");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: example\ndescription: Example task helper\n---\n",
+    )
+    .unwrap();
+
+    let scan_args = |state: &Path, summary: bool| {
+        let mut args = vec![
+            "--home".to_owned(),
+            home.to_string_lossy().into_owned(),
+            "--state-dir".to_owned(),
+            state.to_string_lossy().into_owned(),
+            "--json".to_owned(),
+        ];
+        for index in 0..12 {
+            args.push("--root".to_owned());
+            args.push(format!(
+                "codex={}",
+                temp.path().join(format!("missing-{index}")).display()
+            ));
+        }
+        args.push("scan".to_owned());
+        if summary {
+            args.push("--summary".to_owned());
+        }
+        args
+    };
+    let full_args = scan_args(&full_state, false);
+    let summary_args = scan_args(&summary_state, true);
+    let full_output = run(
+        &full_args.iter().map(String::as_str).collect::<Vec<_>>(),
+        None,
+    );
+    let summary_output = run(
+        &summary_args.iter().map(String::as_str).collect::<Vec<_>>(),
+        None,
+    );
+    let full = json_output(&full_output);
+    let summary = json_output(&summary_output);
+
+    assert!(full["result"]["roots"].is_array());
+    assert!(full["result"]["coverage"].is_array());
+    assert_eq!(summary["result"]["view"], "summary");
+    assert!(summary["result"].get("roots").is_none());
+    assert!(summary["result"].get("coverage").is_none());
+    assert_eq!(summary["result"]["root_issues"]["returned"], 10);
+    assert_eq!(summary["result"]["root_issues"]["truncated"], true);
+    assert!(summary["result"]["root_issues"]["total"].as_u64().unwrap() > 10);
+    assert_eq!(
+        summary["result"]["session_coverage"]["inference_boundary"]["unused_claim_supported"],
+        false
+    );
+    assert_eq!(
+        summary["result"]["session_coverage"]["inference_boundary"]["automatic_governance_supported"],
+        false
+    );
+    assert!(
+        summary["result"]["session_coverage"]["supported_next_steps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(Value::is_string)
+    );
+    assert!(
+        summary_output.stdout.len() * 100 <= full_output.stdout.len() * 40,
+        "summary={} full={}",
+        summary_output.stdout.len(),
+        full_output.stdout.len()
+    );
+
+    let full_report = json_output(&run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            full_state.to_str().unwrap(),
+            "--json",
+            "report",
+        ],
+        None,
+    ));
+    let summary_report = json_output(&run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            summary_state.to_str().unwrap(),
+            "--json",
+            "report",
+        ],
+        None,
+    ));
+    for field in [
+        "skill_count",
+        "placement_count",
+        "default_exposure",
+        "observed_use_agent_count",
+        "primary_metrics",
+        "session_coverage",
+        "category_counts",
+        "finding_rollups",
+    ] {
+        assert_eq!(
+            summary_report["result"][field], full_report["result"][field],
+            "report field {field}"
+        );
+    }
+}
+
+#[test]
 fn report_help_names_the_safe_default_and_explicit_exhaustive_export() {
     let output = run(&["report", "--help"], None);
     assert!(output.status.success());
@@ -385,7 +502,7 @@ fn healthy_status_does_not_suggest_an_unconditional_rescan() {
     let missing_snapshot = json_output(&run(&[&common[..], &["status"]].concat(), None));
     assert_eq!(
         missing_snapshot["suggested_actions"][0]["argv"],
-        context_action_argv(&home, &state, &["scan", "--json"])
+        context_action_argv(&home, &state, &["scan", "--summary", "--json"])
     );
     assert_eq!(
         missing_snapshot["suggested_actions"][0]["reason_code"],
@@ -1301,7 +1418,7 @@ fn legacy_snapshot_requires_typed_rescan_before_find_or_report() {
         assert_eq!(rejected["error"]["details"]["files_changed"], false);
         assert_eq!(
             rejected["suggested_actions"][0]["argv"],
-            context_action_argv(&home, &state, &["scan", "--json"])
+            context_action_argv(&home, &state, &["scan", "--summary", "--json"])
         );
     }
 
@@ -1525,7 +1642,7 @@ fn same_name_divergent_finding_keeps_variant_paths_and_requires_a_choice() {
     assert!(drifted_find["result"]["matches"][0]["variant_finding"]["finding_id"].is_null());
     assert_eq!(
         drifted_find["suggested_actions"][0]["argv"],
-        context_action_argv(&home, &state, &["scan", "--json"])
+        context_action_argv(&home, &state, &["scan", "--summary", "--json"])
     );
 
     json_output(&run(&[&common[..], &["scan"]].concat(), None));
@@ -3642,7 +3759,7 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
     assert_eq!(output["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(
         output["suggested_actions"][0]["argv"],
-        context_action_argv(&home, &state, &["scan", "--json"])
+        context_action_argv(&home, &state, &["scan", "--summary", "--json"])
     );
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4130,6 +4130,37 @@ fn lifecycle_exclusion_and_database_delete_preserve_user_files() {
                 && root["kind"] == "sessions"
                 && root["status"] == "excluded")
     );
+    let summary = json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+    assert_eq!(summary["result"]["session_coverage"]["supported_agents"], 8);
+    assert_eq!(summary["result"]["session_coverage"]["excluded_agents"], 1);
+    assert_eq!(
+        summary["result"]["session_coverage"]["agents"]
+            .as_array()
+            .unwrap()
+            .len(),
+        8
+    );
+    assert!(
+        summary["result"]["session_coverage"]["agents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|agent| agent["agent"] == "codex" && agent["state"] == "excluded")
+    );
+    assert!(
+        summary["result"]["session_coverage"]["next_step_groups"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|group| group["agents"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("codex"))
+                && group["steps"]
+                    .as_array()
+                    .unwrap()
+                    .contains(&json!("do_not_infer_usage_for_excluded_agent")))
+    );
     let inspect = json_output(&run(
         &[&common[..], &["lifecycle", "inspect"]].concat(),
         None,


### PR DESCRIPTION
## Summary

- add opt-in `scan --summary` while preserving the complete persisted Snapshot and existing full Scan contract
- return bounded root issues, shared coverage metrics, grouped typed per-Agent limitations/actionability, and source-permission counts
- make Agent-generated Scan actions and the Bootstrap governance workflow use the compact continuation
- share primary-metric derivation with Report and skip constructing the discarded full JSON projection in Summary mode

Closes #221.

## Dogfood evidence

Fresh real-home runs found the same 251 Skills and 887 placements:

- full Scan JSON: 18,797 bytes
- Summary Scan JSON: 6,225 bytes (66.9% smaller)
- the test compares byte-identical complete persisted Snapshot payloads and complete bounded Report facts after removing run-scoped IDs
- root issues reported exact total 12, returned 10, and `truncated: true`
- coverage retained 0 complete, 5 sampled/limited, and 3 missing-root Agents; unused and automatic-governance inference remained false
- identical limitation facts and supported next steps are grouped by explicit Agent IDs instead of repeated; all typed fields remain present
- lifecycle-excluded Agents remain in the 8-Agent denominator with an explicit `excluded` state and no usage inference
- every command reported `files_changed: false`; no Apply or Undo ran against the real home

This follows [OpenAI model guidance](https://developers.openai.com/api/docs/guides/latest-model) to reduce large intermediate tool results while preserving required evidence, caveats, and next actions, and validates the change on the representative local workflow.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (240 unit + 8 acceptance + 69 CLI = 317)
- `cargo build --release --locked`
- release binary `scan --help`
- `git diff --check`
- representative 8-Agent fixture: 64 Skills, 64 placements, one missing session root, more than 60% output reduction
- focused simplify-codebase audit: one coverage-metric definition; Summary skips the discarded full projection and groups repeated facts with typed keys

No schema migration, mutation change, Agent-file write, tag, or Release.
