### PR TITLE
ci: bind release validation to exact SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       full: ${{ steps.scope.outputs.full }}
     steps:
       - name: Check out source
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out source
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
@@ -71,35 +71,19 @@ jobs:
           rustup toolchain install 1.85.0 --profile minimal --component clippy --component rustfmt
           rustup default 1.85.0
 
-      - name: Check formatting
-        run: cargo fmt --all --check
-
-      - name: Run Clippy
-        run: cargo clippy --locked --all-targets --all-features -- -D warnings
-
-      - name: Run tests
-        run: cargo test --locked --all-targets --all-features
-
       - name: Set up Node.js 24 for harness checks
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
 
-      - name: Check cold-routing harnesses
+      - name: Run strict repository checks
         shell: bash
-        run: |
-          node --check tests/harness/pi-cold-routing/bounds.mjs
-          node --check tests/harness/pi-cold-routing/runner.mjs
-          node --check tests/harness/codex-cold-routing/driver.mjs
-          node --check tests/harness/byte-ledger/ledger.mjs
-          node --check scripts/byte-ledger.mjs
-          node --experimental-strip-types --check tests/harness/pi-cold-routing/gate.ts
-          node --test tests/harness/pi-cold-routing/*.test.mjs tests/harness/codex-cold-routing/*.test.mjs tests/harness/byte-ledger/*.test.mjs
+        run: bash scripts/ci-full-check.sh
 
   portability:
     name: ${{ matrix.name }}
     needs: changes
-    if: needs.changes.outputs.full == 'true' && github.event_name != 'push'
+    if: needs.changes.outputs.full == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -114,7 +98,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out source
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
@@ -129,21 +113,14 @@ jobs:
 
       - name: Set up Node.js 24 for harness checks
         if: runner.os == 'Windows'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
 
       - name: Check cold-routing harnesses
         if: runner.os == 'Windows'
         shell: bash
-        run: |
-          node --check tests/harness/pi-cold-routing/bounds.mjs
-          node --check tests/harness/pi-cold-routing/runner.mjs
-          node --check tests/harness/codex-cold-routing/driver.mjs
-          node --check tests/harness/byte-ledger/ledger.mjs
-          node --check scripts/byte-ledger.mjs
-          node --experimental-strip-types --check tests/harness/pi-cold-routing/gate.ts
-          node --test tests/harness/pi-cold-routing/*.test.mjs tests/harness/codex-cold-routing/*.test.mjs tests/harness/byte-ledger/*.test.mjs
+        run: bash scripts/ci-node-harness.sh
 
   gate:
     name: CI gate
@@ -152,7 +129,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
-      EVENT_NAME: ${{ github.event_name }}
       FULL: ${{ needs.changes.outputs.full }}
       LINUX_RESULT: ${{ needs.linux.result }}
       PORTABILITY_RESULT: ${{ needs.portability.result }}
@@ -164,7 +140,5 @@ jobs:
           [[ "$SCOPE_RESULT" == "success" ]] || exit 1
           if [[ "$FULL" == "true" ]]; then
             [[ "$LINUX_RESULT" == "success" ]] || exit 1
-            if [[ "$EVENT_NAME" != "push" ]]; then
-              [[ "$PORTABILITY_RESULT" == "success" ]] || exit 1
-            fi
+            [[ "$PORTABILITY_RESULT" == "success" ]] || exit 1
           fi

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -19,8 +19,45 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate:
+    name: Validate exact release SHA
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Record exact release SHA
+        shell: bash
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+          [[ "$actual_sha" == "$GITHUB_SHA" ]] || {
+            echo "Checked out $actual_sha instead of event SHA $GITHUB_SHA" >&2
+            exit 1
+          }
+          echo "Validated release SHA: \`$actual_sha\`" >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Install Rust 1.85
+        shell: bash
+        run: |
+          rustup toolchain install 1.85.0 --profile minimal --component clippy --component rustfmt
+          rustup default 1.85.0
+
+      - name: Set up Node.js 24 for harness checks
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+
+      - name: Run strict repository checks
+        shell: bash
+        run: bash scripts/ci-full-check.sh
+
   build:
     name: ${{ matrix.target }}
+    needs: validate
     strategy:
       fail-fast: false
       matrix:
@@ -44,9 +81,14 @@ jobs:
       TARGET: ${{ matrix.target }}
     steps:
       - name: Check out source
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
+
+      - name: Verify exact release SHA
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - name: Install Rust 1.85
         shell: bash
@@ -72,6 +114,9 @@ jobs:
             "$cargo_version"|"$cargo_version"-*) ;;
             *) echo "Version $version does not match Cargo package $cargo_version" >&2; exit 1 ;;
           esac
+
+      - name: Run portability tests at release SHA
+        run: cargo test --locked --all-targets --all-features
 
       - name: Build locked release binary
         run: cargo build --release --locked --target "${{ matrix.target }}"
@@ -108,7 +153,7 @@ jobs:
         run: scripts/release/package-windows.ps1 -Target $env:TARGET -Version ($env:RELEASE_VERSION -replace '^v', '')
 
       - name: Upload release candidate
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: skillroster-${{ matrix.target }}
           path: dist/*
@@ -122,12 +167,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out smoke test
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Download Linux release artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: skillroster-x86_64-unknown-linux-gnu
           path: dist

--- a/scripts/ci-full-check.sh
+++ b/scripts/ci-full-check.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo fmt --all --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all-targets --all-features
+bash scripts/ci-node-harness.sh

--- a/scripts/ci-node-harness.sh
+++ b/scripts/ci-node-harness.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+node --check tests/harness/pi-cold-routing/bounds.mjs
+node --check tests/harness/pi-cold-routing/runner.mjs
+node --check tests/harness/codex-cold-routing/driver.mjs
+node --check tests/harness/byte-ledger/ledger.mjs
+node --check scripts/byte-ledger.mjs
+node --experimental-strip-types --check tests/harness/pi-cold-routing/gate.ts
+node --test \
+  tests/harness/pi-cold-routing/*.test.mjs \
+  tests/harness/codex-cold-routing/*.test.mjs \
+  tests/harness/byte-ledger/*.test.mjs


### PR DESCRIPTION
Closes #242

## Summary
- validate the exact release event SHA before accepting artifact builds
- run formatting, strict Clippy, full Rust tests, and the Node harness in both CI and release validation through shared scripts
- run release portability tests on Linux, Windows, macOS arm64, and macOS x86_64
- run the portability matrix on main pushes as well as pull requests
- pin checkout, setup-node, upload-artifact, and download-artifact to full immutable commit SHAs

## Validation
- both workflow YAML files parsed successfully
- bash syntax checks passed for shared scripts
- strict shared check passed locally: 243 unit, 8 acceptance, 69 CLI, 137 Node
- every workflow `uses:` reference is a 40-character commit SHA
- git diff --check

No tag, artifact publication, merge, or release is performed by this PR.