### PR TITLE
docs: keep installs on the published release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           bash scripts/verify-readme-value.sh
+          bash scripts/verify-installation-surface.sh
           bash scripts/ci-change-scope.sh --self-test
           full=true
           if [[ "$EVENT_NAME" != "workflow_dispatch" && -n "$BASE_SHA" && ! "$BASE_SHA" =~ ^0+$ ]] && git cat-file -e "$BASE_SHA^{commit}"; then

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,9 +91,10 @@ skillroster setup --json
 ```
 
 Published CLI v1.8.28 bundles Bootstrap content version 1.8.28. The current
-source-tree candidate is **v1.8.29** and bundles Bootstrap content version
-1.8.29. CLI and Bootstrap versions can differ intentionally when CLI behavior
-changes without changing the Bootstrap instructions.
+source-tree candidate is **v1.8.29**.
+Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
+differ intentionally when CLI behavior changes without changing the Bootstrap
+instructions.
 In Setup JSON, `cli_version` identifies the executable and
 `bootstrap_content_version` identifies the bundled Skill package.
 `bootstrap_version` remains a compatibility alias for

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,6 +4,11 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
+The current public release is **v1.8.28**. The source tree may contain a newer
+candidate before publication; candidate identity is not an installable tag.
+The examples below deliberately remain on the public release until its Formula,
+tag, archives, and checksums are all available.
+
 ## GitHub Release binaries
 
 Download the archive and matching `.sha256` file for your platform from the
@@ -27,7 +32,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.29
+SKILLROSTER_VERSION=1.8.28
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -51,7 +56,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.29 skillroster
+  --tag v1.8.28 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -85,9 +90,10 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-CLI v1.8.29 bundles Bootstrap content version 1.8.29. These versions can differ
-intentionally when CLI behavior changes without changing the Bootstrap
-instructions.
+Published CLI v1.8.28 bundles Bootstrap content version 1.8.28. The current
+source-tree candidate is **v1.8.29** and bundles Bootstrap content version
+1.8.29. CLI and Bootstrap versions can differ intentionally when CLI behavior
+changes without changing the Bootstrap instructions.
 In Setup JSON, `cli_version` identifies the executable and
 `bootstrap_content_version` identifies the bundled Skill package.
 `bootstrap_version` remains a compatibility alias for

--- a/scripts/ci-full-check.sh
+++ b/scripts/ci-full-check.sh
@@ -6,3 +6,4 @@ cargo clippy --locked --all-targets --all-features -- -D warnings
 cargo test --locked --all-targets --all-features
 bash scripts/ci-node-harness.sh
 bash scripts/verify-readme-value.sh
+bash scripts/verify-installation-surface.sh

--- a/scripts/verify-installation-surface.sh
+++ b/scripts/verify-installation-surface.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+formula="Formula/skillroster.rb"
+manifest="Cargo.toml"
+installation="docs/installation.md"
+website="website/index.html"
+
+published_version="$(awk -F '"' '/^[[:space:]]*version "/ { print $2; exit }' "$formula")"
+candidate_version="$(awk -F '"' '/^version = "/ { print $2; exit }' "$manifest")"
+
+[[ "$published_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "could not derive the published version from $formula" >&2
+  exit 1
+}
+[[ "$candidate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "could not derive the source candidate version from $manifest" >&2
+  exit 1
+}
+
+require_literal() {
+  local file="$1"
+  local literal="$2"
+  grep -Fq -- "$literal" "$file" || {
+    echo "$file is missing installation-surface text: $literal" >&2
+    exit 1
+  }
+}
+
+reject_literal() {
+  local file="$1"
+  local literal="$2"
+  if grep -Fq -- "$literal" "$file"; then
+    echo "$file contains forbidden installation-surface text: $literal" >&2
+    exit 1
+  fi
+}
+
+require_literal "$installation" "The current public release is **v${published_version}**."
+require_literal "$installation" "SKILLROSTER_VERSION=${published_version}"
+require_literal "$installation" "--tag v${published_version} skillroster"
+require_literal "$installation" "Published CLI v${published_version} bundles Bootstrap content version ${published_version}."
+require_literal "$installation" "source-tree candidate is **v${candidate_version}**"
+
+require_literal "$website" "CURRENT RELEASE v${published_version}"
+require_literal "$website" "IMMUTABLE CURRENT RELEASE · v${published_version}"
+require_literal "$website" "--tag v${published_version} skillroster"
+require_literal "$website" 'data-copy="brew install tt-a1i/skillroster/skillroster"'
+require_literal "$website" "SOURCE TREE v${candidate_version}"
+reject_literal "$website" "brew tap tt-a1i/skillroster https://github.com/tt-a1i/skillroster.git"

--- a/scripts/verify-installation-surface.sh
+++ b/scripts/verify-installation-surface.sh
@@ -3,11 +3,13 @@ set -euo pipefail
 
 formula="Formula/skillroster.rb"
 manifest="Cargo.toml"
+bootstrap="skill/skillroster/SKILL.md"
 installation="docs/installation.md"
 website="website/index.html"
 
 published_version="$(awk -F '"' '/^[[:space:]]*version "/ { print $2; exit }' "$formula")"
 candidate_version="$(awk -F '"' '/^version = "/ { print $2; exit }' "$manifest")"
+bootstrap_version="$(awk -F '"' '/^[[:space:]]*bootstrap-version:/ { print $2; exit }' "$bootstrap")"
 
 [[ "$published_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
   echo "could not derive the published version from $formula" >&2
@@ -15,6 +17,10 @@ candidate_version="$(awk -F '"' '/^version = "/ { print $2; exit }' "$manifest")
 }
 [[ "$candidate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
   echo "could not derive the source candidate version from $manifest" >&2
+  exit 1
+}
+[[ "$bootstrap_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "could not derive the bundled Bootstrap version from $bootstrap" >&2
   exit 1
 }
 
@@ -41,6 +47,7 @@ require_literal "$installation" "SKILLROSTER_VERSION=${published_version}"
 require_literal "$installation" "--tag v${published_version} skillroster"
 require_literal "$installation" "Published CLI v${published_version} bundles Bootstrap content version ${published_version}."
 require_literal "$installation" "source-tree candidate is **v${candidate_version}**"
+require_literal "$installation" "Its bundled Bootstrap content version is ${bootstrap_version}."
 
 require_literal "$website" "CURRENT RELEASE v${published_version}"
 require_literal "$website" "IMMUTABLE CURRENT RELEASE · v${published_version}"

--- a/website/index.html
+++ b/website/index.html
@@ -1451,23 +1451,21 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">REPOSITORY-BACKED TAP · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.28 · MACOS &amp; LINUX</div>
         <div class="code-block">
-          <div><span class="prompt">$</span>brew tap tt-a1i/skillroster \</div>
-          <div>&nbsp;&nbsp;https://github.com/tt-a1i/skillroster.git</div>
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
-          <button class="copy-btn" data-copy="brew tap tt-a1i/skillroster https://github.com/tt-a1i/skillroster.git && brew install tt-a1i/skillroster/skillroster">COPY</button>
+          <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
         </div>
       </div>
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE RELEASE TAG · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.28 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.29 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.29 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.28 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.28 skillroster">COPY</button>
         </div>
       </div>
     </div>
@@ -1498,7 +1496,7 @@ footer { overflow: hidden; }
       </div>
     </div>
     <div class="footer-rule">
-      <span>SKILLROSTER v1.8.29 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
+      <span>SOURCE TREE v1.8.29 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
       <span>NO DAEMON · NO CLOUD · NO TELEMETRY</span>
     </div>
   </div>


### PR DESCRIPTION
## Problem

Public copy-paste installation surfaces mixed the unreleased v1.8.29 source candidate with the latest published v1.8.28 release. The website also pointed `brew tap` at the source repository instead of the official Homebrew tap.

## Solution

- keep archive and Cargo examples on the version declared by the main-repository Formula
- distinguish the published release from the newer source-tree candidate
- replace the incorrect website tap command with the fully-qualified official Formula install
- add an installation-surface verifier derived from Formula and Cargo metadata
- run the verifier both in full checks and the unconditional change-scope job

## Evidence

- current public tag, GitHub Release, and Homebrew Formula: v1.8.28
- source-tree candidate: v1.8.29
- fault injection changing the documented install version to 9.9.9 was rejected by the verifier
- no tag, Release, Homebrew tap, or public artifact was changed

## Checks

- `bash scripts/ci-full-check.sh`
- `bash scripts/ci-change-scope.sh --self-test`
- `bash scripts/verify-installation-surface.sh`
- `bash scripts/verify-readme-value.sh`
- `git diff --check`

Closes #264
