### PR TITLE
fix: bind mutations to approved root handles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ulid = { version = "1.2", features = ["serde"] }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Wdk_Storage_FileSystem", "Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading"] }
 
 [dev-dependencies]
 tempfile = "3.20"

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -164,6 +164,13 @@ removal uses a handle-bound disposition that ignores readonly without first
 weakening the original path's attributes. SkillRoster does not claim portable
 preservation of owner, ACLs, or extended attributes.
 
+Apply, compensation, and Undo open approved roots and the private state root as
+directory capabilities before mutation. Filesystem paths are resolved relative
+to those retained handles for fingerprinting, copy, rename, replacement, and
+link operations. If an opened root and its directory entry no longer identify
+the same directory, or if an ancestor symlink would escape the handle, the
+operation fails closed without touching the escaped target.
+
 ### 4.5 Source updates
 
 SkillRoster records source, revision, and content hash when available. A source-update request submitted through `plan --stdin` first produces a diff and Plan; there is no silent update path. Local modifications stop automatic replacement and require an explicit choice to retain local content, adopt upstream content, or preserve both.

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -1,0 +1,288 @@
+use std::ffi::OsString;
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
+use sha2::{Digest, Sha256};
+
+struct Anchor {
+    path: PathBuf,
+    dir: Dir,
+}
+
+/// Filesystem authority bound to already-open approved directory handles.
+///
+/// Ambient paths are accepted only to select an anchor and produce diagnostics.
+/// Every read, write, link, copy, and rename is then resolved relative to the
+/// retained handle, so a concurrent ancestor rename or symlink swap cannot
+/// redirect the operation outside that authority.
+pub(crate) struct AnchoredFs {
+    anchors: Vec<Anchor>,
+}
+
+impl AnchoredFs {
+    pub(crate) fn open(approved_roots: &[PathBuf], state_dir: &Path) -> io::Result<Self> {
+        let mut paths = approved_roots
+            .iter()
+            .filter(|path| path.is_dir() && !path.starts_with(state_dir))
+            .cloned()
+            .collect::<Vec<_>>();
+        paths.push(state_dir.to_path_buf());
+        paths.sort();
+        paths.dedup();
+
+        let mut anchors = Vec::with_capacity(paths.len());
+        for path in paths {
+            let dir = Dir::open_ambient_dir(&path, ambient_authority())?;
+            let opened = dir.dir_metadata()?;
+            let entry = fs::symlink_metadata(&path)?;
+            if entry.file_type().is_symlink() || !same_directory(&opened, &entry) {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "approved root entry changed while its directory handle was opened: {}",
+                        path.display()
+                    ),
+                ));
+            }
+            anchors.push(Anchor { path, dir });
+        }
+        anchors.sort_by(|left, right| {
+            right
+                .path
+                .components()
+                .count()
+                .cmp(&left.path.components().count())
+        });
+        Ok(Self { anchors })
+    }
+
+    pub(crate) fn fingerprint(&self, path: &Path) -> io::Result<String> {
+        let (anchor, relative) = self.resolve(path)?;
+        match self.fingerprint_relative(anchor, &relative) {
+            Ok(value) => Ok(value),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok("missing".into()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn fingerprint_relative(&self, anchor: &Anchor, relative: &Path) -> io::Result<String> {
+        let metadata = anchor.dir.symlink_metadata(relative)?;
+        if metadata.is_symlink() {
+            let target = anchor.dir.read_link_contents(relative)?;
+            return Ok(format!(
+                "symlink:sha256:{}",
+                hex::encode(Sha256::digest(target.as_os_str().as_encoded_bytes()))
+            ));
+        }
+        if metadata.is_file() {
+            let mut file = anchor.dir.open(relative)?;
+            let mut hash = Sha256::new();
+            let mut buffer = [0_u8; 64 * 1024];
+            loop {
+                let read = file.read(&mut buffer)?;
+                if read == 0 {
+                    break;
+                }
+                hash.update(&buffer[..read]);
+            }
+            return Ok(format!("file:sha256:{}", hex::encode(hash.finalize())));
+        }
+        if metadata.is_dir() {
+            let mut entries = anchor
+                .dir
+                .read_dir(relative)?
+                .map(|entry| entry.map(|entry| entry.file_name()))
+                .collect::<io::Result<Vec<OsString>>>()?;
+            entries.sort();
+            let mut hash = Sha256::new();
+            for name in entries {
+                hash.update(name.as_encoded_bytes());
+                hash.update(
+                    self.fingerprint_relative(anchor, &relative.join(&name))?
+                        .as_bytes(),
+                );
+            }
+            return Ok(format!("directory:sha256:{}", hex::encode(hash.finalize())));
+        }
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path is not a file, directory, or symlink",
+        ))
+    }
+
+    pub(crate) fn create_dir(&self, path: &Path) -> io::Result<()> {
+        let (anchor, relative) = self.resolve(path)?;
+        anchor.dir.create_dir(relative)
+    }
+
+    pub(crate) fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        let (anchor, relative) = self.resolve(path)?;
+        anchor.dir.create_dir_all(relative)
+    }
+
+    pub(crate) fn create_file(&self, path: &Path, content: &[u8]) -> io::Result<()> {
+        let (anchor, relative) = self.resolve(path)?;
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        let mut file = anchor.dir.open_with(relative, &options)?;
+        file.write_all(content)?;
+        file.sync_all()
+    }
+
+    pub(crate) fn replace_file(
+        &self,
+        target: &Path,
+        temp: &Path,
+        content: &[u8],
+    ) -> io::Result<()> {
+        self.create_file(temp, content)?;
+        self.remove_file(target)?;
+        self.rename(temp, target)
+    }
+
+    pub(crate) fn read_link(&self, path: &Path) -> io::Result<PathBuf> {
+        let (anchor, relative) = self.resolve(path)?;
+        anchor.dir.read_link_contents(relative)
+    }
+
+    pub(crate) fn create_symlink(&self, source: &Path, target: &Path) -> io::Result<()> {
+        let (target_anchor, target_relative) = self.resolve(target)?;
+        #[cfg(unix)]
+        {
+            target_anchor.dir.symlink_contents(source, target_relative)
+        }
+        #[cfg(windows)]
+        {
+            let (source_anchor, source_relative) = self.resolve(source)?;
+            if source_anchor.dir.metadata(source_relative)?.is_dir() {
+                target_anchor.dir.symlink_dir(source, target_relative)
+            } else {
+                target_anchor.dir.symlink_file(source, target_relative)
+            }
+        }
+    }
+
+    pub(crate) fn remove_file(&self, path: &Path) -> io::Result<()> {
+        let (anchor, relative) = self.resolve(path)?;
+        anchor.dir.remove_file(relative)
+    }
+
+    pub(crate) fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        let (from_anchor, from_relative) = self.resolve(from)?;
+        let (to_anchor, to_relative) = self.resolve(to)?;
+        from_anchor
+            .dir
+            .rename(from_relative, &to_anchor.dir, to_relative)
+    }
+
+    pub(crate) fn copy_file(&self, source: &Path, target: &Path) -> io::Result<u64> {
+        let (source_anchor, source_relative) = self.resolve(source)?;
+        let (target_anchor, target_relative) = self.resolve(target)?;
+        source_anchor
+            .dir
+            .copy(source_relative, &target_anchor.dir, target_relative)
+    }
+
+    pub(crate) fn copy_tree(&self, source: &Path, target: &Path) -> io::Result<()> {
+        let (source_anchor, source_relative) = self.resolve(source)?;
+        let (target_anchor, target_relative) = self.resolve(target)?;
+        self.copy_tree_relative(
+            source_anchor,
+            &source_relative,
+            target_anchor,
+            &target_relative,
+        )
+    }
+
+    fn copy_tree_relative(
+        &self,
+        source_anchor: &Anchor,
+        source: &Path,
+        target_anchor: &Anchor,
+        target: &Path,
+    ) -> io::Result<()> {
+        let metadata = source_anchor.dir.symlink_metadata(source)?;
+        if metadata.is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "refusing to recursively copy a symlink",
+            ));
+        }
+        if metadata.is_file() {
+            source_anchor.dir.copy(source, &target_anchor.dir, target)?;
+            return Ok(());
+        }
+        if !metadata.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "source is not a supported file type",
+            ));
+        }
+        target_anchor.dir.create_dir(target)?;
+        let entries = source_anchor
+            .dir
+            .read_dir(source)?
+            .map(|entry| entry.map(|entry| entry.file_name()))
+            .collect::<io::Result<Vec<_>>>()?;
+        for name in entries {
+            self.copy_tree_relative(
+                source_anchor,
+                &source.join(&name),
+                target_anchor,
+                &target.join(name),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn resolve<'a>(&'a self, path: &Path) -> io::Result<(&'a Anchor, PathBuf)> {
+        for anchor in &self.anchors {
+            if let Ok(relative) = path.strip_prefix(&anchor.path) {
+                let relative = if relative.as_os_str().is_empty() {
+                    PathBuf::from(".")
+                } else {
+                    relative.to_path_buf()
+                };
+                if relative.is_absolute()
+                    || relative.components().any(|component| {
+                        matches!(
+                            component,
+                            std::path::Component::ParentDir
+                                | std::path::Component::Prefix(_)
+                                | std::path::Component::RootDir
+                        )
+                    })
+                {
+                    break;
+                }
+                return Ok((anchor, relative));
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("path has no approved directory handle: {}", path.display()),
+        ))
+    }
+}
+
+#[cfg(unix)]
+fn same_directory(opened: &cap_std::fs::Metadata, entry: &fs::Metadata) -> bool {
+    use cap_std::fs::MetadataExt as _;
+    use std::os::unix::fs::MetadataExt as _;
+
+    opened.dev() == entry.dev() && opened.ino() == entry.ino()
+}
+
+#[cfg(windows)]
+fn same_directory(opened: &cap_std::fs::Metadata, entry: &fs::Metadata) -> bool {
+    use cap_std::fs::MetadataExt as _;
+    use std::os::windows::fs::MetadataExt as _;
+
+    opened.volume_serial_number() == entry.volume_serial_number()
+        && opened.file_index() == entry.file_index()
+        && opened.volume_serial_number().is_some()
+        && opened.file_index().is_some()
+}

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -36,9 +36,9 @@ impl AnchoredFs {
         let mut anchors = Vec::with_capacity(paths.len());
         for path in paths {
             let dir = Dir::open_ambient_dir(&path, ambient_authority())?;
-            let opened = dir.dir_metadata()?;
+            let opened = dir.try_clone()?.into_std_file();
             let entry = fs::symlink_metadata(&path)?;
-            if entry.file_type().is_symlink() || !same_directory(&opened, &entry) {
+            if entry.file_type().is_symlink() || !same_directory(&opened, &path)? {
                 return Err(io::Error::new(
                     io::ErrorKind::PermissionDenied,
                     format!(
@@ -61,14 +61,14 @@ impl AnchoredFs {
 
     pub(crate) fn fingerprint(&self, path: &Path) -> io::Result<String> {
         let (anchor, relative) = self.resolve(path)?;
-        match self.fingerprint_relative(anchor, &relative) {
+        match Self::fingerprint_relative(anchor, &relative) {
             Ok(value) => Ok(value),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok("missing".into()),
             Err(error) => Err(error),
         }
     }
 
-    fn fingerprint_relative(&self, anchor: &Anchor, relative: &Path) -> io::Result<String> {
+    fn fingerprint_relative(anchor: &Anchor, relative: &Path) -> io::Result<String> {
         let metadata = anchor.dir.symlink_metadata(relative)?;
         if metadata.is_symlink() {
             let target = anchor.dir.read_link_contents(relative)?;
@@ -100,10 +100,7 @@ impl AnchoredFs {
             let mut hash = Sha256::new();
             for name in entries {
                 hash.update(name.as_encoded_bytes());
-                hash.update(
-                    self.fingerprint_relative(anchor, &relative.join(&name))?
-                        .as_bytes(),
-                );
+                hash.update(Self::fingerprint_relative(anchor, &relative.join(&name))?.as_bytes());
             }
             return Ok(format!("directory:sha256:{}", hex::encode(hash.finalize())));
         }
@@ -189,7 +186,7 @@ impl AnchoredFs {
     pub(crate) fn copy_tree(&self, source: &Path, target: &Path) -> io::Result<()> {
         let (source_anchor, source_relative) = self.resolve(source)?;
         let (target_anchor, target_relative) = self.resolve(target)?;
-        self.copy_tree_relative(
+        Self::copy_tree_relative(
             source_anchor,
             &source_relative,
             target_anchor,
@@ -198,7 +195,6 @@ impl AnchoredFs {
     }
 
     fn copy_tree_relative(
-        &self,
         source_anchor: &Anchor,
         source: &Path,
         target_anchor: &Anchor,
@@ -228,7 +224,7 @@ impl AnchoredFs {
             .map(|entry| entry.map(|entry| entry.file_name()))
             .collect::<io::Result<Vec<_>>>()?;
         for name in entries {
-            self.copy_tree_relative(
+            Self::copy_tree_relative(
                 source_anchor,
                 &source.join(&name),
                 target_anchor,
@@ -269,20 +265,58 @@ impl AnchoredFs {
 }
 
 #[cfg(unix)]
-fn same_directory(opened: &cap_std::fs::Metadata, entry: &fs::Metadata) -> bool {
-    use cap_std::fs::MetadataExt as _;
+fn same_directory(opened: &fs::File, path: &Path) -> io::Result<bool> {
     use std::os::unix::fs::MetadataExt as _;
 
-    opened.dev() == entry.dev() && opened.ino() == entry.ino()
+    let opened = opened.metadata()?;
+    let entry = fs::symlink_metadata(path)?;
+    Ok(opened.dev() == entry.dev() && opened.ino() == entry.ino())
 }
 
 #[cfg(windows)]
-fn same_directory(opened: &cap_std::fs::Metadata, entry: &fs::Metadata) -> bool {
-    use cap_std::fs::MetadataExt as _;
-    use std::os::windows::fs::MetadataExt as _;
+fn same_directory(opened: &fs::File, path: &Path) -> io::Result<bool> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, CreateFileW, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, GetFileInformationByHandle, OPEN_EXISTING,
+    };
 
-    opened.volume_serial_number() == entry.volume_serial_number()
-        && opened.file_index() == entry.file_index()
-        && opened.volume_serial_number().is_some()
-        && opened.file_index().is_some()
+    fn identity(handle: windows_sys::Win32::Foundation::HANDLE) -> io::Result<(u32, u32, u32)> {
+        let mut information = unsafe { std::mem::zeroed::<BY_HANDLE_FILE_INFORMATION>() };
+        if unsafe { GetFileInformationByHandle(handle, &mut information) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok((
+            information.dwVolumeSerialNumber,
+            information.nFileIndexHigh,
+            information.nFileIndexLow,
+        ))
+    }
+
+    let opened_identity = identity(opened.as_raw_handle())?;
+    let wide = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let entry = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if entry == INVALID_HANDLE_VALUE || entry.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let entry_identity = identity(entry);
+    unsafe { CloseHandle(entry) };
+    Ok(opened_identity == entry_identity?)
 }

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -4,12 +4,487 @@ use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
 use cap_std::ambient_authority;
-use cap_std::fs::{Dir, OpenOptions};
+use cap_std::fs::{Dir, OpenOptions, Permissions};
 use sha2::{Digest, Sha256};
+
+use crate::durable_fs::DirectorySync;
+
+#[cfg(test)]
+thread_local! {
+    static AFTER_SYMLINK_SOURCE_OPEN_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static AFTER_STAGING_FILE_OPEN_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static BEFORE_APPROVED_ROOT_OPEN_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static AFTER_APPROVED_ROOT_CANONICALIZE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static AFTER_CREATED_DIRECTORY_OPEN_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static AFTER_CREATED_SYMLINK_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static AFTER_CREATED_SYMLINK_FIRST_CHECK_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static AFTER_CREATED_ENTRY_FIRST_CHECK_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static AFTER_RENAMED_ENTRY_FIRST_CHECK_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static BEFORE_RENAME_NOREPLACE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+pub(crate) fn set_after_symlink_source_open_hook(hook: impl FnOnce() + 'static) {
+    AFTER_SYMLINK_SOURCE_OPEN_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+pub(crate) fn set_after_staging_file_open_hook(hook: impl FnOnce() + 'static) {
+    AFTER_STAGING_FILE_OPEN_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+pub(crate) fn set_before_approved_root_open_hook(hook: impl FnOnce() + 'static) {
+    BEFORE_APPROVED_ROOT_OPEN_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+pub(crate) fn set_after_approved_root_canonicalize_hook(hook: impl FnOnce() + 'static) {
+    AFTER_APPROVED_ROOT_CANONICALIZE_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+pub(crate) fn set_after_created_directory_open_hook(hook: impl FnOnce() + 'static) {
+    AFTER_CREATED_DIRECTORY_OPEN_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+pub(crate) fn set_after_created_symlink_hook(hook: impl FnOnce() + 'static) {
+    AFTER_CREATED_SYMLINK_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+pub(crate) fn set_after_created_symlink_first_check_hook(hook: impl FnOnce() + 'static) {
+    AFTER_CREATED_SYMLINK_FIRST_CHECK_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+pub(crate) fn set_after_created_entry_first_check_hook(hook: impl FnOnce() + 'static) {
+    AFTER_CREATED_ENTRY_FIRST_CHECK_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, unix))]
+pub(crate) fn set_after_renamed_entry_first_check_hook(hook: impl FnOnce() + 'static) {
+    AFTER_RENAMED_ENTRY_FIRST_CHECK_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(all(test, any(unix, windows)))]
+pub(crate) fn set_before_rename_noreplace_hook(hook: impl FnOnce() + 'static) {
+    BEFORE_RENAME_NOREPLACE_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(test)]
+fn run_after_symlink_source_open_hook() {
+    AFTER_SYMLINK_SOURCE_OPEN_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_after_symlink_source_open_hook() {}
+
+#[cfg(test)]
+fn run_after_staging_file_open_hook() {
+    AFTER_STAGING_FILE_OPEN_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_after_staging_file_open_hook() {}
+
+#[cfg(test)]
+fn run_before_approved_root_open_hook() {
+    BEFORE_APPROVED_ROOT_OPEN_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_before_approved_root_open_hook() {}
+
+#[cfg(test)]
+fn run_after_approved_root_canonicalize_hook() {
+    AFTER_APPROVED_ROOT_CANONICALIZE_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_after_approved_root_canonicalize_hook() {}
+
+#[cfg(test)]
+fn run_after_created_directory_open_hook() {
+    AFTER_CREATED_DIRECTORY_OPEN_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_after_created_directory_open_hook() {}
+
+#[cfg(test)]
+fn run_after_created_symlink_hook() {
+    AFTER_CREATED_SYMLINK_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_after_created_symlink_hook() {}
+
+#[cfg(test)]
+fn run_after_created_symlink_first_check_hook() {
+    AFTER_CREATED_SYMLINK_FIRST_CHECK_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_after_created_symlink_first_check_hook() {}
+
+#[cfg(test)]
+fn run_after_created_entry_first_check_hook() {
+    AFTER_CREATED_ENTRY_FIRST_CHECK_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_after_created_entry_first_check_hook() {}
+
+#[cfg(test)]
+fn run_after_renamed_entry_first_check_hook() {
+    AFTER_RENAMED_ENTRY_FIRST_CHECK_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_after_renamed_entry_first_check_hook() {}
+
+#[cfg(test)]
+fn run_before_rename_noreplace_hook() {
+    BEFORE_RENAME_NOREPLACE_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_before_rename_noreplace_hook() {}
 
 struct Anchor {
     path: PathBuf,
     dir: Dir,
+}
+
+#[cfg(unix)]
+struct EntryIdentity {
+    device: u64,
+    inode: u64,
+}
+
+#[cfg(windows)]
+struct EntryIdentity {
+    handle: fs::File,
+}
+
+#[cfg(unix)]
+fn entry_identity_at(anchor: &Anchor, relative: &Path) -> io::Result<EntryIdentity> {
+    use cap_std::fs::MetadataExt as _;
+
+    let metadata = anchor.dir.symlink_metadata(relative)?;
+    Ok(EntryIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+#[cfg(unix)]
+fn require_entry_identity_at(
+    anchor: &Anchor,
+    relative: &Path,
+    expected: &EntryIdentity,
+) -> io::Result<()> {
+    use cap_std::fs::MetadataExt as _;
+
+    let metadata = anchor.dir.symlink_metadata(relative)?;
+    if metadata.dev() == expected.device && metadata.ino() == expected.inode {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "renamed entry changed while its identity was retained",
+        ))
+    }
+}
+
+fn parent_dir_and_name(anchor: &Anchor, relative: &Path) -> io::Result<(Dir, OsString)> {
+    let name = relative.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "rename target has no file name",
+        )
+    })?;
+    let parent = relative
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    Ok((anchor.dir.open_dir(parent)?, name.to_os_string()))
+}
+
+#[cfg(target_os = "linux")]
+fn rename_noreplace(
+    from_anchor: &Anchor,
+    from: &Path,
+    to_anchor: &Anchor,
+    to: &Path,
+    _retained: &EntryIdentity,
+) -> io::Result<()> {
+    use std::os::fd::AsRawFd as _;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let (from_parent, from_name) = parent_dir_and_name(from_anchor, from)?;
+    let (to_parent, to_name) = parent_dir_and_name(to_anchor, to)?;
+    let from_name = std::ffi::CString::new(from_name.as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "rename source contains NUL"))?;
+    let to_name = std::ffi::CString::new(to_name.as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "rename target contains NUL"))?;
+    let result = unsafe {
+        libc::renameat2(
+            from_parent.as_raw_fd(),
+            from_name.as_ptr(),
+            to_parent.as_raw_fd(),
+            to_name.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn rename_noreplace(
+    from_anchor: &Anchor,
+    from: &Path,
+    to_anchor: &Anchor,
+    to: &Path,
+    _retained: &EntryIdentity,
+) -> io::Result<()> {
+    use std::os::fd::AsRawFd as _;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let (from_parent, from_name) = parent_dir_and_name(from_anchor, from)?;
+    let (to_parent, to_name) = parent_dir_and_name(to_anchor, to)?;
+    let from_name = std::ffi::CString::new(from_name.as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "rename source contains NUL"))?;
+    let to_name = std::ffi::CString::new(to_name.as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "rename target contains NUL"))?;
+    let result = unsafe {
+        libc::renameatx_np(
+            from_parent.as_raw_fd(),
+            from_name.as_ptr(),
+            to_parent.as_raw_fd(),
+            to_name.as_ptr(),
+            libc::RENAME_EXCL,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+fn rename_noreplace(
+    _from_anchor: &Anchor,
+    _from: &Path,
+    _to_anchor: &Anchor,
+    _to: &Path,
+    _retained: &EntryIdentity,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "atomic no-replace rename is unavailable on this platform",
+    ))
+}
+
+#[cfg(windows)]
+fn rename_noreplace(
+    _from_anchor: &Anchor,
+    _from: &Path,
+    to_anchor: &Anchor,
+    to: &Path,
+    retained: &EntryIdentity,
+) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Wdk::Storage::FileSystem::{FileRenameInformation, NtSetInformationFile};
+    use windows_sys::Win32::Foundation::RtlNtStatusToDosError;
+    use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
+
+    const MAX_NAME_CHARS: usize = 32_767;
+
+    #[repr(C)]
+    struct RenameInfo {
+        flags: u32,
+        root_directory: windows_sys::Win32::Foundation::HANDLE,
+        file_name_length: u32,
+        file_name: [u16; MAX_NAME_CHARS],
+    }
+
+    let (to_parent, to_name) = parent_dir_and_name(to_anchor, to)?;
+    let name = to_name.encode_wide().collect::<Vec<_>>();
+    if name.len() > MAX_NAME_CHARS {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "rename target name exceeds the Windows limit",
+        ));
+    }
+    let mut info = Box::new(RenameInfo {
+        flags: 0,
+        root_directory: to_parent.as_raw_handle(),
+        file_name_length: (name.len() * 2) as u32,
+        file_name: [0; MAX_NAME_CHARS],
+    });
+    info.file_name[..name.len()].copy_from_slice(&name);
+    let size = std::mem::offset_of!(RenameInfo, file_name) + name.len() * 2;
+    let mut status_block = IO_STATUS_BLOCK::default();
+    let status = unsafe {
+        NtSetInformationFile(
+            retained.handle.as_raw_handle(),
+            &mut status_block,
+            (&raw const *info).cast(),
+            size as u32,
+            FileRenameInformation,
+        )
+    };
+    if status >= 0 {
+        Ok(())
+    } else {
+        let error = unsafe { RtlNtStatusToDosError(status) };
+        Err(io::Error::from_raw_os_error(error as i32))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn rename_noreplace(
+    _from_anchor: &Anchor,
+    _from: &Path,
+    _to_anchor: &Anchor,
+    _to: &Path,
+    _retained: &EntryIdentity,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "atomic no-replace rename is unavailable on this platform",
+    ))
+}
+
+#[cfg(windows)]
+fn entry_identity_at(anchor: &Anchor, relative: &Path) -> io::Result<EntryIdentity> {
+    use cap_std::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        DELETE, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut options = OpenOptions::new();
+    options
+        .access_mode(FILE_READ_ATTRIBUTES | DELETE)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+    Ok(EntryIdentity {
+        handle: anchor.dir.open_with(relative, &options)?.into_std(),
+    })
+}
+
+#[cfg(windows)]
+fn require_entry_identity_at(
+    anchor: &Anchor,
+    relative: &Path,
+    expected: &EntryIdentity,
+) -> io::Result<()> {
+    let actual = entry_identity_at(anchor, relative)?;
+    if same_file_identity(&expected.handle, &actual.handle)? {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "renamed entry changed while its handle was retained",
+        ))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+struct EntryIdentity {
+    fingerprint: String,
+}
+
+#[cfg(not(any(unix, windows)))]
+fn entry_identity_at(anchor: &Anchor, relative: &Path) -> io::Result<EntryIdentity> {
+    Ok(EntryIdentity {
+        fingerprint: AnchoredFs::fingerprint_relative(anchor, relative)?,
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn require_entry_identity_at(
+    anchor: &Anchor,
+    relative: &Path,
+    expected: &EntryIdentity,
+) -> io::Result<()> {
+    if AnchoredFs::fingerprint_relative(anchor, relative)? == expected.fingerprint {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "renamed entry changed while its identity was retained",
+        ))
+    }
+}
+
+impl Anchor {
+    fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            path: self.path.clone(),
+            dir: self.dir.try_clone()?,
+        })
+    }
 }
 
 /// Filesystem authority bound to already-open approved directory handles.
@@ -18,12 +493,35 @@ struct Anchor {
 /// Every read, write, link, copy, and rename is then resolved relative to the
 /// retained handle, so a concurrent ancestor rename or symlink swap cannot
 /// redirect the operation outside that authority.
-pub(crate) struct AnchoredFs {
+pub(crate) struct AnchoredFs<'a> {
     anchors: Vec<Anchor>,
+    state_path: PathBuf,
+    directory_sync: &'a dyn DirectorySync,
 }
 
-impl AnchoredFs {
-    pub(crate) fn open(approved_roots: &[PathBuf], state_dir: &Path) -> io::Result<Self> {
+impl<'a> AnchoredFs<'a> {
+    pub(crate) fn state_root(&self) -> &Path {
+        &self.state_path
+    }
+
+    pub(crate) fn matches_state_directory(&self, path: &Path) -> io::Result<bool> {
+        let retained = self
+            .anchors
+            .iter()
+            .find(|anchor| anchor.path == self.state_path)
+            .ok_or_else(|| io::Error::other("state capability is missing"))?;
+        let candidate_path = fs::canonicalize(path)?;
+        let candidate = open_anchor(candidate_path, false)?;
+        let retained = retained.dir.try_clone()?.into_std_file();
+        let candidate = candidate.dir.into_std_file();
+        same_file_identity(&retained, &candidate)
+    }
+
+    pub(crate) fn open(
+        approved_roots: &[PathBuf],
+        state_dir: &Path,
+        directory_sync: &'a dyn DirectorySync,
+    ) -> io::Result<Self> {
         let mut paths = approved_roots
             .iter()
             .filter(|path| path.is_dir() && !path.starts_with(state_dir))
@@ -33,22 +531,16 @@ impl AnchoredFs {
         paths.sort();
         paths.dedup();
 
-        let mut anchors = Vec::with_capacity(paths.len());
-        for path in paths {
-            let dir = Dir::open_ambient_dir(&path, ambient_authority())?;
-            let opened = dir.try_clone()?.into_std_file();
-            let entry = fs::symlink_metadata(&path)?;
-            if entry.file_type().is_symlink() || !same_directory(&opened, &path)? {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!(
-                        "approved root entry changed while its directory handle was opened: {}",
-                        path.display()
-                    ),
-                ));
-            }
-            anchors.push(Anchor { path, dir });
-        }
+        let mut anchors = paths
+            .into_iter()
+            .map(|path| {
+                let approved_root = path != state_dir;
+                if approved_root {
+                    run_before_approved_root_open_hook();
+                }
+                open_anchor(path, approved_root)
+            })
+            .collect::<io::Result<Vec<_>>>()?;
         anchors.sort_by(|left, right| {
             right
                 .path
@@ -56,7 +548,64 @@ impl AnchoredFs {
                 .count()
                 .cmp(&left.path.components().count())
         });
-        Ok(Self { anchors })
+        Ok(Self {
+            anchors,
+            state_path: state_dir.to_path_buf(),
+            directory_sync,
+        })
+    }
+
+    pub(crate) fn open_with_retained_state(
+        approved_roots: &[PathBuf],
+        state_dir: &Path,
+        retained: &AnchoredFs<'_>,
+        directory_sync: &'a dyn DirectorySync,
+    ) -> io::Result<Self> {
+        if !retained.matches_state_directory(state_dir)? {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "retained capability does not own the requested state directory",
+            ));
+        }
+        let mut retained_state = retained
+            .anchors
+            .iter()
+            .find(|anchor| anchor.path == retained.state_path)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "retained capability does not own the requested state directory",
+                )
+            })?
+            .try_clone()?;
+        retained_state.path = state_dir.to_path_buf();
+        let mut paths = approved_roots
+            .iter()
+            .filter(|path| path.is_dir() && !path.starts_with(state_dir))
+            .cloned()
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths.dedup();
+        let mut anchors = paths
+            .into_iter()
+            .map(|path| {
+                run_before_approved_root_open_hook();
+                open_anchor(path, true)
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+        anchors.push(retained_state);
+        anchors.sort_by(|left, right| {
+            right
+                .path
+                .components()
+                .count()
+                .cmp(&left.path.components().count())
+        });
+        Ok(Self {
+            anchors,
+            state_path: state_dir.to_path_buf(),
+            directory_sync,
+        })
     }
 
     pub(crate) fn fingerprint(&self, path: &Path) -> io::Result<String> {
@@ -112,21 +661,174 @@ impl AnchoredFs {
 
     pub(crate) fn create_dir(&self, path: &Path) -> io::Result<()> {
         let (anchor, relative) = self.resolve(path)?;
-        anchor.dir.create_dir(relative)
+        anchor.dir.create_dir(&relative)?;
+        let opened = anchor.dir.open_dir(&relative)?.into_std_file();
+        run_after_created_directory_open_hook();
+        self.require_opened_directory_at(anchor, &relative, &opened)?;
+        run_after_created_entry_first_check_hook();
+        self.sync_parent_preserving_identity(anchor, &relative, || {
+            self.require_opened_directory_at(anchor, &relative, &opened)
+        })
     }
 
     pub(crate) fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         let (anchor, relative) = self.resolve(path)?;
-        anchor.dir.create_dir_all(relative)
+        let mut current = PathBuf::new();
+        for component in relative.components() {
+            current.push(component.as_os_str());
+            match anchor.dir.create_dir(&current) {
+                Ok(()) => {
+                    let opened = anchor.dir.open_dir(&current)?.into_std_file();
+                    self.require_opened_directory_at(anchor, &current, &opened)?;
+                    self.sync_parent_preserving_identity(anchor, &current, || {
+                        self.require_opened_directory_at(anchor, &current, &opened)
+                    })?;
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    let metadata = anchor.dir.symlink_metadata(&current)?;
+                    if metadata.is_symlink() || !metadata.is_dir() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "existing path component is not a directory",
+                        ));
+                    }
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn secure_private_directory(&self, path: &Path) -> io::Result<()> {
+        let (anchor, relative) = self.resolve(path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            let directory = open_directory_for_sync(&anchor.dir, &relative)?;
+            directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (anchor, relative);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn open_private_lock(&self, path: &Path) -> io::Result<fs::File> {
+        let (anchor, relative) = self.resolve(path)?;
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            .write(true)
+            .create(true)
+            ._cap_fs_ext_follow(cap_primitives::fs::FollowSymlinks::No);
+        #[cfg(unix)]
+        {
+            use cap_std::fs::OpenOptionsExt as _;
+
+            options.mode(0o600);
+        }
+        let file = anchor.dir.open_with(&relative, &options)?;
+        #[cfg(unix)]
+        {
+            use cap_std::fs::PermissionsExt as _;
+
+            file.set_permissions(Permissions::from_mode(0o600))?;
+        }
+        self.sync_parent(anchor, &relative)?;
+        Ok(file.into_std())
+    }
+
+    pub(crate) fn read_directory_names(&self, path: &Path) -> io::Result<Vec<OsString>> {
+        let (anchor, relative) = self.resolve(path)?;
+        let mut names = anchor
+            .dir
+            .read_dir(relative)?
+            .map(|entry| entry.map(|entry| entry.file_name()))
+            .collect::<io::Result<Vec<_>>>()?;
+        names.sort();
+        Ok(names)
+    }
+
+    pub(crate) fn read_regular_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        let (anchor, relative) = self.resolve(path)?;
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            ._cap_fs_ext_follow(cap_primitives::fs::FollowSymlinks::No);
+        let mut file = anchor.dir.open_with(relative, &options)?;
+        let metadata = file.metadata()?;
+        if !metadata.is_file() || metadata.is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "path is not a regular file",
+            ));
+        }
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        Ok(bytes)
     }
 
     pub(crate) fn create_file(&self, path: &Path, content: &[u8]) -> io::Result<()> {
         let (anchor, relative) = self.resolve(path)?;
         let mut options = OpenOptions::new();
         options.write(true).create_new(true);
-        let mut file = anchor.dir.open_with(relative, &options)?;
+        let mut file = anchor.dir.open_with(&relative, &options)?;
+        run_after_staging_file_open_hook();
         file.write_all(content)?;
-        file.sync_all()
+        file.sync_all()?;
+        self.require_opened_file_at(anchor, &relative, &file)?;
+        run_after_created_entry_first_check_hook();
+        self.sync_parent_preserving_identity(anchor, &relative, || {
+            self.require_opened_file_at(anchor, &relative, &file)
+        })
+    }
+
+    pub(crate) fn write_private_file_atomic(
+        &self,
+        path: &Path,
+        temp: &Path,
+        content: &[u8],
+    ) -> io::Result<()> {
+        let (path_anchor, path_relative) = self.resolve(path)?;
+        let (temp_anchor, temp_relative) = self.resolve(temp)?;
+        if !std::ptr::eq(path_anchor, temp_anchor) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "private staging path must share the target anchor",
+            ));
+        }
+        let mut options = OpenOptions::new();
+        options
+            .write(true)
+            .create(true)
+            .truncate(true)
+            ._cap_fs_ext_follow(cap_primitives::fs::FollowSymlinks::No);
+        #[cfg(unix)]
+        {
+            use cap_std::fs::OpenOptionsExt as _;
+
+            options.mode(0o600);
+        }
+        let mut file = temp_anchor.dir.open_with(&temp_relative, &options)?;
+        run_after_staging_file_open_hook();
+        file.write_all(content)?;
+        #[cfg(unix)]
+        {
+            use cap_std::fs::PermissionsExt as _;
+
+            file.set_permissions(Permissions::from_mode(0o600))?;
+        }
+        file.sync_all()?;
+        self.require_opened_file_at(temp_anchor, &temp_relative, &file)?;
+        path_anchor
+            .dir
+            .rename(&temp_relative, &path_anchor.dir, &path_relative)?;
+        self.require_opened_file_at(path_anchor, &path_relative, &file)?;
+        self.sync_parent_preserving_identity(path_anchor, &path_relative, || {
+            self.require_opened_file_at(path_anchor, &path_relative, &file)
+        })
     }
 
     pub(crate) fn replace_file(
@@ -135,24 +837,38 @@ impl AnchoredFs {
         temp: &Path,
         content: &[u8],
     ) -> io::Result<()> {
-        self.create_file(temp, content)?;
-        self.remove_file(target)?;
-        self.rename(temp, target)
-    }
-
-    pub(crate) fn read_link(&self, path: &Path) -> io::Result<PathBuf> {
-        let (anchor, relative) = self.resolve(path)?;
-        anchor.dir.read_link_contents(relative)
+        let (target_anchor, target_relative) = self.resolve(target)?;
+        let (temp_anchor, temp_relative) = self.resolve(temp)?;
+        if !std::ptr::eq(target_anchor, temp_anchor) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "replacement staging path must share the target anchor",
+            ));
+        }
+        let permissions = target_anchor.dir.metadata(&target_relative)?.permissions();
+        let staged =
+            self.create_file_with_permissions(temp_anchor, &temp_relative, content, permissions)?;
+        self.remove_regular_file(target_anchor, &target_relative)?;
+        self.sync_parent(target_anchor, &target_relative)?;
+        self.rename(temp, target)?;
+        self.require_opened_file_at(target_anchor, &target_relative, &staged)?;
+        Ok(())
     }
 
     pub(crate) fn create_symlink(&self, source: &Path, target: &Path) -> io::Result<()> {
+        let source_handle = self.open_object_handle(source)?;
+        run_after_symlink_source_open_hook();
+        if !same_opened_path(&source_handle, source, false)? {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "symlink source entry changed after its capability was opened",
+            ));
+        }
         let (target_anchor, target_relative) = self.resolve(target)?;
         #[cfg(unix)]
-        {
-            target_anchor.dir.symlink_contents(source, target_relative)
-        }
+        let link_source = source.to_path_buf();
         #[cfg(windows)]
-        {
+        let (link_source, source_is_dir) = {
             let target_parent = target.parent().ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidInput, "symlink target has no parent")
             })?;
@@ -172,54 +888,175 @@ impl AnchoredFs {
             } else {
                 source.to_path_buf()
             };
-            if source_anchor.dir.metadata(source_relative)?.is_dir() {
-                target_anchor.dir.symlink_dir(link_source, target_relative)
+            (
+                link_source,
+                source_anchor.dir.metadata(source_relative)?.is_dir(),
+            )
+        };
+        #[cfg(unix)]
+        target_anchor
+            .dir
+            .symlink_contents(&link_source, &target_relative)?;
+        #[cfg(windows)]
+        {
+            if source_is_dir {
+                target_anchor
+                    .dir
+                    .symlink_dir(&link_source, &target_relative)?;
             } else {
-                target_anchor.dir.symlink_file(link_source, target_relative)
+                target_anchor
+                    .dir
+                    .symlink_file(&link_source, &target_relative)?;
             }
+        }
+        run_after_created_symlink_hook();
+        self.require_symlink_contents_at(target_anchor, &target_relative, &link_source)?;
+        run_after_created_symlink_first_check_hook();
+        if let Err(error) = self.sync_parent(target_anchor, &target_relative) {
+            let identity =
+                self.require_symlink_contents_at(target_anchor, &target_relative, &link_source);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                match identity {
+                    Ok(()) => format!(
+                        "created symlink durability is uncertain after directory sync failed: {error}"
+                    ),
+                    Err(identity_error) => format!(
+                        "created symlink identity and durability are uncertain: {identity_error}; {error}"
+                    ),
+                },
+            ));
+        }
+        self.require_symlink_contents_at(target_anchor, &target_relative, &link_source)?;
+        if same_opened_path(&source_handle, source, false)?
+            && same_opened_path(&source_handle, target, true)?
+        {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "published symlink does not resolve to the retained source object",
+            ))
+        }
+    }
+
+    /// Restores previously recorded link contents without reinterpreting them as
+    /// fresh source authority. The target entry is still created and synced
+    /// relative to its retained approved-root handle.
+    #[cfg(unix)]
+    pub(crate) fn restore_symlink_contents(&self, source: &Path, target: &Path) -> io::Result<()> {
+        let (target_anchor, target_relative) = self.resolve(target)?;
+        target_anchor
+            .dir
+            .symlink_contents(source, &target_relative)?;
+        self.sync_parent(target_anchor, &target_relative)
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn restore_symlink_contents(&self, source: &Path, target: &Path) -> io::Result<()> {
+        if source.is_absolute() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "legacy absolute symlink contents cannot be restored handle-bound on Windows",
+            ));
+        }
+        let target_parent = target.parent().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "symlink target has no parent")
+        })?;
+        let resolved_source = target_parent.join(source);
+        let source_handle = self.open_object_handle(&resolved_source)?;
+        run_after_symlink_source_open_hook();
+        if !same_opened_path(&source_handle, &resolved_source, false)? {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "legacy symlink source entry changed after its capability was opened",
+            ));
+        }
+        let (target_anchor, target_relative) = self.resolve(target)?;
+        if source_handle.metadata()?.is_dir() {
+            target_anchor.dir.symlink_dir(source, &target_relative)?;
+        } else {
+            target_anchor.dir.symlink_file(source, &target_relative)?;
+        }
+        self.require_symlink_contents_at(target_anchor, &target_relative, source)?;
+        if !same_opened_path(&source_handle, &resolved_source, false)?
+            || !same_opened_path(&source_handle, target, true)?
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "legacy symlink restoration did not publish the retained source object",
+            ));
+        }
+        self.sync_parent(target_anchor, &target_relative)?;
+        self.require_symlink_contents_at(target_anchor, &target_relative, source)?;
+        if same_opened_path(&source_handle, &resolved_source, false)?
+            && same_opened_path(&source_handle, target, true)?
+        {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "legacy symlink source changed before restoration completed",
+            ))
         }
     }
 
     pub(crate) fn remove_file(&self, path: &Path) -> io::Result<()> {
         let (anchor, relative) = self.resolve(path)?;
-        anchor.dir.remove_file(relative)
-    }
-
-    pub(crate) fn remove_symlink(&self, path: &Path) -> io::Result<()> {
-        let (anchor, relative) = self.resolve(path)?;
-        #[cfg(unix)]
-        {
-            anchor.dir.remove_file(relative)
-        }
-        #[cfg(windows)]
-        {
-            match anchor.dir.remove_file(&relative) {
-                Ok(()) => Ok(()),
-                Err(file_error) => anchor.dir.remove_dir(relative).or(Err(file_error)),
-            }
-        }
+        self.remove_regular_file(anchor, &relative)?;
+        self.sync_parent(anchor, &relative)
     }
 
     pub(crate) fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
         let (from_anchor, from_relative) = self.resolve(from)?;
         let (to_anchor, to_relative) = self.resolve(to)?;
-        from_anchor
-            .dir
-            .rename(from_relative, &to_anchor.dir, to_relative)
+        let retained = entry_identity_at(from_anchor, &from_relative)?;
+        require_entry_identity_at(from_anchor, &from_relative, &retained)?;
+        run_before_rename_noreplace_hook();
+        if let Err(error) = rename_noreplace(
+            from_anchor,
+            &from_relative,
+            to_anchor,
+            &to_relative,
+            &retained,
+        ) {
+            return Err(if error.kind() == io::ErrorKind::AlreadyExists {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "rename destination appeared after it was validated as missing",
+                )
+            } else {
+                error
+            });
+        }
+        require_entry_identity_at(to_anchor, &to_relative, &retained)?;
+        run_after_renamed_entry_first_check_hook();
+        self.sync_parent_preserving_identity(from_anchor, &from_relative, || {
+            require_entry_identity_at(to_anchor, &to_relative, &retained)
+        })?;
+        if std::ptr::eq(from_anchor, to_anchor) && from_relative.parent() == to_relative.parent() {
+            return require_entry_identity_at(to_anchor, &to_relative, &retained);
+        }
+        self.sync_parent_preserving_identity(to_anchor, &to_relative, || {
+            require_entry_identity_at(to_anchor, &to_relative, &retained)
+        })
     }
 
     pub(crate) fn copy_file(&self, source: &Path, target: &Path) -> io::Result<u64> {
         let (source_anchor, source_relative) = self.resolve(source)?;
         let (target_anchor, target_relative) = self.resolve(target)?;
-        source_anchor
-            .dir
-            .copy(source_relative, &target_anchor.dir, target_relative)
+        self.copy_file_relative(
+            source_anchor,
+            &source_relative,
+            target_anchor,
+            &target_relative,
+        )
     }
 
     pub(crate) fn copy_tree(&self, source: &Path, target: &Path) -> io::Result<()> {
         let (source_anchor, source_relative) = self.resolve(source)?;
         let (target_anchor, target_relative) = self.resolve(target)?;
-        Self::copy_tree_relative(
+        self.copy_tree_relative(
             source_anchor,
             &source_relative,
             target_anchor,
@@ -228,6 +1065,7 @@ impl AnchoredFs {
     }
 
     fn copy_tree_relative(
+        &self,
         source_anchor: &Anchor,
         source: &Path,
         target_anchor: &Anchor,
@@ -241,7 +1079,7 @@ impl AnchoredFs {
             ));
         }
         if metadata.is_file() {
-            source_anchor.dir.copy(source, &target_anchor.dir, target)?;
+            self.copy_file_relative(source_anchor, source, target_anchor, target)?;
             return Ok(());
         }
         if !metadata.is_dir() {
@@ -251,13 +1089,19 @@ impl AnchoredFs {
             ));
         }
         target_anchor.dir.create_dir(target)?;
+        let opened = target_anchor.dir.open_dir(target)?.into_std_file();
+        self.require_opened_directory_at(target_anchor, target, &opened)?;
+        run_after_created_entry_first_check_hook();
+        self.sync_parent_preserving_identity(target_anchor, target, || {
+            self.require_opened_directory_at(target_anchor, target, &opened)
+        })?;
         let entries = source_anchor
             .dir
             .read_dir(source)?
             .map(|entry| entry.map(|entry| entry.file_name()))
             .collect::<io::Result<Vec<_>>>()?;
         for name in entries {
-            Self::copy_tree_relative(
+            self.copy_tree_relative(
                 source_anchor,
                 &source.join(&name),
                 target_anchor,
@@ -267,7 +1111,228 @@ impl AnchoredFs {
         Ok(())
     }
 
-    fn resolve<'a>(&'a self, path: &Path) -> io::Result<(&'a Anchor, PathBuf)> {
+    fn create_file_with_permissions(
+        &self,
+        anchor: &Anchor,
+        relative: &Path,
+        content: &[u8],
+        permissions: Permissions,
+    ) -> io::Result<cap_std::fs::File> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use cap_std::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
+            options.mode(permissions.mode() & 0o7777);
+        }
+        let mut file = anchor.dir.open_with(relative, &options)?;
+        run_after_staging_file_open_hook();
+        file.write_all(content)?;
+        file.set_permissions(permissions)?;
+        file.sync_all()?;
+        self.require_opened_file_at(anchor, relative, &file)?;
+        run_after_created_entry_first_check_hook();
+        self.sync_parent_preserving_identity(anchor, relative, || {
+            self.require_opened_file_at(anchor, relative, &file)
+        })?;
+        Ok(file)
+    }
+
+    fn copy_file_relative(
+        &self,
+        source_anchor: &Anchor,
+        source: &Path,
+        target_anchor: &Anchor,
+        target: &Path,
+    ) -> io::Result<u64> {
+        let mut source_file = source_anchor.dir.open(source)?;
+        let permissions = source_file.metadata()?.permissions();
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use cap_std::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
+            options.mode(permissions.mode() & 0o7777);
+        }
+        let mut target_file = target_anchor.dir.open_with(target, &options)?;
+        run_after_staging_file_open_hook();
+        let copied = io::copy(&mut source_file, &mut target_file)?;
+        target_file.set_permissions(permissions)?;
+        target_file.sync_all()?;
+        self.require_opened_file_at(target_anchor, target, &target_file)?;
+        run_after_created_entry_first_check_hook();
+        self.sync_parent_preserving_identity(target_anchor, target, || {
+            self.require_opened_file_at(target_anchor, target, &target_file)
+        })?;
+        Ok(copied)
+    }
+
+    fn require_opened_file_at(
+        &self,
+        anchor: &Anchor,
+        relative: &Path,
+        opened: &cap_std::fs::File,
+    ) -> io::Result<()> {
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            ._cap_fs_ext_follow(cap_primitives::fs::FollowSymlinks::No);
+        let current = anchor.dir.open_with(relative, &options)?.into_std();
+        let opened = opened.try_clone()?.into_std();
+        if same_file_identity(&opened, &current)? {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "created file entry changed while its handle was retained",
+            ))
+        }
+    }
+
+    fn require_opened_directory_at(
+        &self,
+        anchor: &Anchor,
+        relative: &Path,
+        opened: &fs::File,
+    ) -> io::Result<()> {
+        let current = anchor.dir.open_dir(relative)?.into_std_file();
+        if same_file_identity(opened, &current)? {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "created directory entry changed while its handle was retained",
+            ))
+        }
+    }
+
+    fn require_symlink_contents_at(
+        &self,
+        anchor: &Anchor,
+        relative: &Path,
+        expected: &Path,
+    ) -> io::Result<()> {
+        let metadata = anchor.dir.symlink_metadata(relative)?;
+        if !metadata.is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "created symlink entry changed before publication completed",
+            ));
+        }
+        let actual = anchor.dir.read_link_contents(relative)?;
+        if actual == expected {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "created symlink entry changed before publication completed",
+            ))
+        }
+    }
+
+    fn sync_parent(&self, anchor: &Anchor, relative: &Path) -> io::Result<()> {
+        let parent = relative
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let directory = open_directory_for_sync(&anchor.dir, parent)?;
+        self.directory_sync
+            .sync_directory_handle(&directory, &anchor.path.join(parent))
+    }
+
+    fn sync_parent_preserving_identity(
+        &self,
+        anchor: &Anchor,
+        relative: &Path,
+        verify: impl Fn() -> io::Result<()>,
+    ) -> io::Result<()> {
+        match self.sync_parent(anchor, relative) {
+            Ok(()) => verify(),
+            Err(sync_error) => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                match verify() {
+                    Ok(()) => format!(
+                        "published entry durability is uncertain after directory sync failed: {sync_error}"
+                    ),
+                    Err(identity_error) => format!(
+                        "published entry identity and durability are uncertain: {identity_error}; {sync_error}"
+                    ),
+                },
+            )),
+        }
+    }
+
+    fn open_object_handle(&self, path: &Path) -> io::Result<fs::File> {
+        let (anchor, relative) = self.resolve(path)?;
+        let metadata = anchor.dir.symlink_metadata(&relative)?;
+        if metadata.is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "expected a non-symlink source object",
+            ));
+        }
+        if metadata.is_dir() {
+            Ok(anchor.dir.open_dir(relative)?.into_std_file())
+        } else if metadata.is_file() {
+            Ok(anchor.dir.open(relative)?.into_std())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "source is not a file or directory",
+            ))
+        }
+    }
+
+    #[cfg(not(windows))]
+    fn remove_regular_file(&self, anchor: &Anchor, relative: &Path) -> io::Result<()> {
+        anchor.dir.remove_file(relative)
+    }
+
+    #[cfg(windows)]
+    fn remove_regular_file(&self, anchor: &Anchor, relative: &Path) -> io::Result<()> {
+        use std::os::windows::io::AsRawHandle as _;
+        use windows_sys::Win32::Storage::FileSystem::{
+            DELETE, FILE_DISPOSITION_FLAG_DELETE, FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE,
+            FILE_DISPOSITION_INFO_EX, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE,
+            FILE_SHARE_READ, FILE_SHARE_WRITE, FileDispositionInfoEx, SetFileInformationByHandle,
+        };
+
+        use cap_std::fs::OpenOptionsExt as _;
+
+        let mut options = OpenOptions::new();
+        options
+            .access_mode(DELETE)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+        let file = anchor.dir.open_with(relative, &options)?.into_std();
+        let metadata = file.metadata()?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "path is not a regular file",
+            ));
+        }
+        let disposition = FILE_DISPOSITION_INFO_EX {
+            Flags: FILE_DISPOSITION_FLAG_DELETE | FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE,
+        };
+        let removed = unsafe {
+            SetFileInformationByHandle(
+                file.as_raw_handle(),
+                FileDispositionInfoEx,
+                (&raw const disposition).cast(),
+                std::mem::size_of::<FILE_DISPOSITION_INFO_EX>() as u32,
+            )
+        };
+        if removed == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        drop(file);
+        Ok(())
+    }
+
+    fn resolve<'b>(&'b self, path: &Path) -> io::Result<(&'b Anchor, PathBuf)> {
         for anchor in &self.anchors {
             if let Ok(relative) = path.strip_prefix(&anchor.path) {
                 let relative = if relative.as_os_str().is_empty() {
@@ -297,6 +1362,138 @@ impl AnchoredFs {
     }
 }
 
+fn open_anchor(path: PathBuf, approved_root: bool) -> io::Result<Anchor> {
+    let handle_path = fs::canonicalize(&path)?;
+    if approved_root && handle_path != path {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("approved root path is not canonical: {}", path.display()),
+        ));
+    }
+    if approved_root {
+        run_after_approved_root_canonicalize_hook();
+    }
+    let dir = open_directory_handle_bound(&handle_path)?;
+    Ok(Anchor { path, dir })
+}
+
+#[cfg(unix)]
+fn open_directory_handle_bound(path: &Path) -> io::Result<Dir> {
+    use cap_std::fs::OpenOptionsExt as _;
+
+    if !path.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "approved root must be absolute",
+        ));
+    }
+    let mut current = Dir::open_ambient_dir(Path::new("/"), ambient_authority())?;
+    for component in path.components() {
+        let std::path::Component::Normal(name) = component else {
+            continue;
+        };
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW);
+        let next = current.open_with(Path::new(name), &options)?.into_std();
+        current = Dir::from_std_file(next);
+    }
+    Ok(current)
+}
+
+#[cfg(windows)]
+fn open_directory_handle_bound(path: &Path) -> io::Result<Dir> {
+    use cap_std::fs::OpenOptionsExt as _;
+    use std::os::windows::fs::MetadataExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE,
+    };
+
+    let mut components = path.components();
+    let prefix = match components.next() {
+        Some(std::path::Component::Prefix(prefix)) => prefix.as_os_str(),
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "approved root must include a Windows volume prefix",
+            ));
+        }
+    };
+    if !matches!(components.next(), Some(std::path::Component::RootDir)) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "approved root must be absolute",
+        ));
+    }
+    let mut volume_root = PathBuf::from(prefix);
+    volume_root.push("\\");
+    let mut current = Dir::open_ambient_dir(volume_root, ambient_authority())?;
+    for component in components {
+        let std::path::Component::Normal(name) = component else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "approved root contains an unsupported component",
+            ));
+        };
+        let mut options = OpenOptions::new();
+        options
+            .access_mode(FILE_READ_ATTRIBUTES)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+        let next = current.open_with(Path::new(name), &options)?.into_std();
+        let attributes = next.metadata()?.file_attributes();
+        if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+            || attributes & FILE_ATTRIBUTE_DIRECTORY == 0
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "approved root traversal encountered a reparse point or non-directory",
+            ));
+        }
+        current = Dir::from_std_file(next);
+    }
+    Ok(current)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_directory_handle_bound(path: &Path) -> io::Result<Dir> {
+    Dir::open_ambient_dir(path, ambient_authority())
+}
+
+#[cfg(unix)]
+fn open_directory_for_sync(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
+    use cap_std::fs::OpenOptionsExt as _;
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY);
+    Ok(dir.open_with(relative, &options)?.into_std())
+}
+
+#[cfg(windows)]
+fn open_directory_for_sync(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
+    use cap_std::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut options = OpenOptions::new();
+    options
+        .write(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+    Ok(dir.open_with(relative, &options)?.into_std())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_directory_for_sync(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
+    Ok(dir.open_dir(relative)?.into_std_file())
+}
+
 #[cfg(windows)]
 fn relative_path(from: &Path, to: &Path) -> Option<PathBuf> {
     let from = from.components().collect::<Vec<_>>();
@@ -323,23 +1520,72 @@ fn relative_path(from: &Path, to: &Path) -> Option<PathBuf> {
 }
 
 #[cfg(unix)]
-fn same_directory(opened: &fs::File, path: &Path) -> io::Result<bool> {
+fn same_opened_path(opened: &fs::File, path: &Path, follow: bool) -> io::Result<bool> {
+    let options = if follow {
+        fs::File::open(path)
+    } else {
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+    }?;
+    same_file_identity(opened, &options)
+}
+
+#[cfg(unix)]
+fn same_file_identity(left: &fs::File, right: &fs::File) -> io::Result<bool> {
     use std::os::unix::fs::MetadataExt as _;
 
-    let opened = opened.metadata()?;
-    let entry = fs::symlink_metadata(path)?;
-    Ok(opened.dev() == entry.dev() && opened.ino() == entry.ino())
+    let left = left.metadata()?;
+    let right = right.metadata()?;
+    Ok(left.dev() == right.dev() && left.ino() == right.ino())
 }
 
 #[cfg(windows)]
-fn same_directory(opened: &fs::File, path: &Path) -> io::Result<bool> {
+fn same_opened_path(opened: &fs::File, path: &Path, follow: bool) -> io::Result<bool> {
     use std::os::windows::ffi::OsStrExt as _;
-    use std::os::windows::io::AsRawHandle as _;
-    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use std::os::windows::io::FromRawHandle as _;
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::Storage::FileSystem::{
-        BY_HANDLE_FILE_INFORMATION, CreateFileW, FILE_FLAG_BACKUP_SEMANTICS,
-        FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
-        FILE_SHARE_WRITE, GetFileInformationByHandle, OPEN_EXISTING,
+        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    let wide = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let flags = if follow {
+        FILE_FLAG_BACKUP_SEMANTICS
+    } else {
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT
+    };
+    let entry = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            flags,
+            std::ptr::null_mut(),
+        )
+    };
+    if entry == INVALID_HANDLE_VALUE || entry.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let entry = unsafe { fs::File::from_raw_handle(entry.cast()) };
+    same_file_identity(opened, &entry)
+}
+
+#[cfg(windows)]
+fn same_file_identity(left: &fs::File, right: &fs::File) -> io::Result<bool> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
     };
 
     fn identity(handle: windows_sys::Win32::Foundation::HANDLE) -> io::Result<(u32, u32, u32)> {
@@ -354,27 +1600,5 @@ fn same_directory(opened: &fs::File, path: &Path) -> io::Result<bool> {
         ))
     }
 
-    let opened_identity = identity(opened.as_raw_handle())?;
-    let wide = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect::<Vec<_>>();
-    let entry = unsafe {
-        CreateFileW(
-            wide.as_ptr(),
-            FILE_READ_ATTRIBUTES,
-            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            std::ptr::null(),
-            OPEN_EXISTING,
-            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
-            std::ptr::null_mut(),
-        )
-    };
-    if entry == INVALID_HANDLE_VALUE || entry.is_null() {
-        return Err(io::Error::last_os_error());
-    }
-    let entry_identity = identity(entry);
-    unsafe { CloseHandle(entry) };
-    Ok(opened_identity == entry_identity?)
+    Ok(identity(left.as_raw_handle())? == identity(right.as_raw_handle())?)
 }

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -153,11 +153,29 @@ impl AnchoredFs {
         }
         #[cfg(windows)]
         {
-            let (source_anchor, source_relative) = self.resolve(source)?;
-            if source_anchor.dir.metadata(source_relative)?.is_dir() {
-                target_anchor.dir.symlink_dir(source, target_relative)
+            let target_parent = target.parent().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "symlink target has no parent")
+            })?;
+            let resolved_source = if source.is_absolute() {
+                source.to_path_buf()
             } else {
-                target_anchor.dir.symlink_file(source, target_relative)
+                target_parent.join(source)
+            };
+            let (source_anchor, source_relative) = self.resolve(&resolved_source)?;
+            let link_source = if source.is_absolute() {
+                relative_path(target_parent, source).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "cannot create a handle-bound symlink across Windows volumes",
+                    )
+                })?
+            } else {
+                source.to_path_buf()
+            };
+            if source_anchor.dir.metadata(source_relative)?.is_dir() {
+                target_anchor.dir.symlink_dir(link_source, target_relative)
+            } else {
+                target_anchor.dir.symlink_file(link_source, target_relative)
             }
         }
     }
