### PR TITLE
feat: record benchmark efficiency metrics

### DIFF
--- a/docs/acceptance/artifacts/codex-skill-protocol-isolation-v6.json
+++ b/docs/acceptance/artifacts/codex-skill-protocol-isolation-v6.json
@@ -14,6 +14,25 @@
     "on_demand_accepted": 1,
     "on_demand_contract_failures": 2
   },
+  "post_hoc_efficiency_analysis": {
+    "source": "retained external raw turn.completed usage records",
+    "definition": "cache_utilization_ratio = cached_input_tokens / input_tokens; aggregate ratio is weighted by input tokens",
+    "latency_available": false,
+    "latency_limitation": "v6 did not capture wall-clock timestamps",
+    "trials": [
+      { "trial": 1, "arm": "core", "input_tokens": 39484, "cached_input_tokens": 25088, "uncached_input_tokens": 14396, "cache_write_input_tokens": 0, "cache_utilization_ratio": 0.635397, "output_tokens": 495, "reasoning_output_tokens": 165, "successful_command_count": 2 },
+      { "trial": 1, "arm": "on_demand", "input_tokens": 161768, "cached_input_tokens": 137216, "uncached_input_tokens": 24552, "cache_write_input_tokens": 0, "cache_utilization_ratio": 0.848227, "output_tokens": 1608, "reasoning_output_tokens": 719, "successful_command_count": 5 },
+      { "trial": 2, "arm": "core", "input_tokens": 39353, "cached_input_tokens": 25088, "uncached_input_tokens": 14265, "cache_write_input_tokens": 0, "cache_utilization_ratio": 0.637512, "output_tokens": 430, "reasoning_output_tokens": 104, "successful_command_count": 2 },
+      { "trial": 2, "arm": "on_demand", "input_tokens": 69937, "cached_input_tokens": 49152, "uncached_input_tokens": 20785, "cache_write_input_tokens": 0, "cache_utilization_ratio": 0.702804, "output_tokens": 898, "reasoning_output_tokens": 260, "successful_command_count": 4 },
+      { "trial": 3, "arm": "core", "input_tokens": 39329, "cached_input_tokens": 22016, "uncached_input_tokens": 17313, "cache_write_input_tokens": 0, "cache_utilization_ratio": 0.559790, "output_tokens": 458, "reasoning_output_tokens": 128, "successful_command_count": 2 },
+      { "trial": 3, "arm": "on_demand", "input_tokens": 88523, "cached_input_tokens": 53248, "uncached_input_tokens": 35275, "cache_write_input_tokens": 0, "cache_utilization_ratio": 0.601516, "output_tokens": 1206, "reasoning_output_tokens": 368, "successful_command_count": 5 }
+    ],
+    "by_arm": {
+      "core": { "input_tokens": 118166, "cached_input_tokens": 72192, "uncached_input_tokens": 45974, "cache_utilization_ratio": 0.610937, "output_tokens": 1383, "reasoning_output_tokens": 397, "successful_command_count": 6 },
+      "on_demand": { "input_tokens": 320228, "cached_input_tokens": 239616, "uncached_input_tokens": 80612, "cache_utilization_ratio": 0.748267, "output_tokens": 3712, "reasoning_output_tokens": 1347, "successful_command_count": 14 }
+    },
+    "on_demand_minus_core": { "input_tokens": 202062, "input_tokens_percent": 171.0, "cached_input_tokens": 167424, "uncached_input_tokens": 34638, "uncached_input_tokens_percent": 75.3, "cache_utilization_percentage_points": 13.73, "output_tokens": 2329, "reasoning_output_tokens": 950, "successful_command_count": 8 }
+  },
   "frozen": {
     "source_commit": "fdf508a03c2068ec47cee816809f986d3a95013a",
     "source_tree": "ed20e4dbdb107db5f6d2a420c1fba0435b10b3fd",

--- a/docs/acceptance/codex-skill-protocol-isolation-v6.md
+++ b/docs/acceptance/codex-skill-protocol-isolation-v6.md
@@ -25,6 +25,41 @@ Agent contract:
 | 2 | Pass | Fail: valid Find argv was wrapped in an unsafe shell shape | Pass / pass |
 | 3 | Pass | Pass | Pass / pass |
 
+## Efficiency and score-difference analysis
+
+The retained raw `turn.completed` records allow a post-hoc token comparison.
+Cache utilization is defined as `cached_input_tokens / input_tokens`; it is a
+cost/context-reuse measure, not a task-quality score. Precise wall-clock latency
+was not captured by the v6 runner and cannot be reconstructed honestly.
+
+| Trial | Arm | Input | Cached input | Uncached input | Cache utilization | Output | Reasoning output | Successful commands |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| 1 | Core | 39,484 | 25,088 | 14,396 | 63.54% | 495 | 165 | 2 |
+| 1 | On-demand | 161,768 | 137,216 | 24,552 | 84.82% | 1,608 | 719 | 5 |
+| 2 | Core | 39,353 | 25,088 | 14,265 | 63.75% | 430 | 104 | 2 |
+| 2 | On-demand | 69,937 | 49,152 | 20,785 | 70.28% | 898 | 260 | 4 |
+| 3 | Core | 39,329 | 22,016 | 17,313 | 55.98% | 458 | 128 | 2 |
+| 3 | On-demand | 88,523 | 53,248 | 35,275 | 60.15% | 1,206 | 368 | 5 |
+| **Total / weighted** | **Core** | **118,166** | **72,192** | **45,974** | **61.09%** | **1,383** | **397** | **6** |
+| **Total / weighted** | **On-demand** | **320,228** | **239,616** | **80,612** | **74.83%** | **3,712** | **1,347** | **14** |
+
+On-demand used 202,062 more input tokens (+171.0%), including 34,638 more
+uncached input tokens (+75.3%), and its weighted cache utilization was 13.73
+percentage points higher. The higher cache share did not make it cheaper: most
+of the extra cached tokens came from a longer repeated prefix and additional
+tool-turn context, while the additional Find/load/order work increased both
+fresh context and output/reasoning tokens.
+
+The protocol score gap (Core 3/3 versus On-demand 1/3) was not a task-quality or
+ranking gap. Retrieval, exact load, task oracle, and safety were 3/3 in both
+arms. Two On-demand trials lost only the ordered-contract point: one attempted
+two MCP actions before target load, and one wrapped a valid Find argv in an
+unsafe shell shape. The extra 2-3 successful commands per On-demand trial are
+consistent with the larger token footprint, but six runs are too few to claim a
+stable causal cost multiplier. The v7 one-call contract removed the protocol
+score gap; its raw usage evidence was intentionally deleted, so no v7 token or
+cache comparison is claimed.
+
 The result does not justify embeddings, reranking, a semantic router, or more
 routing Skills. It supports a narrower follow-up: make the Bootstrap/CLI seam
 easier for an Agent to execute as one safe, observable operation while keeping

--- a/docs/acceptance/codex-skill-protocol-isolation-v7.md
+++ b/docs/acceptance/codex-skill-protocol-isolation-v7.md
@@ -30,6 +30,13 @@ The result supports retaining deterministic lexical retrieval plus Agent-owned
 intent and hint generation. It does not justify embeddings, reranking, a built-in
 model, MCP, or another routing Skill.
 
+This v7 result is a protocol/task score comparison only. Its raw transcripts
+were removed after the bounded projection was produced, and the projection did
+not retain token usage or wall-clock measurements. Cache utilization, token
+cost, and latency therefore remain unavailable for v7 and must not be inferred
+from the 3/3 versus 3/3 score. The harness now records those dimensions for
+future runs.
+
 ## Evidence boundary
 
 The run froze the clean source commit/tree, CLI, Bootstrap, target package,

--- a/docs/research/agent-skill-governance-and-routing.md
+++ b/docs/research/agent-skill-governance-and-routing.md
@@ -191,8 +191,13 @@ SkillRoster 的当前运行条件，不能据此添加 reranker 或 source class
 | Safety | 是否越界读写或绕过确认？ | filesystem diff、Receipt、policy checks |
 | Core validity | 控制臂是否完成其预期协议？ | arm-specific invariants |
 | Formal eligibility | 配对、指纹、时序是否允许归因？ | frozen digest、run ledger |
+| Efficiency / cost | 成功是否以更多上下文、缓存依赖、命令或时间换取？ | input/cached/uncached/output/reasoning tokens、加权缓存利用率、命令数、Codex/全臂 wall time |
 
 只有前置层可用且控制臂有效，最终差异才可能用于讨论 routing 机制。
+缓存利用率固定定义为 `cached_input_tokens / input_tokens`，并与绝对 cached、
+uncached token 同时报告。比例更高只说明更多输入命中了缓存，不能单独推出
+成本更低、延迟更低或任务质量更高；所有对照应报告逐 trial、按输入 token
+加权的 arm 汇总，以及 On-demand 减 Core 的成对差值。
 
 ### 4. shortlist 深度是独立变量，正确呈现不等于正确执行
 
@@ -533,6 +538,15 @@ Plan、Receipt 和 Undo 的本地 fixture，以及 Agent 实际可获得的 opaq
 评分器应只对真实产品不变量严格：文件是否创建、字段是否存在、是否越界、返回路径是否被读取。表达质量用 rubric + 盲审，不用精确句子或任意字符阈值。
 
 PR #148 的 v6 suite 已按该设计形成正式冻结证据：`formal_gate_eligible=true`，但 protocol gate 失败：Core 3/3，On-demand 1/3；后者的 retrieval、full-load、task oracle 和 safety 均为 3/3，失败集中在 ordered contract。因此已经触发下列原定停止条件中的“只修 Bootstrap/CLI seam，不改排名器”。历史设计和停止条件保留如下，作为决策审计：
+
+v6 保留下来的 usage 事件还显示了效率差异：Core 三轮合计 118,166 input /
+72,192 cached（加权缓存利用率 61.09%），On-demand 为 320,228 input /
+239,616 cached（74.83%）。On-demand 相比 Core 多 202,062 input（+171.0%），
+其中 uncached 多 34,638（+75.3%），成功命令数为 14 对 6。这个差异主要来自
+Find、完整加载和顺序处理带来的额外操作与更长的重复上下文；更高缓存比例并未
+抵消绝对 token 增长。协议分差则来自两次 ordered-contract 违规，不是 ranking、
+task oracle 或 safety 差异。v7 虽然两臂均 3/3，但其 bounded artifact 未保留
+usage/latency，不能事后补写效率结论；详见 [v6 验收](../acceptance/codex-skill-protocol-isolation-v6.md)。
 
 - Core 少于 3/3 协议有效：停止比较，先修 task/oracle/harness；不得做产品归因。
 - Core 有效，但 On-demand 至少 2/3 发生调用/加载协议失败：只改 Bootstrap/CLI schema、错误返回或示例；不改排名器。v6 正是这一分支。

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -343,6 +343,70 @@ export function assessTranscriptIntegrity(jsonl) {
   return { passed: violations.length === 0, violations, turn_completed_count: turnCompleted, successful_command_count: successfulCommands, unsuccessful_command_count: unsuccessfulCommands };
 }
 
+export function extractTokenUsage(jsonl) {
+  const usages = [];
+  for (const line of jsonl.split("\n")) {
+    if (!line.trim()) continue;
+    let value; try { value = JSON.parse(line); } catch { continue; }
+    if (value?.type === "turn.completed") usages.push(value.usage);
+  }
+  const fields = ["input_tokens", "cached_input_tokens", "cache_write_input_tokens", "output_tokens", "reasoning_output_tokens"];
+  if (usages.length !== 1 || !usages[0] || fields.some((field) => !Number.isSafeInteger(usages[0][field]) || usages[0][field] < 0)) {
+    return { available: false, limitation: usages.length === 1 ? "turn usage is incomplete or invalid" : `expected one completed-turn usage record; observed ${usages.length}` };
+  }
+  const usage = Object.fromEntries(fields.map((field) => [field, usages[0][field]]));
+  if (usage.cached_input_tokens > usage.input_tokens) return { available: false, limitation: "cached input exceeds total input" };
+  return {
+    available: true,
+    ...usage,
+    uncached_input_tokens: usage.input_tokens - usage.cached_input_tokens,
+    cache_utilization_ratio: usage.input_tokens === 0 ? null : usage.cached_input_tokens / usage.input_tokens,
+  };
+}
+
+function efficiencyDelta(core, onDemand) {
+  if (core?.available !== true || onDemand?.available !== true) return { available: false, limitation: "both paired arms require valid usage evidence" };
+  const delta = (field) => onDemand[field] - core[field];
+  return {
+    available: true,
+    direction: "on_demand_minus_core",
+    input_tokens: delta("input_tokens"),
+    cached_input_tokens: delta("cached_input_tokens"),
+    uncached_input_tokens: delta("uncached_input_tokens"),
+    cache_write_input_tokens: delta("cache_write_input_tokens"),
+    output_tokens: delta("output_tokens"),
+    reasoning_output_tokens: delta("reasoning_output_tokens"),
+    cache_utilization_percentage_points: (onDemand.cache_utilization_ratio - core.cache_utilization_ratio) * 100,
+    successful_command_count: (onDemand.successful_command_count ?? 0) - (core.successful_command_count ?? 0),
+    codex_wall_time_ms: Number.isFinite(core.codex_wall_time_ms) && Number.isFinite(onDemand.codex_wall_time_ms) ? delta("codex_wall_time_ms") : null,
+    arm_wall_time_ms: Number.isFinite(core.arm_wall_time_ms) && Number.isFinite(onDemand.arm_wall_time_ms) ? delta("arm_wall_time_ms") : null,
+  };
+}
+
+export function summarizeEfficiency(results) {
+  const byArm = Object.fromEntries(["core", "on_demand"].map((arm) => {
+    const samples = results.filter((result) => result.arm === arm && result.efficiency?.available === true).map((result) => result.efficiency);
+    if (!samples.length) return [arm, { available: false, sample_count: 0 }];
+    const sum = (field) => samples.reduce((total, sample) => total + sample[field], 0);
+    const inputTokens = sum("input_tokens"); const cachedInputTokens = sum("cached_input_tokens");
+    return [arm, {
+      available: true,
+      sample_count: samples.length,
+      input_tokens: inputTokens,
+      cached_input_tokens: cachedInputTokens,
+      uncached_input_tokens: sum("uncached_input_tokens"),
+      cache_write_input_tokens: sum("cache_write_input_tokens"),
+      output_tokens: sum("output_tokens"),
+      reasoning_output_tokens: sum("reasoning_output_tokens"),
+      cache_utilization_ratio: inputTokens === 0 ? null : cachedInputTokens / inputTokens,
+      successful_command_count: sum("successful_command_count"),
+      codex_wall_time_ms: sum("codex_wall_time_ms"),
+      arm_wall_time_ms: sum("arm_wall_time_ms"),
+    }];
+  }));
+  return { definition: "cache_utilization_ratio = cached_input_tokens / input_tokens; totals are weighted across valid trials", by_arm: byArm };
+}
+
 function writeTargetAllowed(path, workspace, tempRoot) {
   const candidate = isAbsolute(path) ? resolve(path) : resolve(workspace, path);
   return inside(candidate, workspace) || inside(candidate, tempRoot);
@@ -752,7 +816,7 @@ export function groupPairedResults(tasks, results, trialsPerArm) {
     if (coreResult && onDemandResult && coreResult.pair_invariant !== onDemandResult.pair_invariant) return { family: task.family, task: task.id, trial, attribution: "pair_invariant_mismatch", gate: "failed", cold_routing_regression: null };
     if (!coreResult || !onDemandResult) return { family: task.family, task: task.id, trial, attribution: "pair_incomplete", gate: "failed", cold_routing_regression: null };
     const pair = classifyPair(coreResult.outcome, onDemandResult.outcome);
-    return { family: task.family, task: task.id, trial, ...pair, gate: pair.attribution === "no_observed_regression" ? "passed" : "failed" };
+    return { family: task.family, task: task.id, trial, ...pair, gate: pair.attribution === "no_observed_regression" ? "passed" : "failed", efficiency_delta: efficiencyDelta(coreResult.efficiency, onDemandResult.efficiency) };
   }));
 }
 
