### PR TITLE
refactor: drive Finding behavior by stable kind

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2866,10 +2866,10 @@ fn report_command(
         let mut details = stored.details.clone();
         if let Some(object) = details.as_object_mut() {
             object.insert("report_id".into(), json!(stored.report_id));
-            if object.get("kind").and_then(Value::as_str).is_none() {
+            if object.get("kind").is_none_or(Value::is_null) {
                 object.insert(
                     "kind".into(),
-                    json!(stable_finding_kind(&stored.category, &stored.title)),
+                    json!(crate::query::stored_finding_kind(&stored)),
                 );
             }
             object.insert("files_changed".into(), json!(false));
@@ -2930,7 +2930,10 @@ fn report_command(
                 .filter_map(|placement| placement.link_target.as_ref())
                 .map(|path| path.display().to_string())
                 .collect::<BTreeSet<_>>();
-            let ordered_evidence = if stored.title == "Five-stage usage evidence" {
+            let ordered_evidence = if crate::query::stored_finding_is(
+                &stored,
+                crate::query::FindingKind::FiveStageUsageEvidence,
+            ) {
                 let mut evidence = store.finding_evidence(&id)?;
                 for record in &mut evidence {
                     if record.kind == EvidenceKind::Coverage {
@@ -3214,8 +3217,13 @@ fn report_supports_source_confirmation_kind(report: &ReportRecord) -> bool {
         .into_iter()
         .flatten()
         .all(|finding| {
-            finding["title"] != crate::source_policy::ESCAPING_LINK_FINDING_TITLE
-                || finding["kind"] == crate::source_policy::ESCAPING_LINK_FINDING_KIND
+            let legacy_kind = crate::query::finding_kind_from_stored_value(
+                None,
+                finding.get("title").and_then(Value::as_str).unwrap_or(""),
+            );
+            legacy_kind != Some(crate::query::FindingKind::EscapingLinkSourceConfirmation)
+                || finding.get("kind").and_then(Value::as_str)
+                    == Some(crate::query::FindingKind::EscapingLinkSourceConfirmation.as_str())
         })
 }
 
@@ -3504,9 +3512,11 @@ fn add_semantic_overlap_comparison(
     scan: &ScanResult,
     state_dir: &Path,
 ) -> Result<()> {
-    if object.get("title").and_then(Value::as_str)
-        != Some(crate::query::SEMANTIC_OVERLAP_FINDING_TITLE)
-    {
+    let kind = crate::query::finding_kind_from_stored_value(
+        object.get("kind"),
+        object.get("title").and_then(Value::as_str).unwrap_or(""),
+    );
+    if kind != Some(crate::query::FindingKind::SemanticOverlapCandidate) {
         return Ok(());
     }
     let affected_skill_ids = object
@@ -4764,6 +4774,7 @@ fn compact_finding_summary(finding: &Value) -> Value {
 }
 
 struct FindingRollup {
+    kind: String,
     category: String,
     severity: String,
     title: String,
@@ -4775,16 +4786,18 @@ struct FindingRollup {
 fn finding_rollups(findings: &[Value]) -> Vec<Value> {
     let mut rollups = Vec::<FindingRollup>::new();
     for finding in findings {
+        let kind = finding_family_kind(finding);
         let category = finding["category"].as_str().unwrap_or("unknown");
         let severity = finding["severity"].as_str().unwrap_or("unknown");
         let title = finding["title"].as_str().unwrap_or("Unknown Finding");
         let index = rollups
             .iter()
             .position(|rollup| {
-                rollup.category == category && rollup.severity == severity && rollup.title == title
+                rollup.kind == kind && rollup.category == category && rollup.severity == severity
             })
             .unwrap_or_else(|| {
                 rollups.push(FindingRollup {
+                    kind,
                     category: category.to_owned(),
                     severity: severity.to_owned(),
                     title: title.to_owned(),
@@ -4826,6 +4839,21 @@ fn finding_rollups(findings: &[Value]) -> Vec<Value> {
             })
         })
         .collect()
+}
+
+fn finding_family_kind(finding: &Value) -> String {
+    crate::query::finding_kind_from_stored_value(
+        finding.get("kind"),
+        finding.get("title").and_then(Value::as_str).unwrap_or(""),
+    )
+    .map(|kind| kind.as_str().to_owned())
+    .or_else(|| {
+        finding
+            .get("kind")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    })
+    .unwrap_or_else(|| "unknown".into())
 }
 
 fn report_finding_rollups(report: &Value) -> Value {
@@ -4905,18 +4933,18 @@ fn paged_finding_report(
 }
 
 fn interleave_finding_families(findings: Vec<&Value>) -> Vec<&Value> {
-    let mut families = Vec::<((&str, &str, &str), Vec<&Value>)>::new();
-    let mut family_indices = BTreeMap::<(&str, &str, &str), usize>::new();
+    let mut families = Vec::<((String, String, String), Vec<&Value>)>::new();
+    let mut family_indices = BTreeMap::<(String, String, String), usize>::new();
     for finding in findings {
         let key = (
-            finding["category"].as_str().unwrap_or("unknown"),
-            finding["severity"].as_str().unwrap_or("unknown"),
-            finding["title"].as_str().unwrap_or("Unknown Finding"),
+            finding_family_kind(finding),
+            finding["category"].as_str().unwrap_or("unknown").to_owned(),
+            finding["severity"].as_str().unwrap_or("unknown").to_owned(),
         );
         if let Some(index) = family_indices.get(&key).copied() {
             families[index].1.push(finding);
         } else {
-            family_indices.insert(key, families.len());
+            family_indices.insert(key.clone(), families.len());
             families.push((key, vec![finding]));
         }
     }
@@ -4977,11 +5005,9 @@ fn finding_json(
     evidence_ids: &[EvidenceId],
     scan: &ScanResult,
 ) -> Value {
-    let category = finding_category(finding.category);
-    let kind = stable_finding_kind(&category, &finding.title);
     let mut value = json!({
         "id": id,
-        "kind": kind,
+        "kind": finding.kind,
         "category": finding.category,
         "severity": finding.severity,
         "title": finding.title,
@@ -4994,26 +5020,10 @@ fn finding_json(
         "coverage": finding_coverage(finding, scan),
         "files_changed": false
     });
-    if finding.category == crate::query::FindingCategory::Usage
-        && finding.title == "Five-stage usage evidence"
-    {
+    if finding.kind == crate::query::FindingKind::FiveStageUsageEvidence {
         value["usage_overview"] = json!(crate::query::usage_overview(scan));
     }
     value
-}
-
-fn stable_finding_kind(category: &FindingCategory, title: &str) -> Option<&'static str> {
-    crate::roster_recommendation::finding_kind(category, title).or_else(|| {
-        if *category != FindingCategory::Layout {
-            None
-        } else if title == crate::query::SAME_NAME_DIVERGENT_FINDING_TITLE {
-            Some(crate::query::SAME_NAME_DIVERGENT_FINDING_KIND)
-        } else if title == crate::source_policy::ESCAPING_LINK_FINDING_TITLE {
-            Some(crate::source_policy::ESCAPING_LINK_FINDING_KIND)
-        } else {
-            None
-        }
-    })
 }
 
 fn finding_impact(finding: &crate::query::Finding) -> Value {
@@ -5070,17 +5080,21 @@ fn stored_finding_coverage_basis(
 
     // Records written before coverage dimensions were introduced have no typed basis.
     // Reconstruct only those legacy records from the stable Finding identity.
-    Ok(match finding.category {
-        FindingCategory::Usage => crate::query::FindingCoverageBasis::SessionUsage,
-        FindingCategory::Lifecycle
-            if matches!(
-                finding.title.as_str(),
-                crate::query::STALE_ARCHIVE_FINDING_TITLE
-                    | crate::query::UNKNOWN_ARCHIVE_FINDING_TITLE
-            ) =>
-        {
-            crate::query::FindingCoverageBasis::SessionUsage
+    let kind = crate::query::finding_kind_from_stored_value(details.get("kind"), &finding.title);
+    if kind.is_none() && details.get("kind").is_some_and(|value| !value.is_null()) {
+        return Err(StoredFindingCoverageInvalid {
+            finding_id: finding.id.clone(),
+            reason: "unsupported_finding_kind",
         }
+        .into());
+    }
+    Ok(match kind {
+        Some(
+            crate::query::FindingKind::FiveStageUsageEvidence
+            | crate::query::FindingKind::UsageCoverageIncomplete
+            | crate::query::FindingKind::StaleArchiveCandidates
+            | crate::query::FindingKind::ArchiveCandidacyUnknown,
+        ) => crate::query::FindingCoverageBasis::SessionUsage,
         _ => crate::query::FindingCoverageBasis::SkillRootScan,
     })
 }
@@ -7078,7 +7092,12 @@ fn exact_duplicate_finding_scope(
     finding: &FindingRecord,
     scan: &ScanResult,
 ) -> Result<(String, Vec<String>)> {
-    if finding.category != FindingCategory::Overlap {
+    if finding.category != FindingCategory::Overlap
+        || !crate::query::stored_finding_is(
+            finding,
+            crate::query::FindingKind::ExactDuplicatePlacements,
+        )
+    {
         bail!("Finding {} is not an exact-duplicate Finding", finding.id);
     }
     let object = finding
@@ -10150,6 +10169,7 @@ mod recovery_tests {
     fn coverage_finding(basis: crate::query::FindingCoverageBasis) -> crate::query::Finding {
         crate::query::Finding {
             id: "finding_coverage".into(),
+            kind: crate::query::FindingKind::ExactDuplicatePlacements,
             category: crate::query::FindingCategory::Overlap,
             severity: crate::query::Severity::Medium,
             title: "Exact duplicate Skill placements".into(),
@@ -10453,6 +10473,7 @@ mod recovery_tests {
                 "unsupported_coverage_basis",
             ),
             (json!({"coverage": []}), "malformed_coverage"),
+            (json!({"kind": "future_kind"}), "unsupported_finding_kind"),
         ] {
             let error =
                 stored_finding_coverage_basis(&finding, invalid.as_object().unwrap()).unwrap_err();
@@ -10467,6 +10488,26 @@ mod recovery_tests {
             assert_eq!(output["error"]["details"]["files_changed"], false);
             assert_eq!(output["error"]["details"]["next_action"], "scan");
         }
+    }
+
+    #[test]
+    fn legacy_escaping_link_report_requires_a_typed_kind_before_reuse() {
+        let mut report = ReportRecord {
+            id: ReportId::new(),
+            scan_id: ScanId::new(),
+            created_at: 0,
+            summary: json!({
+                "findings": [{
+                    "kind": null,
+                    "title": crate::source_policy::ESCAPING_LINK_FINDING_TITLE
+                }]
+            }),
+        };
+
+        assert!(!report_supports_source_confirmation_kind(&report));
+        report.summary["findings"][0]["kind"] =
+            json!(crate::query::FindingKind::EscapingLinkSourceConfirmation);
+        assert!(report_supports_source_confirmation_kind(&report));
     }
 
     #[test]
@@ -10787,6 +10828,7 @@ mod recovery_tests {
     fn finding_rollups_count_unique_affected_subjects() {
         let findings = vec![
             json!({
+                "kind": "exact_duplicate_placements",
                 "category": "overlap",
                 "severity": "medium",
                 "title": "Exact duplicate Skill placements",
@@ -10794,9 +10836,10 @@ mod recovery_tests {
                 "affected_placement_ids": ["placement_a", "placement_b"]
             }),
             json!({
+                "kind": "exact_duplicate_placements",
                 "category": "overlap",
                 "severity": "medium",
-                "title": "Exact duplicate Skill placements",
+                "title": "Copy-edited duplicate placement title",
                 "affected_skill_ids": ["skill_a", "skill_b"],
                 "affected_placement_ids": ["placement_b", "placement_c"]
             }),
@@ -10812,9 +10855,10 @@ mod recovery_tests {
 
     #[test]
     fn finding_pages_interleave_families_without_losing_instances() {
-        let finding = |id: &str, category: &str, title: &str| {
+        let finding = |id: &str, category: &str, kind: &str, title: &str| {
             json!({
                 "id": id,
+                "kind": kind,
                 "category": category,
                 "severity": "medium",
                 "title": title,
@@ -10824,12 +10868,12 @@ mod recovery_tests {
         };
         let report = json!({
             "findings": [
-                finding("a1", "overlap", "family-a"),
-                finding("a2", "overlap", "family-a"),
-                finding("a3", "overlap", "family-a"),
-                finding("b1", "overlap", "family-b"),
-                finding("b2", "overlap", "family-b"),
-                finding("c1", "usage", "family-c")
+                finding("a1", "overlap", "exact_duplicate_placements", "family-a"),
+                finding("a2", "overlap", "exact_duplicate_placements", "edited-a"),
+                finding("a3", "overlap", "exact_duplicate_placements", "edited-again-a"),
+                finding("b1", "overlap", "semantic_overlap_candidate", "family-b"),
+                finding("b2", "overlap", "semantic_overlap_candidate", "edited-b"),
+                finding("c1", "usage", "usage_coverage_incomplete", "family-c")
             ]
         });
 
@@ -11161,12 +11205,24 @@ mod recovery_tests {
             title: "Exact duplicate".into(),
             summary: String::new(),
             details: json!({
+                "kind": "exact_duplicate_placements",
                 "affected_skill_ids": ["skill_shared"],
                 "affected_placement_ids": ["placement_agent", "placement_plugin"]
             }),
             evidence_ids: vec![EvidenceId::parse("evidence_external-duplicate").unwrap()],
         };
         let scan_id = ScanId::parse("scan_external-duplicate").unwrap();
+
+        for wrong_kind in [
+            json!("semantic_overlap_candidate"),
+            json!("future_kind"),
+            json!(7),
+        ] {
+            let mut wrong = finding.clone();
+            wrong.details["kind"] = wrong_kind;
+            assert!(exact_duplicate_finding_scope(&wrong, &scan).is_err());
+            assert!(finding_library_planning(&wrong, &scan_id, &scan_id, &scan).is_none());
+        }
 
         let planning = finding_library_planning(&finding, &scan_id, &scan_id, &scan).unwrap();
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,5 @@
 use crate::harness::AgentKind;
+use crate::model::FindingRecord;
 use crate::scan::{
     EvidenceQuality, LinkStatus, ScanResult, ScannedSkill, UsageStage, agents_with_usage,
     placements_by_skill, skill_search_text,
@@ -87,6 +88,116 @@ pub enum FindingCategory {
     Lifecycle,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingKind {
+    ConfiguredRootsInaccessible,
+    ConfiguredRootsBounded,
+    IncompletePackageFingerprints,
+    BrokenSkillLinks,
+    EscapingLinkSourceConfirmation,
+    SameNameDivergentContent,
+    DeclaredIdentityDivergentContent,
+    DeclaredNameDirectoryMismatch,
+    LargeDefaultRoster,
+    FiveStageUsageEvidence,
+    UsageCoverageIncomplete,
+    ExactDuplicatePlacements,
+    SemanticOverlapCandidate,
+    MissingRoutingMetadata,
+    ExecutableScriptsPresent,
+    UnknownProvenance,
+    UpstreamDriftUnverified,
+    SourceVersionDivergence,
+    ManagementStateReview,
+    StaleArchiveCandidates,
+    ArchiveCandidacyUnknown,
+}
+
+impl FindingKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ConfiguredRootsInaccessible => "configured_roots_inaccessible",
+            Self::ConfiguredRootsBounded => "configured_roots_bounded",
+            Self::IncompletePackageFingerprints => "incomplete_package_fingerprints",
+            Self::BrokenSkillLinks => "broken_skill_links",
+            Self::EscapingLinkSourceConfirmation => "escaping_link_source_confirmation",
+            Self::SameNameDivergentContent => "same_name_divergent_content",
+            Self::DeclaredIdentityDivergentContent => "declared_identity_divergent_content",
+            Self::DeclaredNameDirectoryMismatch => "declared_name_directory_mismatch",
+            Self::LargeDefaultRoster => "large_default_roster",
+            Self::FiveStageUsageEvidence => "five_stage_usage_evidence",
+            Self::UsageCoverageIncomplete => "usage_coverage_incomplete",
+            Self::ExactDuplicatePlacements => "exact_duplicate_placements",
+            Self::SemanticOverlapCandidate => "semantic_overlap_candidate",
+            Self::MissingRoutingMetadata => "missing_routing_metadata",
+            Self::ExecutableScriptsPresent => "executable_scripts_present",
+            Self::UnknownProvenance => "unknown_provenance",
+            Self::UpstreamDriftUnverified => "upstream_drift_unverified",
+            Self::SourceVersionDivergence => "source_version_divergence",
+            Self::ManagementStateReview => "management_state_review",
+            Self::StaleArchiveCandidates => "stale_archive_candidates",
+            Self::ArchiveCandidacyUnknown => "archive_candidacy_unknown",
+        }
+    }
+
+    fn from_legacy_title(title: &str) -> Option<Self> {
+        match title {
+            "Some configured roots were inaccessible" => Some(Self::ConfiguredRootsInaccessible),
+            "Some configured roots had bounded discovery" => Some(Self::ConfiguredRootsBounded),
+            "Some Skill package fingerprints are incomplete" => {
+                Some(Self::IncompletePackageFingerprints)
+            }
+            "Broken Skill links" => Some(Self::BrokenSkillLinks),
+            crate::source_policy::ESCAPING_LINK_FINDING_TITLE => {
+                Some(Self::EscapingLinkSourceConfirmation)
+            }
+            SAME_NAME_DIVERGENT_FINDING_TITLE => Some(Self::SameNameDivergentContent),
+            "Declared identity has divergent local content" => {
+                Some(Self::DeclaredIdentityDivergentContent)
+            }
+            "Declared Skill names differ from placement directories" => {
+                Some(Self::DeclaredNameDirectoryMismatch)
+            }
+            "Large default Rosters need review" => Some(Self::LargeDefaultRoster),
+            "Five-stage usage evidence" => Some(Self::FiveStageUsageEvidence),
+            "Usage coverage is incomplete" => Some(Self::UsageCoverageIncomplete),
+            "Exact duplicate Skill placements" => Some(Self::ExactDuplicatePlacements),
+            SEMANTIC_OVERLAP_FINDING_TITLE => Some(Self::SemanticOverlapCandidate),
+            "Skills lack routing metadata" => Some(Self::MissingRoutingMetadata),
+            "Skill packages contain executable scripts" => Some(Self::ExecutableScriptsPresent),
+            "Skill provenance is unknown" => Some(Self::UnknownProvenance),
+            "Upstream update drift is not verified" => Some(Self::UpstreamDriftUnverified),
+            "Declared source has version divergence" => Some(Self::SourceVersionDivergence),
+            "Management state needs review" => Some(Self::ManagementStateReview),
+            STALE_ARCHIVE_FINDING_TITLE => Some(Self::StaleArchiveCandidates),
+            UNKNOWN_ARCHIVE_FINDING_TITLE => Some(Self::ArchiveCandidacyUnknown),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) fn finding_kind_from_stored_value(
+    stored_kind: Option<&serde_json::Value>,
+    legacy_title: &str,
+) -> Option<FindingKind> {
+    match stored_kind {
+        Some(serde_json::Value::String(stored)) => {
+            serde_json::from_value(serde_json::Value::String(stored.clone())).ok()
+        }
+        None | Some(serde_json::Value::Null) => FindingKind::from_legacy_title(legacy_title),
+        Some(_) => None,
+    }
+}
+
+pub fn stored_finding_kind(finding: &FindingRecord) -> Option<FindingKind> {
+    finding_kind_from_stored_value(finding.details.get("kind"), &finding.title)
+}
+
+pub fn stored_finding_is(finding: &FindingRecord, kind: FindingKind) -> bool {
+    stored_finding_kind(finding) == Some(kind)
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FindingCoverageBasis {
@@ -107,6 +218,7 @@ pub enum Severity {
 #[derive(Clone, Debug, Serialize)]
 pub struct Finding {
     pub id: String,
+    pub kind: FindingKind,
     pub category: FindingCategory,
     pub severity: Severity,
     pub title: String,
@@ -431,7 +543,7 @@ fn prioritize_report_findings(findings: &mut Vec<Finding>, first_view_limit: usi
                     .len()
                     .cmp(&left.affected_skill_ids.len())
             })
-            .then_with(|| left.title.cmp(&right.title))
+            .then_with(|| left.kind.as_str().cmp(right.kind.as_str()))
             .then_with(|| left.id.cmp(&right.id))
     });
     if first_view_limit == 0 || findings.is_empty() {
@@ -498,6 +610,7 @@ fn inventory_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     if !unavailable.is_empty() {
         push_finding(
             findings,
+            FindingKind::ConfiguredRootsInaccessible,
             FindingCategory::Inventory,
             Severity::Medium,
             "Some configured roots were inaccessible",
@@ -530,6 +643,7 @@ fn inventory_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     if !bounded.is_empty() {
         push_finding(
             findings,
+            FindingKind::ConfiguredRootsBounded,
             FindingCategory::Inventory,
             Severity::Medium,
             "Some configured roots had bounded discovery",
@@ -567,6 +681,7 @@ fn inventory_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     if !incomplete_fingerprints.is_empty() {
         push_finding(
             findings,
+            FindingKind::IncompletePackageFingerprints,
             FindingCategory::Inventory,
             Severity::Medium,
             "Some Skill package fingerprints are incomplete",
@@ -592,10 +707,16 @@ fn inventory_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
 }
 
 fn layout_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
-    for (status, title, severity) in [
-        (LinkStatus::Broken, "Broken Skill links", Severity::High),
+    for (status, kind, title, severity) in [
+        (
+            LinkStatus::Broken,
+            FindingKind::BrokenSkillLinks,
+            "Broken Skill links",
+            Severity::High,
+        ),
         (
             LinkStatus::EscapesRoot,
+            FindingKind::EscapingLinkSourceConfirmation,
             crate::source_policy::ESCAPING_LINK_FINDING_TITLE,
             Severity::High,
         ),
@@ -608,6 +729,7 @@ fn layout_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
         if !placements.is_empty() {
             push_finding(
                 findings,
+                kind,
                 FindingCategory::Layout,
                 severity,
                 title,
@@ -657,6 +779,7 @@ fn layout_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
                 .collect::<Vec<_>>();
             push_finding(
                 findings,
+                FindingKind::SameNameDivergentContent,
                 FindingCategory::Layout,
                 Severity::Medium,
                 SAME_NAME_DIVERGENT_FINDING_TITLE,
@@ -695,6 +818,7 @@ fn layout_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             let skill_name = skill.name.as_str();
             push_finding(
                 findings,
+                FindingKind::DeclaredIdentityDivergentContent,
                 FindingCategory::Layout,
                 Severity::High,
                 "Declared identity has divergent local content",
@@ -729,6 +853,7 @@ fn layout_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     if !mismatches.is_empty() {
         push_finding(
             findings,
+            FindingKind::DeclaredNameDirectoryMismatch,
             FindingCategory::Layout,
             Severity::Low,
             "Declared Skill names differ from placement directories",
@@ -779,6 +904,7 @@ fn exposure_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     // This is a review threshold, not a claim that any Skill is useless.
     push_finding(
         findings,
+        FindingKind::LargeDefaultRoster,
         FindingCategory::Exposure,
         Severity::Medium,
         "Large default Rosters need review",
@@ -1064,6 +1190,7 @@ fn usage_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     let coverage = &overview.coverage;
     push_session_finding(
         findings,
+        FindingKind::FiveStageUsageEvidence,
         FindingCategory::Usage,
         Severity::Info,
         "Five-stage usage evidence",
@@ -1109,6 +1236,7 @@ fn usage_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     if incomplete_count != 0 {
         push_session_finding(
             findings,
+            FindingKind::UsageCoverageIncomplete,
             FindingCategory::Usage,
             Severity::Info,
             "Usage coverage is incomplete",
@@ -1160,6 +1288,7 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             }
             push_finding(
                 findings,
+                FindingKind::ExactDuplicatePlacements,
                 FindingCategory::Overlap,
                 Severity::Medium,
                 "Exact duplicate Skill placements",
@@ -1229,6 +1358,7 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     for (similarity, left, right) in candidates.into_iter().take(25) {
         push_finding(
             findings,
+            FindingKind::SemanticOverlapCandidate,
             FindingCategory::Overlap,
             Severity::Low,
             SEMANTIC_OVERLAP_FINDING_TITLE,
@@ -1301,6 +1431,7 @@ fn routing_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     if !weak.is_empty() {
         push_finding(
             findings,
+            FindingKind::MissingRoutingMetadata,
             FindingCategory::Routing,
             Severity::Low,
             "Skills lack routing metadata",
@@ -1329,6 +1460,7 @@ fn lifecycle_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             .sum::<usize>();
         push_finding(
             findings,
+            FindingKind::ExecutableScriptsPresent,
             FindingCategory::Lifecycle,
             Severity::Info,
             "Skill packages contain executable scripts",
@@ -1360,6 +1492,7 @@ fn lifecycle_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     if !unknown_source.is_empty() {
         push_finding(
             findings,
+            FindingKind::UnknownProvenance,
             FindingCategory::Lifecycle,
             Severity::Low,
             "Skill provenance is unknown",
@@ -1402,6 +1535,7 @@ fn lifecycle_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
             .join(", ");
         push_finding(
             findings,
+            FindingKind::UpstreamDriftUnverified,
             FindingCategory::Lifecycle,
             Severity::Info,
             "Upstream update drift is not verified",
@@ -1446,6 +1580,7 @@ fn lifecycle_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
         }
         push_finding(
             findings,
+            FindingKind::SourceVersionDivergence,
             FindingCategory::Lifecycle,
             Severity::Medium,
             "Declared source has version divergence",
@@ -1467,6 +1602,7 @@ fn lifecycle_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     if !multi_placement.is_empty() {
         push_finding(
             findings,
+            FindingKind::ManagementStateReview,
             FindingCategory::Lifecycle,
             Severity::Low,
             "Management state needs review",
@@ -1527,6 +1663,7 @@ fn lifecycle_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     if !stale_candidates.is_empty() {
         push_session_finding(
             findings,
+            FindingKind::StaleArchiveCandidates,
             FindingCategory::Lifecycle,
             Severity::Low,
             STALE_ARCHIVE_FINDING_TITLE,
@@ -1548,6 +1685,7 @@ fn lifecycle_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     } else if reliable_agents.len() < AgentKind::ALL.len() {
         push_session_finding(
             findings,
+            FindingKind::ArchiveCandidacyUnknown,
             FindingCategory::Lifecycle,
             Severity::Info,
             UNKNOWN_ARCHIVE_FINDING_TITLE,
@@ -1588,6 +1726,7 @@ fn evidence_paths_for_skills(scan: &ScanResult, skills: &[&ScannedSkill]) -> Vec
 #[allow(clippy::too_many_arguments)]
 fn push_finding(
     findings: &mut Vec<Finding>,
+    kind: FindingKind,
     category: FindingCategory,
     severity: Severity,
     title: impl Into<String>,
@@ -1599,6 +1738,7 @@ fn push_finding(
 ) {
     push_finding_with_coverage(
         findings,
+        kind,
         category,
         severity,
         title,
@@ -1614,6 +1754,7 @@ fn push_finding(
 #[allow(clippy::too_many_arguments)]
 fn push_session_finding(
     findings: &mut Vec<Finding>,
+    kind: FindingKind,
     category: FindingCategory,
     severity: Severity,
     title: impl Into<String>,
@@ -1625,6 +1766,7 @@ fn push_session_finding(
 ) {
     push_finding_with_coverage(
         findings,
+        kind,
         category,
         severity,
         title,
@@ -1640,6 +1782,7 @@ fn push_session_finding(
 #[allow(clippy::too_many_arguments)]
 fn push_finding_with_coverage(
     findings: &mut Vec<Finding>,
+    kind: FindingKind,
     category: FindingCategory,
     severity: Severity,
     title: impl Into<String>,
@@ -1660,12 +1803,13 @@ fn push_finding_with_coverage(
     let id_basis = format!(
         "{}\0{}\0{}\0{}",
         category_name(category),
-        title,
+        kind.as_str(),
         affected_skill_ids.join(","),
         affected_placement_ids.join(",")
     );
     findings.push(Finding {
         id: format!("finding_{}", fnv1a64(id_basis.as_bytes())),
+        kind,
         category,
         severity,
         title,
@@ -2369,6 +2513,61 @@ fn fnv1a64(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn finding_identity_and_behavior_do_not_depend_on_display_title() {
+        let mut findings = Vec::new();
+        for title in ["Original title", "Copy-edited title"] {
+            push_finding(
+                &mut findings,
+                FindingKind::ExactDuplicatePlacements,
+                FindingCategory::Overlap,
+                Severity::Medium,
+                title,
+                "same facts",
+                vec!["skill_one".into()],
+                vec!["placement_one".into()],
+                Vec::new(),
+                EvidenceQuality::Observed,
+            );
+        }
+
+        assert_eq!(findings[0].id, findings[1].id);
+        assert_eq!(findings[0].kind, findings[1].kind);
+        assert_ne!(findings[0].title, findings[1].title);
+    }
+
+    #[test]
+    fn stored_finding_kind_prefers_typed_details_and_bounds_legacy_title_fallback() {
+        let mut finding = FindingRecord {
+            id: crate::model::FindingId::new(),
+            report_id: crate::model::ReportId::new(),
+            category: crate::model::FindingCategory::Exposure,
+            severity: crate::model::Severity::Warning,
+            title: "A translated display title".into(),
+            summary: String::new(),
+            details: serde_json::json!({"kind": "large_default_roster"}),
+            evidence_ids: Vec::new(),
+        };
+
+        assert!(stored_finding_is(&finding, FindingKind::LargeDefaultRoster));
+        finding.details = serde_json::json!({"kind": null});
+        finding.title = "Large default Rosters need review".into();
+        assert!(stored_finding_is(&finding, FindingKind::LargeDefaultRoster));
+        finding.details = serde_json::json!({"kind": 7});
+        assert!(!stored_finding_is(
+            &finding,
+            FindingKind::LargeDefaultRoster
+        ));
+        finding.details = serde_json::json!({});
+        finding.title = "A translated display title".into();
+        assert!(!stored_finding_is(
+            &finding,
+            FindingKind::LargeDefaultRoster
+        ));
+        finding.title = "Large default Rosters need review".into();
+        assert!(stored_finding_is(&finding, FindingKind::LargeDefaultRoster));
+    }
 
     fn matched(name: &str, rank: usize, reasons: &[&str]) -> FindMatch {
         FindMatch {
@@ -3485,6 +3684,7 @@ mod tests {
         ) -> Finding {
             Finding {
                 id: format!("finding_{title}"),
+                kind: FindingKind::ManagementStateReview,
                 category,
                 severity,
                 title: title.into(),

--- a/src/roster_recommendation.rs
+++ b/src/roster_recommendation.rs
@@ -5,26 +5,15 @@ use anyhow::{Result, anyhow, bail};
 
 use crate::change::RosterChange;
 use crate::harness::AgentKind;
-use crate::model::{FindingCategory, FindingRecord};
+#[cfg(test)]
+use crate::model::FindingCategory;
+use crate::model::FindingRecord;
 use crate::scan::{EvidenceQuality, ScanResult, UsageStage};
 
 pub const MAX_CORE_BUDGET: usize = 50;
-pub const LARGE_ROSTER_FINDING_KIND: &str = "large_default_roster";
-pub const LARGE_ROSTER_FINDING_TITLE: &str = "Large default Rosters need review";
-
-pub fn finding_kind(category: &FindingCategory, title: &str) -> Option<&'static str> {
-    (*category == FindingCategory::Exposure && title == LARGE_ROSTER_FINDING_TITLE)
-        .then_some(LARGE_ROSTER_FINDING_KIND)
-}
 
 pub fn is_large_roster_finding(finding: &FindingRecord) -> bool {
-    finding
-        .details
-        .get("kind")
-        .and_then(serde_json::Value::as_str)
-        == Some(LARGE_ROSTER_FINDING_KIND)
-        || (finding.details.get("kind").is_none()
-            && finding_kind(&finding.category, &finding.title).is_some())
+    crate::query::stored_finding_is(finding, crate::query::FindingKind::LargeDefaultRoster)
 }
 
 #[derive(Clone, Debug)]

--- a/src/source_policy.rs
+++ b/src/source_policy.rs
@@ -352,7 +352,10 @@ pub fn confirm_source_root(
     snapshot: &ScanResult,
     requested: &Path,
 ) -> anyhow::Result<ConfirmOutcome> {
-    if finding.title != ESCAPING_LINK_FINDING_TITLE {
+    if !crate::query::stored_finding_is(
+        finding,
+        crate::query::FindingKind::EscapingLinkSourceConfirmation,
+    ) {
         return Err(SourceRootPolicyError::NotEscapingLinkFinding {
             finding_id: finding.id.as_str().to_owned(),
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -624,6 +624,28 @@ fn semantic_overlap_detail_is_decision_complete_for_agent_comparison() {
         .unwrap()["id"]
         .as_str()
         .unwrap();
+    {
+        let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+        let encoded: String = database
+            .query_row(
+                "SELECT details_json FROM findings WHERE id = ?1",
+                [finding_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let mut details: Value = serde_json::from_str(&encoded).unwrap();
+        details["title"] = json!("Copy-edited semantic comparison title");
+        database
+            .execute(
+                "UPDATE findings SET title = ?1, details_json = ?2 WHERE id = ?3",
+                (
+                    "Copy-edited semantic comparison title",
+                    details.to_string(),
+                    finding_id,
+                ),
+            )
+            .unwrap();
+    }
     let compact = json_output(&run(
         &[
             &common[..],


### PR DESCRIPTION
Closes #246

## Summary
- add an exhaustive serialized `FindingKind` for every current report family
- require report construction to choose kind separately from display title
- derive Finding identity from category, kind, and affected facts instead of title
- drive usage detail and source-confirmation/Roster behavior through stored kinds
- retain title-to-kind matching only for historical records without a stored kind
- preserve existing public kind strings for large Roster, same-name divergence, and escaping-link confirmation

## Simplification evidence
- removes distributed English-title control flow from new records
- centralizes bounded legacy compatibility in one conversion function
- copy edits no longer change Finding identity or behavior

## Validation
- cargo test --locked --all-targets --all-features: 245 unit, 8 acceptance, 69 CLI
- strict Clippy passed
- Node harness: 137/137
- cargo fmt --all --check
- git diff --check

The PR remains unmerged pending review.