### PR TITLE
ci: test bundled Bootstrap change scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,12 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
+          bash scripts/ci-change-scope.sh --self-test
           full=true
           if [[ "$EVENT_NAME" != "workflow_dispatch" && -n "$BASE_SHA" && ! "$BASE_SHA" =~ ^0+$ ]] && git cat-file -e "$BASE_SHA^{commit}"; then
             git diff --check "$BASE_SHA" "$HEAD_SHA"
             changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
-            if [[ -n "$changed" ]] && ! grep -Evq '(\.md$|^LICENSE$)' <<<"$changed"; then
-              full=false
-            fi
+            full="$(printf '%s\n' "$changed" | bash scripts/ci-change-scope.sh)"
             {
               echo "### Change scope"
               echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
           full=true
           if [[ "$EVENT_NAME" != "workflow_dispatch" && -n "$BASE_SHA" && ! "$BASE_SHA" =~ ^0+$ ]] && git cat-file -e "$BASE_SHA^{commit}"; then
             git diff --check "$BASE_SHA" "$HEAD_SHA"
-            changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
-            full="$(printf '%s\n' "$changed" | bash scripts/ci-change-scope.sh)"
+            changed="$(git -c core.quotePath=true diff --name-status --no-renames "$BASE_SHA" "$HEAD_SHA")"
+            full="$(git diff --name-only --no-renames -z "$BASE_SHA" "$HEAD_SHA" | bash scripts/ci-change-scope.sh --null)"
             {
               echo "### Change scope"
               echo

--- a/scripts/ci-change-scope.sh
+++ b/scripts/ci-change-scope.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+classify_paths() {
+  local full=false
+  local saw_path=false
+  local path
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    saw_path=true
+    case "$path" in
+      skill/skillroster/*)
+        full=true
+        ;;
+      LICENSE|*.md)
+        ;;
+      *)
+        full=true
+        ;;
+    esac
+  done
+  if [[ "$saw_path" == false ]]; then
+    full=true
+  fi
+  printf '%s\n' "$full"
+}
+
+self_test() {
+  local actual
+  actual="$(printf '%s\n' 'README.md' 'docs/product-spec.md' 'LICENSE' | classify_paths)"
+  [[ "$actual" == false ]]
+
+  for runtime_path in \
+    'skill/skillroster/SKILL.md' \
+    'skill/skillroster/references/routing.md' \
+    'skill/skillroster/manifest.json' \
+    'src/bootstrap.rs'; do
+    actual="$(printf '%s\n' "$runtime_path" | classify_paths)"
+    [[ "$actual" == true ]]
+  done
+
+  actual="$(printf '%s\n' 'README.md' 'src/lib.rs' | classify_paths)"
+  [[ "$actual" == true ]]
+  actual="$(printf '' | classify_paths)"
+  [[ "$actual" == true ]]
+}
+
+if [[ "${1:-}" == '--self-test' ]]; then
+  self_test
+  exit 0
+fi
+
+classify_paths

--- a/scripts/ci-change-scope.sh
+++ b/scripts/ci-change-scope.sh
@@ -2,10 +2,14 @@
 set -euo pipefail
 
 classify_paths() {
+  local -a read_options=(-r)
+  if [[ "${1:-}" == '--null' ]]; then
+    read_options+=(-d '')
+  fi
   local full=false
   local saw_path=false
   local path
-  while IFS= read -r path; do
+  while IFS= read "${read_options[@]}" path; do
     [[ -z "$path" ]] && continue
     saw_path=true
     case "$path" in
@@ -41,6 +45,10 @@ self_test() {
 
   actual="$(printf '%s\n' 'README.md' 'src/lib.rs' | classify_paths)"
   [[ "$actual" == true ]]
+  actual="$(printf '%s\0' 'skill/skillroster/SKILL.md' 'docs/renamed.md' | classify_paths --null)"
+  [[ "$actual" == true ]]
+  actual="$(printf '%s\0' 'README.md' 'docs/product-spec.md' 'LICENSE' | classify_paths --null)"
+  [[ "$actual" == false ]]
   actual="$(printf '' | classify_paths)"
   [[ "$actual" == true ]]
 }
@@ -50,4 +58,4 @@ if [[ "${1:-}" == '--self-test' ]]; then
   exit 0
 fi
 
-classify_paths
+classify_paths "${1:-}"


### PR DESCRIPTION
## Problem

CI treated every Markdown file as documentation-only even though `skill/skillroster/**` is compiled into the binary with `include_str!`. A Bootstrap-only change could skip all Rust, Node, and portability gates.

## Solution

- centralize change classification in `scripts/ci-change-scope.sh`
- classify every bundled Bootstrap package path as runtime code regardless of extension
- preserve the fast path for ordinary Markdown and LICENSE-only changes
- default empty and mixed inputs to full CI
- run executable classifier self-tests before CI consumes the result

## Checks

- `bash -n scripts/ci-change-scope.sh`
- `bash scripts/ci-change-scope.sh --self-test`
- explicit Bootstrap-only case returns `true`
- explicit docs-only case returns `false`
- `cargo fmt --all --check`
- `git diff --check`

Remote CI is the independent proof that the extracted classifier still expands the full repository matrix.

Closes #238