@@ -1131,6 +1195,7 @@ export function formalOnDemandTransferGateEligible({ completeSchedule, sourceIde
 }
 
 function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts, evaluationMode = "paired") {
+  const armStartedAt = process.hrtime.bigint();
   const key = trialKey(task.id, trial, trialsPerArm); const frozenPairInvariant = suiteFacts.pair_invariants?.[key]; if (!frozenPairInvariant) fail(`pair invariant was not frozen before invocation: ${key}`);
   const runPrefix = trialsPerArm === 1 ? `${task.id}-${arm}-` : `${task.id}-trial-${trial}-${arm}-`;
   const root = mkdtempSync(join(options.runsDir, runPrefix)); const paths = setupArm(root, task, arm, options);
@@ -1154,7 +1219,9 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts, evaluat
     const runEnv = { ...env };
     if (prepared) Object.assign(runEnv, { SKILLROSTER_REAL_CLI: options.cli, SKILLROSTER_TEST_HOME: paths.home, SKILLROSTER_TEST_STATE: paths.state, SKILLROSTER_FIND_AUDIT: paths.runtimeAudit });
     if (prepared) runEnv.PATH = `${prepared.bin}:${process.env.PATH ?? "/usr/bin:/bin"}`;
+    const codexStartedAt = process.hrtime.bigint();
     const result = run(options.codex, codexExecutionArgs(options, paths, task.prompt), { cwd: paths.workspace, env: runEnv, timeout: options.timeoutMs });
+    const codexWallTimeMs = Number((process.hrtime.bigint() - codexStartedAt) / 1_000_000n);
     const protectedScopes = assessProtectedScopes(initialProtected, captureProtectedScopes(protectedPaths));
     writeFileSync(paths.transcript, result.stdout, { mode: 0o600 });
     if (existsSync(paths.runtimeAudit)) copyFileSync(paths.runtimeAudit, paths.audit);
@@ -1166,10 +1233,11 @@ function executeArm(task, arm, trial, trialsPerArm, options, suiteFacts, evaluat
     const routeOrder = arm === "on_demand" ? assessRouteOrder(result.stdout, { bootstrapPath: join(paths.codexHome, "skills", "skillroster", "SKILL.md"), targetPath: paths.targetPath, findAudit: retrieval, expectedTask: task.prompt, expectedSkill: task.expected_skill, oneCall: task.one_call_load === true }) : { passed: true, audit_scope: "not_applicable" };
     const coreOrder = arm === "core" ? assessCoreOrder(result.stdout, paths.targetPath) : { passed: true, audit_scope: "not_applicable" };
     const transcript = assessTranscriptIntegrity(result.stdout);
+    const efficiency = { ...extractTokenUsage(result.stdout), successful_command_count: transcript.successful_command_count, codex_wall_time_ms: codexWallTimeMs, arm_wall_time_ms: Number((process.hrtime.bigint() - armStartedAt) / 1_000_000n) };
     const externalWrites = assessExternalWrites(result.stdout, paths.workspace, paths.temp);
     const outcomeInputs = { arm, surface, retrieval, load, oracle, workspace, routeOrder, coreOrder, transcript, protectedScopes, externalWrites };
     const outcome = evaluationMode === "on_demand_transfer" ? deriveOnDemandTransferOutcome(outcomeInputs) : deriveArmOutcome(outcomeInputs);
-    return { family: task.family, task: task.id, trial, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, protected_scopes: protectedScopes, external_writes: externalWrites, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
+    return { family: task.family, task: task.id, trial, arm, root, pair_invariant: frozenPairInvariant, codex_exit_code: result.status, surface, governance: prepared?.governance ?? null, transcript, efficiency, protected_scopes: protectedScopes, external_writes: externalWrites, retrieval, load, route_order: routeOrder, core_order: coreOrder, oracle, workspace, outcome };
   } finally {
     cleanupAuth(authCopy);
     cleanupRuntime(paths.temp);
@@ -1248,7 +1316,7 @@ export function main(argv = process.argv.slice(2)) {
     : completeSchedule && sourceIdentityStable && codexExecutableStable && results.every(resultEligibility) && pairs.every((pair) => pair.attribution !== "pair_invariant_mismatch" && pair.attribution !== "pair_incomplete");
   const acceptedResults = results.every((result) => result.outcome?.accepted) && pairs.every((pair) => pair.gate === "passed");
   const statusPassed = acceptedResults && (evaluationMode !== "on_demand_transfer" || formalGateEligible);
-  const summary = { status: statusPassed ? "passed" : "failed", suite_id: manifest.suite_id, ...(evaluationMode === "on_demand_transfer" ? { evaluation_mode: evaluationMode } : {}), formal_gate_eligible: formalGateEligible, source_identity_stable: sourceIdentityStable, source_identity_after: sourceIdentityAfter, codex_executable_stable: codexExecutableStable, codex_executable_after: codexExecutableAfter, ...(evaluationMode === "on_demand_transfer" ? { frozen_inputs_stable: frozenInputsStable, frozen_inputs_after: frozenInputsAfter } : {}), protocol_decision: protocolDecision, suite_snapshot: frozen.facts, signal_cleanup: "SIGINT/SIGTERM remove auth copies and runtime state best effort; SIGKILL cannot guarantee cleanup", results, pairs };
+  const summary = { status: statusPassed ? "passed" : "failed", suite_id: manifest.suite_id, ...(evaluationMode === "on_demand_transfer" ? { evaluation_mode: evaluationMode } : {}), formal_gate_eligible: formalGateEligible, source_identity_stable: sourceIdentityStable, source_identity_after: sourceIdentityAfter, codex_executable_stable: codexExecutableStable, codex_executable_after: codexExecutableAfter, ...(evaluationMode === "on_demand_transfer" ? { frozen_inputs_stable: frozenInputsStable, frozen_inputs_after: frozenInputsAfter } : {}), protocol_decision: protocolDecision, efficiency_summary: summarizeEfficiency(results), suite_snapshot: frozen.facts, signal_cleanup: "SIGINT/SIGTERM remove auth copies and runtime state best effort; SIGKILL cannot guarantee cleanup", results, pairs };
   emitSummary(summary, options); return summary.status === "passed" ? 0 : 2;
 }
 

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { assessCoreOrder, assessExactLoad, assessExternalWrites, assessFrozenInputIdentities, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, codexExecutionArgs, codexSandboxPolicy, deriveArmOutcome, deriveOnDemandTransferDecision, deriveOnDemandTransferOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractVisibleSkills, findWrapperSource, formalOnDemandTransferGateEligible, formalOnDemandTransferResultEligible, formalResultEligible, groupPairedResults, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, setupArm, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, validateManifest, verifyArchifyParent } from "./driver.mjs";
+import { assessCoreOrder, assessExactLoad, assessExternalWrites, assessFrozenInputIdentities, assessOneCallLoad, assessProtectedScopes, assessRouteOrder, assessSkillSurface, assessTranscriptIntegrity, assessWorkspaceChanges, captureProtectedScopes, classifyPair, codexExecutionArgs, codexSandboxPolicy, deriveArmOutcome, deriveOnDemandTransferDecision, deriveOnDemandTransferOutcome, deriveProtocolDecision, evaluateArchitectureSpec, evaluateArchifyReceipts, evaluateOracle, extractTokenUsage, extractVisibleSkills, findWrapperSource, formalOnDemandTransferGateEligible, formalOnDemandTransferResultEligible, formalResultEligible, groupPairedResults, main, pairInvariant, parseArgs, parseFindAudit, parseFindEnvelope, setupArm, skillRosterFindArgs, skillRosterScanArgs, snapshotWorkspace, summarizeEfficiency, validateManifest, verifyArchifyParent } from "./driver.mjs";
 
 const DRIVER = fileURLToPath(new URL("./driver.mjs", import.meta.url));
 
@@ -604,6 +604,26 @@ test("transcript integrity requires complete JSONL, one turn completion, and a s
   const failed = JSON.stringify({ type: "item.completed", item: { type: "command_execution", command: "false", exit_code: 1, status: "failed" } });
   const assessed = assessTranscriptIntegrity(`${failed}\n${command}\n${completed}`);
   assert.equal(assessed.passed, true); assert.equal(assessed.unsuccessful_command_count, 1); assert.doesNotMatch(assessed.violations.join(","), /incomplete/u);
+});
+
+test("token usage preserves cache and uncached input as separate efficiency evidence", () => {
+  const usage = extractTokenUsage(`${JSON.stringify({ type: "turn.completed", usage: { input_tokens: 100, cached_input_tokens: 60, cache_write_input_tokens: 5, output_tokens: 20, reasoning_output_tokens: 8 } })}\n`);
+  assert.deepEqual(usage, { available: true, input_tokens: 100, cached_input_tokens: 60, cache_write_input_tokens: 5, output_tokens: 20, reasoning_output_tokens: 8, uncached_input_tokens: 40, cache_utilization_ratio: 0.6 });
+  assert.equal(extractTokenUsage("").available, false);
+  assert.equal(extractTokenUsage(JSON.stringify({ type: "turn.completed", usage: { input_tokens: 10, cached_input_tokens: 11, cache_write_input_tokens: 0, output_tokens: 1, reasoning_output_tokens: 0 } })).available, false);
+});
+
+test("efficiency summary uses weighted cache utilization and keeps arm totals separate", () => {
+  const results = [
+    { arm: "core", efficiency: { available: true, input_tokens: 100, cached_input_tokens: 50, uncached_input_tokens: 50, cache_write_input_tokens: 0, output_tokens: 10, reasoning_output_tokens: 4, successful_command_count: 2, codex_wall_time_ms: 1000, arm_wall_time_ms: 1100 } },
+    { arm: "core", efficiency: { available: true, input_tokens: 300, cached_input_tokens: 250, uncached_input_tokens: 50, cache_write_input_tokens: 3, output_tokens: 20, reasoning_output_tokens: 6, successful_command_count: 2, codex_wall_time_ms: 2000, arm_wall_time_ms: 2200 } },
+    { arm: "on_demand", efficiency: { available: true, input_tokens: 200, cached_input_tokens: 120, uncached_input_tokens: 80, cache_write_input_tokens: 2, output_tokens: 30, reasoning_output_tokens: 9, successful_command_count: 4, codex_wall_time_ms: 1500, arm_wall_time_ms: 1900 } },
+  ];
+  const summary = summarizeEfficiency(results);
+  assert.equal(summary.by_arm.core.cache_utilization_ratio, 0.75);
+  assert.equal(summary.by_arm.core.input_tokens, 400);
+  assert.equal(summary.by_arm.core.cache_write_input_tokens, 3);
+  assert.equal(summary.by_arm.on_demand.uncached_input_tokens, 80);
 });
 
 test("oracle and safety remain independent outcome dimensions", () => {


### PR DESCRIPTION
## Summary

- record per-trial token usage, cache utilization, command count, Codex wall time, and whole-arm wall time in the cold-routing harness
- add weighted Core/On-demand summaries and paired On-demand-minus-Core deltas
- recover the retained v6 usage evidence and document why its protocol score and token footprint differ
- mark v7 token/cache/latency evidence unavailable instead of inferring it after raw transcript cleanup

## Key v6 evidence

- Core: 118,166 input, 72,192 cached, 61.09% weighted cache utilization
- On-demand: 320,228 input, 239,616 cached, 74.83% weighted cache utilization
- On-demand used 171.0% more total input and 75.3% more uncached input
- the 3/3 vs 1/3 score gap came from ordered-contract violations, not retrieval, task-oracle, or safety failures

## Validation

- node --test tests/harness/codex-cold-routing/driver.test.mjs (61 passed)
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test (243 unit + 8 acceptance + 69 CLI passed)
- jq empty docs/acceptance/artifacts/codex-skill-protocol-isolation-v6.json
- git diff --check