### PR TITLE
chore: reserve a private local research workbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/local-research/
 .DS_Store
 *.swp


### PR DESCRIPTION
## Summary
- ignore `/local-research/` at the repository root
- keep private research notes, real-machine evidence summaries, and session inventories out of Git

## Verification
- `git check-ignore` confirms the workbench and raw inventory are ignored
- `git diff --check` passes
- no local research content is included in this PR