### PR TITLE
fix: reject lossy path identity

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -72,8 +72,13 @@ discovered non-Unicode Skill directories are skipped and make that root's
 structural coverage incomplete. A Unicode Skill containing a non-Unicode
 package member remains an inventory fact with an `unreadable` fingerprint and
 cannot authorize exact load or governance. SkillRoster never hashes lossy path
-text or persists a replacement-character identity. A future raw-byte or UTF-16
-path encoding requires an explicit versioned schema migration.
+text or persists a replacement-character identity. Snapshots record typed
+`identity_path_coverage` plus an exact skipped-path count; any unverified or
+incomplete value blocks Find, Report, Plan, Apply, and other exact-identity
+decisions until a complete rescan. The `sha256-content-unicode-v2` presence
+marker prevents pre-contract Snapshots from being reused even when every
+currently visible path is Unicode. A future raw-byte or UTF-16 path encoding
+requires an explicit versioned schema migration.
 
 Scan records two deliberately separate hashes in one bounded traversal. The complete package fingerprint covers every retained package file, including `.gitignore`, and remains the only hash used for drift checks, exact load, Plan, Apply, Receipt, Undo, and recovery. The versioned routing content identity excludes only the package-root `.gitignore`; it is used for unsourced logical identity and same-name variant grouping because source-control metadata is not Agent Skills payload. `SKILL.md`, scripts, references, assets, and symlink targets remain identity-bearing. A legacy Snapshot without the current content-identity algorithm must be rescanned; the CLI never backfills or infers equality from old package fingerprints.
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -66,6 +66,15 @@ immutable payloads rather than stale projection rows.
 
 Skill-root discovery and package fingerprints carry explicit completeness facts. A configured root whose depth limit was reached remains Included but is marked discovery-incomplete, making structural coverage unreliable. Each placement fingerprint is `complete`, `bounded`, `unreadable`, or `unknown`; payloads created before this contract default to `unknown`. Only a complete package fingerprint may support an exact-duplicate Finding or any Library/Roster Plan that relies on exact content. Bounded or unreadable packages remain inventory facts and require a new complete Scan before governance. Apply repeats this check so a Ready Plan created by an older binary cannot bypass the boundary.
 
+The current Snapshot schema accepts only Unicode identity-bearing paths. A
+non-Unicode configured root fails the Scan with `non_unicode_identity_path`;
+discovered non-Unicode Skill directories are skipped and make that root's
+structural coverage incomplete. A Unicode Skill containing a non-Unicode
+package member remains an inventory fact with an `unreadable` fingerprint and
+cannot authorize exact load or governance. SkillRoster never hashes lossy path
+text or persists a replacement-character identity. A future raw-byte or UTF-16
+path encoding requires an explicit versioned schema migration.
+
 Scan records two deliberately separate hashes in one bounded traversal. The complete package fingerprint covers every retained package file, including `.gitignore`, and remains the only hash used for drift checks, exact load, Plan, Apply, Receipt, Undo, and recovery. The versioned routing content identity excludes only the package-root `.gitignore`; it is used for unsourced logical identity and same-name variant grouping because source-control metadata is not Agent Skills payload. `SKILL.md`, scripts, references, assets, and symlink targets remain identity-bearing. A legacy Snapshot without the current content-identity algorithm must be rescanned; the CLI never backfills or infers equality from old package fingerprints.
 
 One routing identity may therefore have multiple complete package fingerprints. Existing Core placements may remain unchanged, but any Roster mutation, migration, retarget, or new exposure that would require choosing one package as canonical fails closed with the affected placement IDs and fingerprint count. Routing equivalence never authorizes package consolidation or metadata loss.

--- a/src/app.rs
+++ b/src/app.rs
@@ -8135,6 +8135,7 @@ fn apply_command(store: &StateStore, id: &str) -> Result<Value> {
         }
         .into());
     }
