### PR TITLE
docs: add Chinese and English READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,215 @@
+<h1 align="center">SkillRoster</h1>
+
+<p align="center">
+  <a href="README.md">中文</a> · <strong>English</strong>
+</p>
+
+<p align="center">
+  <strong>One library. The right roster for every agent.</strong>
+</p>
+
+<p align="center">
+  Local-first Skill governance for AI agents.<br>
+  See what is installed, reduce default exposure, find the right Skill on demand, and make reversible changes.
+</p>
+
+<p align="center">
+  <a href="https://github.com/tt-a1i/skillroster/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/tt-a1i/skillroster?style=flat-square&color=4ADE80"></a>
+  <a href="https://github.com/tt-a1i/skillroster/actions/workflows/ci.yml"><img alt="CI status" src="https://img.shields.io/github/actions/workflow/status/tt-a1i/skillroster/ci.yml?branch=main&style=flat-square&label=CI"></a>
+  <a href="https://github.com/tt-a1i/homebrew-skillroster"><img alt="Homebrew tap" src="https://img.shields.io/badge/Homebrew-tap-FBB040?style=flat-square&logo=homebrew&logoColor=111111"></a>
+  <a href="https://www.rust-lang.org"><img alt="Rust 1.85 or newer" src="https://img.shields.io/badge/Rust-1.85%2B-000000?style=flat-square&logo=rust"></a>
+  <a href="LICENSE"><img alt="Apache 2.0 license" src="https://img.shields.io/badge/License-Apache--2.0-60A5FA?style=flat-square"></a>
+</p>
+
+<p align="center">
+  <a href="#start-in-30-seconds">Install</a> ·
+  <a href="#what-it-sees">See it work</a> ·
+  <a href="#how-it-works">How it works</a> ·
+  <a href="docs/product-spec.md">Product spec</a> ·
+  <a href="docs/installation.md">All platforms</a>
+</p>
+
+---
+
+## Your agents do not need every Skill
+
+Skills accumulate across Codex, Claude Code, Pi, OpenCode, Hermes, Cursor,
+Gemini CLI, and GitHub Copilot. Copies drift. Links break. Narrow Skills occupy
+every default context. Usage evidence gets mistaken for certainty.
+
+SkillRoster gives your agent a deterministic local CLI for understanding that
+estate before changing it.
+
+| See the whole estate | Right-size each Roster | Change without fear |
+| --- | --- | --- |
+| Inventory Skills, placements, links, sources, exposure, and bounded usage evidence. | Keep broadly useful Skills in Core and leave narrower ones searchable On-demand. | Preview immutable Plans, require confirmation, record Receipts, and Undo owned changes. |
+
+It is **not** another marketplace, model, or MCP server. The AI agent interprets
+your intent; SkillRoster supplies bounded facts and executes approved changes.
+
+## Start in 30 seconds
+
+Install the current release with Homebrew:
+
+```bash
+brew install tt-a1i/skillroster/skillroster
+skillroster --version
+```
+
+Then ask your agent:
+
+> Use SkillRoster to inspect my local Skills, explain the biggest problems, and
+> propose a safer setup. Do not change files until I approve the complete Plan.
+
+Or begin directly in the terminal:
+
+```bash
+skillroster scan --summary
+skillroster report
+```
+
+Agents add `--json` for one stable machine-readable document. Release archives,
+Cargo installation, Windows instructions, and checksum verification are in the
+[installation guide](docs/installation.md).
+
+## What it sees
+
+This is a real read-only v1.8.28 dogfood result from one changing local estate,
+not a benchmark or a universal inventory size:
+
+```text
+SkillRoster · Report
+
+  Independent Skills     252
+  Placements             892
+  Default exposure       525
+  Observed-use Agents    3
+  Session sample         sampled 5/8 · complete 0/8
+
+  Top Findings
+  high    layout     Skill links escape an approved root
+  medium  exposure   Large default Rosters need review
+  medium  overlap    Exact duplicate Skill placements
+
+Read-only · no Agent files changed
+Review evidence before planning changes
+```
+
+The important part is not the large numbers. It is the boundary: SkillRoster
+reports incomplete coverage instead of turning missing observations into an
+“unused” claim. See the full [release acceptance record](docs/acceptance/release-v1.8.28-candidate.md).
+
+## How it works
+
+```mermaid
+flowchart LR
+    P[Person] --> A[AI agent]
+    A --> B[skillroster bootstrap Skill]
+    B --> C[Rust CLI]
+    C --> S[Snapshot + Evidence]
+    S --> F[Findings]
+    F --> L[Immutable Plan]
+    L -->|one confirmation| R[Apply + Receipt]
+    R -. bounded Undo .-> C
+    C --> D[(Local Library)]
+    D --> V[Per-agent Rosters]
+```
+
+Three ideas keep the model simple:
+
+| Concept | Meaning |
+| --- | --- |
+| **Library** | The complete logical collection of known local Skills. |
+| **Roster** | The curated view exposed to one agent; it is not another copy of the Library. |
+| **On-demand Skill** | A valid Skill omitted from default exposure but retained for local search and exact loading. |
+
+The primary caller is an agent. Semantic judgment stays with the model; identity,
+filesystem boundaries, persistence, validation, and mutation stay with the CLI.
+
+## The Agent-facing loop
+
+```bash
+# Observe
+skillroster scan --summary --json
+skillroster report --findings --limit 20 --json
+
+# Retrieve one complete, fingerprint-verified Skill
+skillroster find "review this pull request" --load --limit 1 --json
+
+# Preview bootstrap installation across detected agents
+skillroster setup --json
+
+# Review and execute an Agent-authored governance decision
+skillroster plan --stdin --json
+skillroster plan --show <plan-id> --json
+skillroster apply <plan-id> --json
+skillroster undo <receipt-id> --json
+
+# Inspect recovery and retained local state
+skillroster status --json
+```
+
+The CLI also supports Finding drilldown, exact same-name variants, confirmed
+source roots, lifecycle export and retention controls. Read the
+[product specification](docs/product-spec.md) for the complete contract and the
+[local data lifecycle](docs/local-data-lifecycle.md) before purging history.
+
+## Safety is product behavior
+
+- **Read-only first.** Scan, Report, Find, Setup preview, and Status do not
+  modify Agent files.
+- **Evidence before action.** A Finding describes an observed condition; it
+  never authorizes a change by itself.
+- **One explicit confirmation.** The agent explains one complete Plan before
+  Apply.
+- **Fail closed on drift.** Changed, ambiguous, unreadable, or unsupported
+  targets block mutation instead of producing a partial success.
+- **Receipts and recovery.** Every successful mutation is journaled, verified,
+  and bounded by an Undo Receipt.
+- **Local by default.** Inventory, fingerprints, bounded usage observations,
+  Plans, and Receipts stay on the machine; raw conversation text is not stored.
+
+## Supported local agents
+
+| Codex | Claude Code | Pi | OpenCode |
+| :---: | :---: | :---: | :---: |
+| ✓ | ✓ | ✓ | ✓ |
+
+| Hermes | Cursor | Gemini CLI | GitHub Copilot |
+| :---: | :---: | :---: | :---: |
+| ✓ | ✓ | ✓ | ✓ |
+
+Support is capability-aware: discovery does not imply that every harness allows
+the same activation or mutation mechanism. SkillRoster reports those boundaries
+instead of pretending the adapters are interchangeable.
+
+## Project status
+
+SkillRoster v1.8.28 implements the local governance loop: discovery, normalized
+inventory, conservative usage evidence, bounded reporting, local retrieval,
+immutable planning, Apply/Undo, recovery, lifecycle controls, and eight direct
+agent adapters.
+
+- [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
+- [Release and platform evidence](docs/acceptance/release-v1.8.28-candidate.md)
+- [Acceptance ledger](docs/acceptance.md)
+- [Product brief](docs/product-brief.md)
+- [Canonical vocabulary](CONTEXT.md)
+
+## Development
+
+Rust 1.85 or newer is required.
+
+```bash
+cargo fmt --check
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+cargo run -- --help
+```
+
+Core logic and high-risk mutation boundaries are tested. See
+[AGENTS.md](AGENTS.md) for repository conventions.
+
+## License
+
+SkillRoster is available under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,77 +1,80 @@
 <h1 align="center">SkillRoster</h1>
 
 <p align="center">
-  <strong>One library. The right roster for every agent.</strong>
+  <strong>中文</strong> · <a href="README.en.md">English</a>
 </p>
 
 <p align="center">
-  Local-first Skill governance for AI agents.<br>
-  See what is installed, reduce default exposure, find the right Skill on demand, and make reversible changes.
+  <strong>一个 Library，为每个 Agent 配好合适的 Roster。</strong>
 </p>
 
 <p align="center">
-  <a href="https://github.com/tt-a1i/skillroster/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/tt-a1i/skillroster?style=flat-square&color=4ADE80"></a>
-  <a href="https://github.com/tt-a1i/skillroster/actions/workflows/ci.yml"><img alt="CI status" src="https://img.shields.io/github/actions/workflow/status/tt-a1i/skillroster/ci.yml?branch=main&style=flat-square&label=CI"></a>
-  <a href="https://github.com/tt-a1i/homebrew-skillroster"><img alt="Homebrew tap" src="https://img.shields.io/badge/Homebrew-tap-FBB040?style=flat-square&logo=homebrew&logoColor=111111"></a>
-  <a href="https://www.rust-lang.org"><img alt="Rust 1.85 or newer" src="https://img.shields.io/badge/Rust-1.85%2B-000000?style=flat-square&logo=rust"></a>
-  <a href="LICENSE"><img alt="Apache 2.0 license" src="https://img.shields.io/badge/License-Apache--2.0-60A5FA?style=flat-square"></a>
+  本地优先的 Agent Skill 治理工具。<br>
+  看清安装情况，缩小默认暴露，需要时找到正确的 Skill，并让每次变更都能撤销。
 </p>
 
 <p align="center">
-  <a href="#start-in-30-seconds">Install</a> ·
-  <a href="#what-it-sees">See it work</a> ·
-  <a href="#how-it-works">How it works</a> ·
-  <a href="docs/product-spec.md">Product spec</a> ·
-  <a href="docs/installation.md">All platforms</a>
+  <a href="https://github.com/tt-a1i/skillroster/releases/latest"><img alt="最新版本" src="https://img.shields.io/github/v/release/tt-a1i/skillroster?style=flat-square&color=4ADE80"></a>
+  <a href="https://github.com/tt-a1i/skillroster/actions/workflows/ci.yml"><img alt="CI 状态" src="https://img.shields.io/github/actions/workflow/status/tt-a1i/skillroster/ci.yml?branch=main&style=flat-square&label=CI"></a>
+  <a href="https://github.com/tt-a1i/homebrew-skillroster"><img alt="Homebrew Tap" src="https://img.shields.io/badge/Homebrew-tap-FBB040?style=flat-square&logo=homebrew&logoColor=111111"></a>
+  <a href="https://www.rust-lang.org"><img alt="Rust 1.85 或更高版本" src="https://img.shields.io/badge/Rust-1.85%2B-000000?style=flat-square&logo=rust"></a>
+  <a href="LICENSE"><img alt="Apache 2.0 许可证" src="https://img.shields.io/badge/License-Apache--2.0-60A5FA?style=flat-square"></a>
+</p>
+
+<p align="center">
+  <a href="#30-秒开始">快速开始</a> ·
+  <a href="#它能看见什么">实际效果</a> ·
+  <a href="#工作原理">工作原理</a> ·
+  <a href="docs/product-spec.md">产品规范</a> ·
+  <a href="docs/installation.md">全部安装方式</a>
 </p>
 
 ---
 
-## Your agents do not need every Skill
+## 你的 Agent 不需要看到所有 Skill
 
-Skills accumulate across Codex, Claude Code, Pi, OpenCode, Hermes, Cursor,
-Gemini CLI, and GitHub Copilot. Copies drift. Links break. Narrow Skills occupy
-every default context. Usage evidence gets mistaken for certainty.
+Codex、Claude Code、Pi、OpenCode、Hermes、Cursor、Gemini CLI 和 GitHub
+Copilot 用久了，Skill 会越装越多。副本会漂移，链接会失效，一些很少用到的
+Skill 仍占着每个 Agent 的默认上下文。更麻烦的是，零散的使用记录很容易被误读成
+确定结论。
 
-SkillRoster gives your agent a deterministic local CLI for understanding that
-estate before changing it.
+SkillRoster 给 Agent 提供一个确定性的本地 CLI。先把情况查清楚，再谈怎么改。
 
-| See the whole estate | Right-size each Roster | Change without fear |
+| 看清现状 | 缩小每个 Roster | 可控变更 |
 | --- | --- | --- |
-| Inventory Skills, placements, links, sources, exposure, and bounded usage evidence. | Keep broadly useful Skills in Core and leave narrower ones searchable On-demand. | Preview immutable Plans, require confirmation, record Receipts, and Undo owned changes. |
+| 盘点 Skill、Placement、链接、来源、暴露范围和有边界的使用证据。 | 常用 Skill 留在 Core，较窄的能力转为可检索的 On-demand Skill。 | 先预览不可变 Plan，确认后执行，留下 Receipt，需要时 Undo。 |
 
-It is **not** another marketplace, model, or MCP server. The AI agent interprets
-your intent; SkillRoster supplies bounded facts and executes approved changes.
+SkillRoster 不提供 Marketplace，也不调用模型或运行 MCP Server。AI Agent 负责理解
+你的意图；SkillRoster 负责返回有边界的事实，并执行已经批准的变更。
 
-## Start in 30 seconds
+## 30 秒开始
 
-Install the current release with Homebrew:
+使用 Homebrew 安装当前版本：
 
 ```bash
 brew install tt-a1i/skillroster/skillroster
 skillroster --version
 ```
 
-Then ask your agent:
+然后直接告诉你的 Agent：
 
-> Use SkillRoster to inspect my local Skills, explain the biggest problems, and
-> propose a safer setup. Do not change files until I approve the complete Plan.
+> 使用 SkillRoster 检查我电脑上的 Skills，解释最需要处理的问题，并给出一套更安全的
+> 整理方案。在我确认完整 Plan 之前，不要修改任何文件。
 
-Or begin directly in the terminal:
+也可以先在终端运行：
 
 ```bash
 skillroster scan --summary
 skillroster report
 ```
 
-Agents add `--json` for one stable machine-readable document. Release archives,
-Cargo installation, Windows instructions, and checksum verification are in the
-[installation guide](docs/installation.md).
+Agent 调用时加上 `--json`，即可得到一份稳定的机器可读结果。Release 压缩包、Cargo、
+Windows 安装和校验和验证请看[安装文档](docs/installation.md)。
 
-## What it sees
+## 它能看见什么
 
-This is a real read-only v1.8.28 dogfood result from one changing local estate,
-not a benchmark or a universal inventory size:
+下面是 v1.8.28 在一台真实电脑上的只读 dogfood 结果。它只代表当时不断变化的本地
+Skill 环境，不是性能基准，也不代表所有用户都会有相同规模：
 
 ```text
 SkillRoster · Report
@@ -91,81 +94,76 @@ Read-only · no Agent files changed
 Review evidence before planning changes
 ```
 
-The important part is not the large numbers. It is the boundary: SkillRoster
-reports incomplete coverage instead of turning missing observations into an
-“unused” claim. See the full [release acceptance record](docs/acceptance/release-v1.8.28-candidate.md).
+这份结果同时写出了证据边界。覆盖不完整时，SkillRoster 会把限制放进结果，不会因为
+没有观察到使用记录，就断言某个 Skill “从未使用”。完整数据见
+[v1.8.28 发布验收记录](docs/acceptance/release-v1.8.28-candidate.md)。
 
-## How it works
+## 工作原理
 
 ```mermaid
 flowchart LR
-    P[Person] --> A[AI agent]
-    A --> B[skillroster bootstrap Skill]
+    P[用户] --> A[AI Agent]
+    A --> B[skillroster 引导 Skill]
     B --> C[Rust CLI]
     C --> S[Snapshot + Evidence]
     S --> F[Findings]
-    F --> L[Immutable Plan]
-    L -->|one confirmation| R[Apply + Receipt]
-    R -. bounded Undo .-> C
-    C --> D[(Local Library)]
-    D --> V[Per-agent Rosters]
+    F --> L[不可变 Plan]
+    L -->|一次确认| R[Apply + Receipt]
+    R -. 有边界的 Undo .-> C
+    C --> D[(本地 Library)]
+    D --> V[每个 Agent 的 Roster]
 ```
 
-Three ideas keep the model simple:
+整个模型建立在三个概念上：
 
-| Concept | Meaning |
+| 概念 | 含义 |
 | --- | --- |
-| **Library** | The complete logical collection of known local Skills. |
-| **Roster** | The curated view exposed to one agent; it is not another copy of the Library. |
-| **On-demand Skill** | A valid Skill omitted from default exposure but retained for local search and exact loading. |
+| **Library** | SkillRoster 已知的全部本地 Skill，是一份逻辑集合。 |
+| **Roster** | 暴露给某个 Agent 的精选视图，不是 Library 的又一份副本。 |
+| **On-demand Skill** | 不占用默认暴露，但仍可在本地检索并精确加载的有效 Skill。 |
 
-The primary caller is an agent. Semantic judgment stays with the model; identity,
-filesystem boundaries, persistence, validation, and mutation stay with the CLI.
+主要调用者是 Agent。语义判断交给模型；身份识别、文件系统边界、持久化、校验和变更
+执行交给 CLI。
 
-## The Agent-facing loop
+## Agent 的主流程
 
 ```bash
-# Observe
+# 观察
 skillroster scan --summary --json
 skillroster report --findings --limit 20 --json
 
-# Retrieve one complete, fingerprint-verified Skill
-skillroster find "review this pull request" --load --limit 1 --json
+# 检索并完整加载一份经过指纹校验的 Skill
+skillroster find "审查这个 Pull Request" --load --limit 1 --json
 
-# Preview bootstrap installation across detected agents
+# 预览为已检测 Agent 安装引导 Skill 的方案
 skillroster setup --json
 
-# Review and execute an Agent-authored governance decision
+# 检查并执行由 Agent 编写的治理决策
 skillroster plan --stdin --json
 skillroster plan --show <plan-id> --json
 skillroster apply <plan-id> --json
 skillroster undo <receipt-id> --json
 
-# Inspect recovery and retained local state
+# 检查恢复状态和保留在本地的数据
 skillroster status --json
 ```
 
-The CLI also supports Finding drilldown, exact same-name variants, confirmed
-source roots, lifecycle export and retention controls. Read the
-[product specification](docs/product-spec.md) for the complete contract and the
-[local data lifecycle](docs/local-data-lifecycle.md) before purging history.
+CLI 还支持 Finding 下钻、同名不同内容的精确选择、已确认的 Source Root，以及生命周期
+导出和保留策略。完整契约见[产品规范](docs/product-spec.md)。清理历史记录前，请先阅读
+[本地数据生命周期](docs/local-data-lifecycle.md)。
 
-## Safety is product behavior
+## 安全约束
 
-- **Read-only first.** Scan, Report, Find, Setup preview, and Status do not
-  modify Agent files.
-- **Evidence before action.** A Finding describes an observed condition; it
-  never authorizes a change by itself.
-- **One explicit confirmation.** The agent explains one complete Plan before
-  Apply.
-- **Fail closed on drift.** Changed, ambiguous, unreadable, or unsupported
-  targets block mutation instead of producing a partial success.
-- **Receipts and recovery.** Every successful mutation is journaled, verified,
-  and bounded by an Undo Receipt.
-- **Local by default.** Inventory, fingerprints, bounded usage observations,
-  Plans, and Receipts stay on the machine; raw conversation text is not stored.
+- **默认只读。** Scan、Report、Find、Setup 预览和 Status 都不会修改 Agent 文件。
+- **先看证据。** Finding 只描述观察到的情况，本身不授权任何变更。
+- **一次明确确认。** Agent 先解释完整 Plan，再执行 Apply。
+- **发现漂移就停止。** 目标发生变化、存在歧义、无法读取或不受支持时，直接阻止变更，
+  不会返回一个看似成功的残缺结果。
+- **Receipt 与恢复。** 每次成功变更都会写入 journal、完成校验，并提供有边界的 Undo。
+- **数据默认留在本地。** Inventory、指纹、有限的使用观察、Plan 和 Receipt 保存在本机，
+  不存储原始会话文本。
 
-## Supported local agents
+## 支持的本地 Agent
 
 | Codex | Claude Code | Pi | OpenCode |
 | :---: | :---: | :---: | :---: |
@@ -175,26 +173,24 @@ source roots, lifecycle export and retention controls. Read the
 | :---: | :---: | :---: | :---: |
 | ✓ | ✓ | ✓ | ✓ |
 
-Support is capability-aware: discovery does not imply that every harness allows
-the same activation or mutation mechanism. SkillRoster reports those boundaries
-instead of pretending the adapters are interchangeable.
+支持范围会按能力区分。能被发现，不等于对应 harness 一定允许相同的激活或变更方式。
+SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
-## Project status
+## 项目状态
 
-SkillRoster v1.8.28 implements the local governance loop: discovery, normalized
-inventory, conservative usage evidence, bounded reporting, local retrieval,
-immutable planning, Apply/Undo, recovery, lifecycle controls, and eight direct
-agent adapters.
+SkillRoster v1.8.28 已实现完整的本地治理闭环：发现、标准化 Inventory、保守的使用证据、
+有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，以及 8 个直接
+Agent Adapter。
 
-- [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [Release and platform evidence](docs/acceptance/release-v1.8.28-candidate.md)
-- [Acceptance ledger](docs/acceptance.md)
-- [Product brief](docs/product-brief.md)
-- [Canonical vocabulary](CONTEXT.md)
+- [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
+- [发布与平台证据](docs/acceptance/release-v1.8.28-candidate.md)
+- [验收记录](docs/acceptance.md)
+- [产品简介](docs/product-brief.md)
+- [统一术语](CONTEXT.md)
 
-## Development
+## 开发
 
-Rust 1.85 or newer is required.
+需要 Rust 1.85 或更高版本。
 
 ```bash
 cargo fmt --check
@@ -203,9 +199,8 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo run -- --help
 ```
 
-Core logic and high-risk mutation boundaries are tested. See
-[AGENTS.md](AGENTS.md) for repository conventions.
+测试集中覆盖核心逻辑和高风险变更边界。仓库约定见 [AGENTS.md](AGENTS.md)。
 
-## License
+## 许可证
 
-SkillRoster is available under the [Apache License 2.0](LICENSE).
+SkillRoster 使用 [Apache License 2.0](LICENSE)。


### PR DESCRIPTION
## Summary

- make `README.md` the default Chinese project entry point
- preserve the current English content as `README.en.md`
- add a visible language switch at the top of both files
- keep headings, commands, safety boundaries, evidence, and documentation links aligned across languages
- rewrite the Chinese copy for natural technical prose instead of translating sentence by sentence

## Verification

- both READMEs render through the GitHub Markdown API
- 10 matching top-level sections in each language
- 12 `skillroster` command examples in each language
- reciprocal language links resolve
- all repository-relative links resolve
- `git diff --check`
- `cargo fmt --all --check`