@@ -262,6 +280,31 @@ impl AnchoredFs {
             format!("path has no approved directory handle: {}", path.display()),
         ))
     }
+}
+
+#[cfg(windows)]
+fn relative_path(from: &Path, to: &Path) -> Option<PathBuf> {
+    let from = from.components().collect::<Vec<_>>();
+    let to = to.components().collect::<Vec<_>>();
+    let common = from
+        .iter()
+        .zip(&to)
+        .take_while(|(left, right)| left == right)
+        .count();
+    if common == 0 {
+        return None;
+    }
+
+    let mut relative = PathBuf::new();
+    for component in &from[common..] {
+        if matches!(component, std::path::Component::Normal(_)) {
+            relative.push("..");
+        }
+    }
+    for component in &to[common..] {
+        relative.push(component.as_os_str());
+    }
+    Some(relative)
 }
 
 #[cfg(unix)]

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -185,6 +185,21 @@ impl AnchoredFs {
         anchor.dir.remove_file(relative)
     }
 
+    pub(crate) fn remove_symlink(&self, path: &Path) -> io::Result<()> {
+        let (anchor, relative) = self.resolve(path)?;
+        #[cfg(unix)]
+        {
+            anchor.dir.remove_file(relative)
+        }
+        #[cfg(windows)]
+        {
+            match anchor.dir.remove_file(&relative) {
+                Ok(()) => Ok(()),
+                Err(file_error) => anchor.dir.remove_dir(relative).or(Err(file_error)),
+            }
+        }
+    }
+
     pub(crate) fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
         let (from_anchor, from_relative) = self.resolve(from)?;
         let (to_anchor, to_relative) = self.resolve(to)?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -212,7 +212,7 @@ pub fn run(cli: Cli) -> Result<Output> {
     }
     // Shared guards let Agent read/analysis commands run concurrently while
     // still excluding lifecycle deletion and filesystem mutations on Windows.
