### PR TITLE
release: finalize SkillRoster v1.8.28

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,7 +2,7 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "a3c36b489f82230ed68a099fde6243dfd86106cf"
+      revision: "37ef503b39f2d9f8e31fc0aa532c51eb4f4dbbf9"
   version "1.8.28"
   license "Apache-2.0"
 

--- a/docs/acceptance/release-v1.8.28-candidate.md
+++ b/docs/acceptance/release-v1.8.28-candidate.md
@@ -18,6 +18,11 @@ ordinary Agent continuations bounded.
   embedding operations, file bodies, or fingerprints.
 - Analysis-only requests stop at the bounded Report. Expected impact comes from
   a validated Plan, and actual impact comes from its Receipt.
+- `scan --summary` persists the same complete Snapshot while returning a bounded
+  Agent continuation with grouped coverage limitations and root issues.
+- A Scan observes each safely bound physical Skill package once while retaining
+  per-placement authority. Binding drift tombstones the observation instead of
+  reusing stale package facts; durable and temporary source reads stay uncached.
 
 The release keeps schema v10, JSON envelope schema 1, local-only operation,
 explicit confirmation, and reversible Apply/Undo. Strict external JSON
@@ -45,31 +50,40 @@ An isolated macOS arm64 upgrade used the exact files from tag v1.8.27:
 
 ## Candidate gates
 
-Candidate source revision `ff357bb96c5487197471eae67b9d3908ba5cb624`
-passed the complete PR CI matrix in run
-[`32809541414`](https://github.com/tt-a1i/skillroster/actions/runs/32809541414).
-Linux x64, macOS arm64, macOS x64, and Windows x64 passed their required tests;
-the CI gate passed.
+The final candidate source revision is
+`37ef503b39f2d9f8e31fc0aa532c51eb4f4dbbf9`. It includes the bounded Scan
+summary and single-observation physical-package optimization merged after the
+earlier candidate. Its default-branch CI passed in run
+[`32819206806`](https://github.com/tt-a1i/skillroster/actions/runs/32819206806).
+Local verification passed strict formatting and Clippy, 243 unit tests, 8
+acceptance tests, 69 CLI tests, a locked release build, and the release
+governance smoke.
 
 Release-candidate run
-[`32809543938`](https://github.com/tt-a1i/skillroster/actions/runs/32809543938)
+[`32821247893`](https://github.com/tt-a1i/skillroster/actions/runs/32821247893)
 passed for macOS arm64, macOS x64, Linux x64, Windows x64, and checksum-pinned
-Ubuntu WSL. All four downloaded archives passed their adjacent SHA-256 checks.
-All tar listings and the Windows zip integrity check passed. The packaged
-macOS arm64 binary reported SkillRoster 1.8.28 and passed its help smoke test.
+Ubuntu WSL. All four independently downloaded archives passed their adjacent
+SHA-256 checks. All tar listings and the Windows zip integrity check passed.
+The packaged macOS arm64 binary reported SkillRoster 1.8.28, passed its help
+smoke test, and completed the release governance smoke. The final preparation
+commit changes only the Formula source pin and this acceptance record, so the
+Formula builds the exact accepted product source.
 
-The same downloaded macOS arm64 candidate then performed a fresh read-only
-real-home cold start against a temporary state directory:
+The same downloaded macOS arm64 final candidate then performed a fresh
+read-only real-home cold start against a temporary state directory:
 
-- Scan completed in 6.47 seconds; Report in 0.59 seconds; Find in 0.13 seconds;
-  Status in 0.01 seconds on this machine. These are observations, not portable
-  performance guarantees.
-- Report found 251 independent Skills, 887 placements, and 521 default
-  exposures, matching the v1.8.27 baseline. It observed use for three Agents.
+- Summary Scan completed in 12.76 seconds and returned 6,322 bytes; Report in
+  0.47 seconds, Find in 0.11 seconds, and Status in 0.01 seconds on this machine.
+  These are observations from a changing local estate, not portable performance
+  guarantees or a comparison with a warmed filesystem cache.
+- Report found 252 independent Skills, 892 placements, 525 default exposures,
+  and 178 Findings. The counts changed from the earlier candidate because the
+  local Skill estate changed; no release claim depends on exact inventory size.
+  It observed use for three Agents.
 - Coverage remained conservative: zero complete Agents, five sampled/limited
   Agents, and three missing session roots. No unused claim is supported.
-- The review task ranked `code-review`, `review`, and `github-code-review` as
-  its Top 3 matches.
+- The review task ranked `code-review`, `github-code-review`, and `review-agent`
+  as its Top 3 matches.
 - Status reported zero pending Plans, no Receipt, clear recovery, and no
   journal issues.
 - Scan, Report, Find, and Status each reported `files_changed: false`. Setup,


### PR DESCRIPTION
Closes #226.

## Summary

- pin the Homebrew Formula to the exact current-main source accepted as `1.8.28-rc.4`
- refresh the v1.8.28 release notes for bounded Scan summaries and safe single-observation physical-package scanning
- replace the earlier candidate evidence with the current-source CI, four-platform, WSL, checksum, archive, governance-smoke, and real-home read-only evidence

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (243 unit + 8 acceptance + 69 CLI)
- `cargo build --release --locked`
- `scripts/release/smoke.sh target/release/skillroster`
- `ruby -c Formula/skillroster.rb`
- `brew style Formula/skillroster.rb`
- Release candidate run 32821247893: Linux x64, Windows x64, macOS arm64/x64, and Ubuntu WSL PASS
- four downloaded archives: adjacent SHA-256 and archive integrity PASS
- downloaded macOS arm64 candidate: version/help/governance smoke and fresh read-only Scan/Report/Find/Status PASS

The accepted product source is `37ef503b39f2d9f8e31fc0aa532c51eb4f4dbbf9`. This PR changes only the Formula source pin and acceptance documentation; final tag and GitHub Release publication remain separate gates after merge.