+    require_content_identity(&scan)?;
     validate_governance_fingerprint_completeness(&prepared, &scan)?;
     validate_physical_placement_bindings(&record, &prepared, &scan)?;
     validate_roster_changes(store, &prepared, &scan)?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1340,6 +1340,9 @@ fn classify_generic_error(error: &(dyn std::error::Error + 'static)) -> (&'stati
         };
     }
     if let Some(io) = error.downcast_ref::<std::io::Error>() {
+        if scan::is_non_unicode_identity_error(io) {
+            return ("non_unicode_identity_path", false);
+        }
         return match io.kind() {
             std::io::ErrorKind::PermissionDenied => ("path_permission_denied", false),
             std::io::ErrorKind::NotFound => ("path_not_found", false),
@@ -2705,6 +2708,7 @@ const fn coverage_retry_disposition(
         | scan::SessionCoverageLimitationCode::SampledByteLimit
         | scan::SessionCoverageLimitationCode::SampledLineLimit
         | scan::SessionCoverageLimitationCode::FileByteLimit
+        | scan::SessionCoverageLimitationCode::FilePathNotUnicode
         | scan::SessionCoverageLimitationCode::JsonExtractionLimit
         | scan::SessionCoverageLimitationCode::JsonRecordLimit
         | scan::SessionCoverageLimitationCode::LineAlignmentLoss => {
@@ -10686,6 +10690,25 @@ mod recovery_tests {
         let error = ActionContext::from_cli(&cli).unwrap_err();
 
         assert!(error.to_string().contains("must be valid Unicode"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn scan_classifies_a_non_unicode_identity_path_without_lossy_text() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let mut options = ScanOptions::for_home("/tmp/skillroster-unicode-home");
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: PathBuf::from(std::ffi::OsString::from_vec(vec![b'/', 0xff])),
+        });
+        let error = scan::scan(&options).unwrap_err();
+
+        assert_eq!(
+            classify_generic_error(&error),
+            ("non_unicode_identity_path", false)
+        );
+        assert!(!error.to_string().contains('\u{fffd}'));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -713,10 +713,7 @@ pub fn error_json_with_context(
     error: &(dyn std::error::Error + 'static),
     action_context: &ActionContext,
 ) -> String {
-    if error
-        .downcast_ref::<ContentIdentityRescanRequired>()
-        .is_some()
-    {
+    if let Some(rescan) = error.downcast_ref::<ContentIdentityRescanRequired>() {
         let mut envelope = JsonEnvelope::<Value>::failure(
             command,
             ApiError {
@@ -726,7 +723,7 @@ pub fn error_json_with_context(
                 relevant_ids: Vec::new(),
                 paths: Vec::new(),
                 details: Some(json!({
-                    "reason": "legacy_snapshot_requires_rescan",
+                    "reason": rescan.reason,
                     "required_algorithm": scan::CONTENT_IDENTITY_ALGORITHM,
                     "files_changed": false,
                     "state_files_changed": false,
@@ -6135,7 +6132,7 @@ fn verified_top_skill_load(
     if !before.is_file() || !allowed_roots.iter().any(|root| before.starts_with(root)) {
         return Err(blocked(
             "entrypoint_escapes_approved_roots",
-            Some(path),
+            Some(path.clone()),
             Some(expected_entrypoint_digest),
             None,
         )
@@ -8902,7 +8899,7 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
 
     let mut root_ids = std::collections::BTreeMap::new();
     for root in &scan.roots {
-        let path = root.path.to_string_lossy().into_owned();
+        let path = scan::unicode_identity_path(&root.path)?.to_owned();
         let root_id = stable_id(
             "root",
             &format!(
@@ -8956,7 +8953,8 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
             .placements
             .iter()
             .find(|placement| placement.skill_id == skill.id)
-            .map(|placement| placement.directory.to_string_lossy().into_owned());
+            .map(|placement| scan::unicode_identity_path(&placement.directory).map(str::to_owned))
+            .transpose()?;
         let declared_revision = skill
             .metadata
             .version
@@ -9039,8 +9037,8 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
     }
 
     for placement in &scan.placements {
-        let path = placement.entrypoint.to_string_lossy().into_owned();
-        let root_path = placement.root.to_string_lossy().into_owned();
+        let path = scan::unicode_identity_path(&placement.entrypoint)?.to_owned();
+        let root_path = scan::unicode_identity_path(&placement.root)?.to_owned();
         let root_key = (placement.agent, root_path.clone());
         let root_id = root_ids
             .get(&root_key)
@@ -9068,7 +9066,8 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
             symlink_target: placement
                 .link_target
                 .as_ref()
-                .map(|target| target.to_string_lossy().into_owned()),
+                .map(|target| scan::unicode_identity_path(target).map(str::to_owned))
+                .transpose()?,
             fingerprint: placement.content_digest.clone(),
             exposed: placement.default_exposed,
         })?;
@@ -9080,7 +9079,7 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
             EvidenceQuality::Observed,
             "placement",
             placement_id.as_str(),
-            Some(path),
+            Some(path.clone()),
             Some(placement.content_digest.clone()),
             json!({
                 "skill_id": skill_id,
@@ -9106,7 +9105,7 @@ fn persist_index(store: &StateStore, scan_id: &ScanId, scan: &ScanResult) -> Res
             EvidenceQuality::Observed,
             "placement",
             placement_id.as_str(),
-            Some(placement.entrypoint.to_string_lossy().into_owned()),
+            Some(path),
             Some(placement.content_digest.clone()),
             json!({
                 "algorithm": "sha256-v1",
@@ -9619,15 +9618,22 @@ fn latest_scan(store: &StateStore) -> Result<(ScanId, ScanResult)> {
 }
 
 #[derive(Debug)]
-struct ContentIdentityRescanRequired;
+struct ContentIdentityRescanRequired {
+    reason: &'static str,
+}
 
 impl std::fmt::Display for ContentIdentityRescanRequired {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            formatter,
-            "latest Snapshot has no {} content identity; run skillroster scan",
-            scan::CONTENT_IDENTITY_ALGORITHM
-        )
+        match self.reason {
+            "non_unicode_identity_coverage_incomplete" => formatter.write_str(
+                "latest Snapshot excluded non-Unicode identity paths; resolve them and run skillroster scan",
+            ),
+            _ => write!(
+                formatter,
+                "latest Snapshot has no {} content identity; run skillroster scan",
+                scan::CONTENT_IDENTITY_ALGORITHM
+            ),
+        }
     }
 }
 
@@ -9635,7 +9641,16 @@ impl std::error::Error for ContentIdentityRescanRequired {}
 
 fn require_content_identity(scan: &ScanResult) -> Result<()> {
     if scan.content_identity_algorithm.as_deref() != Some(scan::CONTENT_IDENTITY_ALGORITHM) {
-        return Err(ContentIdentityRescanRequired.into());
+        return Err(ContentIdentityRescanRequired {
+            reason: "legacy_snapshot_requires_rescan",
+        }
+        .into());
+    }
+    if scan.identity_path_coverage != scan::IdentityPathCoverage::Complete {
+        return Err(ContentIdentityRescanRequired {
+            reason: "non_unicode_identity_coverage_incomplete",
+        }
+        .into());
     }
     Ok(())
 }
@@ -9721,19 +9736,16 @@ fn plan_record(
         .operations
         .iter()
         .enumerate()
-        .map(|(position, operation)| PlanOperation {
-            id: OperationId::new(),
-            position: position as u32,
-            target_path: operation.target().to_string_lossy().into_owned(),
-            expected_fingerprint: Some(expected_fingerprint(operation).into()),
-            action: match operation {
+        .map(|(position, operation)| -> Result<PlanOperation> {
+            let target_path = scan::unicode_identity_path(operation.target())?.to_owned();
+            let action = match operation {
                 Operation::CreateDirectory { .. } => OperationAction::CreateDirectory,
                 Operation::CreateSymlink {
                     source,
                     expected_source_fingerprint,
                     ..
                 } => OperationAction::CreateSymlink {
-                    source: source.to_string_lossy().into_owned(),
+                    source: scan::unicode_identity_path(source)?.to_owned(),
                     expected_source_fingerprint: expected_source_fingerprint.clone(),
                 },
                 Operation::WriteFile { content, .. } => OperationAction::WriteFile {
@@ -9744,14 +9756,21 @@ fn plan_record(
                 },
                 Operation::RemoveSymlink { .. } => OperationAction::RemoveSymlink,
                 Operation::Copy { source, .. } => OperationAction::Copy {
-                    source: source.to_string_lossy().into_owned(),
+                    source: scan::unicode_identity_path(source)?.to_owned(),
                 },
                 Operation::MoveRecoverable { source, .. } => OperationAction::MoveRecoverable {
-                    source: source.to_string_lossy().into_owned(),
+                    source: scan::unicode_identity_path(source)?.to_owned(),
                 },
-            },
+            };
+            Ok(PlanOperation {
+                id: OperationId::new(),
+                position: position as u32,
+                target_path,
+                expected_fingerprint: Some(expected_fingerprint(operation).into()),
+                action,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
     Ok(PlanRecord {
         id: PlanId::parse(prepared.id.clone())?,
         scan_id: ScanId::parse(prepared.scan_id.clone())?,
@@ -10709,6 +10728,58 @@ mod recovery_tests {
             ("non_unicode_identity_path", false)
         );
         assert!(!error.to_string().contains('\u{fffd}'));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn non_unicode_skill_paths_never_reach_sqlite_identity_rows() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("skills");
+        let valid = root.join("valid");
+        std::fs::create_dir_all(&valid).unwrap();
+        std::fs::write(valid.join("SKILL.md"), "---\nname: valid\n---\n").unwrap();
+        for bytes in [vec![0x80], vec![0x81]] {
+            let directory = root.join(OsString::from_vec(bytes));
+            std::fs::create_dir(&directory).unwrap();
+            std::fs::write(directory.join("SKILL.md"), "---\nname: hidden\n---\n").unwrap();
+        }
+        let mut options = ScanOptions::for_home(temp.path().join("home"));
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: root,
+        });
+        options.include_session_evidence = false;
+        let result = scan::scan(&options).unwrap();
+        assert_eq!(result.placements.len(), 1);
+
+        let database_path = temp.path().join("state/skillroster.db");
+        let store = StateStore::open(&database_path).unwrap();
+        let scan_id = ScanId::new();
+        store
+            .save_scan(&ScanRun {
+                id: scan_id.clone(),
+                started_at: 1,
+                completed_at: Some(2),
+                status: ScanStatus::Completed,
+                coverage_notes: Vec::new(),
+            })
+            .unwrap();
+        persist_index(&store, &scan_id, &result).unwrap();
+
+        let database = rusqlite::Connection::open(database_path).unwrap();
+        let (count, path): (u64, String) = database
+            .query_row(
+                "SELECT COUNT(*), MIN(path) FROM placements WHERE scan_id = ?1",
+                [scan_id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+        assert!(path.ends_with("/valid/SKILL.md"));
+        assert!(!path.contains('\u{fffd}'));
     }
 
     #[test]

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -16,7 +16,7 @@ use std::time::UNIX_EPOCH;
 
 const MAX_SKILL_FILE_BYTES: u64 = 2 * 1024 * 1024;
 const MAX_SKILL_PACKAGE_BYTES: u64 = 16 * 1024 * 1024;
-pub const CONTENT_IDENTITY_ALGORITHM: &str = "sha256-content-v1";
+pub const CONTENT_IDENTITY_ALGORITHM: &str = "sha256-content-unicode-v2";
 const MAX_REMOTE_PLUGIN_INSTALL_BYTES: u64 = 16 * 1024;
 const MAX_SESSION_DISCOVERY_FILES_PER_ROOT: usize = 10_000;
 const MAX_SESSION_FILES_PER_ROOT: usize = 250;
@@ -453,6 +453,13 @@ pub struct ScanResult {
     /// legacy Snapshot must be rescanned before identity grouping.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_identity_algorithm: Option<String>,
+    /// Whether every identity-bearing path observed by this Snapshot was
+    /// representable without lossy conversion. Legacy payloads are unverified.
+    #[serde(default)]
+    pub identity_path_coverage: IdentityPathCoverage,
+    /// Exact number of non-Unicode paths excluded from identity-bearing facts.
+    #[serde(default)]
+    pub non_unicode_identity_paths_skipped: u64,
     /// Durable source-root read permissions frozen before this Scan. Drifted
     /// permissions remain typed facts but are excluded from approved roots.
     #[serde(default)]
@@ -461,6 +468,15 @@ pub struct ScanResult {
     /// drift, even if a later path check appears active again.
     #[serde(default)]
     pub durable_read_drifted_permission_ids: BTreeSet<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityPathCoverage {
+    #[default]
+    Unverified,
+    Complete,
+    Incomplete,
 }
 
 #[derive(Clone, Debug)]
@@ -510,17 +526,19 @@ struct DiscoveryState {
 #[derive(Clone, Copy, Default)]
 struct SkillDiscoveryOutcome {
     depth_bounded: bool,
-    non_unicode_skipped: bool,
+    non_unicode_skipped: u64,
 }
 
 impl SkillDiscoveryOutcome {
     fn merge(&mut self, other: Self) {
         self.depth_bounded |= other.depth_bounded;
-        self.non_unicode_skipped |= other.non_unicode_skipped;
+        self.non_unicode_skipped = self
+            .non_unicode_skipped
+            .saturating_add(other.non_unicode_skipped);
     }
 
     fn is_complete(self) -> bool {
-        !self.depth_bounded && !self.non_unicode_skipped
+        !self.depth_bounded && self.non_unicode_skipped == 0
     }
 }
 
@@ -901,6 +919,7 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
     require_unicode_scan_options(options)?;
     let mut result = ScanResult {
         content_identity_algorithm: Some(CONTENT_IDENTITY_ALGORITHM.into()),
+        identity_path_coverage: IdentityPathCoverage::Complete,
         ..ScanResult::default()
     };
     let known = known_agent_roots(&options.home);
@@ -908,13 +927,13 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
     // These paths are already an explicit trust decision from the caller.
     // Inventory and link-containment decisions use the resolved physical
     // sources so an alias and its canonical path have identical semantics.
-    let confirmed_source_roots = normalized_confirmed_source_roots(&options.explicit_source_roots);
+    let confirmed_source_roots = normalized_confirmed_source_roots(&options.explicit_source_roots)?;
     let mut shared_roots = vec![
         options.home.join(".agents_skills"),
         options.home.join(".skillroster/library"),
     ];
     shared_roots.extend(options.managed_source_roots.iter().cloned());
-    let shared_roots = normalized_confirmed_source_roots(&shared_roots);
+    let shared_roots = normalized_confirmed_source_roots(&shared_roots)?;
     let approved_roots = known
         .iter()
         .flat_map(|roots| roots.skill_roots.iter().cloned())
@@ -929,7 +948,7 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
         .chain(options.explicit_source_roots.iter().cloned())
         .chain(confirmed_source_roots.iter().cloned())
         .collect::<Vec<_>>();
-    let approved_roots = normalized_confirmed_source_roots(&approved_roots);
+    let approved_roots = normalized_confirmed_source_roots(&approved_roots)?;
     // Durable paths were already canonicalized and identity-frozen by the
     // caller. Never canonicalize them again here: a post-freeze retarget must
     // not become an approved root.
@@ -1098,18 +1117,20 @@ fn require_unicode_scan_options(options: &ScanOptions) -> io::Result<()> {
     if paths.into_iter().all(|path| path.to_str().is_some()) {
         Ok(())
     } else {
-        Err(non_unicode_identity_error())
+        Err(non_unicode_identity_error(1))
     }
 }
 
-fn normalized_confirmed_source_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
-    let mut normalized = roots
-        .iter()
-        .map(|root| fs::canonicalize(root).unwrap_or_else(|_| root.clone()))
-        .collect::<Vec<_>>();
+fn normalized_confirmed_source_roots(roots: &[PathBuf]) -> io::Result<Vec<PathBuf>> {
+    let mut normalized = Vec::with_capacity(roots.len());
+    for root in roots {
+        let root = fs::canonicalize(root).unwrap_or_else(|_| root.clone());
+        unicode_identity_path(&root)?;
+        normalized.push(root);
+    }
     normalized.sort();
     normalized.dedup();
-    normalized
+    Ok(normalized)
 }
 
 fn observe_excluded_session_roots(
@@ -1172,11 +1193,15 @@ fn observe_skill_root(
             if outcome.depth_bounded {
                 details.push(format!("Skill discovery was bounded at depth {max_depth}"));
             }
-            if outcome.non_unicode_skipped {
-                details.push(
-                    "Skill discovery skipped a non-Unicode path that cannot have stable identity"
-                        .to_owned(),
-                );
+            if outcome.non_unicode_skipped > 0 {
+                result.identity_path_coverage = IdentityPathCoverage::Incomplete;
+                result.non_unicode_identity_paths_skipped = result
+                    .non_unicode_identity_paths_skipped
+                    .saturating_add(outcome.non_unicode_skipped);
+                details.push(format!(
+                    "Skill discovery skipped {} non-Unicode path(s) that cannot have stable identity",
+                    outcome.non_unicode_skipped
+                ));
             }
             let detail = details.join("; ");
             result.warnings.push(format!(
@@ -1304,7 +1329,7 @@ fn discover_entrypoints(
     if depth > max_depth {
         return Ok(SkillDiscoveryOutcome {
             depth_bounded: true,
-            non_unicode_skipped: false,
+            non_unicode_skipped: 0,
         });
     }
     let mut outcome = SkillDiscoveryOutcome::default();
@@ -1335,7 +1360,7 @@ fn discover_entrypoints(
             });
         } else if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
             let Some(child_name) = file_name.to_str() else {
-                outcome.non_unicode_skipped = true;
+                outcome.non_unicode_skipped = outcome.non_unicode_skipped.saturating_add(1);
                 continue;
             };
             let child_state = state.descend(policy.agent, child_name, directory_has_skill);
@@ -1354,7 +1379,7 @@ fn discover_entrypoints(
             let linked_entrypoint = path.join("SKILL.md");
             let (target, status) = inspect_link(approved_roots, &path, &metadata);
             let Some(child_name) = file_name.to_str() else {
-                outcome.non_unicode_skipped = true;
+                outcome.non_unicode_skipped = outcome.non_unicode_skipped.saturating_add(1);
                 continue;
             };
             if linked_entrypoint.exists() || status != LinkStatus::Valid {
@@ -1610,13 +1635,20 @@ fn observe_physical_skill_package(
             fingerprint.executable_relative_files,
         ),
         Err(error) => {
-            let completeness = if is_non_unicode_identity_error(&error) {
+            let non_unicode_paths = non_unicode_identity_error_count(&error);
+            let completeness = if non_unicode_paths.is_some() {
                 FingerprintCompleteness::Unreadable
             } else if error.kind() == io::ErrorKind::InvalidData {
                 FingerprintCompleteness::Bounded
             } else {
                 FingerprintCompleteness::Unreadable
             };
+            if let Some(count) = non_unicode_paths {
+                result.identity_path_coverage = IdentityPathCoverage::Incomplete;
+                result.non_unicode_identity_paths_skipped = result
+                    .non_unicode_identity_paths_skipped
+                    .saturating_add(count);
+            }
             result.warnings.push(format!(
                 "could not completely fingerprint Skill package {}: {error}",
                 display_directory.display()
@@ -2182,7 +2214,9 @@ struct PackageFingerprint {
 const NON_UNICODE_IDENTITY_DETAIL: &str = "non-Unicode path cannot participate in stable identity";
 
 #[derive(Debug)]
-struct NonUnicodeIdentityPath;
+struct NonUnicodeIdentityPath {
+    count: u64,
+}
 
 impl std::fmt::Display for NonUnicodeIdentityPath {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2192,16 +2226,27 @@ impl std::fmt::Display for NonUnicodeIdentityPath {
 
 impl std::error::Error for NonUnicodeIdentityPath {}
 
-fn non_unicode_identity_error() -> io::Error {
-    io::Error::new(io::ErrorKind::InvalidData, NonUnicodeIdentityPath)
+fn non_unicode_identity_error(count: u64) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, NonUnicodeIdentityPath { count })
+}
+
+pub(crate) fn unicode_identity_path(path: &Path) -> io::Result<&str> {
+    path.to_str().ok_or_else(|| non_unicode_identity_error(1))
 }
 
 pub(crate) fn is_non_unicode_identity_error(error: &io::Error) -> bool {
-    error.kind() == io::ErrorKind::InvalidData
-        && error
-            .get_ref()
-            .and_then(|source| source.downcast_ref::<NonUnicodeIdentityPath>())
-            .is_some()
+    non_unicode_identity_error_count(error).is_some()
+}
+
+fn non_unicode_identity_error_count(error: &io::Error) -> Option<u64> {
+    (error.kind() == io::ErrorKind::InvalidData)
+        .then(|| {
+            error
+                .get_ref()
+                .and_then(|source| source.downcast_ref::<NonUnicodeIdentityPath>())
+                .map(|error| error.count)
+        })
+        .flatten()
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2224,50 +2269,54 @@ enum PackageFileKind {
 fn package_file_checkpoints(
     files: &[(PathBuf, PathBuf, fs::FileType)],
 ) -> io::Result<Vec<PackageFileCheckpoint>> {
-    files
-        .iter()
-        .map(|(relative_path, path, _)| {
-            if relative_path.to_str().is_none() {
-                return Err(non_unicode_identity_error());
-            }
-            let metadata = fs::symlink_metadata(path)?;
-            let file_type = metadata.file_type();
-            let symlink_target = file_type
-                .is_symlink()
-                .then(|| fs::read_link(path))
-                .transpose()?;
-            if symlink_target
-                .as_deref()
-                .is_some_and(|target| target.to_str().is_none())
-            {
-                return Err(non_unicode_identity_error());
-            }
-            #[cfg(unix)]
-            let mode = {
-                use std::os::unix::fs::PermissionsExt;
-                metadata.permissions().mode()
-            };
-            #[cfg(not(unix))]
-            let mode = 0;
-            Ok(PackageFileCheckpoint {
-                relative_path: relative_path.clone(),
-                kind: if file_type.is_symlink() {
-                    PackageFileKind::Symlink
-                } else {
-                    PackageFileKind::File
-                },
-                len: metadata.len(),
-                modified_nanos: metadata
-                    .modified()
-                    .ok()
-                    .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
-                    .map(|duration| duration.as_nanos()),
-                readonly: metadata.permissions().readonly(),
-                mode,
-                symlink_target,
-            })
-        })
-        .collect()
+    let mut checkpoints = Vec::with_capacity(files.len());
+    let mut non_unicode_paths = 0_u64;
+    for (relative_path, path, _) in files {
+        if relative_path.to_str().is_none() {
+            non_unicode_paths = non_unicode_paths.saturating_add(1);
+        }
+        let metadata = fs::symlink_metadata(path)?;
+        let file_type = metadata.file_type();
+        let symlink_target = file_type
+            .is_symlink()
+            .then(|| fs::read_link(path))
+            .transpose()?;
+        if symlink_target
+            .as_deref()
+            .is_some_and(|target| target.to_str().is_none())
+        {
+            non_unicode_paths = non_unicode_paths.saturating_add(1);
+        }
+        #[cfg(unix)]
+        let mode = {
+            use std::os::unix::fs::PermissionsExt;
+            metadata.permissions().mode()
+        };
+        #[cfg(not(unix))]
+        let mode = 0;
+        checkpoints.push(PackageFileCheckpoint {
+            relative_path: relative_path.clone(),
+            kind: if file_type.is_symlink() {
+                PackageFileKind::Symlink
+            } else {
+                PackageFileKind::File
+            },
+            len: metadata.len(),
+            modified_nanos: metadata
+                .modified()
+                .ok()
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos()),
+            readonly: metadata.permissions().readonly(),
+            mode,
+            symlink_target,
+        });
+    }
+    if non_unicode_paths > 0 {
+        Err(non_unicode_identity_error(non_unicode_paths))
+    } else {
+        Ok(checkpoints)
+    }
 }
 
 fn package_checkpoint(directory: &Path) -> io::Result<Option<Vec<PackageFileCheckpoint>>> {
@@ -2335,7 +2384,9 @@ fn digest_skill_directory(directory: &Path) -> io::Result<PackageFingerprint> {
         }
         if file_type.is_symlink() {
             let target = fs::read_link(path)?;
-            let target = target.to_str().ok_or_else(non_unicode_identity_error)?;
+            let target = target
+                .to_str()
+                .ok_or_else(|| non_unicode_identity_error(1))?;
             digest.update(b"symlink\0");
             digest.update(target.as_bytes());
             if !is_source_control_metadata {
@@ -2499,6 +2550,7 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
     let mut events = BTreeMap::<(String, UsageStage, String, Option<u64>), UsageEvidence>::new();
     let mut bytes_observed = 0_u64;
     let mut lines_observed = 0_usize;
+    let mut non_unicode_files_skipped = 0_u64;
 
     for root in roots {
         let status = match fs::read_dir(root) {
@@ -2653,12 +2705,16 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
             }
             let Some(file_identity) = file.to_str() else {
                 coverage.files_skipped += 1;
+                non_unicode_files_skipped = non_unicode_files_skipped.saturating_add(1);
+                result.identity_path_coverage = IdentityPathCoverage::Incomplete;
+                result.non_unicode_identity_paths_skipped =
+                    result.non_unicode_identity_paths_skipped.saturating_add(1);
                 record_session_limitation(
                     &mut limitations,
                     SessionCoverageLimitationCode::FilePathNotUnicode,
                     SessionCoverageScope::File,
                     SessionCoverageCountKind::Exact,
-                    Some(coverage.files_skipped as u64),
+                    Some(non_unicode_files_skipped),
                     None,
                     SessionCoverageLimitationSource::SessionSampling,
                 );
@@ -3842,6 +3898,33 @@ enabled = true
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn unicode_root_alias_to_non_unicode_physical_path_fails_closed() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+        use std::os::unix::fs::symlink;
+
+        let parent = temp_directory("non-unicode-root-target");
+        let physical = parent.join(OsString::from_vec(vec![0x80]));
+        fs::create_dir(&physical).unwrap();
+        fs::write(physical.join("SKILL.md"), "---\nname: hidden\n---\n").unwrap();
+        let alias = parent.join("unicode-alias");
+        symlink(&physical, &alias).unwrap();
+        let mut options = ScanOptions::for_home(parent.join("empty-home"));
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: alias,
+        });
+        options.include_session_evidence = false;
+
+        let error = scan(&options).unwrap_err();
+
+        assert!(is_non_unicode_identity_error(&error));
+        assert_eq!(error.to_string(), NON_UNICODE_IDENTITY_DETAIL);
+        fs::remove_dir_all(parent).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn scan_skips_distinct_non_unicode_skill_paths_without_identity_collision() {
         use std::ffi::OsString;
         use std::os::unix::ffi::OsStringExt;
@@ -3867,6 +3950,11 @@ enabled = true
         assert_eq!(result.placements.len(), 1);
         assert_eq!(result.skills.len(), 1);
         assert_eq!(result.skills[0].name, "valid");
+        assert_eq!(
+            result.identity_path_coverage,
+            IdentityPathCoverage::Incomplete
+        );
+        assert_eq!(result.non_unicode_identity_paths_skipped, 2);
         let observed = result.roots.iter().find(|seen| seen.path == root).unwrap();
         assert!(!observed.discovery_complete);
         assert!(
@@ -3918,8 +4006,50 @@ enabled = true
             Some(NON_UNICODE_IDENTITY_DETAIL)
         );
         assert!(first.skills[0].content_identity_digest.is_none());
+        assert_eq!(
+            first.identity_path_coverage,
+            IdentityPathCoverage::Incomplete
+        );
+        assert_eq!(first.non_unicode_identity_paths_skipped, 2);
         assert!(serde_json::to_string(&first).is_ok());
         assert!(inspect_skill_identity(&skill.join("SKILL.md")).is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn non_unicode_session_limitation_counts_only_its_own_skips() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = temp_directory("non-unicode-session-file");
+        fs::write(root.join("empty.json"), b"").unwrap();
+        let mut invalid_name = vec![0x80];
+        invalid_name.extend_from_slice(b".json");
+        fs::write(root.join(OsString::from_vec(invalid_name)), b"{}\n").unwrap();
+        let mut result = ScanResult {
+            content_identity_algorithm: Some(CONTENT_IDENTITY_ALGORITHM.into()),
+            identity_path_coverage: IdentityPathCoverage::Complete,
+            ..ScanResult::default()
+        };
+
+        scan_sessions(AgentKind::Codex, std::slice::from_ref(&root), &mut result);
+
+        let coverage = &result.coverage[0];
+        assert_eq!(coverage.files_skipped, 2);
+        let path_limit = coverage
+            .limitations
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|limit| limit.code == SessionCoverageLimitationCode::FilePathNotUnicode)
+            .unwrap();
+        assert_eq!(path_limit.observed, Some(1));
+        assert_eq!(
+            result.identity_path_coverage,
+            IdentityPathCoverage::Incomplete
+        );
+        assert_eq!(result.non_unicode_identity_paths_skipped, 1);
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -318,6 +318,7 @@ pub enum SessionCoverageLimitationCode {
     FileMetadataFailure,
     FileReadFailure,
     FileZeroRead,
+    FilePathNotUnicode,
     JsonExtractionLimit,
     JsonRecordLimit,
     LineAlignmentLoss,
@@ -504,6 +505,23 @@ struct DiscoveryState {
     hidden_ancestor: bool,
     inside_skill_package: bool,
     harness_excluded: bool,
+}
+
+#[derive(Clone, Copy, Default)]
+struct SkillDiscoveryOutcome {
+    depth_bounded: bool,
+    non_unicode_skipped: bool,
+}
+
+impl SkillDiscoveryOutcome {
+    fn merge(&mut self, other: Self) {
+        self.depth_bounded |= other.depth_bounded;
+        self.non_unicode_skipped |= other.non_unicode_skipped;
+    }
+
+    fn is_complete(self) -> bool {
+        !self.depth_bounded && !self.non_unicode_skipped
+    }
 }
 
 impl DiscoveryState {
@@ -880,6 +898,7 @@ fn contained_directory(base: &Path, candidate: &Path) -> Option<PathBuf> {
 }
 
 pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
+    require_unicode_scan_options(options)?;
     let mut result = ScanResult {
         content_identity_algorithm: Some(CONTENT_IDENTITY_ALGORITHM.into()),
         ..ScanResult::default()
@@ -1060,6 +1079,29 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
     Ok(result)
 }
 
+fn require_unicode_scan_options(options: &ScanOptions) -> io::Result<()> {
+    let paths = std::iter::once(options.home.as_path())
+        .chain(
+            options
+                .explicit_skill_roots
+                .iter()
+                .map(|root| root.path.as_path()),
+        )
+        .chain(options.explicit_source_roots.iter().map(PathBuf::as_path))
+        .chain(
+            options
+                .durable_read_roots
+                .iter()
+                .map(|root| root.path.as_path()),
+        )
+        .chain(options.managed_source_roots.iter().map(PathBuf::as_path));
+    if paths.into_iter().all(|path| path.to_str().is_some()) {
+        Ok(())
+    } else {
+        Err(non_unicode_identity_error())
+    }
+}
+
 fn normalized_confirmed_source_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
     let mut normalized = roots
         .iter()
@@ -1124,9 +1166,19 @@ fn observe_skill_root(
         DiscoveryState::default(),
         candidates,
     ) {
-        Ok(true) => {}
-        Ok(false) => {
-            let detail = format!("Skill discovery was bounded at depth {max_depth}");
+        Ok(outcome) if outcome.is_complete() => {}
+        Ok(outcome) => {
+            let mut details = Vec::new();
+            if outcome.depth_bounded {
+                details.push(format!("Skill discovery was bounded at depth {max_depth}"));
+            }
+            if outcome.non_unicode_skipped {
+                details.push(
+                    "Skill discovery skipped a non-Unicode path that cannot have stable identity"
+                        .to_owned(),
+                );
+            }
+            let detail = details.join("; ");
             result.warnings.push(format!(
                 "could not completely inspect skill root {}: {detail}",
                 root.display()
@@ -1244,15 +1296,18 @@ fn discover_entrypoints(
     max_depth: usize,
     state: DiscoveryState,
     output: &mut Vec<EntryCandidate>,
-) -> io::Result<bool> {
+) -> io::Result<SkillDiscoveryOutcome> {
     let depth = directory
         .strip_prefix(placement_root)
         .map(|path| path.components().count())
         .unwrap_or(max_depth.saturating_add(1));
     if depth > max_depth {
-        return Ok(false);
+        return Ok(SkillDiscoveryOutcome {
+            depth_bounded: true,
+            non_unicode_skipped: false,
+        });
     }
-    let mut complete = true;
+    let mut outcome = SkillDiscoveryOutcome::default();
     let mut entries = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
     entries.sort_by_key(|entry| entry.file_name());
     let directory_has_skill = directory.join("SKILL.md").is_file();
@@ -1262,7 +1317,9 @@ fn discover_entrypoints(
         let file_name = entry.file_name();
         if file_name == "SKILL.md" {
             let (target, link_status) = inspect_link(approved_roots, &path, &metadata);
-            let expected_physical_entrypoint = fs::canonicalize(&path).ok();
+            let expected_physical_entrypoint = fs::canonicalize(&path)
+                .ok()
+                .filter(|path| path.to_str().is_some());
             let default_exposed =
                 default_exposure_for_candidate(policy, placement_root, &path, depth, state);
             output.push(EntryCandidate {
@@ -1277,9 +1334,12 @@ fn discover_entrypoints(
                 default_exposed,
             });
         } else if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
-            let child_name = file_name.to_string_lossy();
-            let child_state = state.descend(policy.agent, &child_name, directory_has_skill);
-            complete &= discover_entrypoints(
+            let Some(child_name) = file_name.to_str() else {
+                outcome.non_unicode_skipped = true;
+                continue;
+            };
+            let child_state = state.descend(policy.agent, child_name, directory_has_skill);
+            outcome.merge(discover_entrypoints(
                 policy,
                 placement_root,
                 approved_roots,
@@ -1287,16 +1347,21 @@ fn discover_entrypoints(
                 max_depth,
                 child_state,
                 output,
-            )?;
+            )?);
         } else if metadata.file_type().is_symlink() {
             // A linked Skill directory is a placement too, but it is never
             // traversed recursively before the boundary has been evaluated.
             let linked_entrypoint = path.join("SKILL.md");
             let (target, status) = inspect_link(approved_roots, &path, &metadata);
+            let Some(child_name) = file_name.to_str() else {
+                outcome.non_unicode_skipped = true;
+                continue;
+            };
             if linked_entrypoint.exists() || status != LinkStatus::Valid {
-                let expected_physical_entrypoint = fs::canonicalize(&linked_entrypoint).ok();
-                let child_name = file_name.to_string_lossy();
-                let child_state = state.descend(policy.agent, &child_name, directory_has_skill);
+                let expected_physical_entrypoint = fs::canonicalize(&linked_entrypoint)
+                    .ok()
+                    .filter(|path| path.to_str().is_some());
+                let child_state = state.descend(policy.agent, child_name, directory_has_skill);
                 let default_exposed = default_exposure_for_candidate(
                     policy,
                     placement_root,
@@ -1318,7 +1383,7 @@ fn discover_entrypoints(
             }
         }
     }
-    Ok(complete)
+    Ok(outcome)
 }
 
 const HERMES_EXCLUDED_SKILL_DIRS: &[&str] = &[
@@ -1368,7 +1433,10 @@ fn default_exposure_for_candidate(
                     let mut components = path.components();
                     (components.next()?.as_os_str() == ".system").then(|| {
                         components.all(|component| {
-                            !component.as_os_str().to_string_lossy().starts_with('.')
+                            component
+                                .as_os_str()
+                                .to_str()
+                                .is_some_and(|name| !name.starts_with('.'))
                         })
                     })
                 })
@@ -1389,7 +1457,8 @@ fn default_exposure_for_candidate(
                 && entrypoint
                     .parent()
                     .and_then(Path::file_name)
-                    .is_some_and(|name| !name.to_string_lossy().starts_with('.'))
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| !name.starts_with('.'))
         }
         SkillDiscoverySemantics::Pi => {
             !state.hidden_ancestor && !state.inside_skill_package && !state.harness_excluded
@@ -1411,6 +1480,9 @@ fn inspect_link(
         Ok(target) => target,
         Err(_) => return (None, LinkStatus::Broken),
     };
+    if raw_target.to_str().is_none() {
+        return (None, LinkStatus::Broken);
+    }
     let target = if raw_target.is_absolute() {
         raw_target
     } else {
@@ -1538,7 +1610,9 @@ fn observe_physical_skill_package(
             fingerprint.executable_relative_files,
         ),
         Err(error) => {
-            let completeness = if error.kind() == io::ErrorKind::InvalidData {
+            let completeness = if is_non_unicode_identity_error(&error) {
+                FingerprintCompleteness::Unreadable
+            } else if error.kind() == io::ErrorKind::InvalidData {
                 FingerprintCompleteness::Bounded
             } else {
                 FingerprintCompleteness::Unreadable
@@ -1576,11 +1650,15 @@ fn observe_physical_skill_package(
 }
 
 fn unreadable_package_observation(candidate: &EntryCandidate) -> PhysicalPackageObservation {
+    let entrypoint = candidate
+        .entrypoint
+        .to_str()
+        .expect("discovery excludes non-Unicode entrypoints");
     PhysicalPackageObservation {
         content: String::new(),
         modified_at: None,
         metadata: SkillMetadata::default(),
-        digest: stable_digest(candidate.entrypoint.to_string_lossy().as_bytes()),
+        digest: stable_digest(entrypoint.as_bytes()),
         content_identity_digest: None,
         fingerprint_completeness: FingerprintCompleteness::Unreadable,
         fingerprint_detail: Some("Skill package was not read because its link is unsafe".into()),
@@ -1758,7 +1836,11 @@ fn materialize_candidates_with_hook(
             content.clear();
             modified_at = None;
             metadata = SkillMetadata::default();
-            digest = stable_digest(candidate.entrypoint.to_string_lossy().as_bytes());
+            let entrypoint = candidate
+                .entrypoint
+                .to_str()
+                .expect("discovery excludes non-Unicode entrypoints");
+            digest = stable_digest(entrypoint.as_bytes());
             content_identity_digest = None;
             fingerprint_completeness = FingerprintCompleteness::Unreadable;
             fingerprint_detail = Some(format!(
@@ -1772,15 +1854,22 @@ fn materialize_candidates_with_hook(
             _ if safe_to_read && !content.is_empty() => {
                 content_identity_digest.as_ref().map_or_else(
                     || {
-                        format!(
-                            "incomplete-content:{}:{digest}",
-                            candidate.entrypoint.display()
-                        )
+                        let entrypoint = candidate
+                            .entrypoint
+                            .to_str()
+                            .expect("discovery excludes non-Unicode entrypoints");
+                        format!("incomplete-content:{entrypoint}:{digest}")
                     },
                     |identity| format!("content:{identity}"),
                 )
             }
-            _ => format!("unreadable-link:{}", candidate.entrypoint.display()),
+            _ => {
+                let entrypoint = candidate
+                    .entrypoint
+                    .to_str()
+                    .expect("discovery excludes non-Unicode entrypoints");
+                format!("unreadable-link:{entrypoint}")
+            }
         };
         let skill_id = format!("skill_{}", stable_digest(identity_basis.as_bytes()));
         let name = metadata
@@ -1789,7 +1878,7 @@ fn materialize_candidates_with_hook(
             .or_else(|| {
                 directory
                     .file_name()
-                    .map(|name| name.to_string_lossy().into())
+                    .and_then(|name| name.to_str().map(str::to_owned))
             })
             .unwrap_or_else(|| "unnamed".into());
         let normalized_text = normalize_search_text(&content);
@@ -1802,7 +1891,9 @@ fn materialize_candidates_with_hook(
         });
         let declared_name_matches_directory = metadata.name.as_ref().and_then(|declared| {
             directory.file_name().map(|directory_name| {
-                declared.eq_ignore_ascii_case(&directory_name.to_string_lossy())
+                directory_name
+                    .to_str()
+                    .is_some_and(|name| declared.eq_ignore_ascii_case(name))
             })
         });
         skills
@@ -1818,11 +1909,19 @@ fn materialize_candidates_with_hook(
                 normalized_text,
                 modified_at_unix: modified_at,
             });
+        let root = candidate
+            .root
+            .to_str()
+            .expect("discovery excludes non-Unicode roots");
+        let entrypoint = candidate
+            .entrypoint
+            .to_str()
+            .expect("discovery excludes non-Unicode entrypoints");
         let placement_basis = format!(
             "{}\0{}\0{}",
             candidate.agent.map(AgentKind::id).unwrap_or("explicit"),
-            candidate.root.display(),
-            candidate.entrypoint.display()
+            root,
+            entrypoint
         );
         let mutation_scope = if candidate.provider.is_some() {
             MutationScope::ProviderReadOnly
@@ -2080,6 +2179,31 @@ struct PackageFingerprint {
     executable_relative_files: Vec<PathBuf>,
 }
 
+const NON_UNICODE_IDENTITY_DETAIL: &str = "non-Unicode path cannot participate in stable identity";
+
+#[derive(Debug)]
+struct NonUnicodeIdentityPath;
+
+impl std::fmt::Display for NonUnicodeIdentityPath {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(NON_UNICODE_IDENTITY_DETAIL)
+    }
+}
+
+impl std::error::Error for NonUnicodeIdentityPath {}
+
+fn non_unicode_identity_error() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, NonUnicodeIdentityPath)
+}
+
+pub(crate) fn is_non_unicode_identity_error(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::InvalidData
+        && error
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<NonUnicodeIdentityPath>())
+            .is_some()
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct PackageFileCheckpoint {
     relative_path: PathBuf,
@@ -2103,12 +2227,21 @@ fn package_file_checkpoints(
     files
         .iter()
         .map(|(relative_path, path, _)| {
+            if relative_path.to_str().is_none() {
+                return Err(non_unicode_identity_error());
+            }
             let metadata = fs::symlink_metadata(path)?;
             let file_type = metadata.file_type();
             let symlink_target = file_type
                 .is_symlink()
                 .then(|| fs::read_link(path))
                 .transpose()?;
+            if symlink_target
+                .as_deref()
+                .is_some_and(|target| target.to_str().is_none())
+            {
+                return Err(non_unicode_identity_error());
+            }
             #[cfg(unix)]
             let mode = {
                 use std::os::unix::fs::PermissionsExt;
@@ -2191,7 +2324,9 @@ fn digest_skill_directory(directory: &Path) -> io::Result<PackageFingerprint> {
     let mut total_bytes = 0_u64;
     for (relative_path, path, file_type) in files {
         let is_source_control_metadata = relative_path == Path::new(".gitignore");
-        let relative_path_bytes = relative_path.to_string_lossy();
+        let relative_path_bytes = relative_path
+            .to_str()
+            .expect("package checkpoints reject non-Unicode paths");
         digest.update(relative_path_bytes.as_bytes());
         digest.update([0]);
         if !is_source_control_metadata {
@@ -2200,11 +2335,12 @@ fn digest_skill_directory(directory: &Path) -> io::Result<PackageFingerprint> {
         }
         if file_type.is_symlink() {
             let target = fs::read_link(path)?;
+            let target = target.to_str().ok_or_else(non_unicode_identity_error)?;
             digest.update(b"symlink\0");
-            digest.update(target.to_string_lossy().as_bytes());
+            digest.update(target.as_bytes());
             if !is_source_control_metadata {
                 content_identity_digest.update(b"symlink\0");
-                content_identity_digest.update(target.to_string_lossy().as_bytes());
+                content_identity_digest.update(target.as_bytes());
             }
         } else {
             let metadata = fs::metadata(&path)?;
@@ -2337,8 +2473,11 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
             }
         }
         for entrypoint in entrypoints {
+            let Some(entrypoint) = entrypoint.to_str() else {
+                continue;
+            };
             skill_ids_by_reference
-                .entry(normalize_reference_text(&entrypoint.to_string_lossy()))
+                .entry(normalize_reference_text(entrypoint))
                 .or_default()
                 .insert(placement.skill_id.clone());
         }
@@ -2512,6 +2651,19 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                 }
                 break;
             }
+            let Some(file_identity) = file.to_str() else {
+                coverage.files_skipped += 1;
+                record_session_limitation(
+                    &mut limitations,
+                    SessionCoverageLimitationCode::FilePathNotUnicode,
+                    SessionCoverageScope::File,
+                    SessionCoverageCountKind::Exact,
+                    Some(coverage.files_skipped as u64),
+                    None,
+                    SessionCoverageLimitationSource::SessionSampling,
+                );
+                continue;
+            };
             let metadata = match fs::metadata(file) {
                 Ok(metadata) => metadata,
                 _ => {
@@ -2608,7 +2760,7 @@ fn scan_sessions(agent: AgentKind, roots: &[PathBuf], result: &mut ScanResult) {
                 &mut coverage.last_seen_unix,
                 timestamp,
             );
-            let source_path_digest = stable_digest(file.to_string_lossy().as_bytes());
+            let source_path_digest = stable_digest(file_identity.as_bytes());
             let sample = String::from_utf8_lossy(&sample);
             let complete_json = is_json
                 && sample_bytes == metadata.len()
@@ -2823,7 +2975,8 @@ const fn limitation_unit(code: SessionCoverageLimitationCode) -> SessionCoverage
         | SessionCoverageLimitationCode::SampledFileLimit
         | SessionCoverageLimitationCode::FileMetadataFailure
         | SessionCoverageLimitationCode::FileReadFailure
-        | SessionCoverageLimitationCode::FileZeroRead => SessionCoverageUnit::Files,
+        | SessionCoverageLimitationCode::FileZeroRead
+        | SessionCoverageLimitationCode::FilePathNotUnicode => SessionCoverageUnit::Files,
         SessionCoverageLimitationCode::DiscoveryDepthLimit => SessionCoverageUnit::Depth,
         SessionCoverageLimitationCode::DiscoveryWalkFailure => SessionCoverageUnit::Walks,
         SessionCoverageLimitationCode::SampledByteLimit
@@ -3666,6 +3819,107 @@ enabled = true
             result.placements[0].executable_files,
             vec![skill.join("repair.sh")]
         );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_non_unicode_root_fails_before_snapshot_construction() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let mut options = ScanOptions::for_home("/tmp/skillroster-unicode-home");
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: PathBuf::from(OsString::from_vec(vec![b'/', 0x80])),
+        });
+
+        let error = scan(&options).unwrap_err();
+
+        assert!(is_non_unicode_identity_error(&error));
+        assert_eq!(error.to_string(), NON_UNICODE_IDENTITY_DETAIL);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn scan_skips_distinct_non_unicode_skill_paths_without_identity_collision() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = temp_directory("non-unicode-entrypoints");
+        let valid = root.join("valid");
+        fs::create_dir(&valid).unwrap();
+        fs::write(valid.join("SKILL.md"), "---\nname: valid\n---\n").unwrap();
+        for bytes in [vec![0x80], vec![0x81]] {
+            let directory = root.join(OsString::from_vec(bytes));
+            fs::create_dir(&directory).unwrap();
+            fs::write(directory.join("SKILL.md"), "---\nname: hidden\n---\n").unwrap();
+        }
+        let mut options = ScanOptions::for_home(root.join("empty-home"));
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: root.clone(),
+        });
+        options.include_session_evidence = false;
+
+        let result = scan(&options).unwrap();
+
+        assert_eq!(result.placements.len(), 1);
+        assert_eq!(result.skills.len(), 1);
+        assert_eq!(result.skills[0].name, "valid");
+        let observed = result.roots.iter().find(|seen| seen.path == root).unwrap();
+        assert!(!observed.discovery_complete);
+        assert!(
+            observed
+                .detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("non-Unicode"))
+        );
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(!json.contains('\u{fffd}'));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn non_unicode_package_member_makes_exact_fingerprint_unreadable() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let root = temp_directory("non-unicode-package-member");
+        let skill = root.join("valid-skill");
+        fs::create_dir(&skill).unwrap();
+        fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: valid-skill\ndescription: Unicode entrypoint\n---\n",
+        )
+        .unwrap();
+        for (bytes, content) in [(vec![0x80], "first"), (vec![0x81], "second")] {
+            fs::write(skill.join(OsString::from_vec(bytes)), content).unwrap();
+        }
+        let mut options = ScanOptions::for_home(root.join("empty-home"));
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: root.clone(),
+        });
+        options.include_session_evidence = false;
+
+        let first = scan(&options).unwrap();
+        let second = scan(&options).unwrap();
+
+        assert_eq!(first.placements.len(), 1);
+        assert_eq!(first.placements[0].id, second.placements[0].id);
+        assert_eq!(
+            first.placements[0].fingerprint_completeness,
+            FingerprintCompleteness::Unreadable
+        );
+        assert_eq!(
+            first.placements[0].fingerprint_detail.as_deref(),
+            Some(NON_UNICODE_IDENTITY_DETAIL)
+        );
+        assert!(first.skills[0].content_identity_digest.is_none());
+        assert!(serde_json::to_string(&first).is_ok());
+        assert!(inspect_skill_identity(&skill.join("SKILL.md")).is_err());
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -4023,10 +4023,19 @@ enabled = true
         use std::os::unix::ffi::OsStringExt;
 
         let root = temp_directory("non-unicode-session-file");
-        fs::write(root.join("empty.json"), b"").unwrap();
+        for index in 0..MAX_SESSION_FILES_PER_ROOT {
+            fs::write(root.join(format!("session-{index:03}.json")), b"").unwrap();
+        }
         let mut invalid_name = vec![0x80];
         invalid_name.extend_from_slice(b".json");
-        fs::write(root.join(OsString::from_vec(invalid_name)), b"{}\n").unwrap();
+        let invalid_path = root.join(OsString::from_vec(invalid_name));
+        fs::write(&invalid_path, b"{}\n").unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&invalid_path)
+            .unwrap()
+            .set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(60))
+            .unwrap();
         let mut result = ScanResult {
             content_identity_algorithm: Some(CONTENT_IDENTITY_ALGORITHM.into()),
             identity_path_coverage: IdentityPathCoverage::Complete,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1663,10 +1663,15 @@ fn legacy_snapshot_requires_typed_rescan_before_find_or_report() {
         )
         .unwrap();
     let mut legacy: Value = serde_json::from_str(&encoded).unwrap();
+    legacy["content_identity_algorithm"] = json!("sha256-content-v1");
     legacy
         .as_object_mut()
         .unwrap()
-        .remove("content_identity_algorithm");
+        .remove("identity_path_coverage");
+    legacy
+        .as_object_mut()
+        .unwrap()
+        .remove("non_unicode_identity_paths_skipped");
     for skill in legacy["skills"].as_array_mut().unwrap() {
         skill
             .as_object_mut()
@@ -1693,7 +1698,7 @@ fn legacy_snapshot_requires_typed_rescan_before_find_or_report() {
         );
         assert_eq!(
             rejected["error"]["details"]["required_algorithm"],
-            "sha256-content-v1"
+            "sha256-content-unicode-v2"
         );
         assert_eq!(rejected["error"]["details"]["files_changed"], false);
         assert_eq!(
@@ -8446,6 +8451,58 @@ fn find_rejects_content_drift_and_requests_rescan() {
         unreadable["error"]["details"]["next_action"],
         "repair_local_read_access_then_scan"
     );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn non_unicode_identity_coverage_blocks_exact_snapshot_consumers() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = temp.path().join("skills");
+    let valid = root.join("valid");
+    fs::create_dir_all(&valid).unwrap();
+    fs::write(
+        valid.join("SKILL.md"),
+        "---\nname: valid\ndescription: exact unicode fixture\n---\n",
+    )
+    .unwrap();
+    let invalid = root.join(OsString::from_vec(vec![0x80]));
+    fs::create_dir(&invalid).unwrap();
+    fs::write(invalid.join("SKILL.md"), "---\nname: hidden\n---\n").unwrap();
+    let explicit_root = format!("codex={}", root.display());
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--root",
+        &explicit_root,
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    for (tail, stdin) in [
+        (vec!["find", "exact unicode fixture", "--load"], None),
+        (vec!["report", "--summary"], None),
+        (vec!["plan", "--stdin"], Some("{}")),
+    ] {
+        let rejected = run(&[&common[..], &tail].concat(), stdin);
+        assert!(!rejected.status.success());
+        let rejected: Value = serde_json::from_slice(&rejected.stdout).unwrap();
+        assert_eq!(
+            rejected["error"]["code"],
+            "content_identity_rescan_required"
+        );
+        assert_eq!(
+            rejected["error"]["details"]["reason"],
+            "non_unicode_identity_coverage_incomplete"
+        );
+    }
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1662,6 +1662,7 @@ fn legacy_snapshot_requires_typed_rescan_before_find_or_report() {
             |row| row.get(0),
         )
         .unwrap();
+
     let mut legacy: Value = serde_json::from_str(&encoded).unwrap();
     legacy["content_identity_algorithm"] = json!("sha256-content-v1");
     legacy
@@ -6886,6 +6887,48 @@ fn apply_rejects_a_legacy_ready_plan_without_mutation() {
             "SELECT payload_json FROM scan_payloads WHERE scan_id = ?1",
             [snapshot],
             |row| row.get(0),
+        )
+        .unwrap();
+
+    for (payload, reason) in [
+        (
+            {
+                let mut payload: Value = serde_json::from_str(&encoded).unwrap();
+                payload["content_identity_algorithm"] = json!("sha256-content-v1");
+                payload
+            },
+            "legacy_snapshot_requires_rescan",
+        ),
+        (
+            {
+                let mut payload: Value = serde_json::from_str(&encoded).unwrap();
+                payload["identity_path_coverage"] = json!("incomplete");
+                payload["non_unicode_identity_paths_skipped"] = json!(1);
+                payload
+            },
+            "non_unicode_identity_coverage_incomplete",
+        ),
+    ] {
+        database
+            .execute(
+                "UPDATE scan_payloads SET payload_json = ?1 WHERE scan_id = ?2",
+                rusqlite::params![payload.to_string(), snapshot],
+            )
+            .unwrap();
+        let rejected = run(&[&common[..], &["apply", plan_id]].concat(), None);
+        assert!(!rejected.status.success());
+        let rejected: Value = serde_json::from_slice(&rejected.stdout).unwrap();
+        assert_eq!(
+            rejected["error"]["code"],
+            "content_identity_rescan_required"
+        );
+        assert_eq!(rejected["error"]["details"]["reason"], reason);
+    }
+
+    database
+        .execute(
+            "UPDATE scan_payloads SET payload_json = ?1 WHERE scan_id = ?2",
+            rusqlite::params![&encoded, snapshot],
         )
         .unwrap();
     let mut legacy: Value = serde_json::from_str(&encoded).unwrap();


### PR DESCRIPTION
## Problem

`Path::display()` and `to_string_lossy()` could collapse distinct Unix path bytes to the same replacement-character text before SkillRoster derived placement IDs, package fingerprints, or usage evidence keys. SQLite could then project ambiguous identity as exact state.

## Solution

- reject non-Unicode configured roots before constructing a Snapshot
- skip discovered non-Unicode Skill paths and mark structural coverage incomplete
- mark a Unicode Skill with any non-Unicode package member or symlink target as `unreadable` for exact fingerprinting
- skip non-Unicode session source paths with a typed coverage limitation
- remove lossy path conversion from scan identity, package hashing, placement IDs, and usage source digests
- return the structured `non_unicode_identity_path` error for configured roots
- preserve the existing hash inputs and IDs for all Unicode paths
- document that raw-byte/UTF-16 identity would require a future versioned schema

## Checks

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (321 macOS tests)
- Node routing/bootstrap harness (137 tests)
- `git diff --check`

Linux CI additionally runs two raw-byte regression tests using distinct invalid UTF-8 names that previously rendered identically. macOS rejects those names at the filesystem boundary; Windows paths remain Unicode-native.

Closes #236