-    let _state_lock = if command_requires_exclusive_state_lock(cli.command.as_ref()) {
+    let state_lock = if command_requires_exclusive_state_lock(cli.command.as_ref()) {
         change::StateLock::acquire_exclusive(&state_dir)?
     } else {
         let shared = change::StateLock::acquire_shared(&state_dir)?;
@@ -486,7 +486,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                 }
             }
             let progress = crate::present::ProgressGuard::start("apply", cli.json);
-            let result = apply_command(&store, &args.id)?;
+            let result = apply_command(&store, &args.id, &state_lock)?;
             progress.finish();
             let id = result["receipt_id"]
                 .as_str()
@@ -516,7 +516,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                 }
             }
             let progress = crate::present::ProgressGuard::start("undo", cli.json);
-            let result = undo_command(&store, &args.id)?;
+            let result = undo_command(&store, &args.id, &state_lock)?;
             progress.finish();
             ("undo", result, vec![], vec![])
         }
@@ -567,6 +567,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                     lifecycle_purge_command(
                         &store,
                         &state_dir,
+                        &state_lock,
                         args.raw_days,
                         args.plans_receipts,
                         args.source_confirmation,
@@ -1695,10 +1696,14 @@ fn lifecycle_exclude_command(store: &StateStore, agent: &str, remove: bool) -> R
 fn lifecycle_purge_command(
     store: &StateStore,
     state_dir: &Path,
+    state_lock: &change::StateLock,
     raw_days: Option<u16>,
     plans_receipts: bool,
     source_confirmation: bool,
 ) -> Result<Value> {
+    if plans_receipts {
+        ensure_no_outstanding_external_recovery_artifacts(state_dir, state_lock)?;
+    }
     if plans_receipts && recovery_text(store, state_dir)? == "required" {
         bail!("recovery is required before Plans and Receipts can be purged");
     }
@@ -1758,9 +1763,10 @@ fn lifecycle_purge_command(
 }
 
 fn lifecycle_delete_command(database_path: &Path, state_dir: &Path) -> Result<Value> {
-    let _write_lock = change::WriteLock::acquire(state_dir)?;
+    let state_lock = change::StateLock::acquire_exclusive(state_dir)?;
+    ensure_no_outstanding_external_recovery_artifacts(state_dir, &state_lock)?;
     let existed = database_path.exists();
-    let journals = change::journals(state_dir)?;
+    let journals = change::journals_locked(state_dir, &state_lock)?;
     source_confirmation_detail_paths(state_dir)?;
     if existed {
         let store = StateStore::open(database_path)?;
@@ -1808,6 +1814,18 @@ fn lifecycle_delete_command(database_path: &Path, state_dir: &Path) -> Result<Va
         "library_files_changed": false,
         "files_changed": files_changed,
     }))
+}
+
+fn ensure_no_outstanding_external_recovery_artifacts(
+    state_dir: &Path,
+    state_lock: &change::StateLock,
+) -> Result<()> {
+    if change::has_external_recovery_material(state_dir, state_lock)? {
+        bail!(
+            "Receipt-owned recovery material remains outside local state; Undo it before purging or deleting Plans and Receipts"
+        );
+    }
+    Ok(())
 }
 
 fn source_confirmation_detail_paths(state_dir: &Path) -> Result<Vec<PathBuf>> {
@@ -8132,7 +8150,7 @@ fn prepare_plan(
     Ok(summary)
 }
 
-fn apply_command(store: &StateStore, id: &str) -> Result<Value> {
+fn apply_command(store: &StateStore, id: &str, state_lock: &change::StateLock) -> Result<Value> {
     if store.recovery_required()? {
         bail!("recovery is required before Apply can continue");
     }
@@ -8169,7 +8187,7 @@ fn apply_command(store: &StateStore, id: &str) -> Result<Value> {
         bail!("Plan {id} is stale; Library governance state has drifted");
     }
     store.update_plan_status(&id, PlanStatus::Applying)?;
-    let mut outcome = match change::apply_locked(&prepared) {
+    let mut outcome = match change::apply_locked(&prepared, state_lock) {
         Ok(outcome) => outcome,
         Err(error) => {
             let next = if journal_issues(store, &prepared.state_dir)?.is_empty() {
@@ -8194,7 +8212,7 @@ fn apply_command(store: &StateStore, id: &str) -> Result<Value> {
                 restore_roster_state(store, &Value::Array(roster_before.clone())).is_ok();
             let library_restored =
                 restore_library_state(store, &Value::Array(library_before.clone())).is_ok();
-            let filesystem_rollback = change::rollback_apply_locked(&outcome.receipt)?;
+            let filesystem_rollback = change::rollback_apply_locked(&outcome.receipt, state_lock)?;
             let recovered =
                 roster_restored && library_restored && filesystem_rollback.verification_passed;
             outcome.receipt = filesystem_rollback.receipt;
@@ -8212,7 +8230,7 @@ fn apply_command(store: &StateStore, id: &str) -> Result<Value> {
             };
         }
     }
-    change::persist_journal_state(&outcome.receipt)?;
+    change::persist_journal_state(&outcome.receipt, state_lock)?;
     let receipt = receipt_record(
         &outcome.receipt,
         &record
@@ -8254,7 +8272,7 @@ fn apply_command(store: &StateStore, id: &str) -> Result<Value> {
     Ok(mutation_result(&outcome, &receipt, None))
 }
 
-fn undo_command(store: &StateStore, id: &str) -> Result<Value> {
+fn undo_command(store: &StateStore, id: &str, state_lock: &change::StateLock) -> Result<Value> {
     let id = ReceiptId::parse(id.to_string())?;
     let record = store
         .get_receipt(&id)?
@@ -8268,7 +8286,7 @@ fn undo_command(store: &StateStore, id: &str) -> Result<Value> {
     let original: ChangeReceipt =
         serde_json::from_value(record.verification["change_receipt"].clone())?;
     require_clear_journals(store, &original.state_dir)?;
-    let mut outcome = change::undo_locked(&original)?;
+    let mut outcome = change::undo_locked(&original, state_lock)?;
     if outcome.verification_passed {
         if let Err(error) =
             restore_roster_state(store, &record.verification["roster_state"]["before"]).and_then(
@@ -8280,7 +8298,7 @@ fn undo_command(store: &StateStore, id: &str) -> Result<Value> {
             outcome.verification_passed = false;
         }
     }
-    change::persist_journal_state(&outcome.receipt)?;
+    change::persist_journal_state(&outcome.receipt, state_lock)?;
     let receipt = receipt_record(
         &outcome.receipt,
         &record
@@ -11798,14 +11816,17 @@ mod recovery_tests {
             upgrade["targets"][0]["installed_version"],
             "previous-complete-fixture"
         );
-        let applied = apply_command(&store, upgrade["plan_id"].as_str().unwrap()).unwrap();
+        let state_lock = change::StateLock::acquire_exclusive(&state).unwrap();
+        let applied =
+            apply_command(&store, upgrade["plan_id"].as_str().unwrap(), &state_lock).unwrap();
         for (relative_path, _, content) in &current {
             assert_eq!(
                 std::fs::read_to_string(package.join(relative_path)).unwrap(),
                 *content
             );
         }
-        let undone = undo_command(&store, applied["receipt_id"].as_str().unwrap()).unwrap();
+        let undone =
+            undo_command(&store, applied["receipt_id"].as_str().unwrap(), &state_lock).unwrap();
         assert_eq!(undone["verification"], "passed");
         for ((relative_path, _, _), content) in current.iter().zip(&previous) {
             assert_eq!(
@@ -11928,6 +11949,138 @@ mod recovery_tests {
                 .join(format!("{}.json", receipt.id))
                 .is_file()
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lifecycle_keeps_external_symlink_recovery_material_until_undo() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("agent-root");
+        let state_dir = temp.path().join("state");
+        let source = root.join("source");
+        let link = root.join("installed-link");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
+        symlink(&source, &link).unwrap();
+        let root = root.canonicalize().unwrap();
+        let state_dir = state_dir.canonicalize().unwrap();
+        let input = json!({
+            "schema_version": 1,
+            "scan_id": "scan_lifecycle_recovery_material",
+            "operations": [{
+                "kind": "remove_symlink",
+                "target": link,
+                "expected_fingerprint": change::fingerprint(&link).unwrap(),
+            }],
+        })
+        .to_string();
+        let plan = change::prepare(
+            &input,
+            &change::PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state_dir.clone(),
+                operation_policy: change::OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let applied = change::apply(&plan).unwrap();
+        assert_eq!(applied.receipt.status, change::ReceiptStatus::Applied);
+
+        let store = StateStore::open_in_memory().unwrap();
+        let state_lock = change::StateLock::acquire_exclusive(&state_dir).unwrap();
+        let purge_error =
+            lifecycle_purge_command(&store, &state_dir, &state_lock, None, true, false)
+                .unwrap_err();
+        assert!(
+            purge_error
+                .to_string()
+                .contains("recovery material remains outside local state")
+        );
+        drop(state_lock);
+
+        let database_path = state_dir.join("skillroster.db");
+        drop(StateStore::open(&database_path).unwrap());
+        let delete_error = lifecycle_delete_command(&database_path, &state_dir).unwrap_err();
+        assert!(
+            delete_error
+                .to_string()
+                .contains("recovery material remains outside local state")
+        );
+        assert!(database_path.is_file());
+        assert!(!link.exists());
+
+        let undone = change::undo(&applied.receipt).unwrap();
+        assert_eq!(undone.receipt.status, change::ReceiptStatus::Undone);
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        let state_lock = change::StateLock::acquire_exclusive(&state_dir).unwrap();
+        ensure_no_outstanding_external_recovery_artifacts(&state_dir, &state_lock).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lifecycle_fails_closed_when_active_external_recovery_material_is_missing() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("agent-root");
+        let state_dir = temp.path().join("state");
+        let source = root.join("source");
+        let link = root.join("installed-link");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
+        symlink(&source, &link).unwrap();
+        let root = root.canonicalize().unwrap();
+        let state_dir = state_dir.canonicalize().unwrap();
+        let plan = change::prepare(
+            &json!({
+                "schema_version": 1,
+                "scan_id": "scan_missing_recovery_material",
+                "operations": [{
+                    "kind": "remove_symlink",
+                    "target": link,
+                    "expected_fingerprint": change::fingerprint(&link).unwrap(),
+                }],
+            })
+            .to_string(),
+            &change::PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state_dir.clone(),
+                operation_policy: change::OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let applied = change::apply(&plan).unwrap();
+        let backup = applied
+            .receipt
+            .compensations
+            .iter()
+            .find_map(|compensation| match compensation {
+                change::Compensation::RestoreRemovedSymlink { from, .. } => Some(from.clone()),
+                _ => None,
+            })
+            .unwrap();
+        std::fs::remove_file(backup).unwrap();
+
+        let store = StateStore::open_in_memory().unwrap();
+        let state_lock = change::StateLock::acquire_exclusive(&state_dir).unwrap();
+        let error = lifecycle_purge_command(&store, &state_dir, &state_lock, None, true, false)
+            .unwrap_err();
+        assert!(error.to_string().contains("recovery material is missing"));
+        drop(state_lock);
+
+        let database_path = state_dir.join("skillroster.db");
+        drop(StateStore::open(&database_path).unwrap());
+        let error = lifecycle_delete_command(&database_path, &state_dir).unwrap_err();
+        assert!(error.to_string().contains("recovery material is missing"));
+        assert!(database_path.is_file());
+        assert!(!change::journals(&state_dir).unwrap().is_empty());
     }
 
     #[test]
@@ -12205,7 +12358,10 @@ mod recovery_tests {
         )
         .unwrap();
 
-        assert!(lifecycle_purge_command(&store, &state_dir, Some(0), true, false).is_err());
+        let state_lock = change::StateLock::acquire_exclusive(&state_dir).unwrap();
+        assert!(
+            lifecycle_purge_command(&store, &state_dir, &state_lock, Some(0), true, false).is_err()
+        );
         let (_, payload): (ScanId, Value) = store.latest_scan_payload().unwrap().unwrap();
         assert_eq!(payload["usage"].as_array().unwrap().len(), 1);
     }
@@ -12246,7 +12402,10 @@ mod recovery_tests {
             )
             .unwrap();
 
-        assert!(lifecycle_purge_command(&store, &state_dir, Some(0), false, true).is_err());
+        let state_lock = change::StateLock::acquire_exclusive(&state_dir).unwrap();
+        assert!(
+            lifecycle_purge_command(&store, &state_dir, &state_lock, Some(0), false, true).is_err()
+        );
 
         let (_, payload): (ScanId, Value) = store.latest_scan_payload().unwrap().unwrap();
         assert_eq!(payload["usage"].as_array().unwrap().len(), 1);

--- a/src/change.rs
+++ b/src/change.rs
@@ -1353,7 +1353,7 @@ fn execute(
                 .read_link(target)
                 .map_err(|e| ChangeError::io("read symlink", target, e))?;
             anchored
-                .remove_file(target)
+                .remove_symlink(target)
                 .map_err(|e| ChangeError::io("remove symlink", target, e))?;
             Ok(Some(Compensation::RestoreSymlink {
                 path: target.clone(),

--- a/src/change.rs
+++ b/src/change.rs
@@ -4,18 +4,34 @@
 //! fingerprints, and every apply/undo obtains the same process write lock.
 
 use std::collections::{HashMap, HashSet};
-use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
 
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::durable_fs::{DirectorySync, SystemDirectorySync};
-use crate::state_security;
+use crate::anchored_fs::AnchoredFs;
+
+#[cfg(test)]
+thread_local! {
+    static BEFORE_MUTATION_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+fn run_before_mutation_hook() {
+    BEFORE_MUTATION_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_before_mutation_hook() {}
 
 #[derive(Debug)]
 pub struct ChangeError {
@@ -126,7 +142,7 @@ pub struct RosterChange {
     pub state: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum OperationInput {
     CreateDirectory {
@@ -307,8 +323,6 @@ pub enum Compensation {
         target: PathBuf,
         expected_original: String,
         expected_replacement: String,
-        #[serde(default)]
-        staged_replacement: Option<PathBuf>,
     },
 }
 
@@ -504,16 +518,10 @@ pub fn apply(plan: &PreparedPlan) -> Result<ApplyOutcome> {
 }
 
 pub(crate) fn apply_locked(plan: &PreparedPlan) -> Result<ApplyOutcome> {
-    apply_locked_with(plan, &SystemDirectorySync)
-}
-
-fn apply_locked_with(
-    plan: &PreparedPlan,
-    directory_sync: &dyn DirectorySync,
-) -> Result<ApplyOutcome> {
     validate_prepared_plan(plan)?;
     reject_unresolved_recovery(&plan.state_dir)?;
     validate_operation_sequence(&plan.operations, &plan.approved_roots)?;
+    let anchored = open_anchored_fs(&plan.approved_roots, &plan.state_dir)?;
 
     let receipt_id = format!("receipt_{}", ulid::Ulid::new());
     let mut receipt = ChangeReceipt {
@@ -528,7 +536,8 @@ fn apply_locked_with(
         reverses_receipt_id: None,
         operation_results: Vec::new(),
     };
-    persist_journal_with(&receipt, directory_sync)?;
+    persist_journal(&receipt)?;
+    run_before_mutation_hook();
 
     for (index, operation) in plan.operations.iter().enumerate() {
         receipt.operation_results.push(JournalOperationResult {
@@ -537,28 +546,18 @@ fn apply_locked_with(
             action: operation_kind(operation).to_owned(),
             target: operation.target().to_path_buf(),
             status: "applying".to_owned(),
-            before_fingerprint: fingerprint(operation.target()).ok(),
+            before_fingerprint: anchored.fingerprint(operation.target()).ok(),
             after_fingerprint: None,
             error: None,
         });
-        persist_journal_with(&receipt, directory_sync)?;
-        if let Some(compensation) = stage_compensation(
-            operation,
-            &receipt.id,
-            index,
-            &plan.state_dir,
-            directory_sync,
-        )? {
+        persist_journal(&receipt)?;
+        if let Some(compensation) =
+            stage_compensation(operation, &receipt.id, index, &plan.state_dir, &anchored)?
+        {
             receipt.compensations.push(compensation);
-            persist_journal_with(&receipt, directory_sync)?;
+            persist_journal(&receipt)?;
         }
-        match execute(
-            operation,
-            &receipt.id,
-            index,
-            &plan.approved_roots,
-            directory_sync,
-        ) {
+        match execute(operation, &receipt.id, index, &anchored) {
             Ok(compensation) => {
                 receipt.changed_paths.push(operation.target().to_path_buf());
                 if let Some(compensation) = compensation {
@@ -566,17 +565,17 @@ fn apply_locked_with(
                 }
                 if let Some(result) = receipt.operation_results.last_mut() {
                     result.status = "applied".to_owned();
-                    result.after_fingerprint = fingerprint(operation.target()).ok();
+                    result.after_fingerprint = anchored.fingerprint(operation.target()).ok();
                 }
-                if let Err(journal_error) = persist_journal_with(&receipt, directory_sync) {
+                if let Err(journal_error) = persist_journal(&receipt) {
                     receipt.error = Some(journal_error.to_string());
-                    let rollback = compensate_all(&receipt, directory_sync);
+                    let rollback = compensate_all(&receipt, &anchored);
                     receipt.status = if rollback.is_ok() {
                         ReceiptStatus::FailedRolledBack
                     } else {
                         ReceiptStatus::RecoveryRequired
                     };
-                    finalize_rollback_results(&mut receipt, rollback.is_ok());
+                    finalize_rollback_results(&mut receipt, rollback.is_ok(), &anchored);
                     if let Err(rollback_error) = rollback {
                         receipt.error = Some(format!(
                             "{journal_error}; compensation failed: {rollback_error}"
@@ -584,7 +583,7 @@ fn apply_locked_with(
                     }
                     // Best effort: if storage remains unavailable, the last durable
                     // journal stays Applying and therefore blocks future writes.
-                    let _ = persist_journal_with(&receipt, directory_sync);
+                    let _ = persist_journal(&receipt);
                     return Ok(ApplyOutcome {
                         receipt,
                         verification_passed: false,
@@ -594,43 +593,51 @@ fn apply_locked_with(
             Err(error) => {
                 if let Some(result) = receipt.operation_results.last_mut() {
                     result.status = "failed".to_owned();
-                    result.after_fingerprint = fingerprint(operation.target()).ok();
+                    result.after_fingerprint = anchored.fingerprint(operation.target()).ok();
                     result.error = Some(error.to_string());
                 }
                 receipt.error = Some(error.to_string());
-                // A durability barrier can fail after the directory entry changed.
-                // Record the concrete recovery action before compensating so the
-                // mutation is never reported as a clean rollback.
-                match partial_operation_compensation(operation, &receipt.id, index) {
-                    Ok(Some(compensation)) => {
-                        receipt.compensations.push(compensation);
-                        receipt.changed_paths.push(operation.target().to_path_buf());
-                        let _ = persist_journal_with(&receipt, directory_sync);
-                    }
-                    Ok(None) => {}
-                    Err(fingerprint_error) => {
-                        receipt.status = ReceiptStatus::RecoveryRequired;
-                        receipt.error = Some(format!(
-                            "{error}; partial target could not be fingerprinted: {fingerprint_error}"
-                        ));
-                        let _ = persist_journal_with(&receipt, directory_sync);
-                        return Ok(ApplyOutcome {
-                            receipt,
-                            verification_passed: false,
-                        });
+                // Recursive copy can fail after creating a partial target. Record
+                // the concrete artifact before compensating so a partial copy is
+                // never reported as a clean rollback.
+                if operation_creates_missing_target(operation)
+                    && anchored
+                        .fingerprint(operation.target())
+                        .is_ok_and(|value| value != "missing")
+                {
+                    match anchored.fingerprint(operation.target()) {
+                        Ok(expected_fingerprint) => {
+                            receipt.compensations.push(Compensation::StashCreated {
+                                path: operation.target().to_path_buf(),
+                                expected_fingerprint,
+                            });
+                            receipt.changed_paths.push(operation.target().to_path_buf());
+                            let _ = persist_journal(&receipt);
+                        }
+                        Err(fingerprint_error) => {
+                            receipt.status = ReceiptStatus::RecoveryRequired;
+                            receipt.error = Some(format!(
+                                "{error}; partial target could not be fingerprinted: {fingerprint_error}"
+                            ));
+                            let _ = persist_journal(&receipt);
+                            return Ok(ApplyOutcome {
+                                receipt,
+                                verification_passed: false,
+                            });
+                        }
                     }
                 }
-                let rollback = compensate_all(&receipt, directory_sync);
+                let rollback = compensate_all(&receipt, &anchored);
                 receipt.status = if rollback.is_ok() {
                     ReceiptStatus::FailedRolledBack
                 } else {
                     ReceiptStatus::RecoveryRequired
                 };
-                finalize_rollback_results(&mut receipt, rollback.is_ok());
+                finalize_rollback_results(&mut receipt, rollback.is_ok(), &anchored);
                 if let Err(rollback_error) = rollback {
                     receipt.error = Some(format!("{error}; compensation failed: {rollback_error}"));
                 }
-                persist_journal_with(&receipt, directory_sync)?;
+                persist_journal(&receipt)?;
                 return Ok(ApplyOutcome {
                     receipt,
                     verification_passed: false,
@@ -640,12 +647,12 @@ fn apply_locked_with(
     }
 
     receipt.status = ReceiptStatus::Applied;
-    if let Err(error) = persist_journal_with(&receipt, directory_sync) {
+    if let Err(error) = persist_journal(&receipt) {
         receipt.status = ReceiptStatus::RecoveryRequired;
         receipt.error = Some(format!(
             "changes were applied but the final receipt could not be persisted: {error}"
         ));
-        let _ = persist_journal_with(&receipt, directory_sync);
+        let _ = persist_journal(&receipt);
         return Ok(ApplyOutcome {
             receipt,
             verification_passed: false,
@@ -669,13 +676,6 @@ pub fn undo(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
 }
 
 pub(crate) fn undo_locked(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
-    undo_locked_with(receipt, &SystemDirectorySync)
-}
-
-fn undo_locked_with(
-    receipt: &ChangeReceipt,
-    directory_sync: &dyn DirectorySync,
-) -> Result<ApplyOutcome> {
     if receipt.status != ReceiptStatus::Applied {
         return Err(ChangeError::new(
             "receipt_not_undoable",
@@ -689,6 +689,7 @@ fn undo_locked_with(
             format!("receipt {} has already been undone", receipt.id),
         ));
     }
+    let anchored = open_anchored_fs(&receipt.approved_roots, &receipt.state_dir)?;
 
     let mut undo_receipt = ChangeReceipt {
         id: format!("receipt_{}", ulid::Ulid::new()),
@@ -709,22 +710,22 @@ fn undo_locked_with(
                 action: format!("undo_{}", original.action),
                 target: original.target.clone(),
                 status: "applying".to_owned(),
-                before_fingerprint: fingerprint(&original.target).ok(),
+                before_fingerprint: anchored.fingerprint(&original.target).ok(),
                 after_fingerprint: None,
                 error: None,
             })
             .collect(),
     };
-    persist_journal_with(&undo_receipt, directory_sync)?;
-    match compensate_all(receipt, directory_sync) {
+    persist_journal(&undo_receipt)?;
+    match compensate_all(receipt, &anchored) {
         Ok(()) => {
             for result in &mut undo_receipt.operation_results {
                 result.status = "undone".to_owned();
-                result.after_fingerprint = fingerprint(&result.target).ok();
+                result.after_fingerprint = anchored.fingerprint(&result.target).ok();
             }
             undo_receipt.status = ReceiptStatus::Undone;
             undo_receipt.changed_paths = receipt.changed_paths.clone();
-            persist_journal_with(&undo_receipt, directory_sync)?;
+            persist_journal(&undo_receipt)?;
             Ok(ApplyOutcome {
                 receipt: undo_receipt,
                 verification_passed: true,
@@ -733,12 +734,12 @@ fn undo_locked_with(
         Err(error) => {
             for result in &mut undo_receipt.operation_results {
                 result.status = "failed".to_owned();
-                result.after_fingerprint = fingerprint(&result.target).ok();
+                result.after_fingerprint = anchored.fingerprint(&result.target).ok();
                 result.error = Some(error.to_string());
             }
             undo_receipt.status = ReceiptStatus::RecoveryRequired;
             undo_receipt.error = Some(error.to_string());
-            persist_journal_with(&undo_receipt, directory_sync)?;
+            persist_journal(&undo_receipt)?;
             Ok(ApplyOutcome {
                 receipt: undo_receipt,
                 verification_passed: false,
@@ -762,28 +763,22 @@ pub fn rollback_apply(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
 }
 
 pub(crate) fn rollback_apply_locked(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
-    rollback_apply_locked_with(receipt, &SystemDirectorySync)
-}
-
-fn rollback_apply_locked_with(
-    receipt: &ChangeReceipt,
-    directory_sync: &dyn DirectorySync,
-) -> Result<ApplyOutcome> {
     if receipt.status != ReceiptStatus::Applied {
         return Err(ChangeError::new(
             "receipt_not_rollbackable",
             "only an applied receipt can be rolled back",
         ));
     }
+    let anchored = open_anchored_fs(&receipt.approved_roots, &receipt.state_dir)?;
     let mut rolled_back = receipt.clone();
-    match compensate_all(receipt, directory_sync) {
+    match compensate_all(receipt, &anchored) {
         Ok(()) => {
             rolled_back.status = ReceiptStatus::FailedRolledBack;
             for result in &mut rolled_back.operation_results {
                 result.status = "failed_rolled_back".to_owned();
-                result.after_fingerprint = fingerprint(&result.target).ok();
+                result.after_fingerprint = anchored.fingerprint(&result.target).ok();
             }
-            persist_journal_with(&rolled_back, directory_sync)?;
+            persist_journal(&rolled_back)?;
             Ok(ApplyOutcome {
                 receipt: rolled_back,
                 verification_passed: true,
@@ -794,10 +789,10 @@ fn rollback_apply_locked_with(
             rolled_back.error = Some(error.to_string());
             for result in &mut rolled_back.operation_results {
                 result.status = "recovery_required".to_owned();
-                result.after_fingerprint = fingerprint(&result.target).ok();
+                result.after_fingerprint = anchored.fingerprint(&result.target).ok();
                 result.error = Some(error.to_string());
             }
-            persist_journal_with(&rolled_back, directory_sync)?;
+            persist_journal(&rolled_back)?;
             Ok(ApplyOutcome {
                 receipt: rolled_back,
                 verification_passed: false,
@@ -818,210 +813,9 @@ fn operation_kind(operation: &Operation) -> &'static str {
     }
 }
 
-fn sync_parent_directory(
-    path: &Path,
-    directory_sync: &dyn DirectorySync,
-    action: &str,
-) -> Result<()> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| ChangeError::new("unsafe_path", path.display().to_string()))?;
-    directory_sync
-        .sync_directory(parent)
-        .map_err(|error| ChangeError::io(action, parent, error))
-}
-
-fn sync_rename_directories(
-    source: &Path,
-    target: &Path,
-    directory_sync: &dyn DirectorySync,
-) -> Result<()> {
-    let source_parent = source
-        .parent()
-        .ok_or_else(|| ChangeError::new("unsafe_path", source.display().to_string()))?;
-    let target_parent = target
-        .parent()
-        .ok_or_else(|| ChangeError::new("unsafe_path", target.display().to_string()))?;
-    let source_result = directory_sync
-        .sync_directory(source_parent)
-        .map_err(|error| ChangeError::io("sync renamed source directory", source_parent, error));
-    let target_result = if source_parent == target_parent {
-        Ok(())
-    } else {
-        directory_sync
-            .sync_directory(target_parent)
-            .map_err(|error| ChangeError::io("sync renamed target directory", target_parent, error))
-    };
-    source_result.and(target_result)
-}
-
-fn create_dir_all_durable(path: &Path, directory_sync: &dyn DirectorySync) -> Result<()> {
-    let mut missing = Vec::new();
-    let mut cursor = path;
-    loop {
-        match fs::symlink_metadata(cursor) {
-            Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => break,
-            Ok(_) => {
-                return Err(ChangeError::new(
-                    "unsafe_path",
-                    format!("{} is not a regular directory", cursor.display()),
-                ));
-            }
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                missing.push(cursor.to_path_buf());
-                cursor = cursor
-                    .parent()
-                    .ok_or_else(|| ChangeError::new("unsafe_path", path.display().to_string()))?;
-            }
-            Err(error) => {
-                return Err(ChangeError::io("inspect directory", cursor, error));
-            }
-        }
-    }
-    for directory in missing.iter().rev() {
-        fs::create_dir(directory)
-            .map_err(|error| ChangeError::io("create directory", directory, error))?;
-        sync_parent_directory(directory, directory_sync, "sync created directory parent")?;
-    }
-    Ok(())
-}
-
-fn create_dir_durable(path: &Path, directory_sync: &dyn DirectorySync) -> Result<()> {
-    fs::create_dir(path).map_err(|error| ChangeError::io("create directory", path, error))?;
-    sync_parent_directory(path, directory_sync, "sync created directory parent")
-}
-
-fn rename_durable(
-    source: &Path,
-    target: &Path,
-    directory_sync: &dyn DirectorySync,
-    action: &str,
-) -> Result<()> {
-    fs::rename(source, target).map_err(|error| ChangeError::io(action, source, error))?;
-    sync_rename_directories(source, target, directory_sync)
-}
-
-fn remove_file_durable(
-    path: &Path,
-    directory_sync: &dyn DirectorySync,
-    action: &str,
-) -> Result<()> {
-    fs::remove_file(path).map_err(|error| ChangeError::io(action, path, error))?;
-    sync_parent_directory(path, directory_sync, "sync removed file parent")
-}
-
-fn remove_file_durable_allowing_readonly(
-    path: &Path,
-    directory_sync: &dyn DirectorySync,
-    action: &str,
-) -> Result<()> {
-    #[cfg(not(windows))]
-    return remove_file_durable(path, directory_sync, action);
-
-    #[cfg(windows)]
-    {
-        remove_file_ignoring_readonly(path, action)?;
-        sync_parent_directory(path, directory_sync, "sync removed file parent")
-    }
-}
-
-#[cfg(windows)]
-fn remove_file_ignoring_readonly(path: &Path, action: &str) -> Result<()> {
-    use std::os::windows::fs::OpenOptionsExt;
-    use std::os::windows::io::AsRawHandle;
-    use windows_sys::Win32::Storage::FileSystem::{
-        DELETE, FILE_DISPOSITION_FLAG_DELETE, FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE,
-        FILE_DISPOSITION_INFO_EX, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE, FILE_SHARE_READ,
-        FILE_SHARE_WRITE, FileDispositionInfoEx, SetFileInformationByHandle,
-    };
-
-    let file = OpenOptions::new()
-        .access_mode(DELETE)
-        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)
-        .map_err(|error| ChangeError::io("open file for removal", path, error))?;
-    let metadata = file
-        .metadata()
-        .map_err(|error| ChangeError::io("inspect file for removal", path, error))?;
-    if !metadata.is_file() || metadata.file_type().is_symlink() {
-        return Err(ChangeError::new(
-            "not_a_regular_file",
-            format!("{} is not a regular file", path.display()),
-        ));
-    }
-    let disposition = FILE_DISPOSITION_INFO_EX {
-        Flags: FILE_DISPOSITION_FLAG_DELETE | FILE_DISPOSITION_FLAG_IGNORE_READONLY_ATTRIBUTE,
-    };
-    let removed = unsafe {
-        SetFileInformationByHandle(
-            file.as_raw_handle(),
-            FileDispositionInfoEx,
-            (&raw const disposition).cast(),
-            std::mem::size_of::<FILE_DISPOSITION_INFO_EX>() as u32,
-        )
-    };
-    if removed == 0 {
-        return Err(ChangeError::io(action, path, io::Error::last_os_error()));
-    }
-    drop(file);
-    Ok(())
-}
-
-fn copy_file_durable(
-    source: &Path,
-    target: &Path,
-    directory_sync: &dyn DirectorySync,
-    action: &str,
-) -> Result<()> {
-    let (file, original_permissions) = copy_file_exclusive(source, target, action)?;
-    file.set_permissions(original_permissions)
-        .map_err(|error| ChangeError::io("restore copied file metadata", target, error))?;
-    file.sync_all()
-        .map_err(|error| ChangeError::io("sync copied file", target, error))?;
-    sync_parent_directory(target, directory_sync, "sync copied file parent")
-}
-
-fn copy_file_exclusive(
-    source: &Path,
-    target: &Path,
-    action: &str,
-) -> Result<(File, fs::Permissions)> {
-    let mut source_file = File::open(source)
-        .map_err(|error| ChangeError::io("open copied file source", source, error))?;
-    let permissions = source_file
-        .metadata()
-        .map_err(|error| ChangeError::io("inspect copied file source", source, error))?
-        .permissions();
-    let mut target_options = OpenOptions::new();
-    target_options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-
-        // The staging entry is visible as soon as it is created. Start it no
-        // wider than the source instead of exposing copied bytes under the
-        // process's default creation mode until set_permissions runs.
-        target_options.mode(permissions.mode() & 0o7777);
-    }
-    let mut target_file = match target_options.open(target) {
-        Ok(file) => file,
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            return Err(ChangeError::new(
-                "target_exists",
-                format!("{} already exists", target.display()),
-            ));
-        }
-        Err(error) => return Err(ChangeError::io(action, target, error)),
-    };
-    io::copy(&mut source_file, &mut target_file)
-        .map_err(|error| ChangeError::io(action, target, error))?;
-    Ok((target_file, permissions))
-}
-
-fn finalize_rollback_results(receipt: &mut ChangeReceipt, recovered: bool) {
+fn finalize_rollback_results(receipt: &mut ChangeReceipt, recovered: bool, anchored: &AnchoredFs) {
     for result in &mut receipt.operation_results {
-        result.after_fingerprint = fingerprint(&result.target).ok();
+        result.after_fingerprint = anchored.fingerprint(&result.target).ok();
         result.status = if recovered {
             if result.status == "failed" {
                 "failed_rolled_back".to_owned()
@@ -1043,51 +837,6 @@ fn operation_creates_missing_target(operation: &Operation) -> bool {
             | Operation::Copy { .. }
             | Operation::MoveRecoverable { .. }
     )
-}
-
-fn move_backup_path(source: &Path, receipt_id: &str, index: usize) -> Result<PathBuf> {
-    let file_name = source
-        .file_name()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| ChangeError::new("unsafe_path", source.display().to_string()))?;
-    Ok(source.with_file_name(format!(
-        ".{file_name}.skillroster-backup-{receipt_id}-{index}"
-    )))
-}
-
-fn partial_operation_compensation(
-    operation: &Operation,
-    receipt_id: &str,
-    index: usize,
-) -> Result<Option<Compensation>> {
-    if !operation_creates_missing_target(operation)
-        || fs::symlink_metadata(operation.target()).is_err()
-    {
-        return Ok(None);
-    }
-    let expected_fingerprint = fingerprint(operation.target())?;
-    if let Operation::MoveRecoverable { target, source, .. } = operation {
-        let backup = move_backup_path(source, receipt_id, index)?;
-        if fs::symlink_metadata(source).is_err() && fs::symlink_metadata(&backup).is_ok() {
-            return Ok(Some(Compensation::RestoreBackup {
-                backup,
-                original: source.clone(),
-                created: target.clone(),
-                expected_created: expected_fingerprint,
-            }));
-        }
-        if fs::symlink_metadata(source).is_err() {
-            return Ok(Some(Compensation::RenameBack {
-                from: target.clone(),
-                to: source.clone(),
-                expected_fingerprint,
-            }));
-        }
-    }
-    Ok(Some(Compensation::StashCreated {
-        path: operation.target().to_path_buf(),
-        expected_fingerprint,
-    }))
 }
 
 fn normalize_operation(
@@ -1400,91 +1149,156 @@ fn project_operation(
     }
 }
 
+fn open_anchored_fs(roots: &[PathBuf], state_dir: &Path) -> Result<AnchoredFs> {
+    AnchoredFs::open(roots, state_dir)
+        .map_err(|error| ChangeError::io("open approved root handles", state_dir, error))
+}
+
+fn validate_anchored_current_state(operation: &Operation, anchored: &AnchoredFs) -> Result<()> {
+    let (path, expected) = match operation {
+        Operation::CreateDirectory {
+            target,
+            expected_fingerprint,
+        }
+        | Operation::CreateSymlink {
+            target,
+            expected_fingerprint,
+            ..
+        }
+        | Operation::WriteFile {
+            target,
+            expected_fingerprint,
+            ..
+        }
+        | Operation::ReplaceFile {
+            target,
+            expected_fingerprint,
+            ..
+        }
+        | Operation::RemoveSymlink {
+            target,
+            expected_fingerprint,
+        } => (target, expected_fingerprint),
+        Operation::Copy {
+            source,
+            expected_fingerprint,
+            ..
+        }
+        | Operation::MoveRecoverable {
+            source,
+            expected_fingerprint,
+            ..
+        } => (source, expected_fingerprint),
+    };
+    let actual = anchored
+        .fingerprint(path)
+        .map_err(|error| ChangeError::io("inspect through approved root handle", path, error))?;
+    if &actual != expected {
+        return Err(ChangeError::new(
+            "plan_drifted",
+            format!("{} expected {expected}, found {actual}", path.display()),
+        ));
+    }
+    if let Operation::CreateSymlink {
+        source,
+        expected_source_fingerprint,
+        ..
+    } = operation
+    {
+        let actual = anchored.fingerprint(source).map_err(|error| {
+            ChangeError::io(
+                "inspect link source through approved root handle",
+                source,
+                error,
+            )
+        })?;
+        if &actual != expected_source_fingerprint {
+            return Err(ChangeError::new(
+                "plan_drifted",
+                format!(
+                    "{} expected {expected_source_fingerprint}, found {actual}",
+                    source.display()
+                ),
+            ));
+        }
+    }
+    if let Operation::Copy { target, .. } | Operation::MoveRecoverable { target, .. } = operation {
+        let target_fingerprint = anchored.fingerprint(target).map_err(|error| {
+            ChangeError::io("inspect target through approved root handle", target, error)
+        })?;
+        if target_fingerprint != "missing" {
+            return Err(ChangeError::new(
+                "target_exists",
+                format!("{} already exists", target.display()),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn stage_compensation(
     operation: &Operation,
     receipt_id: &str,
     index: usize,
     state_dir: &Path,
-    directory_sync: &dyn DirectorySync,
+    anchored: &AnchoredFs,
 ) -> Result<Option<Compensation>> {
-    match operation {
-        Operation::ReplaceFile {
-            target,
-            content,
-            expected_fingerprint,
-        } => {
-            verify_fingerprint(target, expected_fingerprint)?;
-            let directory = create_recovery_dir(state_dir, receipt_id, directory_sync)?;
-            let backup = directory.join(format!("replace-{index}.backup"));
-            require_missing(&backup)?;
-            copy_file_durable(
-                target,
-                &backup,
-                directory_sync,
-                "persist replacement backup",
-            )?;
-            let backup_fingerprint = fingerprint(&backup)?;
-            if backup_fingerprint != *expected_fingerprint {
-                return Err(ChangeError::new(
-                    "backup_verification_failed",
-                    format!(
-                        "backup for {} does not match its precondition",
-                        target.display()
-                    ),
-                ));
-            }
-            Ok(Some(Compensation::RestoreReplacedFile {
-                backup,
-                target: target.clone(),
-                expected_original: expected_fingerprint.clone(),
-                expected_replacement: file_content_fingerprint(content.as_bytes()),
-                staged_replacement: Some(replacement_temp_path(target, receipt_id, index)?),
-            }))
-        }
-        Operation::RemoveSymlink { target, .. } => {
-            let link_target = fs::read_link(target)
-                .map_err(|error| ChangeError::io("read symlink", target, error))?;
-            Ok(Some(Compensation::RestoreSymlink {
-                path: target.clone(),
-                target: link_target,
-            }))
-        }
-        _ => Ok(None),
+    let Operation::ReplaceFile {
+        target,
+        content,
+        expected_fingerprint,
+    } = operation
+    else {
+        return Ok(None);
+    };
+    verify_anchored_fingerprint(anchored, target, expected_fingerprint)?;
+    let directory = recovery_dir(state_dir, receipt_id);
+    anchored
+        .create_dir_all(&directory)
+        .map_err(|error| ChangeError::io("create recovery directory", &directory, error))?;
+    let backup = directory.join(format!("replace-{index}.backup"));
+    require_anchored_missing(anchored, &backup)?;
+    anchored
+        .copy_file(target, &backup)
+        .map_err(|error| ChangeError::io("persist replacement backup", target, error))?;
+    let backup_fingerprint = anchored
+        .fingerprint(&backup)
+        .map_err(|error| ChangeError::io("verify replacement backup", &backup, error))?;
+    if backup_fingerprint != *expected_fingerprint {
+        return Err(ChangeError::new(
+            "backup_verification_failed",
+            format!(
+                "backup for {} does not match its precondition",
+                target.display()
+            ),
+        ));
     }
+    Ok(Some(Compensation::RestoreReplacedFile {
+        backup,
+        target: target.clone(),
+        expected_original: expected_fingerprint.clone(),
+        expected_replacement: file_content_fingerprint(content.as_bytes()),
+    }))
 }
 
 fn replace_file(
+    anchored: &AnchoredFs,
     target: &Path,
     content: &str,
     receipt_id: &str,
     index: usize,
-    directory_sync: &dyn DirectorySync,
 ) -> Result<()> {
-    let temp = replacement_temp_path(target, receipt_id, index)?;
-    let (mut file, original_permissions) =
-        copy_file_exclusive(target, &temp, "stage replacement metadata")?;
-    file.set_len(0)
-        .map_err(|error| ChangeError::io("truncate staged replacement", &temp, error))?;
-    file.seek(SeekFrom::Start(0))
-        .map_err(|error| ChangeError::io("rewind staged replacement", &temp, error))?;
-    file.write_all(content.as_bytes())
-        .map_err(|error| ChangeError::io("write replacement", &temp, error))?;
-    file.set_permissions(original_permissions)
-        .map_err(|error| ChangeError::io("restore replacement metadata", &temp, error))?;
-    file.sync_all()
-        .map_err(|error| ChangeError::io("sync replacement", &temp, error))?;
-    remove_file_durable_allowing_readonly(target, directory_sync, "remove replaced file")?;
-    rename_durable(&temp, target, directory_sync, "publish replacement")
-}
-
-fn replacement_temp_path(target: &Path, receipt_id: &str, index: usize) -> Result<PathBuf> {
     let file_name = target
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| ChangeError::new("unsafe_path", target.display().to_string()))?;
-    Ok(target.with_file_name(format!(
+    let temp = target.with_file_name(format!(
         ".{file_name}.skillroster-replace-{receipt_id}-{index}"
-    )))
+    ));
+    require_anchored_missing(anchored, &temp)?;
+    anchored
+        .replace_file(target, &temp, content.as_bytes())
+        .map_err(|error| ChangeError::io("publish replacement", target, error))
 }
 
 fn file_content_fingerprint(content: &[u8]) -> String {
@@ -1495,66 +1309,70 @@ fn execute(
     operation: &Operation,
     receipt_id: &str,
     index: usize,
-    roots: &[PathBuf],
-    directory_sync: &dyn DirectorySync,
+    anchored: &AnchoredFs,
 ) -> Result<Option<Compensation>> {
+    validate_anchored_current_state(operation, anchored)?;
     match operation {
         Operation::CreateDirectory { target, .. } => {
-            create_dir_durable(target, directory_sync)?;
+            anchored
+                .create_dir(target)
+                .map_err(|e| ChangeError::io("create directory", target, e))?;
             Ok(Some(Compensation::StashCreated {
                 path: target.clone(),
-                expected_fingerprint: fingerprint(target)?,
+                expected_fingerprint: anchored_fingerprint(anchored, target)?,
             }))
         }
         Operation::CreateSymlink { target, source, .. } => {
-            create_symlink(source, target)?;
-            sync_parent_directory(target, directory_sync, "sync created symlink parent")?;
+            anchored
+                .create_symlink(source, target)
+                .map_err(|e| ChangeError::io("create symlink", target, e))?;
             Ok(Some(Compensation::StashCreated {
                 path: target.clone(),
-                expected_fingerprint: fingerprint(target)?,
+                expected_fingerprint: anchored_fingerprint(anchored, target)?,
             }))
         }
         Operation::WriteFile {
             target, content, ..
         } => {
-            let mut file = OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(target)
+            anchored
+                .create_file(target, content.as_bytes())
                 .map_err(|e| ChangeError::io("create file", target, e))?;
-            file.write_all(content.as_bytes())
-                .map_err(|e| ChangeError::io("write file", target, e))?;
-            file.sync_all()
-                .map_err(|e| ChangeError::io("sync file", target, e))?;
-            sync_parent_directory(target, directory_sync, "sync created file parent")?;
             Ok(Some(Compensation::StashCreated {
                 path: target.clone(),
-                expected_fingerprint: fingerprint(target)?,
+                expected_fingerprint: anchored_fingerprint(anchored, target)?,
             }))
         }
         Operation::ReplaceFile {
             target, content, ..
         } => {
-            replace_file(target, content, receipt_id, index, directory_sync)?;
+            replace_file(anchored, target, content, receipt_id, index)?;
             Ok(None)
         }
         Operation::RemoveSymlink { target, .. } => {
-            remove_symlink(target)?;
-            sync_parent_directory(target, directory_sync, "sync removed symlink parent")?;
-            Ok(None)
+            let link_target = anchored
+                .read_link(target)
+                .map_err(|e| ChangeError::io("read symlink", target, e))?;
+            anchored
+                .remove_file(target)
+                .map_err(|e| ChangeError::io("remove symlink", target, e))?;
+            Ok(Some(Compensation::RestoreSymlink {
+                path: target.clone(),
+                target: link_target,
+            }))
         }
         Operation::Copy { target, source, .. } => {
-            copy_tree(source, target, roots, directory_sync)?;
+            anchored
+                .copy_tree(source, target)
+                .map_err(|e| ChangeError::io("copy path", source, e))?;
             Ok(Some(Compensation::StashCreated {
                 path: target.clone(),
-                expected_fingerprint: fingerprint(target)?,
+                expected_fingerprint: anchored_fingerprint(anchored, target)?,
             }))
         }
         Operation::MoveRecoverable { target, source, .. } => {
-            let expected = fingerprint(source)?;
-            match fs::rename(source, target) {
+            let expected = anchored_fingerprint(anchored, source)?;
+            match anchored.rename(source, target) {
                 Ok(()) => {
-                    sync_rename_directories(source, target, directory_sync)?;
                     return Ok(Some(Compensation::RenameBack {
                         from: target.clone(),
                         to: source.clone(),
@@ -1566,10 +1384,20 @@ fn execute(
             }
             // Cross-device recovery must remain on the source filesystem, so the
             // original can be hidden atomically after the destination copy lands.
-            let backup = move_backup_path(source, receipt_id, index)?;
-            require_missing(&backup)?;
-            copy_tree(source, target, roots, directory_sync)?;
-            rename_durable(source, &backup, directory_sync, "move source to recovery")?;
+            let file_name = source
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| ChangeError::new("unsafe_path", source.display().to_string()))?;
+            let backup = source.with_file_name(format!(
+                ".{file_name}.skillroster-backup-{receipt_id}-{index}"
+            ));
+            require_anchored_missing(anchored, &backup)?;
+            anchored
+                .copy_tree(source, target)
+                .map_err(|e| ChangeError::io("copy path", source, e))?;
+            if let Err(error) = anchored.rename(source, &backup) {
+                return Err(ChangeError::io("move source to recovery", source, error));
+            }
             Ok(Some(Compensation::RestoreBackup {
                 backup,
                 original: source.clone(),
@@ -1580,7 +1408,7 @@ fn execute(
     }
 }
 
-fn compensate_all(receipt: &ChangeReceipt, directory_sync: &dyn DirectorySync) -> Result<()> {
+fn compensate_all(receipt: &ChangeReceipt, anchored: &AnchoredFs) -> Result<()> {
     for (index, compensation) in receipt.compensations.iter().enumerate().rev() {
         compensate(
             compensation,
@@ -1588,7 +1416,7 @@ fn compensate_all(receipt: &ChangeReceipt, directory_sync: &dyn DirectorySync) -
             index,
             &receipt.approved_roots,
             &receipt.state_dir,
-            directory_sync,
+            anchored,
         )?;
     }
     Ok(())
@@ -1600,35 +1428,42 @@ fn compensate(
     index: usize,
     roots: &[PathBuf],
     state_dir: &Path,
-    directory_sync: &dyn DirectorySync,
+    anchored: &AnchoredFs,
 ) -> Result<()> {
     match compensation {
         Compensation::StashCreated {
             path,
             expected_fingerprint,
         } => {
-            verify_fingerprint(path, expected_fingerprint)?;
+            verify_anchored_fingerprint(anchored, path, expected_fingerprint)?;
             normalize_target(path, roots)?;
-            let stash = create_recovery_dir(state_dir, receipt_id, directory_sync)?
-                .join(format!("undo-{index}"));
-            rename_durable(path, &stash, directory_sync, "stash created path")?;
+            let stash = recovery_dir(state_dir, receipt_id).join(format!("undo-{index}"));
+            anchored
+                .create_dir_all(stash.parent().expect("stash has parent"))
+                .map_err(|e| ChangeError::io("create recovery directory", state_dir, e))?;
+            anchored
+                .rename(path, &stash)
+                .map_err(|e| ChangeError::io("stash created path", path, e))?;
         }
         Compensation::RestoreSymlink { path, target } => {
-            require_missing(path)?;
+            require_anchored_missing(anchored, path)?;
             normalize_target(path, roots)?;
-            create_symlink(target, path)?;
-            sync_parent_directory(path, directory_sync, "sync restored symlink parent")?;
+            anchored
+                .create_symlink(target, path)
+                .map_err(|e| ChangeError::io("restore symlink", path, e))?;
         }
         Compensation::RenameBack {
             from,
             to,
             expected_fingerprint,
         } => {
-            verify_fingerprint(from, expected_fingerprint)?;
-            require_missing(to)?;
+            verify_anchored_fingerprint(anchored, from, expected_fingerprint)?;
+            require_anchored_missing(anchored, to)?;
             normalize_target(from, roots)?;
             normalize_target(to, roots)?;
-            rename_durable(from, to, directory_sync, "restore moved path")?;
+            anchored
+                .rename(from, to)
+                .map_err(|e| ChangeError::io("restore moved path", from, e))?;
         }
         Compensation::RestoreBackup {
             backup,
@@ -1636,38 +1471,29 @@ fn compensate(
             created,
             expected_created,
         } => {
-            verify_fingerprint(created, expected_created)?;
-            require_missing(original)?;
+            verify_anchored_fingerprint(anchored, created, expected_created)?;
+            require_anchored_missing(anchored, original)?;
             normalize_target(created, roots)?;
             normalize_target(original, roots)?;
-            let stash = create_recovery_dir(state_dir, receipt_id, directory_sync)?
-                .join(format!("undo-created-{index}"));
-            rename_durable(created, &stash, directory_sync, "stash copied destination")?;
-            rename_durable(backup, original, directory_sync, "restore source backup")?;
+            let stash = recovery_dir(state_dir, receipt_id).join(format!("undo-created-{index}"));
+            anchored
+                .rename(created, &stash)
+                .map_err(|e| ChangeError::io("stash copied destination", created, e))?;
+            anchored
+                .rename(backup, original)
+                .map_err(|e| ChangeError::io("restore source backup", backup, e))?;
         }
         Compensation::RestoreReplacedFile {
             backup,
             target,
             expected_original,
             expected_replacement,
-            staged_replacement,
         } => {
-            if let Some(staged_replacement) = staged_replacement {
-                remove_expected_file_if_present_durable(
-                    staged_replacement,
-                    expected_replacement,
-                    directory_sync,
-                    "remove staged replacement",
-                )?;
-            }
-            let actual = fingerprint(target)?;
+            let actual = anchored_fingerprint(anchored, target)?;
             if actual == *expected_original {
-                remove_expected_file_if_present_durable(
-                    backup,
-                    expected_original,
-                    directory_sync,
-                    "remove unused backup",
-                )?;
+                anchored
+                    .remove_file(backup)
+                    .map_err(|error| ChangeError::io("remove unused backup", backup, error))?;
                 return Ok(());
             }
             if actual != "missing" && actual != *expected_replacement {
@@ -1686,49 +1512,25 @@ fn compensate(
                     .and_then(|name| name.to_str())
                     .unwrap_or("file")
             ));
-            require_missing(&restore)?;
-            copy_file_durable(backup, &restore, directory_sync, "stage restored file")?;
+            require_anchored_missing(anchored, &restore)?;
+            anchored
+                .copy_file(backup, &restore)
+                .map_err(|error| ChangeError::io("stage restored file", backup, error))?;
             if actual != "missing" {
-                remove_file_durable_allowing_readonly(
-                    target,
-                    directory_sync,
-                    "remove replacement",
-                )?;
+                anchored
+                    .remove_file(target)
+                    .map_err(|error| ChangeError::io("remove replacement", target, error))?;
             }
-            rename_durable(&restore, target, directory_sync, "restore replaced file")?;
-            verify_fingerprint(target, expected_original)?;
-            remove_expected_file_if_present_durable(
-                backup,
-                expected_original,
-                directory_sync,
-                "remove consumed backup",
-            )?;
+            anchored
+                .rename(&restore, target)
+                .map_err(|error| ChangeError::io("restore replaced file", target, error))?;
+            verify_anchored_fingerprint(anchored, target, expected_original)?;
+            anchored
+                .remove_file(backup)
+                .map_err(|error| ChangeError::io("remove consumed backup", backup, error))?;
         }
     }
     Ok(())
-}
-
-fn remove_expected_file_if_present_durable(
-    path: &Path,
-    expected_fingerprint: &str,
-    directory_sync: &dyn DirectorySync,
-    action: &str,
-) -> Result<()> {
-    match fingerprint(path)? {
-        actual if actual == expected_fingerprint => {
-            remove_file_durable_allowing_readonly(path, directory_sync, action)
-        }
-        actual if actual == "missing" => {
-            sync_parent_directory(path, directory_sync, "sync absent recovery file parent")
-        }
-        actual => Err(ChangeError::new(
-            "undo_drifted",
-            format!(
-                "{} expected {expected_fingerprint} or missing, found {actual}",
-                path.display()
-            ),
-        )),
-    }
 }
 
 fn validate_prepared_plan(plan: &PreparedPlan) -> Result<()> {
@@ -1806,48 +1608,6 @@ pub fn fingerprint(path: &Path) -> Result<String> {
         "unsupported_file_type",
         format!("{} is not a file, directory, or symlink", path.display()),
     ))
-}
-
-fn copy_tree(
-    source: &Path,
-    target: &Path,
-    roots: &[PathBuf],
-    directory_sync: &dyn DirectorySync,
-) -> Result<()> {
-    normalize_source(source, roots)?;
-    normalize_target(target, roots)?;
-    require_missing(target)?;
-    let metadata =
-        fs::symlink_metadata(source).map_err(|e| ChangeError::io("inspect source", source, e))?;
-    if metadata.file_type().is_symlink() {
-        return Err(ChangeError::new(
-            "unsupported_copy_symlink",
-            format!("refusing to recursively copy symlink {}", source.display()),
-        ));
-    }
-    if metadata.is_file() {
-        copy_file_durable(source, target, directory_sync, "copy file")?;
-        return Ok(());
-    }
-    if !metadata.is_dir() {
-        return Err(ChangeError::new(
-            "unsupported_file_type",
-            source.display().to_string(),
-        ));
-    }
-    create_dir_durable(target, directory_sync)?;
-    for entry in
-        fs::read_dir(source).map_err(|e| ChangeError::io("read source directory", source, e))?
-    {
-        let entry = entry.map_err(|e| ChangeError::io("read source directory", source, e))?;
-        copy_tree(
-            &entry.path(),
-            &target.join(entry.file_name()),
-            roots,
-            directory_sync,
-        )?;
-    }
-    Ok(())
 }
 
 fn normalize_roots(roots: &[PathBuf], state_dir: &Path) -> Result<Vec<PathBuf>> {
@@ -2003,6 +1763,34 @@ fn nearest_existing_ancestor(path: &Path) -> Result<PathBuf> {
     }
 }
 
+fn anchored_fingerprint(anchored: &AnchoredFs, path: &Path) -> Result<String> {
+    anchored
+        .fingerprint(path)
+        .map_err(|error| ChangeError::io("inspect through approved root handle", path, error))
+}
+
+fn require_anchored_missing(anchored: &AnchoredFs, path: &Path) -> Result<()> {
+    let actual = anchored_fingerprint(anchored, path)?;
+    if actual != "missing" {
+        return Err(ChangeError::new(
+            "target_exists",
+            format!("{} already exists", path.display()),
+        ));
+    }
+    Ok(())
+}
+
+fn verify_anchored_fingerprint(anchored: &AnchoredFs, path: &Path, expected: &str) -> Result<()> {
+    let actual = anchored_fingerprint(anchored, path)?;
+    if actual != expected {
+        return Err(ChangeError::new(
+            "undo_drifted",
+            format!("{} expected {expected}, found {actual}", path.display()),
+        ));
+    }
+    Ok(())
+}
+
 fn require_missing(path: &Path) -> Result<()> {
     if fs::symlink_metadata(path).is_ok() {
         return Err(ChangeError::new(
@@ -2013,24 +1801,13 @@ fn require_missing(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn verify_fingerprint(path: &Path, expected: &str) -> Result<()> {
-    let actual = fingerprint(path)?;
-    if actual != expected {
-        return Err(ChangeError::new(
-            "undo_drifted",
-            format!("{} expected {expected}, found {actual}", path.display()),
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 fn create_symlink(source: &Path, target: &Path) -> Result<()> {
     std::os::unix::fs::symlink(source, target)
         .map_err(|e| ChangeError::io("create symlink", target, e))
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn create_symlink(source: &Path, target: &Path) -> Result<()> {
     let metadata =
         fs::metadata(source).map_err(|e| ChangeError::io("inspect symlink source", source, e))?;
@@ -2042,85 +1819,30 @@ fn create_symlink(source: &Path, target: &Path) -> Result<()> {
     result.map_err(|e| ChangeError::io("create symlink", target, e))
 }
 
-#[cfg(unix)]
-fn remove_symlink(path: &Path) -> Result<()> {
-    fs::remove_file(path).map_err(|error| ChangeError::io("remove symlink", path, error))
-}
-
-#[cfg(windows)]
-fn remove_symlink(path: &Path) -> Result<()> {
-    let result = match fs::metadata(path) {
-        Ok(metadata) if metadata.is_dir() => fs::remove_dir(path),
-        _ => fs::remove_file(path),
-    };
-    result.map_err(|error| ChangeError::io("remove symlink", path, error))
-}
-
-fn create_recovery_dir(
-    state_dir: &Path,
-    receipt_id: &str,
-    directory_sync: &dyn DirectorySync,
-) -> Result<PathBuf> {
-    let root = state_dir.join("recovery");
-    let directory = root.join(receipt_id);
-    create_dir_all_durable(&directory, directory_sync)?;
-    state_security::secure_directory(&root)
-        .map_err(|error| ChangeError::io("secure recovery directory", &root, error))?;
-    state_security::secure_directory(&directory)
-        .map_err(|error| ChangeError::io("secure recovery directory", &directory, error))?;
-    Ok(directory)
+fn recovery_dir(state_dir: &Path, receipt_id: &str) -> PathBuf {
+    state_dir.join("recovery").join(receipt_id)
 }
 
 fn persist_journal(receipt: &ChangeReceipt) -> Result<()> {
-    persist_journal_with(receipt, &SystemDirectorySync)
-}
-
-fn persist_journal_with(receipt: &ChangeReceipt, directory_sync: &dyn DirectorySync) -> Result<()> {
     let directory = receipt.state_dir.join("receipts");
-    create_dir_all_durable(&directory, directory_sync)?;
-    state_security::secure_directory(&directory)
-        .map_err(|e| ChangeError::io("secure receipt directory", &directory, e))?;
+    fs::create_dir_all(&directory)
+        .map_err(|e| ChangeError::io("create receipt directory", &directory, e))?;
     let path = directory.join(format!("{}.json", receipt.id));
     let temp = directory.join(format!(".{}.tmp", receipt.id));
     let bytes = serde_json::to_vec_pretty(receipt)
         .map_err(|e| ChangeError::new("receipt_encoding_failed", e.to_string()))?;
-    let mut file = state_security::open_private_file_for_replace(&temp)
-        .map_err(|e| ChangeError::io("create receipt journal", &temp, e))?;
+    let mut file =
+        File::create(&temp).map_err(|e| ChangeError::io("create receipt journal", &temp, e))?;
     file.write_all(&bytes)
         .map_err(|e| ChangeError::io("write receipt journal", &temp, e))?;
     file.sync_all()
         .map_err(|e| ChangeError::io("sync receipt journal", &temp, e))?;
-    rename_durable(&temp, &path, directory_sync, "publish receipt journal")
+    fs::rename(&temp, &path).map_err(|e| ChangeError::io("publish receipt journal", &path, e))?;
+    Ok(())
 }
 
 pub(crate) fn persist_journal_state(receipt: &ChangeReceipt) -> Result<()> {
     persist_journal(receipt)
-}
-
-pub(crate) fn owned_receipt_control_file(name: &OsStr, file: &mut File) -> io::Result<bool> {
-    let Some(name) = name.to_str() else {
-        return Ok(false);
-    };
-    if let Some(id) = name
-        .strip_prefix('.')
-        .and_then(|name| name.strip_suffix(".tmp"))
-        .and_then(|name| name.strip_prefix("receipt_"))
-    {
-        return Ok(ulid::Ulid::from_string(id).is_ok());
-    }
-    let Some(id) = name
-        .strip_suffix(".json")
-        .and_then(|name| name.strip_prefix("receipt_"))
-    else {
-        return Ok(false);
-    };
-    if ulid::Ulid::from_string(id).is_err() {
-        return Ok(false);
-    }
-    let Ok(receipt) = serde_json::from_reader::<_, ChangeReceipt>(file) else {
-        return Ok(false);
-    };
-    Ok(receipt.id == name.trim_end_matches(".json"))
 }
 
 /// Loads the durable filesystem journal without changing it. Invalid entries are
@@ -2252,16 +1974,13 @@ impl StateLock {
 
     fn acquire(state_dir: &Path, exclusive: bool) -> Result<Self> {
         let path = state_dir.join("write.lock");
-        let mut options = state_security::private_file_options();
-        let file = options
+        let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
             .open(&path)
             .map_err(|e| ChangeError::io("open state lock", &path, e))?;
-        state_security::secure_opened_file(&file)
-            .map_err(|e| ChangeError::io("secure state lock", &path, e))?;
         let result = if exclusive {
             FileExt::try_lock_exclusive(&file)
         } else {
@@ -2301,32 +2020,7 @@ impl WriteLock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
     use tempfile::TempDir;
-
-    struct FailOnceDirectorySync {
-        path: PathBuf,
-        failed: Cell<bool>,
-    }
-
-    impl FailOnceDirectorySync {
-        fn new(path: PathBuf) -> Self {
-            Self {
-                path,
-                failed: Cell::new(false),
-            }
-        }
-    }
-
-    impl DirectorySync for FailOnceDirectorySync {
-        fn sync_directory(&self, path: &Path) -> io::Result<()> {
-            if path == self.path && !self.failed.replace(true) {
-                Err(io::Error::other("injected directory sync failure"))
-            } else {
-                SystemDirectorySync.sync_directory(path)
-            }
-        }
-    }
 
     fn fixture() -> (TempDir, PathBuf, PathBuf) {
         let temp = TempDir::new().unwrap();
@@ -2388,6 +2082,56 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(error.code, "path_escapes_through_symlink");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_cannot_follow_an_ancestor_swapped_after_root_handles_open() {
+        let (temp, root, state) = fixture();
+        let ancestor = root.join("mutable");
+        let held_ancestor = root.join("held-mutable");
+        let outside = temp.path().join("outside");
+        fs::create_dir(&ancestor).unwrap();
+        fs::create_dir(&outside).unwrap();
+        let target = ancestor.join("written.txt");
+        let external_target = outside.join("written.txt");
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "write_file",
+                "target": target,
+                "content": "must stay contained",
+                "expected_fingerprint": "missing"
+            }]
+        })
+        .to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root.clone()],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let hook_ancestor = ancestor.clone();
+        let hook_held = held_ancestor.clone();
+        let hook_outside = outside.clone();
+        BEFORE_MUTATION_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                fs::rename(&hook_ancestor, &hook_held).unwrap();
+                std::os::unix::fs::symlink(&hook_outside, &hook_ancestor).unwrap();
+            }));
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert!(!outcome.verification_passed);
+        assert!(!external_target.exists());
+        assert!(!held_ancestor.join("written.txt").exists());
+        fs::remove_file(&ancestor).unwrap();
+        fs::rename(&held_ancestor, &ancestor).unwrap();
     }
 
     #[test]
@@ -2527,245 +2271,6 @@ mod tests {
     }
 
     #[test]
-    fn journal_directory_sync_failure_precedes_governed_mutation() {
-        let (_temp, root, state) = fixture();
-        let target = root.join("not-created.md");
-        let input = serde_json::json!({
-            "schema_version": 1,
-            "scan_id": "scan_1",
-            "operations": [{
-                "kind": "write_file",
-                "target": target,
-                "content": "must not be published",
-                "expected_fingerprint": "missing"
-            }]
-        })
-        .to_string();
-        let plan = prepare(
-            &input,
-            &PrepareContext {
-                approved_roots: vec![root],
-                state_dir: state.clone(),
-                operation_policy: OperationPolicy::TestOnly,
-            },
-        )
-        .unwrap();
-        let directory_sync = FailOnceDirectorySync::new(plan.state_dir.join("receipts"));
-
-        let error = apply_locked_with(&plan, &directory_sync).unwrap_err();
-
-        assert_eq!(error.code, "filesystem_error");
-        assert!(error.message.contains("sync renamed source directory"));
-        assert!(directory_sync.failed.get());
-        assert!(!target.exists());
-    }
-
-    #[test]
-    fn journal_reuses_an_owned_temp_left_by_an_interrupted_write() {
-        let (_temp, root, state) = fixture();
-        let receipt = ChangeReceipt {
-            id: format!("receipt_{}", ulid::Ulid::new()),
-            plan_id: "plan_retry".to_owned(),
-            status: ReceiptStatus::Applying,
-            changed_paths: Vec::new(),
-            compensations: Vec::new(),
-            approved_roots: vec![root],
-            state_dir: state.clone(),
-            error: None,
-            reverses_receipt_id: None,
-            operation_results: Vec::new(),
-        };
-        let receipts = state.join("receipts");
-        fs::create_dir(&receipts).unwrap();
-        let temp = receipts.join(format!(".{}.tmp", receipt.id));
-        fs::write(&temp, b"incomplete").unwrap();
-
-        persist_journal(&receipt).unwrap();
-
-        assert!(!temp.exists());
-        let published = receipts.join(format!("{}.json", receipt.id));
-        let decoded: ChangeReceipt = serde_json::from_slice(&fs::read(published).unwrap()).unwrap();
-        assert_eq!(decoded.id, receipt.id);
-        assert_eq!(decoded.status, ReceiptStatus::Applying);
-    }
-
-    #[test]
-    fn owned_receipt_validation_has_no_smaller_limit_than_receipt_creation() {
-        let (_temp, root, state) = fixture();
-        let receipt = ChangeReceipt {
-            id: format!("receipt_{}", ulid::Ulid::new()),
-            plan_id: "plan_large_receipt".to_owned(),
-            status: ReceiptStatus::RecoveryRequired,
-            changed_paths: Vec::new(),
-            compensations: Vec::new(),
-            approved_roots: vec![root],
-            state_dir: state.clone(),
-            error: Some("x".repeat(9 * 1024 * 1024)),
-            reverses_receipt_id: None,
-            operation_results: Vec::new(),
-        };
-        let name = format!("{}.json", receipt.id);
-        let path = state.join(&name);
-        fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
-        let mut file = File::open(path).unwrap();
-
-        assert!(owned_receipt_control_file(OsStr::new(&name), &mut file).unwrap());
-    }
-
-    #[test]
-    fn target_directory_sync_failure_is_not_reported_as_success() {
-        let (_temp, root, state) = fixture();
-        let target = root.join("rolled-back.md");
-        let input = serde_json::json!({
-            "schema_version": 1,
-            "scan_id": "scan_1",
-            "operations": [{
-                "kind": "write_file",
-                "target": target,
-                "content": "published before injected barrier failure",
-                "expected_fingerprint": "missing"
-            }]
-        })
-        .to_string();
-        let plan = prepare(
-            &input,
-            &PrepareContext {
-                approved_roots: vec![root.clone()],
-                state_dir: state,
-                operation_policy: OperationPolicy::TestOnly,
-            },
-        )
-        .unwrap();
-        let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
-
-        let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
-
-        assert!(!outcome.verification_passed);
-        assert_eq!(outcome.receipt.status, ReceiptStatus::FailedRolledBack);
-        assert!(directory_sync.failed.get());
-        assert!(!target.exists());
-    }
-
-    #[test]
-    fn moved_path_sync_failure_restores_the_source() {
-        let (_temp, root, state) = fixture();
-        let source = root.join("source");
-        let target = root.join("target");
-        fs::write(&source, "original").unwrap();
-        let input = serde_json::json!({
-            "schema_version": 1,
-            "scan_id": "scan_1",
-            "operations": [{
-                "kind": "move_recoverable",
-                "source": source,
-                "target": target,
-                "expected_fingerprint": fingerprint(&source).unwrap()
-            }]
-        })
-        .to_string();
-        let plan = prepare(
-            &input,
-            &PrepareContext {
-                approved_roots: vec![root],
-                state_dir: state,
-                operation_policy: OperationPolicy::TestOnly,
-            },
-        )
-        .unwrap();
-        let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
-
-        let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
-
-        assert!(!outcome.verification_passed);
-        assert_eq!(outcome.receipt.status, ReceiptStatus::FailedRolledBack);
-        assert_eq!(fs::read_to_string(&source).unwrap(), "original");
-        assert!(!target.exists());
-    }
-
-    #[test]
-    fn removed_symlink_sync_failure_restores_the_link() {
-        let (_temp, root, state) = fixture();
-        let source = root.join("source");
-        let target = root.join("link");
-        fs::write(&source, "original").unwrap();
-        create_symlink(&source, &target).unwrap();
-        let input = serde_json::json!({
-            "schema_version": 1,
-            "scan_id": "scan_1",
-            "operations": [{
-                "kind": "remove_symlink",
-                "target": target,
-                "expected_fingerprint": fingerprint(&target).unwrap()
-            }]
-        })
-        .to_string();
-        let plan = prepare(
-            &input,
-            &PrepareContext {
-                approved_roots: vec![root],
-                state_dir: state,
-                operation_policy: OperationPolicy::TestOnly,
-            },
-        )
-        .unwrap();
-        let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
-
-        let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
-
-        assert!(!outcome.verification_passed);
-        assert_eq!(outcome.receipt.status, ReceiptStatus::FailedRolledBack);
-        assert_eq!(fs::read_link(&target).unwrap(), source);
-    }
-
-    #[test]
-    fn replaced_file_sync_failure_restores_original_content() {
-        let (_temp, root, state) = fixture();
-        let target = root.join("replace.txt");
-        fs::write(&target, "before").unwrap();
-        let input = serde_json::json!({
-            "schema_version": 1,
-            "scan_id": "scan_1",
-            "operations": [{
-                "kind": "replace_file",
-                "target": target,
-                "content": "after",
-                "expected_fingerprint": fingerprint(&target).unwrap()
-            }]
-        })
-        .to_string();
-        let plan = prepare(
-            &input,
-            &PrepareContext {
-                approved_roots: vec![root.clone()],
-                state_dir: state,
-                operation_policy: OperationPolicy::TestOnly,
-            },
-        )
-        .unwrap();
-        let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
-
-        let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
-
-        assert!(!outcome.verification_passed);
-        assert_eq!(outcome.receipt.status, ReceiptStatus::FailedRolledBack);
-        assert_eq!(fs::read_to_string(&target).unwrap(), "before");
-        let remaining = fs::read_dir(&root)
-            .unwrap()
-            .map(|entry| entry.unwrap().file_name())
-            .collect::<Vec<_>>();
-        assert_eq!(remaining, vec![target.file_name().unwrap()]);
-        assert!(outcome.receipt.compensations.iter().any(|compensation| {
-            matches!(
-                compensation,
-                Compensation::RestoreReplacedFile {
-                    staged_replacement: Some(_),
-                    ..
-                }
-            )
-        }));
-    }
-
-    #[test]
     fn apply_and_undo_round_trip_created_symlink() {
         let (_temp, root, state) = fixture();
         let source = root.join("source");
@@ -2829,27 +2334,12 @@ mod tests {
             &input,
             &PrepareContext {
                 approved_roots: vec![root],
-                state_dir: state.clone(),
+                state_dir: state,
                 operation_policy: OperationPolicy::TestOnly,
             },
         )
         .unwrap();
         let applied = apply(&plan).unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let receipts = state.join("receipts");
-            let journal = receipts.join(format!("{}.json", applied.receipt.id));
-            assert_eq!(
-                fs::metadata(receipts).unwrap().permissions().mode() & 0o777,
-                0o700
-            );
-            assert_eq!(
-                fs::metadata(journal).unwrap().permissions().mode() & 0o777,
-                0o600
-            );
-        }
         assert_eq!(
             fs::read_to_string(&target).unwrap(),
             "---\nname: test\n---\n"
@@ -2857,131 +2347,6 @@ mod tests {
         let undone = undo(&applied.receipt).unwrap();
         assert_eq!(undone.receipt.status, ReceiptStatus::Undone);
         assert!(!target.exists());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn replace_and_undo_preserve_private_and_executable_modes() {
-        use std::os::unix::fs::PermissionsExt;
-
-        for mode in [0o600, 0o500] {
-            assert_replace_and_undo_preserves_permissions(fs::Permissions::from_mode(mode));
-        }
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn replace_and_undo_preserve_readonly_state() {
-        let temp = tempfile::tempdir().unwrap();
-        let probe = temp.path().join("permissions-probe");
-        fs::write(&probe, "probe").unwrap();
-        let mut permissions = fs::metadata(&probe).unwrap().permissions();
-        permissions.set_readonly(true);
-        assert_replace_and_undo_preserves_permissions(permissions);
-    }
-
-    fn assert_replace_and_undo_preserves_permissions(original_permissions: fs::Permissions) {
-        let (_temp, root, state) = fixture();
-        let target = root.join("replace.txt");
-        fs::write(&target, "before").unwrap();
-        fs::set_permissions(&target, original_permissions.clone()).unwrap();
-        let input = serde_json::json!({
-            "schema_version": 1,
-            "scan_id": "scan_1",
-            "operations": [{
-                "kind": "replace_file",
-                "target": target,
-                "content": "after",
-                "expected_fingerprint": fingerprint(&target).unwrap()
-            }]
-        })
-        .to_string();
-        let plan = prepare(
-            &input,
-            &PrepareContext {
-                approved_roots: vec![root],
-                state_dir: state,
-                operation_policy: OperationPolicy::TestOnly,
-            },
-        )
-        .unwrap();
-
-        let applied = apply(&plan).unwrap();
-
-        assert!(
-            applied.verification_passed,
-            "Apply failed: {:?}",
-            applied.receipt.error
-        );
-        assert_eq!(fs::read_to_string(&target).unwrap(), "after");
-        assert_permissions_equal(&target, &original_permissions);
-
-        let undone = undo(&applied.receipt).unwrap();
-
-        assert!(undone.verification_passed);
-        assert_eq!(fs::read_to_string(&target).unwrap(), "before");
-        assert_permissions_equal(&target, &original_permissions);
-        #[cfg(windows)]
-        {
-            let mut writable = original_permissions;
-            writable.set_readonly(false);
-            fs::set_permissions(&target, writable).unwrap();
-        }
-    }
-
-    #[test]
-    fn replacement_staging_failure_leaves_original_content_and_permissions() {
-        let (_temp, root, _state) = fixture();
-        let target = root.join("replace.txt");
-        fs::write(&target, "before").unwrap();
-        let permissions = fs::metadata(&target).unwrap().permissions();
-        let receipt_id = "receipt_fixture";
-        let staged = root.join(format!(".replace.txt.skillroster-replace-{receipt_id}-0"));
-        fs::write(&staged, "must not be overwritten").unwrap();
-
-        let error =
-            replace_file(&target, "after", receipt_id, 0, &SystemDirectorySync).unwrap_err();
-
-        assert_eq!(error.code, "target_exists");
-        assert_eq!(fs::read_to_string(&target).unwrap(), "before");
-        assert_permissions_equal(&target, &permissions);
-        assert_eq!(
-            fs::read_to_string(staged).unwrap(),
-            "must not be overwritten"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn exclusive_copy_never_exposes_private_source_under_wider_mode() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let temp = tempfile::tempdir().unwrap();
-        let source = temp.path().join("private-source");
-        let staged = temp.path().join("visible-staging");
-        fs::write(&source, "private contents").unwrap();
-        fs::set_permissions(&source, fs::Permissions::from_mode(0o600)).unwrap();
-
-        let (_file, permissions) =
-            copy_file_exclusive(&source, &staged, "stage private file").unwrap();
-
-        assert_eq!(permissions.mode() & 0o7777, 0o600);
-        assert_eq!(
-            fs::metadata(&staged).unwrap().permissions().mode() & 0o077,
-            0
-        );
-        assert_eq!(fs::read_to_string(&staged).unwrap(), "private contents");
-    }
-
-    fn assert_permissions_equal(path: &Path, expected: &fs::Permissions) {
-        let actual = fs::metadata(path).unwrap().permissions();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            assert_eq!(actual.mode() & 0o7777, expected.mode() & 0o7777);
-        }
-        #[cfg(windows)]
-        assert_eq!(actual.readonly(), expected.readonly());
     }
 
     #[test]

--- a/src/change.rs
+++ b/src/change.rs
@@ -4,9 +4,10 @@
 //! fingerprints, and every apply/undo obtains the same process write lock.
 
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
 use std::fmt;
-use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read, Write};
+use std::fs::{self, File};
+use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
 
 use fs2::FileExt;
@@ -14,10 +15,17 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::anchored_fs::AnchoredFs;
+use crate::durable_fs::{DirectorySync, SystemDirectorySync};
 
 #[cfg(test)]
 thread_local! {
     static BEFORE_MUTATION_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static BEFORE_EXECUTE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static BEFORE_REMOVE_SYMLINK_RENAME_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+    static BEFORE_SEQUENCE_VALIDATION_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
         std::cell::RefCell::new(None);
 }
 
@@ -32,6 +40,42 @@ fn run_before_mutation_hook() {
 
 #[cfg(not(test))]
 fn run_before_mutation_hook() {}
+
+#[cfg(test)]
+fn run_before_execute_hook() {
+    BEFORE_EXECUTE_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_before_execute_hook() {}
+
+#[cfg(test)]
+fn run_before_remove_symlink_rename_hook() {
+    BEFORE_REMOVE_SYMLINK_RENAME_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_before_remove_symlink_rename_hook() {}
+
+#[cfg(test)]
+fn run_before_sequence_validation_hook() {
+    BEFORE_SEQUENCE_VALIDATION_HOOK.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn run_before_sequence_validation_hook() {}
 
 #[derive(Debug)]
 pub struct ChangeError {
@@ -89,7 +133,7 @@ pub(crate) enum OperationPolicy {
     TestOnly,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PlanInput {
     pub schema_version: u32,
@@ -142,7 +186,7 @@ pub struct RosterChange {
     pub state: String,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum OperationInput {
     CreateDirectory {
@@ -312,6 +356,11 @@ pub enum Compensation {
         to: PathBuf,
         expected_fingerprint: String,
     },
+    RestoreRemovedSymlink {
+        from: PathBuf,
+        to: PathBuf,
+        expected_fingerprint: String,
+    },
     RestoreBackup {
         backup: PathBuf,
         original: PathBuf,
@@ -323,6 +372,8 @@ pub enum Compensation {
         target: PathBuf,
         expected_original: String,
         expected_replacement: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        staged_replacement: Option<PathBuf>,
     },
 }
 
@@ -458,7 +509,7 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
     let mut operations = Vec::with_capacity(input.operations.len());
     let mut projected_missing = HashSet::new();
     let mut projected_present = HashSet::new();
-    let mut projected_fingerprints = HashMap::new();
+    let mut projected_fingerprints: HashMap<PathBuf, String> = HashMap::new();
     for raw in input.operations {
         let operation = normalize_operation(raw, &roots, &projected_present)?;
         if matches!(ctx.operation_policy, OperationPolicy::BootstrapSetup) {
@@ -513,15 +564,33 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
 
 pub fn apply(plan: &PreparedPlan) -> Result<ApplyOutcome> {
     validate_prepared_plan(plan)?;
-    let _lock = WriteLock::acquire(&plan.state_dir)?;
-    apply_locked(plan)
+    let lock = WriteLock::acquire(&plan.state_dir)?;
+    apply_locked(plan, &lock._guard)
 }
 
-pub(crate) fn apply_locked(plan: &PreparedPlan) -> Result<ApplyOutcome> {
+pub(crate) fn apply_locked(plan: &PreparedPlan, state_lock: &StateLock) -> Result<ApplyOutcome> {
+    let anchored =
+        state_lock.filesystem(&plan.approved_roots, &plan.state_dir, &SystemDirectorySync)?;
+    apply_locked_with_anchored(plan, anchored)
+}
+
+#[cfg(test)]
+fn apply_locked_with(
+    plan: &PreparedPlan,
+    directory_sync: &dyn DirectorySync,
+) -> Result<ApplyOutcome> {
+    let anchored = open_anchored_fs(&plan.approved_roots, &plan.state_dir, directory_sync)?;
+    apply_locked_with_anchored(plan, anchored)
+}
+
+fn apply_locked_with_anchored(
+    plan: &PreparedPlan,
+    anchored: AnchoredFs<'_>,
+) -> Result<ApplyOutcome> {
     validate_prepared_plan(plan)?;
-    reject_unresolved_recovery(&plan.state_dir)?;
-    validate_operation_sequence(&plan.operations, &plan.approved_roots)?;
-    let anchored = open_anchored_fs(&plan.approved_roots, &plan.state_dir)?;
+    run_before_sequence_validation_hook();
+    validate_operation_sequence_anchored(&plan.operations, &anchored)?;
+    reject_unresolved_recovery_except(&anchored, &plan.state_dir, "")?;
 
     let receipt_id = format!("receipt_{}", ulid::Ulid::new());
     let mut receipt = ChangeReceipt {
@@ -536,7 +605,7 @@ pub(crate) fn apply_locked(plan: &PreparedPlan) -> Result<ApplyOutcome> {
         reverses_receipt_id: None,
         operation_results: Vec::new(),
     };
-    persist_journal(&receipt)?;
+    persist_journal_with(&receipt, &anchored)?;
     run_before_mutation_hook();
 
     for (index, operation) in plan.operations.iter().enumerate() {
@@ -550,13 +619,14 @@ pub(crate) fn apply_locked(plan: &PreparedPlan) -> Result<ApplyOutcome> {
             after_fingerprint: None,
             error: None,
         });
-        persist_journal(&receipt)?;
+        persist_journal_with(&receipt, &anchored)?;
         if let Some(compensation) =
             stage_compensation(operation, &receipt.id, index, &plan.state_dir, &anchored)?
         {
             receipt.compensations.push(compensation);
-            persist_journal(&receipt)?;
+            persist_journal_with(&receipt, &anchored)?;
         }
+        run_before_execute_hook();
         match execute(operation, &receipt.id, index, &anchored) {
             Ok(compensation) => {
                 receipt.changed_paths.push(operation.target().to_path_buf());
@@ -567,7 +637,7 @@ pub(crate) fn apply_locked(plan: &PreparedPlan) -> Result<ApplyOutcome> {
                     result.status = "applied".to_owned();
                     result.after_fingerprint = anchored.fingerprint(operation.target()).ok();
                 }
-                if let Err(journal_error) = persist_journal(&receipt) {
+                if let Err(journal_error) = persist_journal_with(&receipt, &anchored) {
                     receipt.error = Some(journal_error.to_string());
                     let rollback = compensate_all(&receipt, &anchored);
                     receipt.status = if rollback.is_ok() {
@@ -583,7 +653,7 @@ pub(crate) fn apply_locked(plan: &PreparedPlan) -> Result<ApplyOutcome> {
                     }
                     // Best effort: if storage remains unavailable, the last durable
                     // journal stays Applying and therefore blocks future writes.
-                    let _ = persist_journal(&receipt);
+                    let _ = persist_journal_with(&receipt, &anchored);
                     return Ok(ApplyOutcome {
                         receipt,
                         verification_passed: false,
@@ -597,34 +667,50 @@ pub(crate) fn apply_locked(plan: &PreparedPlan) -> Result<ApplyOutcome> {
                     result.error = Some(error.to_string());
                 }
                 receipt.error = Some(error.to_string());
-                // Recursive copy can fail after creating a partial target. Record
-                // the concrete artifact before compensating so a partial copy is
-                // never reported as a clean rollback.
-                if operation_creates_missing_target(operation)
-                    && anchored
-                        .fingerprint(operation.target())
-                        .is_ok_and(|value| value != "missing")
+                if error.code == "entry_identity_changed"
+                    || operation_is_uncompensated_create(operation)
                 {
-                    match anchored.fingerprint(operation.target()) {
-                        Ok(expected_fingerprint) => {
-                            receipt.compensations.push(Compensation::StashCreated {
-                                path: operation.target().to_path_buf(),
-                                expected_fingerprint,
-                            });
-                            receipt.changed_paths.push(operation.target().to_path_buf());
-                            let _ = persist_journal(&receipt);
-                        }
-                        Err(fingerprint_error) => {
-                            receipt.status = ReceiptStatus::RecoveryRequired;
+                    let rollback = compensate_all(&receipt, &anchored);
+                    receipt.status = ReceiptStatus::RecoveryRequired;
+                    finalize_recovery_required_results(&mut receipt, rollback.is_ok(), &anchored);
+                    if let Err(rollback_error) = rollback {
+                        receipt.error = Some(format!(
+                            "{error}; prior-operation compensation failed: {rollback_error}"
+                        ));
+                    }
+                    let _ = persist_journal_with(&receipt, &anchored);
+                    return Ok(ApplyOutcome {
+                        receipt,
+                        verification_passed: false,
+                    });
+                }
+                // A durability barrier can fail after the directory entry changed.
+                // Record the concrete recovery action before compensating so the
+                // mutation is never reported as a clean rollback.
+                match partial_operation_compensation(operation, &receipt.id, index, &anchored) {
+                    Ok(Some(compensation)) => {
+                        receipt.compensations.push(compensation);
+                        receipt.changed_paths.push(operation.target().to_path_buf());
+                        let _ = persist_journal_with(&receipt, &anchored);
+                    }
+                    Ok(None) => {}
+                    Err(fingerprint_error) => {
+                        receipt.status = ReceiptStatus::RecoveryRequired;
+                        receipt.error = Some(format!(
+                            "{error}; partial target could not be fingerprinted: {fingerprint_error}"
+                        ));
+                        let rollback = compensate_all(&receipt, &anchored);
+                        finalize_rollback_results(&mut receipt, rollback.is_ok(), &anchored);
+                        if let Err(rollback_error) = rollback {
                             receipt.error = Some(format!(
-                                "{error}; partial target could not be fingerprinted: {fingerprint_error}"
+                                "{error}; partial target could not be fingerprinted: {fingerprint_error}; compensation failed: {rollback_error}"
                             ));
-                            let _ = persist_journal(&receipt);
-                            return Ok(ApplyOutcome {
-                                receipt,
-                                verification_passed: false,
-                            });
                         }
+                        let _ = persist_journal_with(&receipt, &anchored);
+                        return Ok(ApplyOutcome {
+                            receipt,
+                            verification_passed: false,
+                        });
                     }
                 }
                 let rollback = compensate_all(&receipt, &anchored);
@@ -637,7 +723,7 @@ pub(crate) fn apply_locked(plan: &PreparedPlan) -> Result<ApplyOutcome> {
                 if let Err(rollback_error) = rollback {
                     receipt.error = Some(format!("{error}; compensation failed: {rollback_error}"));
                 }
-                persist_journal(&receipt)?;
+                persist_journal_with(&receipt, &anchored)?;
                 return Ok(ApplyOutcome {
                     receipt,
                     verification_passed: false,
@@ -647,12 +733,12 @@ pub(crate) fn apply_locked(plan: &PreparedPlan) -> Result<ApplyOutcome> {
     }
 
     receipt.status = ReceiptStatus::Applied;
-    if let Err(error) = persist_journal(&receipt) {
+    if let Err(error) = persist_journal_with(&receipt, &anchored) {
         receipt.status = ReceiptStatus::RecoveryRequired;
         receipt.error = Some(format!(
             "changes were applied but the final receipt could not be persisted: {error}"
         ));
-        let _ = persist_journal(&receipt);
+        let _ = persist_journal_with(&receipt, &anchored);
         return Ok(ApplyOutcome {
             receipt,
             verification_passed: false,
@@ -671,26 +757,36 @@ pub fn undo(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
             "only an applied receipt can be undone",
         ));
     }
-    let _lock = WriteLock::acquire(&receipt.state_dir)?;
-    undo_locked(receipt)
+    let lock = WriteLock::acquire(&receipt.state_dir)?;
+    undo_locked(receipt, &lock._guard)
 }
 
-pub(crate) fn undo_locked(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
+pub(crate) fn undo_locked(receipt: &ChangeReceipt, state_lock: &StateLock) -> Result<ApplyOutcome> {
+    let anchored = state_lock.filesystem(
+        &receipt.approved_roots,
+        &receipt.state_dir,
+        &SystemDirectorySync,
+    )?;
+    undo_locked_with_anchored(receipt, anchored)
+}
+
+fn undo_locked_with_anchored(
+    receipt: &ChangeReceipt,
+    anchored: AnchoredFs<'_>,
+) -> Result<ApplyOutcome> {
     if receipt.status != ReceiptStatus::Applied {
         return Err(ChangeError::new(
             "receipt_not_undoable",
             "only an applied receipt can be undone",
         ));
     }
-    reject_unresolved_recovery_except(&receipt.state_dir, &receipt.id)?;
-    if reverse_receipt_exists(&receipt.state_dir, &receipt.id)? {
+    reject_unresolved_recovery_except(&anchored, &receipt.state_dir, &receipt.id)?;
+    if reverse_receipt_exists(&anchored, &receipt.state_dir, &receipt.id)? {
         return Err(ChangeError::new(
             "receipt_already_undone",
             format!("receipt {} has already been undone", receipt.id),
         ));
     }
-    let anchored = open_anchored_fs(&receipt.approved_roots, &receipt.state_dir)?;
-
     let mut undo_receipt = ChangeReceipt {
         id: format!("receipt_{}", ulid::Ulid::new()),
         plan_id: receipt.plan_id.clone(),
@@ -716,7 +812,7 @@ pub(crate) fn undo_locked(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
             })
             .collect(),
     };
-    persist_journal(&undo_receipt)?;
+    persist_journal_with(&undo_receipt, &anchored)?;
     match compensate_all(receipt, &anchored) {
         Ok(()) => {
             for result in &mut undo_receipt.operation_results {
@@ -725,7 +821,7 @@ pub(crate) fn undo_locked(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
             }
             undo_receipt.status = ReceiptStatus::Undone;
             undo_receipt.changed_paths = receipt.changed_paths.clone();
-            persist_journal(&undo_receipt)?;
+            persist_journal_with(&undo_receipt, &anchored)?;
             Ok(ApplyOutcome {
                 receipt: undo_receipt,
                 verification_passed: true,
@@ -739,7 +835,7 @@ pub(crate) fn undo_locked(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
             }
             undo_receipt.status = ReceiptStatus::RecoveryRequired;
             undo_receipt.error = Some(error.to_string());
-            persist_journal(&undo_receipt)?;
+            persist_journal_with(&undo_receipt, &anchored)?;
             Ok(ApplyOutcome {
                 receipt: undo_receipt,
                 verification_passed: false,
@@ -758,18 +854,32 @@ pub fn rollback_apply(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
             "only an applied receipt can be rolled back",
         ));
     }
-    let _lock = WriteLock::acquire(&receipt.state_dir)?;
-    rollback_apply_locked(receipt)
+    let lock = WriteLock::acquire(&receipt.state_dir)?;
+    rollback_apply_locked(receipt, &lock._guard)
 }
 
-pub(crate) fn rollback_apply_locked(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
+pub(crate) fn rollback_apply_locked(
+    receipt: &ChangeReceipt,
+    state_lock: &StateLock,
+) -> Result<ApplyOutcome> {
+    let anchored = state_lock.filesystem(
+        &receipt.approved_roots,
+        &receipt.state_dir,
+        &SystemDirectorySync,
+    )?;
+    rollback_apply_locked_with_anchored(receipt, anchored)
+}
+
+fn rollback_apply_locked_with_anchored(
+    receipt: &ChangeReceipt,
+    anchored: AnchoredFs<'_>,
+) -> Result<ApplyOutcome> {
     if receipt.status != ReceiptStatus::Applied {
         return Err(ChangeError::new(
             "receipt_not_rollbackable",
             "only an applied receipt can be rolled back",
         ));
     }
-    let anchored = open_anchored_fs(&receipt.approved_roots, &receipt.state_dir)?;
     let mut rolled_back = receipt.clone();
     match compensate_all(receipt, &anchored) {
         Ok(()) => {
@@ -778,7 +888,7 @@ pub(crate) fn rollback_apply_locked(receipt: &ChangeReceipt) -> Result<ApplyOutc
                 result.status = "failed_rolled_back".to_owned();
                 result.after_fingerprint = anchored.fingerprint(&result.target).ok();
             }
-            persist_journal(&rolled_back)?;
+            persist_journal_with(&rolled_back, &anchored)?;
             Ok(ApplyOutcome {
                 receipt: rolled_back,
                 verification_passed: true,
@@ -792,7 +902,7 @@ pub(crate) fn rollback_apply_locked(receipt: &ChangeReceipt) -> Result<ApplyOutc
                 result.after_fingerprint = anchored.fingerprint(&result.target).ok();
                 result.error = Some(error.to_string());
             }
-            persist_journal(&rolled_back)?;
+            persist_journal_with(&rolled_back, &anchored)?;
             Ok(ApplyOutcome {
                 receipt: rolled_back,
                 verification_passed: false,
@@ -828,6 +938,22 @@ fn finalize_rollback_results(receipt: &mut ChangeReceipt, recovered: bool, ancho
     }
 }
 
+fn finalize_recovery_required_results(
+    receipt: &mut ChangeReceipt,
+    prior_recovered: bool,
+    anchored: &AnchoredFs,
+) {
+    let last = receipt.operation_results.len().saturating_sub(1);
+    for (index, result) in receipt.operation_results.iter_mut().enumerate() {
+        result.after_fingerprint = anchored.fingerprint(&result.target).ok();
+        result.status = if index == last || !prior_recovered {
+            "recovery_required".to_owned()
+        } else {
+            "rolled_back".to_owned()
+        };
+    }
+}
+
 fn operation_creates_missing_target(operation: &Operation) -> bool {
     matches!(
         operation,
@@ -837,6 +963,90 @@ fn operation_creates_missing_target(operation: &Operation) -> bool {
             | Operation::Copy { .. }
             | Operation::MoveRecoverable { .. }
     )
+}
+
+fn operation_is_uncompensated_create(operation: &Operation) -> bool {
+    matches!(
+        operation,
+        Operation::CreateDirectory { .. }
+            | Operation::CreateSymlink { .. }
+            | Operation::WriteFile { .. }
+            | Operation::Copy { .. }
+    )
+}
+
+fn move_backup_path(source: &Path, receipt_id: &str, index: usize) -> Result<PathBuf> {
+    let file_name = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| ChangeError::new("unsafe_path", source.display().to_string()))?;
+    Ok(source.with_file_name(format!(
+        ".{file_name}.skillroster-backup-{receipt_id}-{index}"
+    )))
+}
+
+fn partial_operation_compensation(
+    operation: &Operation,
+    receipt_id: &str,
+    index: usize,
+    anchored: &AnchoredFs<'_>,
+) -> Result<Option<Compensation>> {
+    if let Operation::RemoveSymlink {
+        target,
+        expected_fingerprint,
+    } = operation
+    {
+        let backup = move_backup_path(target, receipt_id, index)?;
+        let target_fingerprint = anchored_fingerprint(anchored, target)?;
+        let backup_fingerprint = anchored_fingerprint(anchored, &backup)?;
+        if target_fingerprint == "missing" && backup_fingerprint == *expected_fingerprint {
+            return Ok(Some(Compensation::RestoreRemovedSymlink {
+                from: backup,
+                to: target.clone(),
+                expected_fingerprint: expected_fingerprint.clone(),
+            }));
+        }
+        if target_fingerprint == *expected_fingerprint && backup_fingerprint == "missing" {
+            return Ok(None);
+        }
+        return Err(ChangeError::new(
+            "partial_mutation_ambiguous",
+            format!(
+                "removed symlink state is ambiguous: target {target_fingerprint}, recovery {backup_fingerprint}"
+            ),
+        ));
+    }
+    if !operation_creates_missing_target(operation) {
+        return Ok(None);
+    }
+    let expected_fingerprint = anchored_fingerprint(anchored, operation.target())?;
+    if expected_fingerprint == "missing" {
+        return Ok(None);
+    }
+    if let Operation::MoveRecoverable { target, source, .. } = operation {
+        let source_fingerprint = anchored_fingerprint(anchored, source)?;
+        let backup = move_backup_path(source, receipt_id, index)?;
+        let backup_fingerprint = anchored_fingerprint(anchored, &backup)?;
+        if source_fingerprint == "missing" && backup_fingerprint != "missing" {
+            return Ok(Some(Compensation::RestoreBackup {
+                backup,
+                original: source.clone(),
+                created: target.clone(),
+                expected_created: expected_fingerprint,
+            }));
+        }
+        if source_fingerprint == "missing" {
+            return Ok(Some(Compensation::RenameBack {
+                from: target.clone(),
+                to: source.clone(),
+                expected_fingerprint,
+            }));
+        }
+    }
+    Ok(Some(Compensation::StashCreated {
+        path: operation.target().to_path_buf(),
+        expected_fingerprint,
+    }))
 }
 
 fn normalize_operation(
@@ -1042,18 +1252,57 @@ fn validate_current_state(operation: &Operation, roots: &[PathBuf]) -> Result<()
     Ok(())
 }
 
-fn validate_operation_sequence(operations: &[Operation], roots: &[PathBuf]) -> Result<()> {
+fn validate_operation_sequence_anchored(
+    operations: &[Operation],
+    anchored: &AnchoredFs<'_>,
+) -> Result<()> {
     let mut projected_missing = HashSet::new();
     let mut projected_present = HashSet::new();
-    let mut projected_fingerprints = HashMap::new();
+    let mut projected_fingerprints: HashMap<PathBuf, String> = HashMap::new();
     for operation in operations {
-        validate_projected_state(
-            operation,
-            roots,
-            &projected_missing,
-            &projected_present,
-            &projected_fingerprints,
-        )?;
+        if let Operation::CreateSymlink {
+            target,
+            source,
+            expected_fingerprint,
+            expected_source_fingerprint,
+        } = operation
+        {
+            if projected_missing.contains(target) || projected_present.contains(source) {
+                if projected_missing.contains(target) && expected_fingerprint != "missing" {
+                    return Err(ChangeError::new(
+                        "invalid_projected_fingerprint",
+                        format!(
+                            "{} must expect missing after its planned move",
+                            target.display()
+                        ),
+                    ));
+                }
+                let actual_source = if let Some(actual) = projected_fingerprints.get(source) {
+                    actual.clone()
+                } else {
+                    anchored.fingerprint(source).map_err(|error| {
+                        ChangeError::io(
+                            "inspect projected link source through approved root handle",
+                            source,
+                            error,
+                        )
+                    })?
+                };
+                if &actual_source != expected_source_fingerprint {
+                    return Err(ChangeError::new(
+                        "plan_drifted",
+                        format!(
+                            "{} expected {expected_source_fingerprint}, found {actual_source}",
+                            source.display()
+                        ),
+                    ));
+                }
+            } else {
+                validate_anchored_current_state(operation, anchored)?;
+            }
+        } else {
+            validate_anchored_current_state(operation, anchored)?;
+        }
         project_operation(
             operation,
             &mut projected_missing,
@@ -1149,8 +1398,12 @@ fn project_operation(
     }
 }
 
-fn open_anchored_fs(roots: &[PathBuf], state_dir: &Path) -> Result<AnchoredFs> {
-    AnchoredFs::open(roots, state_dir)
+fn open_anchored_fs<'a>(
+    roots: &[PathBuf],
+    state_dir: &Path,
+    directory_sync: &'a dyn DirectorySync,
+) -> Result<AnchoredFs<'a>> {
+    AnchoredFs::open(roots, state_dir, directory_sync)
         .map_err(|error| ChangeError::io("open approved root handles", state_dir, error))
 }
 
@@ -1243,42 +1496,42 @@ fn stage_compensation(
     state_dir: &Path,
     anchored: &AnchoredFs,
 ) -> Result<Option<Compensation>> {
-    let Operation::ReplaceFile {
-        target,
-        content,
-        expected_fingerprint,
-    } = operation
-    else {
-        return Ok(None);
-    };
-    verify_anchored_fingerprint(anchored, target, expected_fingerprint)?;
-    let directory = recovery_dir(state_dir, receipt_id);
-    anchored
-        .create_dir_all(&directory)
-        .map_err(|error| ChangeError::io("create recovery directory", &directory, error))?;
-    let backup = directory.join(format!("replace-{index}.backup"));
-    require_anchored_missing(anchored, &backup)?;
-    anchored
-        .copy_file(target, &backup)
-        .map_err(|error| ChangeError::io("persist replacement backup", target, error))?;
-    let backup_fingerprint = anchored
-        .fingerprint(&backup)
-        .map_err(|error| ChangeError::io("verify replacement backup", &backup, error))?;
-    if backup_fingerprint != *expected_fingerprint {
-        return Err(ChangeError::new(
-            "backup_verification_failed",
-            format!(
-                "backup for {} does not match its precondition",
-                target.display()
-            ),
-        ));
+    match operation {
+        Operation::ReplaceFile {
+            target,
+            content,
+            expected_fingerprint,
+        } => {
+            verify_anchored_fingerprint(anchored, target, expected_fingerprint)?;
+            let directory = create_recovery_dir(anchored, state_dir, receipt_id)?;
+            let backup = directory.join(format!("replace-{index}.backup"));
+            require_anchored_missing(anchored, &backup)?;
+            anchored
+                .copy_file(target, &backup)
+                .map_err(|error| ChangeError::io("persist replacement backup", target, error))?;
+            let backup_fingerprint = anchored
+                .fingerprint(&backup)
+                .map_err(|error| ChangeError::io("verify replacement backup", &backup, error))?;
+            if backup_fingerprint != *expected_fingerprint {
+                return Err(ChangeError::new(
+                    "backup_verification_failed",
+                    format!(
+                        "backup for {} does not match its precondition",
+                        target.display()
+                    ),
+                ));
+            }
+            Ok(Some(Compensation::RestoreReplacedFile {
+                backup,
+                target: target.clone(),
+                expected_original: expected_fingerprint.clone(),
+                expected_replacement: file_content_fingerprint(content.as_bytes()),
+                staged_replacement: Some(replacement_temp_path(target, receipt_id, index)?),
+            }))
+        }
+        Operation::RemoveSymlink { .. } => Ok(None),
+        _ => Ok(None),
     }
-    Ok(Some(Compensation::RestoreReplacedFile {
-        backup,
-        target: target.clone(),
-        expected_original: expected_fingerprint.clone(),
-        expected_replacement: file_content_fingerprint(content.as_bytes()),
-    }))
 }
 
 fn replace_file(
@@ -1288,17 +1541,21 @@ fn replace_file(
     receipt_id: &str,
     index: usize,
 ) -> Result<()> {
+    let temp = replacement_temp_path(target, receipt_id, index)?;
+    require_anchored_missing(anchored, &temp)?;
+    anchored
+        .replace_file(target, &temp, content.as_bytes())
+        .map_err(|error| anchored_mutation_error("publish replacement", target, error))
+}
+
+fn replacement_temp_path(target: &Path, receipt_id: &str, index: usize) -> Result<PathBuf> {
     let file_name = target
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| ChangeError::new("unsafe_path", target.display().to_string()))?;
-    let temp = target.with_file_name(format!(
+    Ok(target.with_file_name(format!(
         ".{file_name}.skillroster-replace-{receipt_id}-{index}"
-    ));
-    require_anchored_missing(anchored, &temp)?;
-    anchored
-        .replace_file(target, &temp, content.as_bytes())
-        .map_err(|error| ChangeError::io("publish replacement", target, error))
+    )))
 }
 
 fn file_content_fingerprint(content: &[u8]) -> String {
@@ -1316,7 +1573,7 @@ fn execute(
         Operation::CreateDirectory { target, .. } => {
             anchored
                 .create_dir(target)
-                .map_err(|e| ChangeError::io("create directory", target, e))?;
+                .map_err(|e| anchored_mutation_error("create directory", target, e))?;
             Ok(Some(Compensation::StashCreated {
                 path: target.clone(),
                 expected_fingerprint: anchored_fingerprint(anchored, target)?,
@@ -1325,7 +1582,7 @@ fn execute(
         Operation::CreateSymlink { target, source, .. } => {
             anchored
                 .create_symlink(source, target)
-                .map_err(|e| ChangeError::io("create symlink", target, e))?;
+                .map_err(|e| anchored_mutation_error("create symlink", target, e))?;
             Ok(Some(Compensation::StashCreated {
                 path: target.clone(),
                 expected_fingerprint: anchored_fingerprint(anchored, target)?,
@@ -1336,7 +1593,7 @@ fn execute(
         } => {
             anchored
                 .create_file(target, content.as_bytes())
-                .map_err(|e| ChangeError::io("create file", target, e))?;
+                .map_err(|e| anchored_mutation_error("create file", target, e))?;
             Ok(Some(Compensation::StashCreated {
                 path: target.clone(),
                 expected_fingerprint: anchored_fingerprint(anchored, target)?,
@@ -1348,22 +1605,23 @@ fn execute(
             replace_file(anchored, target, content, receipt_id, index)?;
             Ok(None)
         }
-        Operation::RemoveSymlink { target, .. } => {
-            let link_target = anchored
-                .read_link(target)
-                .map_err(|e| ChangeError::io("read symlink", target, e))?;
-            anchored
-                .remove_symlink(target)
-                .map_err(|e| ChangeError::io("remove symlink", target, e))?;
-            Ok(Some(Compensation::RestoreSymlink {
-                path: target.clone(),
-                target: link_target,
+        Operation::RemoveSymlink {
+            target,
+            expected_fingerprint,
+        } => {
+            let backup = move_backup_path(target, receipt_id, index)?;
+            require_anchored_missing(anchored, &backup)?;
+            rename_removed_symlink(anchored, target, &backup, expected_fingerprint)?;
+            Ok(Some(Compensation::RestoreRemovedSymlink {
+                from: backup,
+                to: target.clone(),
+                expected_fingerprint: expected_fingerprint.clone(),
             }))
         }
         Operation::Copy { target, source, .. } => {
             anchored
                 .copy_tree(source, target)
-                .map_err(|e| ChangeError::io("copy path", source, e))?;
+                .map_err(|e| anchored_mutation_error("copy path", source, e))?;
             Ok(Some(Compensation::StashCreated {
                 path: target.clone(),
                 expected_fingerprint: anchored_fingerprint(anchored, target)?,
@@ -1380,23 +1638,21 @@ fn execute(
                     }));
                 }
                 Err(error) if error.kind() == io::ErrorKind::CrossesDevices => {}
-                Err(error) => return Err(ChangeError::io("move path", source, error)),
+                Err(error) => return Err(anchored_mutation_error("move path", source, error)),
             }
             // Cross-device recovery must remain on the source filesystem, so the
             // original can be hidden atomically after the destination copy lands.
-            let file_name = source
-                .file_name()
-                .and_then(|name| name.to_str())
-                .ok_or_else(|| ChangeError::new("unsafe_path", source.display().to_string()))?;
-            let backup = source.with_file_name(format!(
-                ".{file_name}.skillroster-backup-{receipt_id}-{index}"
-            ));
+            let backup = move_backup_path(source, receipt_id, index)?;
             require_anchored_missing(anchored, &backup)?;
             anchored
                 .copy_tree(source, target)
                 .map_err(|e| ChangeError::io("copy path", source, e))?;
             if let Err(error) = anchored.rename(source, &backup) {
-                return Err(ChangeError::io("move source to recovery", source, error));
+                return Err(anchored_mutation_error(
+                    "move source to recovery",
+                    source,
+                    error,
+                ));
             }
             Ok(Some(Compensation::RestoreBackup {
                 backup,
@@ -1408,13 +1664,81 @@ fn execute(
     }
 }
 
+fn anchored_mutation_error(action: &str, path: &Path, error: io::Error) -> ChangeError {
+    if error.kind() == io::ErrorKind::InvalidData {
+        ChangeError::new(
+            "entry_identity_changed",
+            format!("{action} {}: {error}", path.display()),
+        )
+    } else {
+        ChangeError::io(action, path, error)
+    }
+}
+
+fn rename_removed_symlink(
+    anchored: &AnchoredFs<'_>,
+    target: &Path,
+    backup: &Path,
+    expected_fingerprint: &str,
+) -> Result<()> {
+    verify_anchored_fingerprint(anchored, target, expected_fingerprint)?;
+    run_before_remove_symlink_rename_hook();
+    let rename_error = anchored.rename(target, backup).err();
+    let target_fingerprint = anchored_fingerprint(anchored, target)?;
+    let backup_fingerprint = match anchored_fingerprint(anchored, backup) {
+        Ok(fingerprint) => fingerprint,
+        Err(error) => {
+            if target_fingerprint == "missing" {
+                anchored.rename(backup, target).map_err(|restore_error| {
+                    ChangeError::new(
+                        "partial_mutation_ambiguous",
+                        format!(
+                            "removed symlink entry could not be inspected or restored: {error}; {restore_error}"
+                        ),
+                    )
+                })?;
+            }
+            return Err(ChangeError::new(
+                "entry_identity_changed",
+                format!("removed symlink entry could not be verified after rename: {error}"),
+            ));
+        }
+    };
+    if rename_error.is_none()
+        && target_fingerprint == "missing"
+        && backup_fingerprint == expected_fingerprint
+    {
+        return Ok(());
+    }
+    if target_fingerprint == "missing" && backup_fingerprint != "missing" {
+        anchored.rename(backup, target).map_err(|restore_error| {
+            ChangeError::new(
+                "partial_mutation_ambiguous",
+                format!("removed symlink entry changed and could not be restored: {restore_error}"),
+            )
+        })?;
+    }
+    Err(if backup_fingerprint != expected_fingerprint {
+        ChangeError::new(
+            "entry_identity_changed",
+            "removed symlink entry changed before its rename completed",
+        )
+    } else if let Some(error) = rename_error {
+        ChangeError::io("move removed symlink to recovery", target, error)
+    } else {
+        ChangeError::new(
+            "partial_mutation_ambiguous",
+            "removed symlink target changed while its rename completed",
+        )
+    })
+}
+
 fn compensate_all(receipt: &ChangeReceipt, anchored: &AnchoredFs) -> Result<()> {
     for (index, compensation) in receipt.compensations.iter().enumerate().rev() {
         compensate(
             compensation,
             &receipt.id,
             index,
-            &receipt.approved_roots,
             &receipt.state_dir,
             anchored,
         )?;
@@ -1426,7 +1750,6 @@ fn compensate(
     compensation: &Compensation,
     receipt_id: &str,
     index: usize,
-    roots: &[PathBuf],
     state_dir: &Path,
     anchored: &AnchoredFs,
 ) -> Result<()> {
@@ -1436,20 +1759,16 @@ fn compensate(
             expected_fingerprint,
         } => {
             verify_anchored_fingerprint(anchored, path, expected_fingerprint)?;
-            normalize_target(path, roots)?;
-            let stash = recovery_dir(state_dir, receipt_id).join(format!("undo-{index}"));
-            anchored
-                .create_dir_all(stash.parent().expect("stash has parent"))
-                .map_err(|e| ChangeError::io("create recovery directory", state_dir, e))?;
+            let stash =
+                create_recovery_dir(anchored, state_dir, receipt_id)?.join(format!("undo-{index}"));
             anchored
                 .rename(path, &stash)
                 .map_err(|e| ChangeError::io("stash created path", path, e))?;
         }
         Compensation::RestoreSymlink { path, target } => {
             require_anchored_missing(anchored, path)?;
-            normalize_target(path, roots)?;
             anchored
-                .create_symlink(target, path)
+                .restore_symlink_contents(target, path)
                 .map_err(|e| ChangeError::io("restore symlink", path, e))?;
         }
         Compensation::RenameBack {
@@ -1459,11 +1778,20 @@ fn compensate(
         } => {
             verify_anchored_fingerprint(anchored, from, expected_fingerprint)?;
             require_anchored_missing(anchored, to)?;
-            normalize_target(from, roots)?;
-            normalize_target(to, roots)?;
             anchored
                 .rename(from, to)
                 .map_err(|e| ChangeError::io("restore moved path", from, e))?;
+        }
+        Compensation::RestoreRemovedSymlink {
+            from,
+            to,
+            expected_fingerprint,
+        } => {
+            verify_anchored_fingerprint(anchored, from, expected_fingerprint)?;
+            require_anchored_missing(anchored, to)?;
+            anchored
+                .rename(from, to)
+                .map_err(|e| ChangeError::io("restore removed symlink", from, e))?;
         }
         Compensation::RestoreBackup {
             backup,
@@ -1472,10 +1800,10 @@ fn compensate(
             expected_created,
         } => {
             verify_anchored_fingerprint(anchored, created, expected_created)?;
+            verify_anchored_fingerprint(anchored, backup, expected_created)?;
             require_anchored_missing(anchored, original)?;
-            normalize_target(created, roots)?;
-            normalize_target(original, roots)?;
-            let stash = recovery_dir(state_dir, receipt_id).join(format!("undo-created-{index}"));
+            let stash = create_recovery_dir(anchored, state_dir, receipt_id)?
+                .join(format!("undo-created-{index}"));
             anchored
                 .rename(created, &stash)
                 .map_err(|e| ChangeError::io("stash copied destination", created, e))?;
@@ -1488,12 +1816,24 @@ fn compensate(
             target,
             expected_original,
             expected_replacement,
+            staged_replacement,
         } => {
+            if let Some(staged_replacement) = staged_replacement {
+                remove_expected_anchored_file_if_present(
+                    anchored,
+                    staged_replacement,
+                    expected_replacement,
+                    "remove staged replacement",
+                )?;
+            }
             let actual = anchored_fingerprint(anchored, target)?;
             if actual == *expected_original {
-                anchored
-                    .remove_file(backup)
-                    .map_err(|error| ChangeError::io("remove unused backup", backup, error))?;
+                remove_expected_anchored_file_if_present(
+                    anchored,
+                    backup,
+                    expected_original,
+                    "remove unused backup",
+                )?;
                 return Ok(());
             }
             if actual != "missing" && actual != *expected_replacement {
@@ -1525,12 +1865,39 @@ fn compensate(
                 .rename(&restore, target)
                 .map_err(|error| ChangeError::io("restore replaced file", target, error))?;
             verify_anchored_fingerprint(anchored, target, expected_original)?;
-            anchored
-                .remove_file(backup)
-                .map_err(|error| ChangeError::io("remove consumed backup", backup, error))?;
+            remove_expected_anchored_file_if_present(
+                anchored,
+                backup,
+                expected_original,
+                "remove consumed backup",
+            )?;
         }
     }
     Ok(())
+}
+
+fn remove_expected_anchored_file_if_present(
+    anchored: &AnchoredFs<'_>,
+    path: &Path,
+    expected_fingerprint: &str,
+    action: &str,
+) -> Result<()> {
+    let actual = anchored_fingerprint(anchored, path)?;
+    if actual == "missing" {
+        return Ok(());
+    }
+    if actual != expected_fingerprint {
+        return Err(ChangeError::new(
+            "undo_drifted",
+            format!(
+                "{} expected {expected_fingerprint}, found {actual}",
+                path.display()
+            ),
+        ));
+    }
+    anchored
+        .remove_file(path)
+        .map_err(|error| ChangeError::io(action, path, error))
 }
 
 fn validate_prepared_plan(plan: &PreparedPlan) -> Result<()> {
@@ -1819,70 +2186,198 @@ fn create_symlink(source: &Path, target: &Path) -> Result<()> {
     result.map_err(|e| ChangeError::io("create symlink", target, e))
 }
 
-fn recovery_dir(state_dir: &Path, receipt_id: &str) -> PathBuf {
-    state_dir.join("recovery").join(receipt_id)
+fn create_recovery_dir(
+    anchored: &AnchoredFs<'_>,
+    state_dir: &Path,
+    receipt_id: &str,
+) -> Result<PathBuf> {
+    let root = state_dir.join("recovery");
+    let directory = root.join(receipt_id);
+    anchored
+        .create_dir_all(&directory)
+        .map_err(|error| ChangeError::io("create recovery directory", &directory, error))?;
+    anchored
+        .secure_private_directory(&root)
+        .map_err(|error| ChangeError::io("secure recovery directory", &root, error))?;
+    anchored
+        .secure_private_directory(&directory)
+        .map_err(|error| ChangeError::io("secure recovery directory", &directory, error))?;
+    Ok(directory)
 }
 
+#[cfg(test)]
 fn persist_journal(receipt: &ChangeReceipt) -> Result<()> {
+    let anchored = open_anchored_fs(&[], &receipt.state_dir, &SystemDirectorySync)?;
+    persist_journal_with(receipt, &anchored)
+}
+
+fn persist_journal_with(receipt: &ChangeReceipt, anchored: &AnchoredFs<'_>) -> Result<()> {
     let directory = receipt.state_dir.join("receipts");
-    fs::create_dir_all(&directory)
+    anchored
+        .create_dir_all(&directory)
         .map_err(|e| ChangeError::io("create receipt directory", &directory, e))?;
+    anchored
+        .secure_private_directory(&directory)
+        .map_err(|e| ChangeError::io("secure receipt directory", &directory, e))?;
     let path = directory.join(format!("{}.json", receipt.id));
     let temp = directory.join(format!(".{}.tmp", receipt.id));
     let bytes = serde_json::to_vec_pretty(receipt)
         .map_err(|e| ChangeError::new("receipt_encoding_failed", e.to_string()))?;
-    let mut file =
-        File::create(&temp).map_err(|e| ChangeError::io("create receipt journal", &temp, e))?;
-    file.write_all(&bytes)
-        .map_err(|e| ChangeError::io("write receipt journal", &temp, e))?;
-    file.sync_all()
-        .map_err(|e| ChangeError::io("sync receipt journal", &temp, e))?;
-    fs::rename(&temp, &path).map_err(|e| ChangeError::io("publish receipt journal", &path, e))?;
-    Ok(())
+    anchored
+        .write_private_file_atomic(&path, &temp, &bytes)
+        .map_err(|e| ChangeError::io("publish receipt journal", &path, e))
 }
 
-pub(crate) fn persist_journal_state(receipt: &ChangeReceipt) -> Result<()> {
-    persist_journal(receipt)
+pub(crate) fn persist_journal_state(receipt: &ChangeReceipt, state_lock: &StateLock) -> Result<()> {
+    let anchored = state_lock.filesystem(
+        &receipt.approved_roots,
+        &receipt.state_dir,
+        &SystemDirectorySync,
+    )?;
+    persist_journal_with(receipt, &anchored)
+}
+
+pub(crate) fn owned_receipt_control_file(name: &OsStr, file: &mut File) -> io::Result<bool> {
+    let Some(name) = name.to_str() else {
+        return Ok(false);
+    };
+    if let Some(id) = name
+        .strip_prefix('.')
+        .and_then(|name| name.strip_suffix(".tmp"))
+        .and_then(|name| name.strip_prefix("receipt_"))
+    {
+        return Ok(ulid::Ulid::from_string(id).is_ok());
+    }
+    let Some(id) = name
+        .strip_suffix(".json")
+        .and_then(|name| name.strip_prefix("receipt_"))
+    else {
+        return Ok(false);
+    };
+    if ulid::Ulid::from_string(id).is_err() {
+        return Ok(false);
+    }
+    let Ok(receipt) = serde_json::from_reader::<_, ChangeReceipt>(file) else {
+        return Ok(false);
+    };
+    Ok(receipt.id == name.trim_end_matches(".json"))
 }
 
 /// Loads the durable filesystem journal without changing it. Invalid entries are
 /// surfaced as errors because silently skipping one could permit an unsafe write.
 pub fn journals(state_dir: &Path) -> Result<Vec<ChangeReceipt>> {
+    let state_dir = fs::canonicalize(state_dir)
+        .map_err(|error| ChangeError::io("canonicalize state directory", state_dir, error))?;
+    let anchored = open_anchored_fs(&[], &state_dir, &SystemDirectorySync)?;
+    journals_with(&anchored, &state_dir)
+}
+
+pub(crate) fn journals_locked(
+    state_dir: &Path,
+    state_lock: &StateLock,
+) -> Result<Vec<ChangeReceipt>> {
+    let anchored = state_lock.filesystem(&[], state_dir, &SystemDirectorySync)?;
+    journals_with(&anchored, state_dir)
+}
+
+pub(crate) fn has_external_recovery_material(
+    state_dir: &Path,
+    state_lock: &StateLock,
+) -> Result<bool> {
+    let receipts = journals_locked(state_dir, state_lock)?;
+    let reversed_receipts = receipts
+        .iter()
+        .filter(|receipt| receipt.status == ReceiptStatus::Undone)
+        .filter_map(|receipt| receipt.reverses_receipt_id.clone())
+        .collect::<HashSet<_>>();
+    for receipt in receipts {
+        let active = matches!(
+            receipt.status,
+            ReceiptStatus::Applying | ReceiptStatus::Applied | ReceiptStatus::RecoveryRequired
+        ) && !reversed_receipts.contains(receipt.id.as_str());
+        let anchored = state_lock.filesystem(
+            &receipt.approved_roots,
+            &receipt.state_dir,
+            &SystemDirectorySync,
+        )?;
+        for compensation in receipt.compensations {
+            let (artifact, expected) = match compensation {
+                Compensation::RestoreRemovedSymlink {
+                    from,
+                    expected_fingerprint,
+                    ..
+                } if !from.starts_with(state_dir) => (from, Some(expected_fingerprint)),
+                Compensation::RestoreBackup {
+                    backup: from,
+                    expected_created,
+                    ..
+                } if !from.starts_with(state_dir) => (from, Some(expected_created)),
+                _ => continue,
+            };
+            if artifact
+                .components()
+                .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+            {
+                return Err(ChangeError::new(
+                    "invalid_receipt_journal",
+                    "recovery material path is not normalized",
+                ));
+            }
+            let actual = anchored.fingerprint(&artifact).map_err(|error| {
+                ChangeError::io("inspect Receipt-owned recovery material", &artifact, error)
+            })?;
+            if actual == "missing" {
+                if active {
+                    return Err(ChangeError::new(
+                        "recovery_material_missing",
+                        "active Receipt recovery material is missing",
+                    ));
+                }
+                continue;
+            }
+            if expected
+                .as_ref()
+                .is_some_and(|expected| expected != &actual)
+            {
+                return Err(ChangeError::new(
+                    "recovery_material_drifted",
+                    "active Receipt recovery material no longer matches its fingerprint",
+                ));
+            }
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn journals_with(anchored: &AnchoredFs<'_>, state_dir: &Path) -> Result<Vec<ChangeReceipt>> {
     let directory = state_dir.join("receipts");
-    let entries = match fs::read_dir(&directory) {
+    let entries = match anchored.read_directory_names(&directory) {
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(error) => return Err(ChangeError::io("read receipts", &directory, error)),
     };
-    let expected_state_dir = fs::canonicalize(state_dir)
-        .map_err(|error| ChangeError::io("canonicalize state directory", state_dir, error))?;
     let mut receipts = Vec::new();
     for entry in entries {
-        let entry = entry.map_err(|error| ChangeError::io("read receipt", &directory, error))?;
-        let path = entry.path();
+        let path = directory.join(entry);
         if path.extension().and_then(|value| value.to_str()) != Some("json") {
             continue;
         }
-        let metadata = fs::symlink_metadata(&path)
-            .map_err(|error| ChangeError::io("inspect receipt", &path, error))?;
-        if metadata.file_type().is_symlink() || !metadata.is_file() {
-            return Err(ChangeError::new(
+        let bytes = anchored.read_regular_file(&path).map_err(|error| {
+            ChangeError::new(
                 "invalid_receipt_journal",
-                format!("receipt journal {} is not a regular file", path.display()),
-            ));
-        }
-        let bytes =
-            fs::read(&path).map_err(|error| ChangeError::io("read receipt", &path, error))?;
-        let receipt: ChangeReceipt = serde_json::from_slice(&bytes)
-            .map_err(|error| ChangeError::new("invalid_receipt_journal", error.to_string()))?;
-        let receipt_state_dir = fs::canonicalize(&receipt.state_dir).map_err(|error| {
-            ChangeError::io(
-                "canonicalize journal state directory",
-                &receipt.state_dir,
-                error,
+                format!(
+                    "receipt journal {} is not a regular file: {error}",
+                    path.display()
+                ),
             )
         })?;
-        if receipt_state_dir != expected_state_dir {
+        let receipt: ChangeReceipt = serde_json::from_slice(&bytes)
+            .map_err(|error| ChangeError::new("invalid_receipt_journal", error.to_string()))?;
+        if !anchored
+            .matches_state_directory(&receipt.state_dir)
+            .unwrap_or(false)
+        {
             return Err(ChangeError::new(
                 "invalid_receipt_journal",
                 format!(
@@ -1897,26 +2392,12 @@ pub fn journals(state_dir: &Path) -> Result<Vec<ChangeReceipt>> {
     Ok(receipts)
 }
 
-fn reject_unresolved_recovery(state_dir: &Path) -> Result<()> {
-    reject_unresolved_recovery_except(state_dir, "")
-}
-
-fn reverse_receipt_exists(state_dir: &Path, original_receipt_id: &str) -> Result<bool> {
-    let directory = state_dir.join("receipts");
-    let entries = match fs::read_dir(&directory) {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(ChangeError::io("read receipts", &directory, error)),
-    };
-    for entry in entries {
-        let entry = entry.map_err(|error| ChangeError::io("read receipt", &directory, error))?;
-        if entry.path().extension().and_then(|value| value.to_str()) != Some("json") {
-            continue;
-        }
-        let bytes = fs::read(entry.path())
-            .map_err(|error| ChangeError::io("read receipt", &entry.path(), error))?;
-        let existing: ChangeReceipt = serde_json::from_slice(&bytes)
-            .map_err(|error| ChangeError::new("invalid_receipt_journal", error.to_string()))?;
+fn reverse_receipt_exists(
+    anchored: &AnchoredFs<'_>,
+    state_dir: &Path,
+    original_receipt_id: &str,
+) -> Result<bool> {
+    for existing in journals_with(anchored, state_dir)? {
         if existing.status == ReceiptStatus::Undone
             && existing.reverses_receipt_id.as_deref() == Some(original_receipt_id)
         {
@@ -1926,22 +2407,12 @@ fn reverse_receipt_exists(state_dir: &Path, original_receipt_id: &str) -> Result
     Ok(false)
 }
 
-fn reject_unresolved_recovery_except(state_dir: &Path, except: &str) -> Result<()> {
-    let directory = state_dir.join("receipts");
-    let entries = match fs::read_dir(&directory) {
-        Ok(entries) => entries,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(ChangeError::io("read receipts", &directory, e)),
-    };
-    for entry in entries {
-        let entry = entry.map_err(|e| ChangeError::io("read receipts", &directory, e))?;
-        if entry.path().extension().and_then(|v| v.to_str()) != Some("json") {
-            continue;
-        }
-        let bytes = fs::read(entry.path())
-            .map_err(|e| ChangeError::io("read receipt", &entry.path(), e))?;
-        let existing: ChangeReceipt = serde_json::from_slice(&bytes)
-            .map_err(|e| ChangeError::new("invalid_receipt_journal", e.to_string()))?;
+fn reject_unresolved_recovery_except(
+    anchored: &AnchoredFs<'_>,
+    state_dir: &Path,
+    except: &str,
+) -> Result<()> {
+    for existing in journals_with(anchored, state_dir)? {
         if existing.id != except
             && matches!(
                 existing.status,
@@ -1960,8 +2431,16 @@ fn reject_unresolved_recovery_except(state_dir: &Path, except: &str) -> Result<(
     Ok(())
 }
 
-#[derive(Debug)]
-pub(crate) struct StateLock(File);
+pub(crate) struct StateLock {
+    file: File,
+    anchored: AnchoredFs<'static>,
+}
+
+impl fmt::Debug for StateLock {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("StateLock")
+    }
+}
 
 impl StateLock {
     pub(crate) fn acquire_shared(state_dir: &Path) -> Result<Self> {
@@ -1974,12 +2453,10 @@ impl StateLock {
 
     fn acquire(state_dir: &Path, exclusive: bool) -> Result<Self> {
         let path = state_dir.join("write.lock");
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&path)
+        let anchored = AnchoredFs::open(&[], state_dir, &SystemDirectorySync)
+            .map_err(|error| ChangeError::io("open state root handle", state_dir, error))?;
+        let file = anchored
+            .open_private_lock(&path)
             .map_err(|e| ChangeError::io("open state lock", &path, e))?;
         let result = if exclusive {
             FileExt::try_lock_exclusive(&file)
@@ -1997,13 +2474,48 @@ impl StateLock {
             result.retryable = true;
             result
         })?;
-        Ok(Self(file))
+        Ok(Self { file, anchored })
+    }
+
+    fn filesystem<'a>(
+        &self,
+        approved_roots: &[PathBuf],
+        state_dir: &Path,
+        directory_sync: &'a dyn DirectorySync,
+    ) -> Result<AnchoredFs<'a>> {
+        if !self
+            .anchored
+            .matches_state_directory(state_dir)
+            .map_err(|error| ChangeError::io("verify retained state directory", state_dir, error))?
+        {
+            return Err(ChangeError::new(
+                "unsafe_state_directory",
+                "retained lock and requested state directory differ",
+            ));
+        }
+        AnchoredFs::open_with_retained_state(
+            approved_roots,
+            state_dir,
+            &self.anchored,
+            directory_sync,
+        )
+        .map_err(|error| {
+            ChangeError::io(
+                "extend retained state root handle",
+                self.anchored_state_dir(),
+                error,
+            )
+        })
+    }
+
+    fn anchored_state_dir(&self) -> &Path {
+        self.anchored.state_root()
     }
 }
 
 impl Drop for StateLock {
     fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.0);
+        let _ = FileExt::unlock(&self.file);
     }
 }
 
@@ -2020,7 +2532,34 @@ impl WriteLock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+    #[cfg(windows)]
+    use std::rc::Rc;
     use tempfile::TempDir;
+
+    struct FailOnceDirectorySync {
+        path: PathBuf,
+        failed: Cell<bool>,
+    }
+
+    impl FailOnceDirectorySync {
+        fn new(path: PathBuf) -> Self {
+            Self {
+                path,
+                failed: Cell::new(false),
+            }
+        }
+    }
+
+    impl DirectorySync for FailOnceDirectorySync {
+        fn sync_directory(&self, path: &Path) -> io::Result<()> {
+            if path == self.path && !self.failed.replace(true) {
+                Err(io::Error::other("injected directory sync failure"))
+            } else {
+                SystemDirectorySync.sync_directory(path)
+            }
+        }
+    }
 
     fn fixture() -> (TempDir, PathBuf, PathBuf) {
         let temp = TempDir::new().unwrap();
@@ -2028,7 +2567,11 @@ mod tests {
         let state = temp.path().join("state");
         fs::create_dir(&root).unwrap();
         fs::create_dir(&state).unwrap();
-        (temp, root, state)
+        (
+            temp,
+            fs::canonicalize(root).unwrap(),
+            fs::canonicalize(state).unwrap(),
+        )
     }
 
     #[test]
@@ -2076,7 +2619,7 @@ mod tests {
             &input,
             &PrepareContext {
                 approved_roots: vec![root],
-                state_dir: state,
+                state_dir: state.clone(),
                 operation_policy: OperationPolicy::TestOnly,
             },
         )
@@ -2132,6 +2675,306 @@ mod tests {
         assert!(!held_ancestor.join("written.txt").exists());
         fs::remove_file(&ancestor).unwrap();
         fs::rename(&held_ancestor, &ancestor).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_sequence_validation_uses_the_retained_root_handle() {
+        let (temp, root, state) = fixture();
+        let ancestor = root.join("mutable");
+        let held_ancestor = root.join("held-mutable");
+        let outside = temp.path().join("outside");
+        fs::create_dir(&ancestor).unwrap();
+        fs::create_dir(&outside).unwrap();
+        let target = ancestor.join("written.txt");
+        let plan = prepared_write(&root, &state, &target);
+        let hook_ancestor = ancestor.clone();
+        let hook_held = held_ancestor.clone();
+        let hook_outside = outside.clone();
+        BEFORE_SEQUENCE_VALIDATION_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                fs::rename(&hook_ancestor, &hook_held).unwrap();
+                std::os::unix::fs::symlink(&hook_outside, &hook_ancestor).unwrap();
+            }));
+        });
+
+        let error = apply(&plan).unwrap_err();
+
+        assert_eq!(error.code, "filesystem_error");
+        assert!(!outside.join("written.txt").exists());
+        assert!(!held_ancestor.join("written.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_rejects_an_approved_root_ancestor_swapped_before_handle_open() {
+        let temp = TempDir::new().unwrap();
+        let root_parent = temp.path().join("root-parent");
+        let held_parent = temp.path().join("held-root-parent");
+        let outside_parent = temp.path().join("outside-root-parent");
+        let root = root_parent.join("root");
+        let outside_root = outside_parent.join("root");
+        let state = temp.path().join("state");
+        fs::create_dir(&root_parent).unwrap();
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&outside_parent).unwrap();
+        fs::create_dir(&outside_root).unwrap();
+        fs::create_dir(&state).unwrap();
+        let target = root.join("written.txt");
+        let plan = prepared_write(&root, &state, &target);
+        let hook_root_parent = root_parent.clone();
+        let hook_held_parent = held_parent.clone();
+        let hook_outside_parent = outside_parent.clone();
+        crate::anchored_fs::set_before_approved_root_open_hook(move || {
+            fs::rename(&hook_root_parent, &hook_held_parent).unwrap();
+            std::os::unix::fs::symlink(&hook_outside_parent, &hook_root_parent).unwrap();
+        });
+
+        let error = apply(&plan).unwrap_err();
+
+        assert_eq!(error.code, "filesystem_error");
+        assert!(!outside_root.join("written.txt").exists());
+        assert!(!held_parent.join("root/written.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn approved_root_walk_rejects_a_swap_after_canonical_validation() {
+        let temp = TempDir::new().unwrap();
+        let root_parent = fs::canonicalize(temp.path()).unwrap().join("root-parent");
+        let held_parent = fs::canonicalize(temp.path())
+            .unwrap()
+            .join("held-root-parent");
+        let outside_parent = fs::canonicalize(temp.path())
+            .unwrap()
+            .join("outside-root-parent");
+        let root = root_parent.join("root");
+        let outside_root = outside_parent.join("root");
+        let state = fs::canonicalize(temp.path()).unwrap().join("state");
+        fs::create_dir(&root_parent).unwrap();
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&outside_parent).unwrap();
+        fs::create_dir(&outside_root).unwrap();
+        fs::create_dir(&state).unwrap();
+        let target = root.join("written.txt");
+        let plan = prepared_write(&root, &state, &target);
+        let hook_root_parent = root_parent.clone();
+        let hook_held_parent = held_parent.clone();
+        let hook_outside_parent = outside_parent.clone();
+        crate::anchored_fs::set_after_approved_root_canonicalize_hook(move || {
+            fs::rename(&hook_root_parent, &hook_held_parent).unwrap();
+            std::os::unix::fs::symlink(&hook_outside_parent, &hook_root_parent).unwrap();
+        });
+
+        let error = apply(&plan).unwrap_err();
+
+        assert_eq!(error.code, "filesystem_error");
+        assert!(!outside_root.join("written.txt").exists());
+        assert!(!held_parent.join("root/written.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_keeps_journaling_through_the_retained_state_handle() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("root");
+        let state_parent = temp.path().join("state-parent");
+        let state = state_parent.join("state");
+        let held_parent = temp.path().join("held-state-parent");
+        let outside_parent = temp.path().join("outside-state-parent");
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&state_parent).unwrap();
+        fs::create_dir(&state).unwrap();
+        fs::create_dir(&outside_parent).unwrap();
+        fs::create_dir(outside_parent.join("state")).unwrap();
+        let target = root.join("written.txt");
+        let plan = prepared_write(&root, &state, &target);
+        let hook_state_parent = state_parent.clone();
+        let hook_held_parent = held_parent.clone();
+        let hook_outside_parent = outside_parent.clone();
+        BEFORE_MUTATION_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                fs::rename(&hook_state_parent, &hook_held_parent).unwrap();
+                std::os::unix::fs::symlink(&hook_outside_parent, &hook_state_parent).unwrap();
+            }));
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert!(outcome.verification_passed, "{:?}", outcome.receipt.error);
+        assert!(target.exists());
+        assert!(
+            held_parent
+                .join("state/receipts")
+                .join(format!("{}.json", outcome.receipt.id))
+                .exists()
+        );
+        assert!(!outside_parent.join("state/receipts").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compensation_uses_retained_handles_after_an_unrelated_ancestor_swap() {
+        let (temp, root, state) = fixture();
+        let mutable = root.join("mutable");
+        let held_mutable = root.join("held-mutable");
+        let outside = temp.path().join("outside");
+        fs::create_dir(&mutable).unwrap();
+        fs::create_dir(&outside).unwrap();
+        let stable_target = root.join("stable.txt");
+        let swapped_target = mutable.join("must-not-escape.txt");
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [
+                {
+                    "kind": "write_file",
+                    "target": stable_target,
+                    "content": "first mutation",
+                    "expected_fingerprint": "missing"
+                },
+                {
+                    "kind": "write_file",
+                    "target": swapped_target,
+                    "content": "must stay contained",
+                    "expected_fingerprint": "missing"
+                }
+            ]
+        })
+        .to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root.clone()],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let hook_mutable = mutable.clone();
+        let hook_held = held_mutable.clone();
+        let hook_outside = outside.clone();
+        BEFORE_MUTATION_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                fs::rename(&hook_mutable, &hook_held).unwrap();
+                std::os::unix::fs::symlink(&hook_outside, &hook_mutable).unwrap();
+            }));
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert!(!outcome.verification_passed);
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert!(!stable_target.exists());
+        assert!(!outside.join("must-not-escape.txt").exists());
+        assert!(!held_mutable.join("must-not-escape.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_creation_rejects_a_source_ancestor_swap_after_open() {
+        let (temp, root, state) = fixture();
+        let source_parent = root.join("source-parent");
+        let held_parent = root.join("held-source-parent");
+        let outside_parent = temp.path().join("outside-source-parent");
+        fs::create_dir(&source_parent).unwrap();
+        fs::create_dir(&outside_parent).unwrap();
+        let source = source_parent.join("source");
+        let outside_source = outside_parent.join("source");
+        let target = root.join("link");
+        fs::write(&source, "approved").unwrap();
+        fs::write(&outside_source, "external").unwrap();
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "create_symlink",
+                "source": source,
+                "target": target,
+                "expected_fingerprint": "missing",
+                "expected_source_fingerprint": fingerprint(&source).unwrap()
+            }]
+        })
+        .to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state.clone(),
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let hook_source_parent = source_parent.clone();
+        let hook_held_parent = held_parent.clone();
+        let hook_outside_parent = outside_parent.clone();
+        crate::anchored_fs::set_after_symlink_source_open_hook(move || {
+            fs::rename(&hook_source_parent, &hook_held_parent).unwrap();
+            std::os::unix::fs::symlink(&hook_outside_parent, &hook_source_parent).unwrap();
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert!(!outcome.verification_passed);
+        assert!(!target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_publication_cannot_follow_a_swapped_target_ancestor() {
+        let (temp, root, state) = fixture();
+        let mutable = root.join("mutable");
+        let held_mutable = root.join("held-mutable");
+        let outside = temp.path().join("outside");
+        let source = root.join("source");
+        let target = mutable.join("link");
+        let outside_link = outside.join("link");
+        fs::create_dir(&mutable).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::write(&source, "approved").unwrap();
+        std::os::unix::fs::symlink(&source, &outside_link).unwrap();
+        let plan = prepare(
+            &serde_json::json!({
+                "schema_version": 1,
+                "scan_id": "scan_1",
+                "operations": [{
+                    "kind": "create_symlink",
+                    "source": source,
+                    "target": target,
+                    "expected_fingerprint": "missing",
+                    "expected_source_fingerprint": fingerprint(&source).unwrap(),
+                }],
+            })
+            .to_string(),
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let hook_mutable = mutable.clone();
+        let hook_held = held_mutable.clone();
+        let hook_outside = outside.clone();
+        BEFORE_EXECUTE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                crate::anchored_fs::set_after_created_symlink_hook(move || {
+                    fs::rename(&hook_mutable, &hook_held).unwrap();
+                    std::os::unix::fs::symlink(&hook_outside, &hook_mutable).unwrap();
+                });
+            }));
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert_eq!(fs::read_link(&outside_link).unwrap(), source);
+        assert!(
+            fs::symlink_metadata(held_mutable.join("link"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]
@@ -2261,13 +3104,529 @@ mod tests {
             &input,
             &PrepareContext {
                 approved_roots: vec![root],
-                state_dir: state,
+                state_dir: state.clone(),
                 operation_policy: OperationPolicy::TestOnly,
             },
         )
         .unwrap();
         fs::write(&source, "after").unwrap();
         assert_eq!(apply(&plan).unwrap_err().code, "plan_drifted");
+    }
+
+    fn prepared_write(root: &Path, state: &Path, target: &Path) -> PreparedPlan {
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "write_file",
+                "target": target,
+                "content": "published before injected barrier failure",
+                "expected_fingerprint": "missing"
+            }]
+        })
+        .to_string();
+        prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root.to_path_buf()],
+                state_dir: state.to_path_buf(),
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn journal_directory_sync_failure_precedes_governed_mutation() {
+        let (_temp, root, state) = fixture();
+        let target = root.join("not-created.md");
+        let plan = prepared_write(&root, &state, &target);
+        let directory_sync = FailOnceDirectorySync::new(plan.state_dir.join("receipts"));
+
+        let error = apply_locked_with(&plan, &directory_sync).unwrap_err();
+
+        assert_eq!(error.code, "filesystem_error");
+        assert!(directory_sync.failed.get());
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn journal_reuses_an_owned_temp_left_by_an_interrupted_write() {
+        let (_temp, root, state) = fixture();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: "plan_retry".to_owned(),
+            status: ReceiptStatus::Applying,
+            changed_paths: Vec::new(),
+            compensations: Vec::new(),
+            approved_roots: vec![root],
+            state_dir: state.clone(),
+            error: None,
+            reverses_receipt_id: None,
+            operation_results: Vec::new(),
+        };
+        let receipts = state.join("receipts");
+        fs::create_dir(&receipts).unwrap();
+        let temp = receipts.join(format!(".{}.tmp", receipt.id));
+        fs::write(&temp, b"incomplete").unwrap();
+
+        persist_journal(&receipt).unwrap();
+
+        assert!(!temp.exists());
+        let published = receipts.join(format!("{}.json", receipt.id));
+        let decoded: ChangeReceipt = serde_json::from_slice(&fs::read(published).unwrap()).unwrap();
+        assert_eq!(decoded.id, receipt.id);
+    }
+
+    #[test]
+    fn journal_temp_symlink_never_truncates_its_target() {
+        let (temp_dir, root, state) = fixture();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: "plan_retry".to_owned(),
+            status: ReceiptStatus::Applying,
+            changed_paths: Vec::new(),
+            compensations: Vec::new(),
+            approved_roots: vec![root],
+            state_dir: state.clone(),
+            error: None,
+            reverses_receipt_id: None,
+            operation_results: Vec::new(),
+        };
+        let receipts = state.join("receipts");
+        fs::create_dir(&receipts).unwrap();
+        let outside = temp_dir.path().join("outside");
+        fs::write(&outside, "must survive").unwrap();
+        let temp = receipts.join(format!(".{}.tmp", receipt.id));
+        create_symlink(&outside, &temp).unwrap();
+
+        let error = persist_journal(&receipt).unwrap_err();
+
+        assert_eq!(error.code, "filesystem_error");
+        assert_eq!(fs::read_to_string(outside).unwrap(), "must survive");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_never_publishes_a_temp_entry_swapped_after_open() {
+        let (_temp, root, state) = fixture();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: "plan_retry".to_owned(),
+            status: ReceiptStatus::Applying,
+            changed_paths: Vec::new(),
+            compensations: Vec::new(),
+            approved_roots: vec![root],
+            state_dir: state.clone(),
+            error: None,
+            reverses_receipt_id: None,
+            operation_results: Vec::new(),
+        };
+        let receipts = state.join("receipts");
+        fs::create_dir(&receipts).unwrap();
+        let temp = receipts.join(format!(".{}.tmp", receipt.id));
+        let held = receipts.join(format!(".{}.held", receipt.id));
+        let hook_temp = temp.clone();
+        crate::anchored_fs::set_after_staging_file_open_hook(move || {
+            fs::rename(&hook_temp, &held).unwrap();
+            fs::write(&hook_temp, "decoy").unwrap();
+        });
+
+        let error = persist_journal(&receipt).unwrap_err();
+
+        assert_eq!(error.code, "filesystem_error");
+        assert!(!receipts.join(format!("{}.json", receipt.id)).exists());
+        assert_eq!(fs::read_to_string(temp).unwrap(), "decoy");
+    }
+
+    #[test]
+    fn owned_receipt_validation_has_no_smaller_limit_than_receipt_creation() {
+        let (_temp, root, state) = fixture();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: "plan_large_receipt".to_owned(),
+            status: ReceiptStatus::RecoveryRequired,
+            changed_paths: Vec::new(),
+            compensations: Vec::new(),
+            approved_roots: vec![root],
+            state_dir: state.clone(),
+            error: Some("x".repeat(9 * 1024 * 1024)),
+            reverses_receipt_id: None,
+            operation_results: Vec::new(),
+        };
+        let name = format!("{}.json", receipt.id);
+        let path = state.join(&name);
+        fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+        let mut file = File::open(path).unwrap();
+
+        assert!(owned_receipt_control_file(OsStr::new(&name), &mut file).unwrap());
+    }
+
+    #[test]
+    fn target_directory_sync_failure_requires_recovery_without_path_compensation() {
+        let (_temp, root, state) = fixture();
+        let target = root.join("rolled-back.md");
+        let plan = prepared_write(&root, &state, &target);
+        let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
+
+        let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
+
+        assert!(!outcome.verification_passed);
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert!(directory_sync.failed.get());
+        assert_eq!(
+            fs::read_to_string(target).unwrap(),
+            "published before injected barrier failure"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_failure_never_compensates_an_entry_swapped_after_its_first_check() {
+        for kind in ["write_file", "create_directory", "copy", "create_symlink"] {
+            let (_temp, root, state) = fixture();
+            let source = root.join("source");
+            let target = root.join("target");
+            let held_target = root.join("held-target");
+            fs::write(&source, "approved").unwrap();
+            let operation = match kind {
+                "write_file" => serde_json::json!({
+                    "kind": kind,
+                    "target": target,
+                    "content": "approved",
+                    "expected_fingerprint": "missing",
+                }),
+                "create_directory" => serde_json::json!({
+                    "kind": kind,
+                    "target": target,
+                    "expected_fingerprint": "missing",
+                }),
+                "copy" => serde_json::json!({
+                    "kind": kind,
+                    "source": source,
+                    "target": target,
+                    "expected_fingerprint": fingerprint(&source).unwrap(),
+                }),
+                "create_symlink" => serde_json::json!({
+                    "kind": kind,
+                    "source": source,
+                    "target": target,
+                    "expected_fingerprint": "missing",
+                    "expected_source_fingerprint": fingerprint(&source).unwrap(),
+                }),
+                _ => unreachable!(),
+            };
+            let plan = prepare(
+                &serde_json::json!({
+                    "schema_version": 1,
+                    "scan_id": "scan_1",
+                    "operations": [operation],
+                })
+                .to_string(),
+                &PrepareContext {
+                    approved_roots: vec![root],
+                    state_dir: state,
+                    operation_policy: OperationPolicy::TestOnly,
+                },
+            )
+            .unwrap();
+            let hook_target = target.clone();
+            let hook_held_target = held_target.clone();
+            BEFORE_EXECUTE_HOOK.with(|hook| {
+                *hook.borrow_mut() = Some(Box::new(move || {
+                    let swap = move || {
+                        fs::rename(&hook_target, &hook_held_target).unwrap();
+                        if kind == "create_directory" {
+                            fs::create_dir(&hook_target).unwrap();
+                        } else {
+                            fs::write(&hook_target, "external decoy").unwrap();
+                        }
+                    };
+                    if kind == "create_symlink" {
+                        crate::anchored_fs::set_after_created_symlink_first_check_hook(swap);
+                    } else {
+                        crate::anchored_fs::set_after_created_entry_first_check_hook(swap);
+                    }
+                }));
+            });
+            let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
+
+            let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
+
+            assert_eq!(
+                outcome.receipt.status,
+                ReceiptStatus::RecoveryRequired,
+                "{kind}: {:?}",
+                outcome.receipt.error
+            );
+            assert!(target.exists());
+            assert!(held_target.exists());
+            if kind != "create_directory" {
+                assert_eq!(fs::read_to_string(&target).unwrap(), "external decoy");
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn move_sync_failure_never_compensates_a_swapped_destination() {
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("target");
+        let held_target = root.join("held-target");
+        fs::write(&source, "approved").unwrap();
+        let plan = prepare(
+            &serde_json::json!({
+                "schema_version": 1,
+                "scan_id": "scan_1",
+                "operations": [{
+                    "kind": "move_recoverable",
+                    "source": source,
+                    "target": target,
+                    "expected_fingerprint": fingerprint(&source).unwrap(),
+                }],
+            })
+            .to_string(),
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let hook_target = target.clone();
+        let hook_held_target = held_target.clone();
+        BEFORE_EXECUTE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                crate::anchored_fs::set_after_renamed_entry_first_check_hook(move || {
+                    fs::rename(&hook_target, &hook_held_target).unwrap();
+                    fs::write(&hook_target, "external decoy").unwrap();
+                });
+            }));
+        });
+        let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
+
+        let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
+
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert_eq!(fs::read_to_string(target).unwrap(), "external decoy");
+        assert_eq!(fs::read_to_string(held_target).unwrap(), "approved");
+        assert!(!source.exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn move_never_replaces_a_destination_created_after_validation() {
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("target");
+        fs::write(&source, "approved").unwrap();
+        let plan = prepare(
+            &serde_json::json!({
+                "schema_version": 1,
+                "scan_id": "scan_1",
+                "operations": [{
+                    "kind": "move_recoverable",
+                    "source": source,
+                    "target": target,
+                    "expected_fingerprint": fingerprint(&source).unwrap(),
+                }],
+            })
+            .to_string(),
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let hook_target = target.clone();
+        BEFORE_EXECUTE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                crate::anchored_fs::set_before_rename_noreplace_hook(move || {
+                    fs::write(&hook_target, "external decoy").unwrap();
+                });
+            }));
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert!(
+            outcome
+                .receipt
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("entry_identity_changed")),
+            "{:?}",
+            outcome.receipt.error
+        );
+        assert_eq!(fs::read_to_string(source).unwrap(), "approved");
+        assert_eq!(fs::read_to_string(target).unwrap(), "external decoy");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replacement_never_reports_applied_after_its_published_entry_is_swapped() {
+        let (_temp, root, state) = fixture();
+        let target = root.join("target");
+        let held_target = root.join("held-target");
+        fs::write(&target, "before").unwrap();
+        let plan = prepare(
+            &serde_json::json!({
+                "schema_version": 1,
+                "scan_id": "scan_1",
+                "operations": [{
+                    "kind": "replace_file",
+                    "target": target,
+                    "content": "after",
+                    "expected_fingerprint": fingerprint(&target).unwrap(),
+                }],
+            })
+            .to_string(),
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let hook_target = target.clone();
+        let hook_held_target = held_target.clone();
+        BEFORE_EXECUTE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                crate::anchored_fs::set_after_renamed_entry_first_check_hook(move || {
+                    fs::rename(&hook_target, &hook_held_target).unwrap();
+                    fs::write(&hook_target, "external decoy").unwrap();
+                });
+            }));
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert_eq!(fs::read_to_string(target).unwrap(), "external decoy");
+        assert_eq!(fs::read_to_string(held_target).unwrap(), "after");
+    }
+
+    #[test]
+    fn moved_path_sync_failure_requires_recovery_without_path_compensation() {
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("target");
+        fs::write(&source, "original").unwrap();
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "move_recoverable",
+                "source": source,
+                "target": target,
+                "expected_fingerprint": fingerprint(&source).unwrap()
+            }]
+        })
+        .to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root.clone()],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
+
+        let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
+
+        assert!(!outcome.verification_passed);
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert!(!source.exists());
+        assert_eq!(fs::read_to_string(target).unwrap(), "original");
+    }
+
+    #[test]
+    fn removed_symlink_sync_failure_restores_the_link() {
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("link");
+        fs::write(&source, "original").unwrap();
+        create_symlink(&source, &target).unwrap();
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "remove_symlink",
+                "target": target,
+                "expected_fingerprint": fingerprint(&target).unwrap()
+            }]
+        })
+        .to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root.clone()],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
+
+        let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
+
+        assert!(!outcome.verification_passed);
+        assert_eq!(
+            outcome.receipt.status,
+            ReceiptStatus::FailedRolledBack,
+            "{:?}",
+            outcome.receipt.error
+        );
+        assert!(
+            fs::symlink_metadata(&target)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(
+            fs::canonicalize(&target).unwrap(),
+            fs::canonicalize(source).unwrap()
+        );
+    }
+
+    #[test]
+    fn replaced_file_sync_failure_restores_original_content() {
+        let (_temp, root, state) = fixture();
+        let target = root.join("replace.txt");
+        fs::write(&target, "before").unwrap();
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "replace_file",
+                "target": target,
+                "content": "after",
+                "expected_fingerprint": fingerprint(&target).unwrap()
+            }]
+        })
+        .to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root.clone()],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let directory_sync = FailOnceDirectorySync::new(plan.approved_roots[0].clone());
+
+        let outcome = apply_locked_with(&plan, &directory_sync).unwrap();
+
+        assert!(!outcome.verification_passed);
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert_eq!(fs::read_to_string(&target).unwrap(), "before");
+        assert_eq!(fs::read_dir(root).unwrap().count(), 1);
     }
 
     #[test]
@@ -2282,13 +3641,18 @@ mod tests {
             &input,
             &PrepareContext {
                 approved_roots: vec![root],
-                state_dir: state,
+                state_dir: state.clone(),
                 operation_policy: OperationPolicy::TestOnly,
             },
         )
         .unwrap();
         let applied = apply(&plan).unwrap();
-        assert_eq!(applied.receipt.status, ReceiptStatus::Applied);
+        assert_eq!(
+            applied.receipt.status,
+            ReceiptStatus::Applied,
+            "{:?}",
+            applied.receipt.error
+        );
         assert!(
             fs::symlink_metadata(&target)
                 .unwrap()
@@ -2326,10 +3690,300 @@ mod tests {
     }
 
     #[test]
+    fn undo_refuses_a_drifted_cross_device_backup_before_mutation() {
+        let (_temp, root, state) = fixture();
+        let original = root.join("original");
+        let backup = root.join(".original.skillroster-backup-test");
+        let created = root.join("created");
+        fs::write(&backup, "drifted backup").unwrap();
+        fs::write(&created, "approved").unwrap();
+        let expected = fingerprint(&created).unwrap();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: format!("plan_{}", ulid::Ulid::new()),
+            status: ReceiptStatus::Applied,
+            changed_paths: vec![created.clone()],
+            compensations: vec![Compensation::RestoreBackup {
+                backup: backup.clone(),
+                original: original.clone(),
+                created: created.clone(),
+                expected_created: expected,
+            }],
+            approved_roots: vec![root],
+            state_dir: state,
+            error: None,
+            reverses_receipt_id: None,
+            operation_results: vec![],
+        };
+
+        let outcome = undo(&receipt).unwrap();
+
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert_eq!(fs::read_to_string(created).unwrap(), "approved");
+        assert_eq!(fs::read_to_string(backup).unwrap(), "drifted backup");
+        assert!(!original.exists());
+    }
+
+    #[test]
+    fn lifecycle_check_refuses_a_drifted_cross_device_backup() {
+        let (_temp, root, state) = fixture();
+        let backup = root.join(".original.skillroster-backup-test");
+        let created = root.join("created");
+        fs::write(&backup, "drifted backup").unwrap();
+        fs::write(&created, "approved").unwrap();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: format!("plan_{}", ulid::Ulid::new()),
+            status: ReceiptStatus::Applied,
+            changed_paths: vec![created.clone()],
+            compensations: vec![Compensation::RestoreBackup {
+                backup,
+                original: root.join("original"),
+                created: created.clone(),
+                expected_created: fingerprint(&created).unwrap(),
+            }],
+            approved_roots: vec![root],
+            state_dir: state.clone(),
+            error: None,
+            reverses_receipt_id: None,
+            operation_results: vec![],
+        };
+        persist_journal(&receipt).unwrap();
+        let state_lock = StateLock::acquire_exclusive(&state).unwrap();
+
+        let error = has_external_recovery_material(&state, &state_lock).unwrap_err();
+
+        assert_eq!(error.code, "recovery_material_drifted");
+    }
+
+    #[test]
     fn write_file_round_trips_without_overwriting_existing_content() {
         let (_temp, root, state) = fixture();
         let target = root.join("SKILL.md");
         let input = serde_json::json!({"schema_version":1,"scan_id":"scan_1","operations":[{"kind":"write_file","target":target,"content":"---\nname: test\n---\n","expected_fingerprint":"missing"}]}).to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state.clone(),
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let applied = apply(&plan).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            let receipts = state.join("receipts");
+            let journal = receipts.join(format!("{}.json", applied.receipt.id));
+            assert_eq!(
+                fs::metadata(receipts).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(journal).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "---\nname: test\n---\n"
+        );
+        let undone = undo(&applied.receipt).unwrap();
+        assert_eq!(undone.receipt.status, ReceiptStatus::Undone);
+        assert!(!target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replace_and_undo_preserve_private_and_executable_modes() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        for mode in [0o600, 0o500] {
+            assert_replace_and_undo_preserves_permissions(fs::Permissions::from_mode(mode));
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn replace_and_undo_preserve_readonly_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let probe = temp.path().join("permissions-probe");
+        fs::write(&probe, "probe").unwrap();
+        let mut permissions = fs::metadata(&probe).unwrap().permissions();
+        permissions.set_readonly(true);
+        assert_replace_and_undo_preserves_permissions(permissions);
+    }
+
+    fn assert_replace_and_undo_preserves_permissions(original_permissions: fs::Permissions) {
+        let (_temp, root, state) = fixture();
+        let target = root.join("replace.txt");
+        fs::write(&target, "before").unwrap();
+        fs::set_permissions(&target, original_permissions.clone()).unwrap();
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "replace_file",
+                "target": target,
+                "content": "after",
+                "expected_fingerprint": fingerprint(&target).unwrap()
+            }]
+        })
+        .to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state.clone(),
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+
+        let applied = apply(&plan).unwrap();
+
+        assert!(
+            applied.verification_passed,
+            "Apply failed: {:?}",
+            applied.receipt.error
+        );
+        assert_eq!(fs::read_to_string(&target).unwrap(), "after");
+        assert_permissions_equal(&target, &original_permissions);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            let recovery = state.join("recovery");
+            let receipt_recovery = recovery.join(&applied.receipt.id);
+            assert_eq!(
+                fs::metadata(recovery).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(receipt_recovery).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+
+        let undone = undo(&applied.receipt).unwrap();
+
+        assert!(undone.verification_passed);
+        assert_eq!(fs::read_to_string(&target).unwrap(), "before");
+        assert_permissions_equal(&target, &original_permissions);
+        #[cfg(windows)]
+        {
+            let mut writable = original_permissions;
+            writable.set_readonly(false);
+            fs::set_permissions(&target, writable).unwrap();
+        }
+    }
+
+    #[test]
+    fn replacement_staging_failure_leaves_original_content_and_permissions() {
+        let (_temp, root, state) = fixture();
+        let target = root.join("replace.txt");
+        fs::write(&target, "before").unwrap();
+        let permissions = fs::metadata(&target).unwrap().permissions();
+        let receipt_id = "receipt_fixture";
+        let staged = root.join(format!(".replace.txt.skillroster-replace-{receipt_id}-0"));
+        fs::write(&staged, "must not be overwritten").unwrap();
+        let anchored = open_anchored_fs(&[root], &state, &SystemDirectorySync).unwrap();
+
+        let error = replace_file(&anchored, &target, "after", receipt_id, 0).unwrap_err();
+
+        assert_eq!(error.code, "target_exists");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "before");
+        assert_permissions_equal(&target, &permissions);
+        assert_eq!(
+            fs::read_to_string(staged).unwrap(),
+            "must not be overwritten"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exclusive_copy_never_exposes_private_source_under_wider_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("root");
+        let state = temp.path().join("state");
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&state).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let state = fs::canonicalize(state).unwrap();
+        let source = root.join("private-source");
+        let staged = root.join("visible-staging");
+        fs::write(&source, "private contents").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o600)).unwrap();
+        let anchored = open_anchored_fs(&[root], &state, &SystemDirectorySync).unwrap();
+
+        anchored.copy_file(&source, &staged).unwrap();
+
+        assert_eq!(
+            fs::metadata(&staged).unwrap().permissions().mode() & 0o077,
+            0
+        );
+        assert_eq!(fs::read_to_string(&staged).unwrap(), "private contents");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staging_permissions_are_applied_to_the_created_file_handle() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let (temp, root, state) = fixture();
+        let source = root.join("private-source");
+        let target = root.join("staging");
+        let held_target = root.join("held-staging");
+        fs::write(&source, "private contents").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o600)).unwrap();
+        let hook_target = target.clone();
+        let hook_held_target = held_target.clone();
+        crate::anchored_fs::set_after_staging_file_open_hook(move || {
+            fs::rename(&hook_target, &hook_held_target).unwrap();
+            fs::write(&hook_target, "decoy").unwrap();
+            fs::set_permissions(&hook_target, fs::Permissions::from_mode(0o666)).unwrap();
+        });
+        let anchored = open_anchored_fs(&[root], &state, &SystemDirectorySync).unwrap();
+
+        let error = anchored.copy_file(&source, &target).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            fs::metadata(&held_target).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o666
+        );
+        assert_eq!(fs::read_to_string(held_target).unwrap(), "private contents");
+        assert_eq!(fs::read_to_string(target).unwrap(), "decoy");
+        drop(temp);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_never_compensates_an_entry_swapped_onto_a_copy_target() {
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("target");
+        let held_target = root.join("held-target");
+        fs::write(&source, "approved").unwrap();
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "copy",
+                "source": source,
+                "target": target,
+                "expected_fingerprint": fingerprint(&source).unwrap()
+            }]
+        })
+        .to_string();
         let plan = prepare(
             &input,
             &PrepareContext {
@@ -2339,14 +3993,319 @@ mod tests {
             },
         )
         .unwrap();
-        let applied = apply(&plan).unwrap();
-        assert_eq!(
-            fs::read_to_string(&target).unwrap(),
-            "---\nname: test\n---\n"
+        let hook_target = target.clone();
+        let hook_held_target = held_target.clone();
+        BEFORE_EXECUTE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                crate::anchored_fs::set_after_staging_file_open_hook(move || {
+                    fs::rename(&hook_target, &hook_held_target).unwrap();
+                    fs::write(&hook_target, "external decoy").unwrap();
+                });
+            }));
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert_eq!(fs::read_to_string(&target).unwrap(), "external decoy");
+        assert_eq!(fs::read_to_string(&held_target).unwrap(), "approved");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_never_compensates_entries_swapped_after_creation() {
+        for kind in [
+            "write_file",
+            "create_directory",
+            "create_symlink",
+            "create_symlink_after_first_check",
+        ] {
+            let (_temp, root, state) = fixture();
+            let source = root.join("source");
+            let target = root.join("target");
+            let held_target = root.join("held-target");
+            fs::write(&source, "approved").unwrap();
+            let operation = match kind {
+                "write_file" => serde_json::json!({
+                    "kind": kind,
+                    "target": target,
+                    "content": "approved",
+                    "expected_fingerprint": "missing",
+                }),
+                "create_directory" => serde_json::json!({
+                    "kind": kind,
+                    "target": target,
+                    "expected_fingerprint": "missing",
+                }),
+                "create_symlink" | "create_symlink_after_first_check" => serde_json::json!({
+                    "kind": "create_symlink",
+                    "source": source,
+                    "target": target,
+                    "expected_fingerprint": "missing",
+                    "expected_source_fingerprint": fingerprint(&source).unwrap(),
+                }),
+                _ => unreachable!(),
+            };
+            let plan = prepare(
+                &serde_json::json!({
+                    "schema_version": 1,
+                    "scan_id": "scan_1",
+                    "operations": [operation],
+                })
+                .to_string(),
+                &PrepareContext {
+                    approved_roots: vec![root],
+                    state_dir: state,
+                    operation_policy: OperationPolicy::TestOnly,
+                },
+            )
+            .unwrap();
+            let hook_target = target.clone();
+            let hook_held_target = held_target.clone();
+            BEFORE_EXECUTE_HOOK.with(|hook| {
+                *hook.borrow_mut() = Some(Box::new(move || match kind {
+                    "write_file" => {
+                        crate::anchored_fs::set_after_staging_file_open_hook(move || {
+                            fs::rename(&hook_target, &hook_held_target).unwrap();
+                            fs::write(&hook_target, "external decoy").unwrap();
+                        });
+                    }
+                    "create_directory" => {
+                        crate::anchored_fs::set_after_created_directory_open_hook(move || {
+                            fs::rename(&hook_target, &hook_held_target).unwrap();
+                            fs::create_dir(&hook_target).unwrap();
+                        });
+                    }
+                    "create_symlink" => {
+                        crate::anchored_fs::set_after_created_symlink_hook(move || {
+                            fs::remove_file(&hook_target).unwrap();
+                            fs::hard_link(&source, &hook_target).unwrap();
+                        });
+                    }
+                    "create_symlink_after_first_check" => {
+                        crate::anchored_fs::set_after_created_symlink_first_check_hook(move || {
+                            fs::remove_file(&hook_target).unwrap();
+                            fs::hard_link(&source, &hook_target).unwrap();
+                        });
+                    }
+                    _ => unreachable!(),
+                }));
+            });
+
+            let outcome = apply(&plan).unwrap();
+
+            assert_eq!(
+                outcome.receipt.status,
+                ReceiptStatus::RecoveryRequired,
+                "{kind}: {:?}",
+                outcome.receipt.error
+            );
+            assert!(target.exists());
+            if !kind.starts_with("create_symlink") {
+                assert!(held_target.exists());
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_symlink_restores_an_entry_swapped_before_rename() {
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("target");
+        let held_target = root.join("held-target");
+        fs::write(&source, "approved").unwrap();
+        create_symlink(&source, &target).unwrap();
+        let plan = prepare(
+            &serde_json::json!({
+                "schema_version": 1,
+                "scan_id": "scan_1",
+                "operations": [{
+                    "kind": "remove_symlink",
+                    "target": target,
+                    "expected_fingerprint": fingerprint(&target).unwrap(),
+                }],
+            })
+            .to_string(),
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let hook_target = target.clone();
+        let hook_held_target = held_target.clone();
+        BEFORE_REMOVE_SYMLINK_RENAME_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                fs::rename(&hook_target, &hook_held_target).unwrap();
+                fs::write(&hook_target, "external decoy").unwrap();
+            }));
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert_eq!(fs::read_to_string(&target).unwrap(), "external decoy");
+        assert!(
+            fs::symlink_metadata(&held_target)
+                .unwrap()
+                .file_type()
+                .is_symlink()
         );
-        let undone = undo(&applied.receipt).unwrap();
-        assert_eq!(undone.receipt.status, ReceiptStatus::Undone);
-        assert!(!target.exists());
+        let backup = move_backup_path(&target, &outcome.receipt.id, 0).unwrap();
+        assert!(!backup.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_undo_restores_exact_legacy_relative_symlink_contents() {
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("target");
+        fs::write(&source, "approved").unwrap();
+        std::os::windows::fs::symlink_file(Path::new("source"), &target).unwrap();
+        let original_contents = fs::read_link(&target).unwrap();
+        let original_fingerprint = fingerprint(&target).unwrap();
+        fs::remove_file(&target).unwrap();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: format!("plan_{}", ulid::Ulid::new()),
+            status: ReceiptStatus::Applied,
+            changed_paths: vec![target.clone()],
+            compensations: vec![Compensation::RestoreSymlink {
+                path: target.clone(),
+                target: original_contents.clone(),
+            }],
+            approved_roots: vec![root],
+            state_dir: state,
+            error: None,
+            reverses_receipt_id: None,
+            operation_results: vec![],
+        };
+
+        let outcome = undo(&receipt).unwrap();
+
+        assert_eq!(
+            outcome.receipt.status,
+            ReceiptStatus::Undone,
+            "{:?}",
+            outcome.receipt.error
+        );
+        assert!(
+            fs::symlink_metadata(&target)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(fs::read_link(&target).unwrap(), original_contents);
+        assert_eq!(fingerprint(&target).unwrap(), original_fingerprint);
+        assert_eq!(
+            fs::canonicalize(target).unwrap(),
+            fs::canonicalize(source).unwrap()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_legacy_absolute_symlink_restore_fails_before_mutation() {
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("target");
+        fs::write(&source, "approved").unwrap();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: format!("plan_{}", ulid::Ulid::new()),
+            status: ReceiptStatus::Applied,
+            changed_paths: vec![target.clone()],
+            compensations: vec![Compensation::RestoreSymlink {
+                path: target.clone(),
+                target: source,
+            }],
+            approved_roots: vec![root],
+            state_dir: state,
+            error: None,
+            reverses_receipt_id: None,
+            operation_results: vec![],
+        };
+
+        let outcome = undo(&receipt).unwrap();
+
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert!(fs::symlink_metadata(target).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_legacy_relative_restore_cannot_be_redirected_by_an_ancestor_swap() {
+        let (temp, root, state) = fixture();
+        let mutable = root.join("mutable");
+        let held_mutable = root.join("held-mutable");
+        let outside = temp.path().join("outside");
+        let source = mutable.join("source");
+        let outside_source = outside.join("source");
+        let target = root.join("target");
+        fs::create_dir(&mutable).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::write(&source, "approved").unwrap();
+        fs::write(&outside_source, "external").unwrap();
+        let receipt = ChangeReceipt {
+            id: format!("receipt_{}", ulid::Ulid::new()),
+            plan_id: format!("plan_{}", ulid::Ulid::new()),
+            status: ReceiptStatus::Applied,
+            changed_paths: vec![target.clone()],
+            compensations: vec![Compensation::RestoreSymlink {
+                path: target.clone(),
+                target: PathBuf::from("mutable").join("source"),
+            }],
+            approved_roots: vec![root],
+            state_dir: state,
+            error: None,
+            reverses_receipt_id: None,
+            operation_results: vec![],
+        };
+        let swap_succeeded = Rc::new(Cell::new(false));
+        let hook_swap_succeeded = Rc::clone(&swap_succeeded);
+        crate::anchored_fs::set_after_symlink_source_open_hook(move || {
+            if fs::rename(&mutable, &held_mutable).is_ok() {
+                std::os::windows::fs::symlink_dir(&outside, &mutable).unwrap();
+                hook_swap_succeeded.set(true);
+            }
+        });
+
+        let outcome = undo(&receipt).unwrap();
+
+        assert!(matches!(
+            outcome.receipt.status,
+            ReceiptStatus::Undone | ReceiptStatus::RecoveryRequired
+        ));
+        match fs::symlink_metadata(&target) {
+            Ok(metadata) => {
+                assert!(metadata.file_type().is_symlink());
+                assert_eq!(
+                    fs::read_link(&target).unwrap(),
+                    PathBuf::from("mutable").join("source")
+                );
+                assert_eq!(fs::read_to_string(&target).unwrap(), "approved");
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+            }
+            Err(error) => panic!("unexpected target state: {error}"),
+        }
+        assert!(!swap_succeeded.get() || outcome.receipt.status == ReceiptStatus::RecoveryRequired);
+        assert_eq!(fs::read_to_string(outside_source).unwrap(), "external");
+    }
+
+    fn assert_permissions_equal(path: &Path, expected: &fs::Permissions) {
+        let actual = fs::metadata(path).unwrap().permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(actual.mode() & 0o7777, expected.mode() & 0o7777);
+        }
+        #[cfg(windows)]
+        assert_eq!(actual.readonly(), expected.readonly());
     }
 
     #[test]
@@ -2466,7 +4425,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_step_is_journaled_and_partial_copy_is_rolled_back() {
+    fn failed_copy_is_journaled_without_path_compensating_its_partial_target() {
         let (_temp, root, state) = fixture();
         let unsafe_source = root.join("unsafe-source");
         fs::create_dir(&unsafe_source).unwrap();
@@ -2489,14 +4448,14 @@ mod tests {
         )
         .unwrap();
         let outcome = apply(&plan).unwrap();
-        assert_eq!(outcome.receipt.status, ReceiptStatus::FailedRolledBack);
+        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
         assert_eq!(outcome.receipt.operation_results[0].status, "rolled_back");
         assert_eq!(
             outcome.receipt.operation_results[1].status,
-            "failed_rolled_back"
+            "recovery_required"
         );
         assert!(outcome.receipt.operation_results[1].error.is_some());
         assert!(!root.join("first").exists());
-        assert!(!root.join("partial-copy").exists());
+        assert!(root.join("partial-copy").is_dir());
     }
 }

--- a/src/durable_fs.rs
+++ b/src/durable_fs.rs
@@ -4,14 +4,20 @@
 //! The containing directory must also be flushed before the mutation can be
 //! treated as recoverable after a crash.
 
+use std::fs::File;
 use std::io;
 use std::path::Path;
 
-#[cfg(unix)]
-use std::fs::File;
-
 pub(crate) trait DirectorySync {
     fn sync_directory(&self, path: &Path) -> io::Result<()>;
+
+    /// Flush an already-open directory capability. The diagnostic path is
+    /// supplied separately so tests can inject failures without making
+    /// production durability depend on ambient path resolution.
+    fn sync_directory_handle(&self, directory: &File, path: &Path) -> io::Result<()> {
+        let _ = directory;
+        self.sync_directory(path)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -20,6 +26,10 @@ pub(crate) struct SystemDirectorySync;
 impl DirectorySync for SystemDirectorySync {
     fn sync_directory(&self, path: &Path) -> io::Result<()> {
         sync_directory(path)
+    }
+
+    fn sync_directory_handle(&self, directory: &File, _path: &Path) -> io::Result<()> {
+        directory.sync_all()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod anchored_fs;
 pub mod app;
 mod bootstrap;
 pub mod change;

--- a/src/state_security.rs
+++ b/src/state_security.rs
@@ -79,19 +79,6 @@ pub(crate) fn prepare_private_file(path: &Path) -> io::Result<()> {
     }
 }
 
-pub(crate) fn open_private_file_for_replace(path: &Path) -> io::Result<File> {
-    let mut options = private_file_options();
-    let file = options
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(path)?;
-    secure_opened_file(&file)?;
-    file.set_len(0)?;
-    Ok(file)
-}
-
 pub(crate) fn secure_state_layout(state_dir: &Path) -> io::Result<()> {
     prepare_state_root(state_dir)?;
     for name in [


### PR DESCRIPTION
Closes #248

## Summary
- add a dedicated capability-filesystem module backed by retained directory handles
- verify every opened root handle still identifies its non-symlink directory entry
- resolve Apply, compensation, rollback, and Undo fingerprints and mutations relative to approved handles
- perform file creation, replacement, link operations, recursive copy, and cross-root rename without ambient path re-resolution
- publish moves and replacements with platform-native atomic no-replace operations so a concurrently created destination is never overwritten
- keep state-controlled library, backup, and recovery paths under the state directory handle
- add deterministic ancestor-symlink swap regressions proving external targets remain untouched

## Security boundary
The ambient absolute path is used only to choose an approved anchor and report errors. Each filesystem operation is executed relative to the retained handle; escaping symlink traversal is rejected by the capability resolver on Linux, macOS, and Windows.

Windows legacy Receipts with relative symlink contents are restored byte-for-byte and verified against the retained source before and after directory sync. Legacy absolute symlink contents fail closed before mutation because cap-std rejects absolute link contents, `CreateSymbolicLinkW` accepts only an ambient link path, and direct reparse-point mutation requires extra privilege. Such Undo attempts become `RecoveryRequired` instead of silently changing link identity or weakening the handle-bound boundary.

## Validation
- `bash scripts/ci-full-check.sh`: 287 unit, 8 acceptance, 74 CLI, 137 Node harness
- strict Clippy passed
- `cargo fmt --all --check`
- `git diff --check`
- deterministic source/target ancestor-swap, sync-failure, and destination-race regressions passed on macOS; the destination-race regression also runs in Windows CI
- four-platform CI required on the exact latest head before merge

## Coordination
This PR includes the replacement-permission preservation that landed on main through #241; the branch was rebased after that merge.

The PR remains unmerged pending exact-head review and four-platform CI.
