### PR TITLE
fix: keep local state private by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -111,6 +117,36 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
 
 [[package]]
 name = "cc"
@@ -227,7 +263,7 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -258,7 +294,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -280,7 +316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -312,6 +348,17 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fs2"
@@ -446,6 +493,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +580,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -681,7 +762,17 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -756,6 +847,8 @@ version = "1.8.28"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "cap-primitives",
+ "cap-std",
  "chrono",
  "clap",
  "ctrlc",
@@ -769,7 +862,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "ulid",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -822,7 +915,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1039,11 +1132,168 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "directories",
  "fs2",
  "hex",
+ "libc",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0"
 aho-corasick = "1.1"
+cap-primitives = "4.0"
+cap-std = "4.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 directories = "6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,11 @@ serde_json = "1.0"
 sha2 = "0.10"
 ulid = { version = "1.2", features = ["serde"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
 
 [dev-dependencies]
 tempfile = "3.20"

--- a/docs/local-data-lifecycle.md
+++ b/docs/local-data-lifecycle.md
@@ -4,6 +4,16 @@ SkillRoster keeps governance state in `~/.skillroster/skillroster.db`. It reads
 supported Agent sessions in place and stores only derived evidence summaries;
 exports do not contain raw prompts or responses.
 
+The state root is private by default. On Unix, SkillRoster creates and repairs
+the root and control directories to `0700` and control files such as SQLite,
+its sidecars, locks, Receipts, and source-confirmation details to `0600`. It
+opens existing paths without following a final symlink and refuses paths not
+owned by the current user. On Windows, the state root receives a protected,
+inheritable DACL for the current user. Existing installations are tightened on
+the next command; a path that cannot be secured is rejected before the command
+uses the state store. Recovery objects that must retain original metadata stay
+protected by the private state-root ancestor.
+
 Exact source-root read permissions are also local SQLite policy. Each record
 keeps the confirmed canonical directory, bound Finding/Snapshot, approval and
 optional revocation time, and stable filesystem identity. Use

--- a/docs/local-data-lifecycle.md
+++ b/docs/local-data-lifecycle.md
@@ -9,9 +9,11 @@ the root and control directories to `0700` and control files such as SQLite,
 its sidecars, locks, Receipts, and source-confirmation details to `0600`. It
 opens existing paths without following a final symlink and refuses paths not
 owned by the current user. On Windows, the state root receives a protected,
-inheritable DACL for the current user. Existing installations are tightened on
-the next command; a path that cannot be secured is rejected before the command
-uses the state store. Recovery objects that must retain original metadata stay
+inheritable DACL for the current user. Reparse points and paths owned by another
+user are rejected before their ACL can change; validation and DACL updates use
+the same open handle. Existing installations, including retained Receipt and
+source-confirmation files, are tightened on the next command before the state
+store is opened. Recovery objects that must retain original metadata stay
 protected by the private state-root ancestor.
 
 Exact source-root read permissions are also local SQLite policy. Each record

--- a/src/app.rs
+++ b/src/app.rs
@@ -653,8 +653,6 @@ fn owned_source_confirmation_control_file(
     name: &std::ffi::OsStr,
     file: &mut std::fs::File,
 ) -> std::io::Result<bool> {
-    const MAX_DETAIL_BYTES: u64 = 8 * 1024 * 1024;
-
     let path = Path::new(name);
     if path.extension().and_then(|value| value.to_str()) != Some("json") {
         return Ok(false);
@@ -665,12 +663,7 @@ fn owned_source_confirmation_control_file(
     if ulid::Ulid::from_string(stem).is_err() {
         return Ok(false);
     }
-    let mut bytes = Vec::new();
-    file.take(MAX_DETAIL_BYTES + 1).read_to_end(&mut bytes)?;
-    if bytes.len() as u64 > MAX_DETAIL_BYTES {
-        return Ok(false);
-    }
-    let Ok(detail) = serde_json::from_slice::<Value>(&bytes) else {
+    let Ok(detail) = serde_json::from_reader::<_, Value>(file) else {
         return Ok(false);
     };
     Ok(recognized_source_confirmation_detail(&detail))

--- a/src/app.rs
+++ b/src/app.rs
@@ -180,6 +180,10 @@ pub fn run(cli: Cli) -> Result<Output> {
     let home = resolve_home(cli.home)?;
     let state_dir = cli.state_dir.unwrap_or_else(|| home.join(".skillroster"));
     let database_path = state_dir.join("skillroster.db");
+    state_security::prepare_state_root(&state_dir)
+        .with_context(|| format!("cannot secure state root {}", state_dir.display()))?;
+    state_security::secure_state_layout(&state_dir)
+        .with_context(|| format!("cannot secure state layout {}", state_dir.display()))?;
     if let Some(Command::Lifecycle(args)) = &cli.command {
         if let LifecycleCommand::Delete(args) = &args.command {
             if args.confirm != "DELETE-LOCAL-STATE" {
@@ -204,8 +208,6 @@ pub fn run(cli: Cli) -> Result<Output> {
             });
         }
     }
-    state_security::prepare_state_root(&state_dir)
-        .with_context(|| format!("cannot secure state root {}", state_dir.display()))?;
     // Shared guards let Agent read/analysis commands run concurrently while
     // still excluding lifecycle deletion and filesystem mutations on Windows.
     let _state_lock = if command_requires_exclusive_state_lock(cli.command.as_ref()) {
@@ -1706,8 +1708,6 @@ fn lifecycle_purge_command(
 }
 
 fn lifecycle_delete_command(database_path: &Path, state_dir: &Path) -> Result<Value> {
-    std::fs::create_dir_all(state_dir)
-        .with_context(|| format!("cannot create {}", state_dir.display()))?;
     let _write_lock = change::WriteLock::acquire(state_dir)?;
     let existed = database_path.exists();
     let journals = change::journals(state_dir)?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -184,6 +184,7 @@ pub fn run(cli: Cli) -> Result<Output> {
         .with_context(|| format!("cannot secure state root {}", state_dir.display()))?;
     state_security::secure_state_layout(&state_dir)
         .with_context(|| format!("cannot secure state layout {}", state_dir.display()))?;
+    secure_owned_control_files(&state_dir)?;
     if let Some(Command::Lifecycle(args)) = &cli.command {
         if let LifecycleCommand::Delete(args) = &args.command {
             if args.confirm != "DELETE-LOCAL-STATE" {
@@ -632,6 +633,47 @@ pub fn run(cli: Cli) -> Result<Output> {
         json: serde_json::to_string(&envelope)?,
         human: crate::present::human(command, &result),
     })
+}
+
+fn secure_owned_control_files(state_dir: &Path) -> Result<()> {
+    state_security::secure_control_directory(
+        &state_dir.join("receipts"),
+        change::owned_receipt_control_file,
+    )
+    .with_context(|| "cannot validate and secure Receipt journals")?;
+    state_security::secure_control_directory(
+        &state_dir.join("source-confirmation"),
+        owned_source_confirmation_control_file,
+    )
+    .with_context(|| "cannot validate and secure source-confirmation details")?;
+    Ok(())
+}
+
+fn owned_source_confirmation_control_file(
+    name: &std::ffi::OsStr,
+    file: &mut std::fs::File,
+) -> std::io::Result<bool> {
+    const MAX_DETAIL_BYTES: u64 = 8 * 1024 * 1024;
+
+    let path = Path::new(name);
+    if path.extension().and_then(|value| value.to_str()) != Some("json") {
+        return Ok(false);
+    }
+    let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+        return Ok(false);
+    };
+    if ulid::Ulid::from_string(stem).is_err() {
+        return Ok(false);
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_DETAIL_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_DETAIL_BYTES {
+        return Ok(false);
+    }
+    let Ok(detail) = serde_json::from_slice::<Value>(&bytes) else {
+        return Ok(false);
+    };
+    Ok(recognized_source_confirmation_detail(&detail))
 }
 
 fn command_requires_exclusive_state_lock(command: Option<&Command>) -> bool {

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,7 @@ use crate::model::{
 };
 use crate::scan::{self, ExplicitSkillRoot, RootKind, ScanOptions, ScanResult};
 use crate::sqlite::StateStore;
+use crate::state_security;
 
 const STATUS_PENDING_PLAN_LIMIT: usize = 20;
 const SETUP_PLAN_SUMMARY_FIELDS: &[&str] = &[
@@ -203,8 +204,8 @@ pub fn run(cli: Cli) -> Result<Output> {
             });
         }
     }
-    std::fs::create_dir_all(&state_dir)
-        .with_context(|| format!("cannot create {}", state_dir.display()))?;
+    state_security::prepare_state_root(&state_dir)
+        .with_context(|| format!("cannot secure state root {}", state_dir.display()))?;
     // Shared guards let Agent read/analysis commands run concurrently while
     // still excluding lifecycle deletion and filesystem mutations on Windows.
     let _state_lock = if command_requires_exclusive_state_lock(cli.command.as_ref()) {
@@ -219,6 +220,8 @@ pub fn run(cli: Cli) -> Result<Output> {
         }
     };
     let store = StateStore::open(&database_path)?;
+    state_security::secure_state_layout(&state_dir)
+        .with_context(|| format!("cannot secure state layout {}", state_dir.display()))?;
 
     let (command, mut result, warnings, actions) = match cli.command {
         None => ("home", home_result(&store, &state_dir)?, vec![], vec![]),
@@ -617,6 +620,8 @@ pub fn run(cli: Cli) -> Result<Output> {
     };
 
     action_context.apply_result(command, &mut result);
+    state_security::secure_state_layout(&state_dir)
+        .with_context(|| format!("cannot secure state layout {}", state_dir.display()))?;
     let mut envelope = JsonEnvelope::success(command, result.clone());
     envelope.warnings = warnings;
     envelope.suggested_actions = actions;

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,7 @@ use crate::cli::{
     Cli, Command, LifecycleCommand, ModifiedBootstrapChoice, ReportCategory, ReportSeverity,
     SourceRootCommand,
 };
+use crate::durable_fs::{DirectorySync, SystemDirectorySync};
 use crate::harness::{self, AgentKind};
 use crate::model::{
     AgentId, AgentRecord, ApiError, EvidenceId, EvidenceKind, EvidenceQuality, EvidenceRecord,
@@ -653,6 +654,9 @@ fn owned_source_confirmation_control_file(
     name: &std::ffi::OsStr,
     file: &mut std::fs::File,
 ) -> std::io::Result<bool> {
+    if owned_source_confirmation_temp_name(name) {
+        return Ok(true);
+    }
     let path = Path::new(name);
     if path.extension().and_then(|value| value.to_str()) != Some("json") {
         return Ok(false);
@@ -667,6 +671,17 @@ fn owned_source_confirmation_control_file(
         return Ok(false);
     };
     Ok(recognized_source_confirmation_detail(&detail))
+}
+
+fn owned_source_confirmation_temp_name(name: &std::ffi::OsStr) -> bool {
+    let Some(id) = name
+        .to_str()
+        .and_then(|name| name.strip_prefix('.'))
+        .and_then(|name| name.strip_suffix(".tmp"))
+    else {
+        return false;
+    };
+    ulid::Ulid::from_string(id).is_ok()
 }
 
 fn command_requires_exclusive_state_lock(command: Option<&Command>) -> bool {
@@ -1815,10 +1830,16 @@ fn source_confirmation_detail_paths(state_dir: &Path) -> Result<Vec<PathBuf>> {
         let entry = entry?;
         let path = entry.path();
         let metadata = std::fs::symlink_metadata(&path)?;
-        if metadata.file_type().is_symlink()
-            || !metadata.is_file()
-            || path.extension().and_then(|value| value.to_str()) != Some("json")
-        {
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            bail!(
+                "refusing invalid source-confirmation detail: {}",
+                path.display()
+            );
+        }
+        if owned_source_confirmation_temp_name(&entry.file_name()) {
+            continue;
+        }
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
             bail!(
                 "refusing invalid source-confirmation detail: {}",
                 path.display()
@@ -2014,11 +2035,31 @@ fn remove_source_confirmation_details(state_dir: &Path) -> Result<u64> {
     for path in &paths {
         std::fs::remove_file(path).with_context(|| format!("cannot delete {}", path.display()))?;
     }
+    let mut removed_temps = 0_u64;
+    if directory.is_dir() {
+        for entry in std::fs::read_dir(&directory)? {
+            let entry = entry?;
+            if !owned_source_confirmation_temp_name(&entry.file_name()) {
+                bail!(
+                    "refusing invalid source-confirmation detail: {}",
+                    entry.path().display()
+                );
+            }
+            std::fs::remove_file(entry.path())?;
+            removed_temps += 1;
+        }
+        SystemDirectorySync
+            .sync_directory(&directory)
+            .with_context(|| format!("cannot sync {}", directory.display()))?;
+    }
     if std::fs::symlink_metadata(&directory).is_ok() {
         std::fs::remove_dir(&directory)
             .with_context(|| format!("cannot delete {}", directory.display()))?;
+        SystemDirectorySync
+            .sync_directory(state_dir)
+            .with_context(|| format!("cannot sync {}", state_dir.display()))?;
     }
-    Ok(paths.len() as u64)
+    Ok(paths.len() as u64 + removed_temps)
 }
 
 fn remove_receipt_journals(state_dir: &Path) -> Result<u64> {

--- a/src/change.rs
+++ b/src/change.rs
@@ -1999,8 +1999,6 @@ pub(crate) fn persist_journal_state(receipt: &ChangeReceipt) -> Result<()> {
 }
 
 pub(crate) fn owned_receipt_control_file(name: &OsStr, file: &mut File) -> io::Result<bool> {
-    const MAX_RECEIPT_BYTES: u64 = 8 * 1024 * 1024;
-
     let Some(name) = name.to_str() else {
         return Ok(false);
     };
@@ -2020,12 +2018,7 @@ pub(crate) fn owned_receipt_control_file(name: &OsStr, file: &mut File) -> io::R
     if ulid::Ulid::from_string(id).is_err() {
         return Ok(false);
     }
-    let mut bytes = Vec::new();
-    file.take(MAX_RECEIPT_BYTES + 1).read_to_end(&mut bytes)?;
-    if bytes.len() as u64 > MAX_RECEIPT_BYTES {
-        return Ok(false);
-    }
-    let Ok(receipt) = serde_json::from_slice::<ChangeReceipt>(&bytes) else {
+    let Ok(receipt) = serde_json::from_reader::<_, ChangeReceipt>(file) else {
         return Ok(false);
     };
     Ok(receipt.id == name.trim_end_matches(".json"))
@@ -2495,6 +2488,29 @@ mod tests {
         let decoded: ChangeReceipt = serde_json::from_slice(&fs::read(published).unwrap()).unwrap();
         assert_eq!(decoded.id, receipt.id);
         assert_eq!(decoded.status, ReceiptStatus::Applying);
+    }
+
+    #[test]
+    fn owned_receipt_validation_has_no_smaller_limit_than_receipt_creation() {
+        let (_temp, root, state) = fixture();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: "plan_large_receipt".to_owned(),
+            status: ReceiptStatus::RecoveryRequired,
+            changed_paths: Vec::new(),
+            compensations: Vec::new(),
+            approved_roots: vec![root],
+            state_dir: state.clone(),
+            error: Some("x".repeat(9 * 1024 * 1024)),
+            reverses_receipt_id: None,
+            operation_results: Vec::new(),
+        };
+        let name = format!("{}.json", receipt.id);
+        let path = state.join(&name);
+        fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+        let mut file = File::open(path).unwrap();
+
+        assert!(owned_receipt_control_file(OsStr::new(&name), &mut file).unwrap());
     }
 
     #[test]

--- a/src/change.rs
+++ b/src/change.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::durable_fs::{DirectorySync, SystemDirectorySync};
+use crate::state_security;
 
 #[derive(Debug)]
 pub struct ChangeError {
@@ -1319,8 +1320,7 @@ fn stage_compensation(
             expected_fingerprint,
         } => {
             verify_fingerprint(target, expected_fingerprint)?;
-            let directory = recovery_dir(state_dir, receipt_id);
-            create_dir_all_durable(&directory, directory_sync)?;
+            let directory = create_recovery_dir(state_dir, receipt_id, directory_sync)?;
             let backup = directory.join(format!("replace-{index}.backup"));
             require_missing(&backup)?;
             copy_file_durable(
@@ -1513,8 +1513,8 @@ fn compensate(
         } => {
             verify_fingerprint(path, expected_fingerprint)?;
             normalize_target(path, roots)?;
-            let stash = recovery_dir(state_dir, receipt_id).join(format!("undo-{index}"));
-            create_dir_all_durable(stash.parent().expect("stash has parent"), directory_sync)?;
+            let stash = create_recovery_dir(state_dir, receipt_id, directory_sync)?
+                .join(format!("undo-{index}"));
             rename_durable(path, &stash, directory_sync, "stash created path")?;
         }
         Compensation::RestoreSymlink { path, target } => {
@@ -1544,8 +1544,8 @@ fn compensate(
             require_missing(original)?;
             normalize_target(created, roots)?;
             normalize_target(original, roots)?;
-            let stash = recovery_dir(state_dir, receipt_id).join(format!("undo-created-{index}"));
-            create_dir_all_durable(stash.parent().expect("stash has parent"), directory_sync)?;
+            let stash = create_recovery_dir(state_dir, receipt_id, directory_sync)?
+                .join(format!("undo-created-{index}"));
             rename_durable(created, &stash, directory_sync, "stash copied destination")?;
             rename_durable(backup, original, directory_sync, "restore source backup")?;
         }
@@ -1956,8 +1956,25 @@ fn remove_symlink(path: &Path) -> Result<()> {
     result.map_err(|error| ChangeError::io("remove symlink", path, error))
 }
 
-fn recovery_dir(state_dir: &Path, receipt_id: &str) -> PathBuf {
-    state_dir.join("recovery").join(receipt_id)
+fn create_recovery_dir(
+    state_dir: &Path,
+    receipt_id: &str,
+    directory_sync: &dyn DirectorySync,
+) -> Result<PathBuf> {
+    let root = state_dir.join("recovery");
+    let directory = root.join(receipt_id);
+    create_dir_all_durable(&directory, directory_sync)?;
+    state_security::secure_directory(&root)
+        .map_err(|error| ChangeError::io("secure recovery directory", &root, error))?;
+    state_security::secure_directory(&directory)
+        .map_err(|error| ChangeError::io("secure recovery directory", &directory, error))?;
+    directory_sync
+        .sync_directory(&root)
+        .map_err(|error| ChangeError::io("sync secured recovery directory", &root, error))?;
+    directory_sync
+        .sync_directory(&directory)
+        .map_err(|error| ChangeError::io("sync secured recovery directory", &directory, error))?;
+    Ok(directory)
 }
 
 fn persist_journal(receipt: &ChangeReceipt) -> Result<()> {
@@ -1967,12 +1984,24 @@ fn persist_journal(receipt: &ChangeReceipt) -> Result<()> {
 fn persist_journal_with(receipt: &ChangeReceipt, directory_sync: &dyn DirectorySync) -> Result<()> {
     let directory = receipt.state_dir.join("receipts");
     create_dir_all_durable(&directory, directory_sync)?;
+    state_security::secure_directory(&directory)
+        .map_err(|e| ChangeError::io("secure receipt directory", &directory, e))?;
+    directory_sync
+        .sync_directory(&directory)
+        .map_err(|e| ChangeError::io("sync secured receipt directory", &directory, e))?;
     let path = directory.join(format!("{}.json", receipt.id));
     let temp = directory.join(format!(".{}.tmp", receipt.id));
     let bytes = serde_json::to_vec_pretty(receipt)
         .map_err(|e| ChangeError::new("receipt_encoding_failed", e.to_string()))?;
-    let mut file =
-        File::create(&temp).map_err(|e| ChangeError::io("create receipt journal", &temp, e))?;
+    let mut options = state_security::private_file_options();
+    let mut file = options
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&temp)
+        .map_err(|e| ChangeError::io("create receipt journal", &temp, e))?;
+    state_security::secure_file(&temp)
+        .map_err(|e| ChangeError::io("secure receipt journal", &temp, e))?;
     file.write_all(&bytes)
         .map_err(|e| ChangeError::io("write receipt journal", &temp, e))?;
     file.sync_all()
@@ -2113,13 +2142,16 @@ impl StateLock {
 
     fn acquire(state_dir: &Path, exclusive: bool) -> Result<Self> {
         let path = state_dir.join("write.lock");
-        let file = OpenOptions::new()
+        let mut options = state_security::private_file_options();
+        let file = options
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
             .open(&path)
             .map_err(|e| ChangeError::io("open state lock", &path, e))?;
+        state_security::secure_file(&path)
+            .map_err(|e| ChangeError::io("secure state lock", &path, e))?;
         let result = if exclusive {
             FileExt::try_lock_exclusive(&file)
         } else {
@@ -2635,12 +2667,27 @@ mod tests {
             &input,
             &PrepareContext {
                 approved_roots: vec![root],
-                state_dir: state,
+                state_dir: state.clone(),
                 operation_policy: OperationPolicy::TestOnly,
             },
         )
         .unwrap();
         let applied = apply(&plan).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let receipts = state.join("receipts");
+            let journal = receipts.join(format!("{}.json", applied.receipt.id));
+            assert_eq!(
+                fs::metadata(receipts).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(journal).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
         assert_eq!(
             fs::read_to_string(&target).unwrap(),
             "---\nname: test\n---\n"

--- a/src/change.rs
+++ b/src/change.rs
@@ -1968,12 +1968,6 @@ fn create_recovery_dir(
         .map_err(|error| ChangeError::io("secure recovery directory", &root, error))?;
     state_security::secure_directory(&directory)
         .map_err(|error| ChangeError::io("secure recovery directory", &directory, error))?;
-    directory_sync
-        .sync_directory(&root)
-        .map_err(|error| ChangeError::io("sync secured recovery directory", &root, error))?;
-    directory_sync
-        .sync_directory(&directory)
-        .map_err(|error| ChangeError::io("sync secured recovery directory", &directory, error))?;
     Ok(directory)
 }
 
@@ -1986,9 +1980,6 @@ fn persist_journal_with(receipt: &ChangeReceipt, directory_sync: &dyn DirectoryS
     create_dir_all_durable(&directory, directory_sync)?;
     state_security::secure_directory(&directory)
         .map_err(|e| ChangeError::io("secure receipt directory", &directory, e))?;
-    directory_sync
-        .sync_directory(&directory)
-        .map_err(|e| ChangeError::io("sync secured receipt directory", &directory, e))?;
     let path = directory.join(format!("{}.json", receipt.id));
     let temp = directory.join(format!(".{}.tmp", receipt.id));
     let bytes = serde_json::to_vec_pretty(receipt)
@@ -1996,11 +1987,10 @@ fn persist_journal_with(receipt: &ChangeReceipt, directory_sync: &dyn DirectoryS
     let mut options = state_security::private_file_options();
     let mut file = options
         .write(true)
-        .create(true)
-        .truncate(true)
+        .create_new(true)
         .open(&temp)
         .map_err(|e| ChangeError::io("create receipt journal", &temp, e))?;
-    state_security::secure_file(&temp)
+    state_security::secure_opened_file(&file)
         .map_err(|e| ChangeError::io("secure receipt journal", &temp, e))?;
     file.write_all(&bytes)
         .map_err(|e| ChangeError::io("write receipt journal", &temp, e))?;
@@ -2150,7 +2140,7 @@ impl StateLock {
             .truncate(false)
             .open(&path)
             .map_err(|e| ChangeError::io("open state lock", &path, e))?;
-        state_security::secure_file(&path)
+        state_security::secure_opened_file(&file)
             .map_err(|e| ChangeError::io("secure state lock", &path, e))?;
         let result = if exclusive {
             FileExt::try_lock_exclusive(&file)

--- a/src/change.rs
+++ b/src/change.rs
@@ -4,6 +4,7 @@
 //! fingerprints, and every apply/undo obtains the same process write lock.
 
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
@@ -1984,14 +1985,8 @@ fn persist_journal_with(receipt: &ChangeReceipt, directory_sync: &dyn DirectoryS
     let temp = directory.join(format!(".{}.tmp", receipt.id));
     let bytes = serde_json::to_vec_pretty(receipt)
         .map_err(|e| ChangeError::new("receipt_encoding_failed", e.to_string()))?;
-    let mut options = state_security::private_file_options();
-    let mut file = options
-        .write(true)
-        .create_new(true)
-        .open(&temp)
+    let mut file = state_security::open_private_file_for_replace(&temp)
         .map_err(|e| ChangeError::io("create receipt journal", &temp, e))?;
-    state_security::secure_opened_file(&file)
-        .map_err(|e| ChangeError::io("secure receipt journal", &temp, e))?;
     file.write_all(&bytes)
         .map_err(|e| ChangeError::io("write receipt journal", &temp, e))?;
     file.sync_all()
@@ -2001,6 +1996,39 @@ fn persist_journal_with(receipt: &ChangeReceipt, directory_sync: &dyn DirectoryS
 
 pub(crate) fn persist_journal_state(receipt: &ChangeReceipt) -> Result<()> {
     persist_journal(receipt)
+}
+
+pub(crate) fn owned_receipt_control_file(name: &OsStr, file: &mut File) -> io::Result<bool> {
+    const MAX_RECEIPT_BYTES: u64 = 8 * 1024 * 1024;
+
+    let Some(name) = name.to_str() else {
+        return Ok(false);
+    };
+    if let Some(id) = name
+        .strip_prefix('.')
+        .and_then(|name| name.strip_suffix(".tmp"))
+        .and_then(|name| name.strip_prefix("receipt_"))
+    {
+        return Ok(ulid::Ulid::from_string(id).is_ok());
+    }
+    let Some(id) = name
+        .strip_suffix(".json")
+        .and_then(|name| name.strip_prefix("receipt_"))
+    else {
+        return Ok(false);
+    };
+    if ulid::Ulid::from_string(id).is_err() {
+        return Ok(false);
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_RECEIPT_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_RECEIPT_BYTES {
+        return Ok(false);
+    }
+    let Ok(receipt) = serde_json::from_slice::<ChangeReceipt>(&bytes) else {
+        return Ok(false);
+    };
+    Ok(receipt.id == name.trim_end_matches(".json"))
 }
 
 /// Loads the durable filesystem journal without changing it. Invalid entries are
@@ -2438,6 +2466,35 @@ mod tests {
         assert!(error.message.contains("sync renamed source directory"));
         assert!(directory_sync.failed.get());
         assert!(!target.exists());
+    }
+
+    #[test]
+    fn journal_reuses_an_owned_temp_left_by_an_interrupted_write() {
+        let (_temp, root, state) = fixture();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: "plan_retry".to_owned(),
+            status: ReceiptStatus::Applying,
+            changed_paths: Vec::new(),
+            compensations: Vec::new(),
+            approved_roots: vec![root],
+            state_dir: state.clone(),
+            error: None,
+            reverses_receipt_id: None,
+            operation_results: Vec::new(),
+        };
+        let receipts = state.join("receipts");
+        fs::create_dir(&receipts).unwrap();
+        let temp = receipts.join(format!(".{}.tmp", receipt.id));
+        fs::write(&temp, b"incomplete").unwrap();
+
+        persist_journal(&receipt).unwrap();
+
+        assert!(!temp.exists());
+        let published = receipts.join(format!("{}.json", receipt.id));
+        let decoded: ChangeReceipt = serde_json::from_slice(&fs::read(published).unwrap()).unwrap();
+        assert_eq!(decoded.id, receipt.id);
+        assert_eq!(decoded.status, ReceiptStatus::Applying);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub mod roster_recommendation;
 pub mod scan;
 pub mod source_policy;
 pub mod sqlite;
+mod state_security;

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -421,6 +421,8 @@ fn write_source_confirmation_detail(state_dir: &Path, complete: Value) -> Result
             return Err(error).with_context(|| format!("cannot inspect {}", directory.display()));
         }
     }
+    crate::state_security::secure_directory(&directory)
+        .with_context(|| format!("cannot secure {}", directory.display()))?;
     let id = ulid::Ulid::new();
     let path = directory.join(format!("{id}.json"));
     let temporary_path = directory.join(format!(".{id}.tmp"));
@@ -435,6 +437,8 @@ fn write_source_confirmation_detail(state_dir: &Path, complete: Value) -> Result
     let mut file = options
         .open(&temporary_path)
         .with_context(|| format!("cannot create {}", temporary_path.display()))?;
+    crate::state_security::secure_file(&temporary_path)
+        .with_context(|| format!("cannot secure {}", temporary_path.display()))?;
     let write_result = (|| -> Result<()> {
         file.write_all(&bytes)
             .with_context(|| format!("cannot write {}", temporary_path.display()))?;
@@ -457,6 +461,8 @@ fn write_source_confirmation_detail(state_dir: &Path, complete: Value) -> Result
         }
     }
     write_result?;
+    crate::state_security::secure_file(&path)
+        .with_context(|| format!("cannot secure {}", path.display()))?;
     Ok(path)
 }
 
@@ -2343,6 +2349,23 @@ mod tests {
             json!(bounded_roots)
         );
         let detail_path = blocked.details["detail"]["path"].as_str().unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            assert_eq!(
+                fs::metadata(state.path().join("source-confirmation"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(detail_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
         let detail_name = Path::new(detail_path)
             .file_stem()
             .and_then(|value| value.to_str())

--- a/src/roster_plan.rs
+++ b/src/roster_plan.rs
@@ -427,17 +427,12 @@ fn write_source_confirmation_detail(state_dir: &Path, complete: Value) -> Result
     let path = directory.join(format!("{id}.json"));
     let temporary_path = directory.join(format!(".{id}.tmp"));
     let bytes = serde_json::to_vec(&complete)?;
-    let mut options = std::fs::OpenOptions::new();
+    let mut options = crate::state_security::private_file_options();
     options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
     let mut file = options
         .open(&temporary_path)
         .with_context(|| format!("cannot create {}", temporary_path.display()))?;
-    crate::state_security::secure_file(&temporary_path)
+    crate::state_security::secure_opened_file(&file)
         .with_context(|| format!("cannot secure {}", temporary_path.display()))?;
     let write_result = (|| -> Result<()> {
         file.write_all(&bytes)

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rusqlite::{Connection, OpenFlags, OptionalExtension, Transaction, params};
 use serde::de::DeserializeOwned;
@@ -13,6 +13,33 @@ use crate::source_policy::{RootIdentity, SourcePermissionId, SourceRootPermissio
 use crate::state_security;
 
 const SCHEMA_VERSION: i64 = 10;
+
+fn sqlite_nofollow_path(path: &Path) -> StorageResult<PathBuf> {
+    let parent = path.parent().ok_or_else(|| {
+        StorageError::InvalidData(format!(
+            "state database path has no parent: {}",
+            path.display()
+        ))
+    })?;
+    let name = path.file_name().ok_or_else(|| {
+        StorageError::InvalidData(format!(
+            "state database path has no file name: {}",
+            path.display()
+        ))
+    })?;
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    let parent = parent.canonicalize().map_err(|error| {
+        StorageError::InvalidData(format!(
+            "cannot resolve state database directory {}: {error}",
+            parent.display()
+        ))
+    })?;
+    Ok(parent.join(name))
+}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct LifecycleCounts {
@@ -163,7 +190,10 @@ impl StateStore {
                 )));
             }
         }
-        let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let connection = Connection::open_with_flags(
+            sqlite_nofollow_path(path)?,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NOFOLLOW,
+        )?;
         let version: i64 = connection.pragma_query_value(None, "user_version", |row| row.get(0))?;
         Ok(version != SCHEMA_VERSION)
     }
@@ -204,7 +234,10 @@ impl StateStore {
                 path.display()
             ))
         })?;
-        let connection = Connection::open(path)?;
+        let connection = Connection::open_with_flags(
+            sqlite_nofollow_path(path)?,
+            OpenFlags::default() | OpenFlags::SQLITE_OPEN_NOFOLLOW,
+        )?;
         let store = Self::initialize(connection)?;
         for sidecar in [path.with_extension("db-wal"), path.with_extension("db-shm")] {
             state_security::secure_optional_file(&sidecar).map_err(|error| {

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -147,8 +147,21 @@ pub struct StateStore {
 
 impl StateStore {
     pub fn requires_migration(path: impl AsRef<Path>) -> StorageResult<bool> {
-        if !path.as_ref().exists() {
-            return Ok(true);
+        let path = path.as_ref();
+        match std::fs::symlink_metadata(path) {
+            Ok(_) => state_security::secure_file(path).map_err(|error| {
+                StorageError::InvalidData(format!(
+                    "cannot secure state database {}: {error}",
+                    path.display()
+                ))
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+            Err(error) => {
+                return Err(StorageError::InvalidData(format!(
+                    "cannot inspect state database {}: {error}",
+                    path.display()
+                )));
+            }
         }
         let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
         let version: i64 = connection.pragma_query_value(None, "user_version", |row| row.get(0))?;
@@ -185,13 +198,13 @@ impl StateStore {
             })?;
         }
         let path = path.as_ref();
-        let connection = Connection::open(path)?;
-        state_security::secure_file(path).map_err(|error| {
+        state_security::prepare_private_file(path).map_err(|error| {
             StorageError::InvalidData(format!(
-                "cannot secure state database {}: {error}",
+                "cannot prepare state database {}: {error}",
                 path.display()
             ))
         })?;
+        let connection = Connection::open(path)?;
         let store = Self::initialize(connection)?;
         for sidecar in [path.with_extension("db-wal"), path.with_extension("db-shm")] {
             state_security::secure_optional_file(&sidecar).map_err(|error| {

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -10,6 +10,7 @@ use crate::model::{
     RosterEntry, ScanId, ScanRun, SkillId, SkillRecord, UsageEvent,
 };
 use crate::source_policy::{RootIdentity, SourcePermissionId, SourceRootPermission};
+use crate::state_security;
 
 const SCHEMA_VERSION: i64 = 10;
 
@@ -176,15 +177,31 @@ impl StateStore {
 
     pub fn open(path: impl AsRef<Path>) -> StorageResult<Self> {
         if let Some(parent) = path.as_ref().parent() {
-            std::fs::create_dir_all(parent).map_err(|error| {
+            state_security::prepare_state_root(parent).map_err(|error| {
                 StorageError::InvalidData(format!(
-                    "cannot create state directory {}: {error}",
+                    "cannot secure state directory {}: {error}",
                     parent.display()
                 ))
             })?;
         }
+        let path = path.as_ref();
         let connection = Connection::open(path)?;
-        Self::initialize(connection)
+        state_security::secure_file(path).map_err(|error| {
+            StorageError::InvalidData(format!(
+                "cannot secure state database {}: {error}",
+                path.display()
+            ))
+        })?;
+        let store = Self::initialize(connection)?;
+        for sidecar in [path.with_extension("db-wal"), path.with_extension("db-shm")] {
+            state_security::secure_optional_file(&sidecar).map_err(|error| {
+                StorageError::InvalidData(format!(
+                    "cannot secure state database sidecar {}: {error}",
+                    sidecar.display()
+                ))
+            })?;
+        }
+        Ok(store)
     }
 
     pub fn open_in_memory() -> StorageResult<Self> {

--- a/src/state_security.rs
+++ b/src/state_security.rs
@@ -26,14 +26,18 @@ pub(crate) fn prepare_state_root(path: &Path) -> io::Result<()> {
     secure_directory(path)
 }
 
+#[cfg(unix)]
 pub(crate) fn private_file_options() -> OpenOptions {
+    use std::os::unix::fs::OpenOptionsExt;
+
     let mut options = OpenOptions::new();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(STATE_FILE_MODE);
-    }
+    options.mode(STATE_FILE_MODE);
     options
+}
+
+#[cfg(not(unix))]
+pub(crate) fn private_file_options() -> OpenOptions {
+    OpenOptions::new()
 }
 
 pub(crate) fn secure_file(path: &Path) -> io::Result<()> {
@@ -174,7 +178,7 @@ fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
         ));
     }
 
-    let mut token = 0;
+    let mut token: HANDLE = null_mut();
     // SAFETY: token points to writable storage and GetCurrentProcess returns a pseudo-handle.
     if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
         return Err(io::Error::last_os_error());
@@ -256,12 +260,11 @@ fn secure_path(path: &Path, _directory: bool) -> io::Result<()> {
     ))
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    #[cfg(unix)]
     #[test]
     fn narrows_existing_state_directory_and_file() {
         use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
@@ -292,7 +295,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn refuses_a_symlink_state_root() {
         use std::os::unix::fs::{PermissionsExt, symlink};
@@ -312,7 +314,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn narrows_existing_control_layout_and_sidecars() {
         use std::os::unix::fs::PermissionsExt;

--- a/src/state_security.rs
+++ b/src/state_security.rs
@@ -1,0 +1,374 @@
+//! Private-by-default storage for SkillRoster control state.
+//!
+//! The state root protects every descendant, including recovery objects whose
+//! original metadata must survive Undo. Control files are additionally narrowed
+//! to owner-only access so copied or inspected artifacts keep the same boundary.
+
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::path::Path;
+
+const STATE_DIRECTORY_MODE: u32 = 0o700;
+const STATE_FILE_MODE: u32 = 0o600;
+
+pub(crate) fn prepare_state_root(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("state root is not a regular directory: {}", path.display()),
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => create_private_dir_all(path)?,
+        Err(error) => return Err(error),
+    }
+    secure_directory(path)
+}
+
+pub(crate) fn private_file_options() -> OpenOptions {
+    let mut options = OpenOptions::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(STATE_FILE_MODE);
+    }
+    options
+}
+
+pub(crate) fn secure_file(path: &Path) -> io::Result<()> {
+    secure_path(path, false)
+}
+
+pub(crate) fn secure_directory(path: &Path) -> io::Result<()> {
+    secure_path(path, true)
+}
+
+pub(crate) fn secure_optional_file(path: &Path) -> io::Result<()> {
+    match secure_file(path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        result => result,
+    }
+}
+
+pub(crate) fn secure_state_layout(state_dir: &Path) -> io::Result<()> {
+    prepare_state_root(state_dir)?;
+    for name in [
+        "receipts",
+        "recovery",
+        "source-confirmation",
+        "plan-backups",
+        "library",
+    ] {
+        let path = state_dir.join(name);
+        match secure_directory(&path) {
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            result => result?,
+        }
+    }
+    for name in [
+        "skillroster.db",
+        "skillroster.db-wal",
+        "skillroster.db-shm",
+        "write.lock",
+    ] {
+        secure_optional_file(&state_dir.join(name))?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_private_dir_all(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true).mode(STATE_DIRECTORY_MODE);
+    builder.create(path)
+}
+
+#[cfg(not(unix))]
+fn create_private_dir_all(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)
+}
+
+#[cfg(unix)]
+fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    if directory {
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_DIRECTORY);
+    }
+    let file = options.open(path)?;
+    let metadata = file.metadata()?;
+    let valid_kind = if directory {
+        metadata.is_dir()
+    } else {
+        metadata.is_file()
+    };
+    if !valid_kind {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("state path has an unsafe file type: {}", path.display()),
+        ));
+    }
+    // SAFETY: geteuid has no preconditions and does not retain borrowed data.
+    let current_uid = unsafe { libc::geteuid() };
+    if metadata.uid() != current_uid {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "state path is not owned by the current user: {}",
+                path.display()
+            ),
+        ));
+    }
+    let mode = if directory {
+        STATE_DIRECTORY_MODE
+    } else {
+        STATE_FILE_MODE
+    };
+    file.set_permissions(fs::Permissions::from_mode(mode))
+}
+
+#[cfg(windows)]
+fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
+    use std::ffi::c_void;
+    use std::mem::size_of;
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr::{null, null_mut};
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, ERROR_INSUFFICIENT_BUFFER, GENERIC_ALL, GetLastError, HANDLE,
+    };
+    use windows_sys::Win32::Security::Authorization::{SE_FILE_OBJECT, SetNamedSecurityInfoW};
+    use windows_sys::Win32::Security::{
+        ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, AddAccessAllowedAceEx, CONTAINER_INHERIT_ACE,
+        DACL_SECURITY_INFORMATION, GetLengthSid, GetTokenInformation, InitializeAcl,
+        OBJECT_INHERIT_ACE, PROTECTED_DACL_SECURITY_INFORMATION, PSID, TOKEN_QUERY, TOKEN_USER,
+        TokenUser,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    struct Handle(HANDLE);
+    impl Drop for Handle {
+        fn drop(&mut self) {
+            // SAFETY: the handle was returned by OpenProcessToken and is owned here.
+            unsafe { CloseHandle(self.0) };
+        }
+    }
+
+    let metadata = fs::symlink_metadata(path)?;
+    let valid_kind = !metadata.file_type().is_symlink()
+        && if directory {
+            metadata.is_dir()
+        } else {
+            metadata.is_file()
+        };
+    if !valid_kind {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("state path has an unsafe file type: {}", path.display()),
+        ));
+    }
+
+    let mut token = 0;
+    // SAFETY: token points to writable storage and GetCurrentProcess returns a pseudo-handle.
+    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let token = Handle(token);
+    let mut token_bytes = 0;
+    // SAFETY: the null-buffer call obtains the required size.
+    let first = unsafe { GetTokenInformation(token.0, TokenUser, null_mut(), 0, &mut token_bytes) };
+    if first != 0 || unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER {
+        return Err(io::Error::last_os_error());
+    }
+    let mut token_buffer = vec![0_u8; token_bytes as usize];
+    // SAFETY: token_buffer is writable for token_bytes and remains alive while its SID is used.
+    if unsafe {
+        GetTokenInformation(
+            token.0,
+            TokenUser,
+            token_buffer.as_mut_ptr().cast::<c_void>(),
+            token_bytes,
+            &mut token_bytes,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: a successful TokenUser query starts with a TOKEN_USER value.
+    let user = unsafe { &*token_buffer.as_ptr().cast::<TOKEN_USER>() };
+    let sid: PSID = user.User.Sid;
+    // SAFETY: sid belongs to the validated TOKEN_USER buffer.
+    let sid_length = unsafe { GetLengthSid(sid) } as usize;
+    let acl_length =
+        size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + sid_length;
+    let acl_length =
+        u32::try_from(acl_length).map_err(|_| io::Error::other("state ACL is too large"))?;
+    let mut acl_buffer = vec![0_u8; acl_length as usize];
+    let acl = acl_buffer.as_mut_ptr().cast::<ACL>();
+    // SAFETY: acl_buffer is writable for acl_length bytes.
+    if unsafe { InitializeAcl(acl, acl_length, ACL_REVISION) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let inheritance = if directory {
+        OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE
+    } else {
+        0
+    };
+    // SAFETY: acl was initialized and sid remains valid for the duration of this call.
+    if unsafe { AddAccessAllowedAceEx(acl, ACL_REVISION, inheritance, GENERIC_ALL, sid) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut wide_path = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    wide_path.push(0);
+    // SAFETY: wide_path is NUL-terminated; acl remains valid for the call.
+    let status = unsafe {
+        SetNamedSecurityInfoW(
+            wide_path.as_mut_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            null_mut(),
+            null_mut(),
+            acl,
+            null(),
+        )
+    };
+    if status == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::from_raw_os_error(status as i32))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn secure_path(path: &Path, _directory: bool) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!(
+            "private state permissions are unsupported on this platform: {}",
+            path.display()
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[cfg(unix)]
+    #[test]
+    fn narrows_existing_state_directory_and_file() {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let temp = TempDir::new().unwrap();
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+        fs::set_permissions(&state, fs::Permissions::from_mode(0o755)).unwrap();
+        let file = state.join("skillroster.db");
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o666)
+            .open(&file)
+            .unwrap();
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).unwrap();
+
+        prepare_state_root(&state).unwrap();
+        secure_file(&file).unwrap();
+
+        assert_eq!(
+            fs::metadata(&state).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(&file).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_a_symlink_state_root() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let temp = TempDir::new().unwrap();
+        let outside = temp.path().join("outside");
+        fs::create_dir(&outside).unwrap();
+        let state = temp.path().join("state");
+        symlink(&outside, &state).unwrap();
+
+        let error = prepare_state_root(&state).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn narrows_existing_control_layout_and_sidecars() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+        fs::set_permissions(&state, fs::Permissions::from_mode(0o755)).unwrap();
+        for name in [
+            "receipts",
+            "recovery",
+            "source-confirmation",
+            "plan-backups",
+            "library",
+        ] {
+            let path = state.join(name);
+            fs::create_dir(&path).unwrap();
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        for name in [
+            "skillroster.db",
+            "skillroster.db-wal",
+            "skillroster.db-shm",
+            "write.lock",
+        ] {
+            let path = state.join(name);
+            fs::write(&path, "fixture").unwrap();
+            fs::set_permissions(path, fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        secure_state_layout(&state).unwrap();
+
+        for name in [
+            "receipts",
+            "recovery",
+            "source-confirmation",
+            "plan-backups",
+            "library",
+        ] {
+            assert_eq!(
+                fs::metadata(state.join(name)).unwrap().permissions().mode() & 0o777,
+                0o700,
+                "unexpected directory permissions for {name}"
+            );
+        }
+        for name in [
+            "skillroster.db",
+            "skillroster.db-wal",
+            "skillroster.db-shm",
+            "write.lock",
+        ] {
+            assert_eq!(
+                fs::metadata(state.join(name)).unwrap().permissions().mode() & 0o777,
+                0o600,
+                "unexpected file permissions for {name}"
+            );
+        }
+    }
+}

--- a/src/state_security.rs
+++ b/src/state_security.rs
@@ -4,11 +4,14 @@
 //! original metadata must survive Undo. Control files are additionally narrowed
 //! to owner-only access so copied or inspected artifacts keep the same boundary.
 
+use std::ffi::OsStr;
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::Path;
 
+#[cfg(unix)]
 const STATE_DIRECTORY_MODE: u32 = 0o700;
+#[cfg(unix)]
 const STATE_FILE_MODE: u32 = 0o600;
 
 pub(crate) fn prepare_state_root(path: &Path) -> io::Result<()> {
@@ -76,17 +79,33 @@ pub(crate) fn prepare_private_file(path: &Path) -> io::Result<()> {
     }
 }
 
+pub(crate) fn open_private_file_for_replace(path: &Path) -> io::Result<File> {
+    let mut options = private_file_options();
+    let file = options
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    secure_opened_file(&file)?;
+    file.set_len(0)?;
+    Ok(file)
+}
+
 pub(crate) fn secure_state_layout(state_dir: &Path) -> io::Result<()> {
     prepare_state_root(state_dir)?;
-    for name in ["recovery", "plan-backups", "library"] {
+    for name in [
+        "receipts",
+        "recovery",
+        "source-confirmation",
+        "plan-backups",
+        "library",
+    ] {
         let path = state_dir.join(name);
         match secure_directory(&path) {
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             result => result?,
         }
-    }
-    for name in ["receipts", "source-confirmation"] {
-        secure_control_directory(&state_dir.join(name))?;
     }
     for name in [
         "skillroster.db",
@@ -99,16 +118,68 @@ pub(crate) fn secure_state_layout(state_dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn secure_control_directory(path: &Path) -> io::Result<()> {
-    match secure_directory(path) {
+pub(crate) fn secure_control_directory(
+    path: &Path,
+    mut validate: impl FnMut(&OsStr, &mut File) -> io::Result<bool>,
+) -> io::Result<()> {
+    use cap_primitives::fs::FollowSymlinks;
+    use cap_std::fs::{Dir, OpenOptions as CapOpenOptions};
+
+    let directory = match open_directory(path) {
+        Ok(directory) => directory,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        result => result?,
+        Err(error) => return Err(error),
+    };
+    validate_opened_path(&directory, true)?;
+    let dir = Dir::from_std_file(directory.try_clone()?);
+    let mut entries = dir.read_dir(".")?.collect::<io::Result<Vec<_>>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    let mut owned_files = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let name = entry.file_name();
+        let mut options = CapOpenOptions::new();
+        options.read(true)._cap_fs_ext_follow(FollowSymlinks::No);
+        let mut file = entry.open_with(&options)?.into_std();
+        validate_opened_path(&file, false)?;
+        if !validate(&name, &mut file)? {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("unrecognized control file: {}", name.to_string_lossy()),
+            ));
+        }
+        owned_files.push(file);
     }
-    for entry in fs::read_dir(path)? {
-        let entry = entry?;
-        secure_file(&entry.path())?;
+
+    secure_opened_path(&directory, true)?;
+    for file in &owned_files {
+        secure_opened_file(file)?;
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn open_directory(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_DIRECTORY)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn open_directory(path: &Path) -> io::Result<File> {
+    open_windows_path(path)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_directory(_path: &Path) -> io::Result<File> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "private state permissions are unsupported on this platform",
+    ))
 }
 
 #[cfg(unix)]
@@ -147,7 +218,20 @@ pub(crate) fn secure_opened_file(file: &File) -> io::Result<()> {
 
 #[cfg(unix)]
 fn secure_opened_path(file: &File, directory: bool) -> io::Result<()> {
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    use std::os::unix::fs::PermissionsExt;
+
+    validate_opened_path(file, directory)?;
+    let mode = if directory {
+        STATE_DIRECTORY_MODE
+    } else {
+        STATE_FILE_MODE
+    };
+    file.set_permissions(fs::Permissions::from_mode(mode))
+}
+
+#[cfg(unix)]
+fn validate_opened_path(file: &File, directory: bool) -> io::Result<()> {
+    use std::os::unix::fs::MetadataExt;
 
     let metadata = file.metadata()?;
     let valid_kind = if directory {
@@ -169,29 +253,30 @@ fn secure_opened_path(file: &File, directory: bool) -> io::Result<()> {
             "opened state path is not owned by the current user",
         ));
     }
-    let mode = if directory {
-        STATE_DIRECTORY_MODE
-    } else {
-        STATE_FILE_MODE
-    };
-    file.set_permissions(fs::Permissions::from_mode(mode))
+    Ok(())
 }
 
 #[cfg(windows)]
 fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
+    let file = open_windows_path(path)?;
+    secure_opened_path(&file, directory)
+}
+
+#[cfg(windows)]
+fn open_windows_path(path: &Path) -> io::Result<File> {
     use std::os::windows::fs::OpenOptionsExt;
     use windows_sys::Win32::Storage::FileSystem::{
-        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
-        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, READ_CONTROL, WRITE_DAC,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_LIST_DIRECTORY,
+        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, READ_CONTROL,
+        WRITE_DAC,
     };
 
     let mut options = OpenOptions::new();
     options
-        .access_mode(READ_CONTROL | WRITE_DAC | FILE_READ_ATTRIBUTES)
+        .access_mode(READ_CONTROL | WRITE_DAC | FILE_READ_ATTRIBUTES | FILE_LIST_DIRECTORY)
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
-    let file = options.open(path)?;
-    secure_windows_file(&file, directory)
+    options.open(path)
 }
 
 #[cfg(windows)]
@@ -220,7 +305,14 @@ pub(crate) fn secure_opened_file(file: &File) -> io::Result<()> {
 }
 
 #[cfg(windows)]
-fn secure_windows_file(file: &File, directory: bool) -> io::Result<()> {
+fn validate_opened_path(file: &File, directory: bool) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+
+    validate_windows_handle(file.as_raw_handle().cast(), directory).map(|_| ())
+}
+
+#[cfg(windows)]
+fn secure_opened_path(file: &File, directory: bool) -> io::Result<()> {
     use std::os::windows::io::AsRawHandle;
 
     secure_windows_handle(file.as_raw_handle().cast(), directory)
@@ -242,16 +334,76 @@ fn secure_windows_handle(
     handle: windows_sys::Win32::Foundation::HANDLE,
     directory: bool,
 ) -> io::Result<()> {
-    use std::mem::{size_of, zeroed};
+    use std::mem::size_of;
     use std::ptr::{null, null_mut};
     use windows_sys::Win32::Foundation::GENERIC_ALL;
-    use windows_sys::Win32::Security::Authorization::{
-        GetSecurityInfo, SE_FILE_OBJECT, SetSecurityInfo,
-    };
+    use windows_sys::Win32::Security::Authorization::{SE_FILE_OBJECT, SetSecurityInfo};
     use windows_sys::Win32::Security::{
         ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, AddAccessAllowedAceEx, CONTAINER_INHERIT_ACE,
-        DACL_SECURITY_INFORMATION, GetLengthSid, InitializeAcl, OBJECT_INHERIT_ACE,
-        OWNER_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSID,
+        DACL_SECURITY_INFORMATION, InitializeAcl, OBJECT_INHERIT_ACE,
+        PROTECTED_DACL_SECURITY_INFORMATION,
+    };
+
+    let current_sid = validate_windows_handle(handle, directory)?;
+
+    let acl_length =
+        size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + current_sid.len();
+    let acl_length =
+        u32::try_from(acl_length).map_err(|_| io::Error::other("state ACL is too large"))?;
+    let word_count = (acl_length as usize).div_ceil(size_of::<u32>());
+    let mut acl_buffer = vec![0_u32; word_count];
+    let acl = acl_buffer.as_mut_ptr().cast::<ACL>();
+    // SAFETY: acl_buffer is aligned and writable for at least acl_length bytes.
+    if unsafe { InitializeAcl(acl, acl_length, ACL_REVISION) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let inheritance = if directory {
+        OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE
+    } else {
+        0
+    };
+    // SAFETY: the ACL is initialized and current_sid remains live during the call.
+    if unsafe {
+        AddAccessAllowedAceEx(
+            acl,
+            ACL_REVISION,
+            inheritance,
+            GENERIC_ALL,
+            current_sid.as_ptr().cast_mut().cast(),
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: handle names the validated object; the ACL remains live during the call.
+    let status = unsafe {
+        SetSecurityInfo(
+            handle,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            null_mut(),
+            null_mut(),
+            acl,
+            null(),
+        )
+    };
+    if status == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::from_raw_os_error(status as i32))
+    }
+}
+
+#[cfg(windows)]
+fn validate_windows_handle(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    directory: bool,
+) -> io::Result<Vec<u8>> {
+    use std::mem::{size_of, zeroed};
+    use std::ptr::null_mut;
+    use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT};
+    use windows_sys::Win32::Security::{
+        CheckTokenMembership, GetLengthSid, OWNER_SECURITY_INFORMATION, PSID,
     };
     use windows_sys::Win32::Storage::FileSystem::{
         FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO,
@@ -310,59 +462,29 @@ fn secure_windows_handle(
         // SAFETY: both SIDs were returned by Windows and are live for this comparison.
         && unsafe { std::slice::from_raw_parts(owner.cast::<u8>(), owner_length) }
             == current_sid.as_slice();
-    if !owner_matches {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "state path is not owned by the current user",
-        ));
-    }
-
-    let acl_length =
-        size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + current_sid.len();
-    let acl_length =
-        u32::try_from(acl_length).map_err(|_| io::Error::other("state ACL is too large"))?;
-    let word_count = (acl_length as usize).div_ceil(size_of::<u32>());
-    let mut acl_buffer = vec![0_u32; word_count];
-    let acl = acl_buffer.as_mut_ptr().cast::<ACL>();
-    // SAFETY: acl_buffer is aligned and writable for at least acl_length bytes.
-    if unsafe { InitializeAcl(acl, acl_length, ACL_REVISION) } == 0 {
-        return Err(io::Error::last_os_error());
-    }
-    let inheritance = if directory {
-        OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE
+    // Windows may assign a newly created object to an enabled owner group such
+    // as Administrators rather than directly to the token's user SID. Treat
+    // that as locally controlled, while rejecting owners outside the effective
+    // token. The replacement DACL below still grants access only to the user.
+    let owner_is_controlled = if owner_matches {
+        true
     } else {
-        0
-    };
-    // SAFETY: the ACL is initialized and current_sid remains live during the call.
-    if unsafe {
-        AddAccessAllowedAceEx(
-            acl,
-            ACL_REVISION,
-            inheritance,
-            GENERIC_ALL,
-            current_sid.as_ptr().cast_mut().cast(),
-        )
-    } == 0
-    {
-        return Err(io::Error::last_os_error());
-    }
-    // SAFETY: handle names the validated object; the ACL remains live during the call.
-    let status = unsafe {
-        SetSecurityInfo(
-            handle,
-            SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
-            null_mut(),
-            null_mut(),
-            acl,
-            null(),
-        )
+        let mut is_member = 0;
+        // SAFETY: owner belongs to the live descriptor and a null token asks
+        // Windows to check the effective token for the current thread/process.
+        if unsafe { CheckTokenMembership(null_mut(), owner, &mut is_member) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        is_member != 0
     };
     drop(descriptor);
-    if status == 0 {
-        Ok(())
+    if !owner_is_controlled {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "state path is not controlled by the current user",
+        ))
     } else {
-        Err(io::Error::from_raw_os_error(status as i32))
+        Ok(current_sid)
     }
 }
 
@@ -434,6 +556,22 @@ fn secure_path(path: &Path, _directory: bool) -> io::Result<()> {
 
 #[cfg(not(any(unix, windows)))]
 pub(crate) fn secure_opened_file(_file: &File) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "private state permissions are unsupported on this platform",
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn validate_opened_path(_file: &File, _directory: bool) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "private state permissions are unsupported on this platform",
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn secure_opened_path(_file: &File, _directory: bool) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "private state permissions are unsupported on this platform",
@@ -533,6 +671,8 @@ mod tests {
         }
 
         secure_state_layout(&state).unwrap();
+        secure_control_directory(&state.join("receipts"), |_, _| Ok(true)).unwrap();
+        secure_control_directory(&state.join("source-confirmation"), |_, _| Ok(true)).unwrap();
 
         for name in [
             "receipts",
@@ -588,7 +728,7 @@ mod tests {
         fs::set_permissions(&outside, fs::Permissions::from_mode(0o644)).unwrap();
         symlink(&outside, receipts.join("receipt.json")).unwrap();
 
-        secure_state_layout(&state).unwrap_err();
+        secure_control_directory(&receipts, |_, _| Ok(true)).unwrap_err();
 
         assert_eq!(
             fs::metadata(&outside).unwrap().permissions().mode() & 0o777,

--- a/src/state_security.rs
+++ b/src/state_security.rs
@@ -4,7 +4,7 @@
 //! original metadata must survive Undo. Control files are additionally narrowed
 //! to owner-only access so copied or inspected artifacts keep the same boundary.
 
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::Path;
 
@@ -31,11 +31,23 @@ pub(crate) fn private_file_options() -> OpenOptions {
     use std::os::unix::fs::OpenOptionsExt;
 
     let mut options = OpenOptions::new();
-    options.mode(STATE_FILE_MODE);
+    options
+        .mode(STATE_FILE_MODE)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
     options
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+pub(crate) fn private_file_options() -> OpenOptions {
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT;
+
+    let mut options = OpenOptions::new();
+    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    options
+}
+
+#[cfg(not(any(unix, windows)))]
 pub(crate) fn private_file_options() -> OpenOptions {
     OpenOptions::new()
 }
@@ -55,20 +67,26 @@ pub(crate) fn secure_optional_file(path: &Path) -> io::Result<()> {
     }
 }
 
+pub(crate) fn prepare_private_file(path: &Path) -> io::Result<()> {
+    let mut options = private_file_options();
+    match options.read(true).write(true).create_new(true).open(path) {
+        Ok(file) => secure_opened_file(&file),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => secure_file(path),
+        Err(error) => Err(error),
+    }
+}
+
 pub(crate) fn secure_state_layout(state_dir: &Path) -> io::Result<()> {
     prepare_state_root(state_dir)?;
-    for name in [
-        "receipts",
-        "recovery",
-        "source-confirmation",
-        "plan-backups",
-        "library",
-    ] {
+    for name in ["recovery", "plan-backups", "library"] {
         let path = state_dir.join(name);
         match secure_directory(&path) {
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             result => result?,
         }
+    }
+    for name in ["receipts", "source-confirmation"] {
+        secure_control_directory(&state_dir.join(name))?;
     }
     for name in [
         "skillroster.db",
@@ -77,6 +95,18 @@ pub(crate) fn secure_state_layout(state_dir: &Path) -> io::Result<()> {
         "write.lock",
     ] {
         secure_optional_file(&state_dir.join(name))?;
+    }
+    Ok(())
+}
+
+fn secure_control_directory(path: &Path) -> io::Result<()> {
+    match secure_directory(path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        result => result?,
+    }
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        secure_file(&entry.path())?;
     }
     Ok(())
 }
@@ -97,7 +127,7 @@ fn create_private_dir_all(path: &Path) -> io::Result<()> {
 
 #[cfg(unix)]
 fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::os::unix::fs::OpenOptionsExt;
 
     let mut options = OpenOptions::new();
     options
@@ -107,6 +137,18 @@ fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
         options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_DIRECTORY);
     }
     let file = options.open(path)?;
+    secure_opened_path(&file, directory)
+}
+
+#[cfg(unix)]
+pub(crate) fn secure_opened_file(file: &File) -> io::Result<()> {
+    secure_opened_path(file, false)
+}
+
+#[cfg(unix)]
+fn secure_opened_path(file: &File, directory: bool) -> io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
     let metadata = file.metadata()?;
     let valid_kind = if directory {
         metadata.is_dir()
@@ -116,7 +158,7 @@ fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
     if !valid_kind {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
-            format!("state path has an unsafe file type: {}", path.display()),
+            "opened state path has an unsafe file type",
         ));
     }
     // SAFETY: geteuid has no preconditions and does not retain borrowed data.
@@ -124,10 +166,7 @@ fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
     if metadata.uid() != current_uid {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
-            format!(
-                "state path is not owned by the current user: {}",
-                path.display()
-            ),
+            "opened state path is not owned by the current user",
         ));
     }
     let mode = if directory {
@@ -140,50 +179,220 @@ fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
 
 #[cfg(windows)]
 fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
-    use std::ffi::c_void;
-    use std::mem::size_of;
-    use std::os::windows::ffi::OsStrExt;
-    use std::ptr::{null, null_mut};
-    use windows_sys::Win32::Foundation::{
-        CloseHandle, ERROR_INSUFFICIENT_BUFFER, GENERIC_ALL, GetLastError, HANDLE,
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, READ_CONTROL, WRITE_DAC,
     };
-    use windows_sys::Win32::Security::Authorization::{SE_FILE_OBJECT, SetNamedSecurityInfoW};
+
+    let mut options = OpenOptions::new();
+    options
+        .access_mode(READ_CONTROL | WRITE_DAC | FILE_READ_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+    let file = options.open(path)?;
+    secure_windows_file(&file, directory)
+}
+
+#[cfg(windows)]
+pub(crate) fn secure_opened_file(file: &File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, READ_CONTROL, ReOpenFile, WRITE_DAC,
+    };
+
+    // SAFETY: the original handle remains live; a successful ReOpenFile result is newly owned.
+    let handle = unsafe {
+        ReOpenFile(
+            file.as_raw_handle().cast(),
+            READ_CONTROL | WRITE_DAC | FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    let handle = WindowsHandle(handle as HANDLE);
+    secure_windows_handle(handle.0, false)
+}
+
+#[cfg(windows)]
+fn secure_windows_file(file: &File, directory: bool) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+
+    secure_windows_handle(file.as_raw_handle().cast(), directory)
+}
+
+#[cfg(windows)]
+struct WindowsHandle(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for WindowsHandle {
+    fn drop(&mut self) {
+        // SAFETY: this wrapper owns a handle returned by OpenProcessToken or ReOpenFile.
+        unsafe { windows_sys::Win32::Foundation::CloseHandle(self.0) };
+    }
+}
+
+#[cfg(windows)]
+fn secure_windows_handle(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    directory: bool,
+) -> io::Result<()> {
+    use std::mem::{size_of, zeroed};
+    use std::ptr::{null, null_mut};
+    use windows_sys::Win32::Foundation::GENERIC_ALL;
+    use windows_sys::Win32::Security::Authorization::{
+        GetSecurityInfo, SE_FILE_OBJECT, SetSecurityInfo,
+    };
     use windows_sys::Win32::Security::{
         ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, AddAccessAllowedAceEx, CONTAINER_INHERIT_ACE,
-        DACL_SECURITY_INFORMATION, GetLengthSid, GetTokenInformation, InitializeAcl,
-        OBJECT_INHERIT_ACE, PROTECTED_DACL_SECURITY_INFORMATION, PSID, TOKEN_QUERY, TOKEN_USER,
-        TokenUser,
+        DACL_SECURITY_INFORMATION, GetLengthSid, InitializeAcl, OBJECT_INHERIT_ACE,
+        OWNER_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSID,
     };
-    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO,
+        FileAttributeTagInfo, GetFileInformationByHandleEx,
+    };
 
-    struct Handle(HANDLE);
-    impl Drop for Handle {
-        fn drop(&mut self) {
-            // SAFETY: the handle was returned by OpenProcessToken and is owned here.
-            unsafe { CloseHandle(self.0) };
-        }
+    // SAFETY: info is valid writable storage for the requested information class.
+    let mut info: FILE_ATTRIBUTE_TAG_INFO = unsafe { zeroed() };
+    if unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileAttributeTagInfo,
+            (&mut info as *mut FILE_ATTRIBUTE_TAG_INFO).cast(),
+            size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
     }
-
-    let metadata = fs::symlink_metadata(path)?;
-    let valid_kind = !metadata.file_type().is_symlink()
-        && if directory {
-            metadata.is_dir()
-        } else {
-            metadata.is_file()
-        };
-    if !valid_kind {
+    if info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
-            format!("state path has an unsafe file type: {}", path.display()),
+            "state path is a reparse point",
         ));
     }
+    if (info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY != 0) != directory {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "opened state path has an unsafe file type",
+        ));
+    }
+
+    let mut owner: PSID = null_mut();
+    let mut descriptor = null_mut();
+    // SAFETY: output pointers are valid; the returned descriptor is released below.
+    let status = unsafe {
+        GetSecurityInfo(
+            handle,
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION,
+            &mut owner,
+            null_mut(),
+            null_mut(),
+            null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+    let descriptor = LocalSecurityDescriptor(descriptor);
+    let current_sid = current_user_sid()?;
+    // SAFETY: owner belongs to the live security descriptor returned by GetSecurityInfo.
+    let owner_length = unsafe { GetLengthSid(owner) } as usize;
+    let owner_matches = owner_length == current_sid.len()
+        // SAFETY: both SIDs were returned by Windows and are live for this comparison.
+        && unsafe { std::slice::from_raw_parts(owner.cast::<u8>(), owner_length) }
+            == current_sid.as_slice();
+    if !owner_matches {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "state path is not owned by the current user",
+        ));
+    }
+
+    let acl_length =
+        size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + current_sid.len();
+    let acl_length =
+        u32::try_from(acl_length).map_err(|_| io::Error::other("state ACL is too large"))?;
+    let word_count = (acl_length as usize).div_ceil(size_of::<u32>());
+    let mut acl_buffer = vec![0_u32; word_count];
+    let acl = acl_buffer.as_mut_ptr().cast::<ACL>();
+    // SAFETY: acl_buffer is aligned and writable for at least acl_length bytes.
+    if unsafe { InitializeAcl(acl, acl_length, ACL_REVISION) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let inheritance = if directory {
+        OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE
+    } else {
+        0
+    };
+    // SAFETY: the ACL is initialized and current_sid remains live during the call.
+    if unsafe {
+        AddAccessAllowedAceEx(
+            acl,
+            ACL_REVISION,
+            inheritance,
+            GENERIC_ALL,
+            current_sid.as_ptr().cast_mut().cast(),
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: handle names the validated object; the ACL remains live during the call.
+    let status = unsafe {
+        SetSecurityInfo(
+            handle,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            null_mut(),
+            null_mut(),
+            acl,
+            null(),
+        )
+    };
+    drop(descriptor);
+    if status == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::from_raw_os_error(status as i32))
+    }
+}
+
+#[cfg(windows)]
+struct LocalSecurityDescriptor(windows_sys::Win32::Security::PSECURITY_DESCRIPTOR);
+
+#[cfg(windows)]
+impl Drop for LocalSecurityDescriptor {
+    fn drop(&mut self) {
+        // SAFETY: GetSecurityInfo allocated this descriptor with LocalAlloc.
+        unsafe { windows_sys::Win32::Foundation::LocalFree(self.0.cast()) };
+    }
+}
+
+#[cfg(windows)]
+fn current_user_sid() -> io::Result<Vec<u8>> {
+    use std::ffi::c_void;
+    use std::ptr::null_mut;
+    use windows_sys::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, GetLastError, HANDLE};
+    use windows_sys::Win32::Security::{
+        GetLengthSid, GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
     let mut token: HANDLE = null_mut();
     // SAFETY: token points to writable storage and GetCurrentProcess returns a pseudo-handle.
     if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
         return Err(io::Error::last_os_error());
     }
-    let token = Handle(token);
+    let token = WindowsHandle(token);
     let mut token_bytes = 0;
     // SAFETY: the null-buffer call obtains the required size.
     let first = unsafe { GetTokenInformation(token.0, TokenUser, null_mut(), 0, &mut token_bytes) };
@@ -191,7 +400,7 @@ fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
         return Err(io::Error::last_os_error());
     }
     let mut token_buffer = vec![0_u8; token_bytes as usize];
-    // SAFETY: token_buffer is writable for token_bytes and remains alive while its SID is used.
+    // SAFETY: token_buffer is writable for token_bytes.
     if unsafe {
         GetTokenInformation(
             token.0,
@@ -206,47 +415,10 @@ fn secure_path(path: &Path, directory: bool) -> io::Result<()> {
     }
     // SAFETY: a successful TokenUser query starts with a TOKEN_USER value.
     let user = unsafe { &*token_buffer.as_ptr().cast::<TOKEN_USER>() };
-    let sid: PSID = user.User.Sid;
-    // SAFETY: sid belongs to the validated TOKEN_USER buffer.
-    let sid_length = unsafe { GetLengthSid(sid) } as usize;
-    let acl_length =
-        size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + sid_length;
-    let acl_length =
-        u32::try_from(acl_length).map_err(|_| io::Error::other("state ACL is too large"))?;
-    let mut acl_buffer = vec![0_u8; acl_length as usize];
-    let acl = acl_buffer.as_mut_ptr().cast::<ACL>();
-    // SAFETY: acl_buffer is writable for acl_length bytes.
-    if unsafe { InitializeAcl(acl, acl_length, ACL_REVISION) } == 0 {
-        return Err(io::Error::last_os_error());
-    }
-    let inheritance = if directory {
-        OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE
-    } else {
-        0
-    };
-    // SAFETY: acl was initialized and sid remains valid for the duration of this call.
-    if unsafe { AddAccessAllowedAceEx(acl, ACL_REVISION, inheritance, GENERIC_ALL, sid) } == 0 {
-        return Err(io::Error::last_os_error());
-    }
-    let mut wide_path = path.as_os_str().encode_wide().collect::<Vec<_>>();
-    wide_path.push(0);
-    // SAFETY: wide_path is NUL-terminated; acl remains valid for the call.
-    let status = unsafe {
-        SetNamedSecurityInfoW(
-            wide_path.as_mut_ptr(),
-            SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
-            null_mut(),
-            null_mut(),
-            acl,
-            null(),
-        )
-    };
-    if status == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::from_raw_os_error(status as i32))
-    }
+    // SAFETY: the SID belongs to the validated TOKEN_USER buffer.
+    let sid_length = unsafe { GetLengthSid(user.User.Sid) } as usize;
+    // SAFETY: the SID is live and valid for sid_length bytes.
+    Ok(unsafe { std::slice::from_raw_parts(user.User.Sid.cast::<u8>(), sid_length) }.to_vec())
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -257,6 +429,14 @@ fn secure_path(path: &Path, _directory: bool) -> io::Result<()> {
             "private state permissions are unsupported on this platform: {}",
             path.display()
         ),
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn secure_opened_file(_file: &File) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "private state permissions are unsupported on this platform",
     ))
 }
 
@@ -343,6 +523,14 @@ mod tests {
             fs::write(&path, "fixture").unwrap();
             fs::set_permissions(path, fs::Permissions::from_mode(0o644)).unwrap();
         }
+        for (directory, file) in [
+            ("receipts", "receipt.json"),
+            ("source-confirmation", "detail.json"),
+        ] {
+            let path = state.join(directory).join(file);
+            fs::write(&path, "fixture").unwrap();
+            fs::set_permissions(path, fs::Permissions::from_mode(0o644)).unwrap();
+        }
 
         secure_state_layout(&state).unwrap();
 
@@ -371,5 +559,54 @@ mod tests {
                 "unexpected file permissions for {name}"
             );
         }
+        for (directory, file) in [
+            ("receipts", "receipt.json"),
+            ("source-confirmation", "detail.json"),
+        ] {
+            assert_eq!(
+                fs::metadata(state.join(directory).join(file))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600,
+                "unexpected permissions for {directory}/{file}"
+            );
+        }
+    }
+
+    #[test]
+    fn refuses_control_file_symlinks_without_touching_the_target() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let temp = TempDir::new().unwrap();
+        let state = temp.path().join("state");
+        let receipts = state.join("receipts");
+        fs::create_dir_all(&receipts).unwrap();
+        let outside = temp.path().join("outside.json");
+        fs::write(&outside, "outside").unwrap();
+        fs::set_permissions(&outside, fs::Permissions::from_mode(0o644)).unwrap();
+        symlink(&outside, receipts.join("receipt.json")).unwrap();
+
+        secure_state_layout(&state).unwrap_err();
+
+        assert_eq!(
+            fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+        assert_eq!(fs::read_to_string(outside).unwrap(), "outside");
+    }
+
+    #[test]
+    fn private_file_preparation_refuses_a_symlink_without_creating_its_target() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("outside.db");
+        let link = temp.path().join("skillroster.db");
+        symlink(&target, &link).unwrap();
+
+        assert!(prepare_private_file(&link).is_err());
+        assert!(!target.exists());
     }
 }

--- a/src/state_security.rs
+++ b/src/state_security.rs
@@ -148,14 +148,100 @@ pub(crate) fn secure_control_directory(
                 format!("unrecognized control file: {}", name.to_string_lossy()),
             ));
         }
-        owned_files.push(file);
+        owned_files.push((name, opened_path_identity(&file)?));
     }
 
     secure_opened_path(&directory, true)?;
-    for file in &owned_files {
-        secure_opened_file(file)?;
+    for (name, expected_identity) in owned_files {
+        let mut options = CapOpenOptions::new();
+        options.read(true)._cap_fs_ext_follow(FollowSymlinks::No);
+        let mut file = dir.open_with(&name, &options)?.into_std();
+        validate_opened_path(&file, false)?;
+        if opened_path_identity(&file)? != expected_identity {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "control file identity changed during validation: {}",
+                    name.to_string_lossy()
+                ),
+            ));
+        }
+        if !validate(&name, &mut file)? {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "control file changed during validation: {}",
+                    name.to_string_lossy()
+                ),
+            ));
+        }
+        secure_opened_file(&file)?;
     }
     Ok(())
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OpenedPathIdentity {
+    device: u64,
+    inode: u64,
+}
+
+#[cfg(unix)]
+fn opened_path_identity(file: &File) -> io::Result<OpenedPathIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = file.metadata()?;
+    Ok(OpenedPathIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+#[cfg(windows)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OpenedPathIdentity {
+    volume: u64,
+    file_id: [u8; 16],
+}
+
+#[cfg(windows)]
+fn opened_path_identity(file: &File) -> io::Result<OpenedPathIdentity> {
+    use std::mem::{size_of, zeroed};
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ID_INFO, FileIdInfo, GetFileInformationByHandleEx,
+    };
+
+    // SAFETY: info is valid writable storage for the requested information class.
+    let mut info: FILE_ID_INFO = unsafe { zeroed() };
+    if unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle().cast(),
+            FileIdInfo,
+            (&mut info as *mut FILE_ID_INFO).cast(),
+            size_of::<FILE_ID_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(OpenedPathIdentity {
+        volume: info.VolumeSerialNumber,
+        file_id: info.FileId.Identifier,
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OpenedPathIdentity;
+
+#[cfg(not(any(unix, windows)))]
+fn opened_path_identity(_file: &File) -> io::Result<OpenedPathIdentity> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "state file identity is unsupported on this platform",
+    ))
 }
 
 #[cfg(unix)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -196,6 +196,50 @@ fn startup_refuses_database_and_lock_symlinks_before_opening_them() {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn startup_leaves_unrecognized_control_files_untouched() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let cases = [
+        ("receipts", "notes.txt", "user note"),
+        (
+            "source-confirmation",
+            "01ARZ3NDEKTSV4RRFFQ69G5FAV.json",
+            "{}",
+        ),
+    ];
+    for (directory, name, content) in cases {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let state = temp.path().join("state");
+        let control = state.join(directory);
+        fs::create_dir_all(&control).unwrap();
+        let unknown = control.join(name);
+        fs::write(&unknown, content).unwrap();
+        fs::set_permissions(&unknown, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let output = run(
+            &[
+                "--home",
+                home.to_str().unwrap(),
+                "--state-dir",
+                state.to_str().unwrap(),
+                "--json",
+                "status",
+            ],
+            None,
+        );
+
+        assert!(!output.status.success());
+        assert_eq!(fs::read_to_string(&unknown).unwrap(), content);
+        assert_eq!(
+            fs::metadata(&unknown).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+    }
+}
+
 fn context_action_argv(home: &Path, state: &Path, tail: &[&str]) -> Value {
     let mut argv = vec![
         "skillroster".to_owned(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4280,6 +4280,44 @@ fn explicit_roots_preserve_all_eight_agent_identities() {
 }
 
 #[test]
+fn source_confirmation_crash_temp_does_not_block_lifecycle_cleanup() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let details = state.join("source-confirmation");
+    fs::create_dir_all(&details).unwrap();
+    let interrupted = details.join(format!(".{}.tmp", ulid::Ulid::new()));
+    fs::write(&interrupted, b"incomplete").unwrap();
+
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(
+        status["result"]["retention"]["source_confirmation_details"]["count"],
+        0
+    );
+    assert!(interrupted.is_file());
+
+    let purged = json_output(&run(
+        &[
+            &common[..],
+            &["lifecycle", "purge", "--source-confirmation"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(purged["result"]["removed_source_confirmation_details"], 1);
+    assert!(!details.exists());
+}
+
+#[test]
 fn lifecycle_exclusion_and_database_delete_preserve_user_files() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,6 +11,9 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
 fn run(args: &[&str], stdin: Option<&str>) -> std::process::Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_skillroster"));
     command.args(args);
@@ -33,6 +36,21 @@ fn run(args: &[&str], stdin: Option<&str>) -> std::process::Output {
     child.wait_with_output().unwrap()
 }
 
+#[cfg(unix)]
+fn run_with_umask(args: &[&str], umask: libc::mode_t) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_skillroster"));
+    command.args(args);
+    // SAFETY: this callback runs after fork and before exec, calls only the
+    // async-signal-safe umask syscall, and captures a Copy integer.
+    unsafe {
+        command.pre_exec(move || {
+            libc::umask(umask);
+            Ok(())
+        });
+    }
+    command.output().unwrap()
+}
+
 fn json_output(output: &std::process::Output) -> Value {
     assert!(
         output.status.success(),
@@ -47,6 +65,69 @@ fn assert_setup_versions(output: &Value) {
     assert_eq!(output["result"]["cli_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(output["result"]["bootstrap_content_version"], "1.8.28");
     assert_eq!(output["result"]["bootstrap_version"], "1.8.28");
+}
+
+#[cfg(unix)]
+#[test]
+fn local_state_is_private_even_with_a_permissive_umask() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let args = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+        "status",
+    ];
+
+    json_output(&run_with_umask(&args, 0));
+
+    assert_eq!(
+        fs::metadata(&state).unwrap().permissions().mode() & 0o777,
+        0o700
+    );
+    for name in ["skillroster.db", "write.lock"] {
+        assert_eq!(
+            fs::metadata(state.join(name)).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "unexpected permissions for {name}"
+        );
+    }
+
+    fs::set_permissions(&state, fs::Permissions::from_mode(0o755)).unwrap();
+    fs::set_permissions(
+        state.join("skillroster.db"),
+        fs::Permissions::from_mode(0o644),
+    )
+    .unwrap();
+    fs::set_permissions(state.join("write.lock"), fs::Permissions::from_mode(0o644)).unwrap();
+
+    json_output(&run(&args, None));
+
+    assert_eq!(
+        fs::metadata(&state).unwrap().permissions().mode() & 0o777,
+        0o700
+    );
+    assert_eq!(
+        fs::metadata(state.join("skillroster.db"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    assert_eq!(
+        fs::metadata(state.join("write.lock"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
 }
 
 fn context_action_argv(home: &Path, state: &Path, tail: &[&str]) -> Value {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -130,6 +130,72 @@ fn local_state_is_private_even_with_a_permissive_umask() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn lifecycle_delete_refuses_a_symlink_state_root_without_touching_its_target() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let outside = temp.path().join("outside");
+    fs::create_dir(&outside).unwrap();
+    fs::write(outside.join("sentinel"), "keep").unwrap();
+    let state = temp.path().join("state");
+    symlink(&outside, &state).unwrap();
+    let output = run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--json",
+            "lifecycle",
+            "delete",
+            "--confirm",
+            "DELETE-LOCAL-STATE",
+        ],
+        None,
+    );
+
+    assert!(!output.status.success());
+    assert_eq!(
+        fs::read_to_string(outside.join("sentinel")).unwrap(),
+        "keep"
+    );
+    assert!(!outside.join("skillroster.db").exists());
+    assert!(!outside.join("write.lock").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn startup_refuses_database_and_lock_symlinks_before_opening_them() {
+    use std::os::unix::fs::symlink;
+
+    for name in ["skillroster.db", "write.lock"] {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let state = temp.path().join("state");
+        fs::create_dir(&state).unwrap();
+        let outside = temp.path().join(format!("outside-{name}"));
+        symlink(&outside, state.join(name)).unwrap();
+
+        let output = run(
+            &[
+                "--home",
+                home.to_str().unwrap(),
+                "--state-dir",
+                state.to_str().unwrap(),
+                "--json",
+                "status",
+            ],
+            None,
+        );
+
+        assert!(!output.status.success(), "{name} symlink was accepted");
+        assert!(!outside.exists(), "{name} symlink target was created");
+    }
+}
+
 fn context_action_argv(home: &Path, state: &Path, tail: &[&str]) -> Value {
     let mut argv = vec![
         "skillroster".to_owned(),


### PR DESCRIPTION
## Problem

SkillRoster state inherited the process umask, so local inventory, usage, Plans, Receipts, and source-root permissions could be readable by other accounts on the same machine. Existing over-broad installations were not repaired.

## Solution

- centralize state permission enforcement in a focused platform module
- create and repair Unix state directories to `0700` and control files to `0600`
- use no-follow handles and current-user ownership checks before Unix permission changes
- apply a protected, inheritable current-user DACL on Windows
- secure SQLite, WAL/SHM, locks, Receipts, recovery directories, source-confirmation details, and known state roots
- fail closed when a state root is a symlink or cannot be secured
- document compatibility behavior for existing installations

Recovery objects that must preserve original metadata remain protected by the private state-root ancestor.

## Checks

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (323 tests)
- Node routing/bootstrap harness (137 tests)
- `git diff --check`
- real CLI regression under `umask=000`, plus repair of existing `0755`/`0644` state

Local verification was performed on macOS. Windows DACL behavior and the declared MSRV remain independent remote-CI gates.

Closes #234