### PR TITLE
fix: preserve variant load recovery

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -233,9 +233,12 @@ Summary order and bind each stable Finding ID without implying Plan or Apply.
 
 Suggested action argv retains any effective `--state-dir`, `--home`, `--root`,
 and `--source-root` overrides so an Agent can execute the transition against
-the same local Snapshot and explicit read boundary. It never broadens read
-permission, endorses source content, or treats a suggested mutation as
-authorization.
+the same local Snapshot and explicit read boundary. A same-name load recovery
+also carries `--require-snapshot`; if a newer Scan appears before the action
+runs, Find fails closed and offers a read-only retry pinned to the latest
+observed Snapshot instead of silently switching the variant evidence. It never
+broadens read permission, endorses source content, or treats a suggested
+mutation as authorization.
 
 Suggested actions must represent a required or evidence-backed transition.
 Healthy `status` output with a completed Snapshot does not prescribe another

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -182,7 +182,7 @@ The first complete command surface is:
 ```bash
 skillroster scan [--summary] [--json]
 skillroster report [--summary | --full | --findings [--category <category>] [--severity <severity>] | --finding <id> [--full]] [--limit <n>] [--offset <n>] [--json]
-skillroster find <task> [--hint <text>]... [--limit <n>] [--load] [--variant-skill-id <skill-id>] [--json]
+skillroster find <task> [--hint <text>]... [--limit <n>] [--load] [--variant-skill-id <skill-id>] [--require-snapshot <scan-id>] [--json]
 skillroster plan --stdin [--json]
 skillroster plan --show <plan-id> [--json]
 skillroster apply <plan-id> [--json]
@@ -200,6 +200,14 @@ decision and action chain without spending context on a large first page.
 Explicit `--limit` values always win on paged Finding lists and detail;
 `page` totals and continuation actions remain the authoritative path to
 omitted rows. Top-level `report --full` remains an unpaged exhaustive export.
+
+`find --require-snapshot <scan-id>` is an optimistic read boundary used by
+typed continuation actions. Find fails closed with `find_snapshot_changed`
+when another Scan has become latest; it never silently resolves an ambiguity
+or loads exact variant content against a different Snapshot. The returned
+read-only retry replaces the stale requirement with the latest observed
+Snapshot requirement and preserves the task, hints, limit, and discovery
+context so the Agent can restart from those facts without reopening the race.
 
 `source-root confirm` persists one exact local read permission bound to a
 current completed escaping-link Finding, its observed canonical directory, and

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,9 +36,9 @@ pub use crate::action_context::ActionContext;
 mod error;
 
 use error::{
-    ContentIdentityRescanRequired, LibraryRootConflict, MAX_AGENT_LOADED_SKILL_BYTES,
-    PlanSnapshotDrift, SkillLoadBlocked, StoredFindingCoverageInvalid,
-    incomplete_fingerprint_blocker,
+    ContentIdentityRescanRequired, FindSnapshotChanged, LibraryRootConflict,
+    MAX_AGENT_LOADED_SKILL_BYTES, PlanSnapshotDrift, SkillLoadBlocked,
+    StoredFindingCoverageInvalid, incomplete_fingerprint_blocker,
 };
 pub use error::{error_json, error_json_with_context};
 
@@ -323,15 +323,7 @@ pub fn run(cli: Cli) -> Result<Output> {
             ("report", result, vec![], actions)
         }
         Some(Command::Find(args)) => {
-            let (result, actions) = find_command(
-                &store,
-                &state_dir,
-                &args.task,
-                &args.hints,
-                usize::from(args.limit),
-                args.load,
-                args.variant_skill_id.as_deref(),
-            )?;
+            let (result, actions) = find_command(&store, &state_dir, &args)?;
             ("find", result, vec![], actions)
         }
         Some(Command::Plan(args)) => {
@@ -4446,12 +4438,14 @@ fn session_finding_coverage(
 fn find_command(
     store: &StateStore,
     state_dir: &Path,
-    task: &str,
-    hints: &[String],
-    limit: usize,
-    load: bool,
-    variant_skill_id: Option<&str>,
+    args: &crate::cli::FindArgs,
 ) -> Result<(Value, Vec<SuggestedAction>)> {
+    let task = args.task.as_str();
+    let hints = args.hints.as_slice();
+    let limit = usize::from(args.limit);
+    let load = args.load;
+    let variant_skill_id = args.variant_skill_id.as_deref();
+    let required_snapshot_id = args.require_snapshot.as_deref();
     if variant_skill_id.is_some() && !load {
         return Err(SkillLoadBlocked {
             reason: "variant_selector_requires_load",
@@ -4462,12 +4456,29 @@ fn find_command(
             mutation_scopes: Vec::new(),
             expected_digest: None,
             actual_digest: None,
+            retry_argv: None,
         }
         .into());
     }
-    let (scan_id, scan) = latest_scan(store)?;
-    require_content_identity(&scan)?;
     let retrieval_hints = normalize_retrieval_hints(hints);
+    let (scan_id, scan) = latest_scan(store)?;
+    if let Some(expected) = required_snapshot_id {
+        let expected = ScanId::parse(expected.to_owned())?;
+        if expected != scan_id {
+            return Err(FindSnapshotChanged {
+                expected_snapshot_id: expected,
+                actual_snapshot_id: scan_id.clone(),
+                retry_argv: find_action_argv(
+                    task,
+                    &retrieval_hints,
+                    FindActionKind::InspectVariants { limit },
+                    Some(&scan_id),
+                ),
+            }
+            .into());
+        }
+    }
+    require_content_identity(&scan)?;
     let retrieval_query = crate::query::RetrievalQuery::from_parts(
         std::iter::once(task).chain(retrieval_hints.iter().map(String::as_str)),
     );
@@ -4609,13 +4620,24 @@ fn find_command(
             mutation_scopes: Vec::new(),
             expected_digest: None,
             actual_digest: None,
+            retry_argv: None,
         }
         .into());
     }
     let loaded_skill = if load && !matches.is_empty() {
         let ranked = &matches[0];
+        let ambiguity_retry_argv =
+            (ranked.variant_count != 1 && variant_skill_id.is_none()).then(|| {
+                find_action_argv(
+                    task,
+                    &retrieval_hints,
+                    FindActionKind::InspectVariants { limit },
+                    Some(&scan_id),
+                )
+            });
         let selected = select_explicit_variant(ranked, variant_skill_id)?;
-        let mut loaded = verified_top_skill_load(&scan_id, &scan, state_dir, &selected)?;
+        let mut loaded =
+            verified_top_skill_load(&scan_id, &scan, state_dir, &selected, ambiguity_retry_argv)?;
         if let Some(skill_id) = variant_skill_id {
             loaded["selection"]["ranking_evidence_scope"] = json!("ranked_capability_group");
             loaded["selection"]["variant_selection"] = json!({
@@ -4680,7 +4702,12 @@ fn find_command(
                         | Some(crate::query::VariantFindingState::SourceConfirmationRequired)
                 )
         }) {
-            actions.extend(explicit_variant_load_actions(task, &retrieval_hints, found));
+            actions.extend(explicit_variant_load_actions(
+                task,
+                &retrieval_hints,
+                found,
+                required_snapshot_id.map(|_| &scan_id),
+            ));
         }
     }
     let cjk_hint_required = retrieval_hints.is_empty() && crate::query::contains_cjk(task);
@@ -4730,6 +4757,7 @@ fn select_explicit_variant(
         mutation_scopes: Vec::new(),
         expected_digest: None,
         actual_digest: None,
+        retry_argv: None,
     };
     if ranked.variant_count <= 1 {
         return Err(blocked("variant_selector_requires_ambiguous_top_match").into());
@@ -4759,28 +4787,61 @@ fn select_explicit_variant(
     Ok(selected)
 }
 
+#[derive(Clone, Copy)]
+enum FindActionKind<'a> {
+    InspectVariants { limit: usize },
+    LoadVariant { skill_id: &'a str },
+}
+
+fn find_action_argv(
+    task: &str,
+    hints: &[String],
+    kind: FindActionKind<'_>,
+    required_snapshot_id: Option<&ScanId>,
+) -> Vec<String> {
+    let mut argv = vec!["find".to_owned(), task.to_owned()];
+    for hint in hints {
+        argv.extend(["--hint".to_owned(), hint.clone()]);
+    }
+    match kind {
+        FindActionKind::InspectVariants { limit } => {
+            argv.extend(["--limit".to_owned(), limit.to_string()]);
+        }
+        FindActionKind::LoadVariant { skill_id } => argv.extend([
+            "--load".to_owned(),
+            "--limit".to_owned(),
+            "1".to_owned(),
+            "--variant-skill-id".to_owned(),
+            skill_id.to_owned(),
+        ]),
+    }
+    if let Some(snapshot_id) = required_snapshot_id {
+        argv.extend(["--require-snapshot".to_owned(), snapshot_id.to_string()]);
+    }
+    argv.push("--json".to_owned());
+    argv
+}
+
 fn explicit_variant_load_actions(
     task: &str,
     hints: &[String],
     ranked: &crate::query::FindMatch,
+    required_snapshot_id: Option<&ScanId>,
 ) -> Vec<SuggestedAction> {
     ranked
         .variants
         .iter()
         .filter(|variant| !variant.paths.is_empty())
         .map(|variant| {
-            let mut argv = vec!["skillroster".to_owned(), "find".to_owned(), task.to_owned()];
-            for hint in hints {
-                argv.extend(["--hint".to_owned(), hint.clone()]);
-            }
-            argv.extend([
-                "--load".to_owned(),
-                "--limit".to_owned(),
-                "1".to_owned(),
-                "--variant-skill-id".to_owned(),
-                variant.skill_id.clone(),
-                "--json".to_owned(),
-            ]);
+            let mut argv = vec!["skillroster".to_owned()];
+            argv.extend(find_action_argv(
+                task,
+                hints,
+                FindActionKind::LoadVariant {
+                    skill_id: &variant.skill_id,
+                },
+                required_snapshot_id,
+            ));
             SuggestedAction {
                 action: "load_exact_variant_for_comparison".into(),
                 description: "load_exact_variant_for_comparison".into(),
@@ -5234,6 +5295,7 @@ fn verified_top_skill_load(
     scan: &ScanResult,
     state_dir: &Path,
     matched: &crate::query::FindMatch,
+    ambiguity_retry_argv: Option<Vec<String>>,
 ) -> Result<Value> {
     let blocked = |reason, path, expected_digest, actual_digest| SkillLoadBlocked {
         reason,
@@ -5248,6 +5310,7 @@ fn verified_top_skill_load(
             .collect(),
         expected_digest,
         actual_digest,
+        retry_argv: ambiguity_retry_argv.clone(),
     };
 
     if matched.variant_count != 1 {

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -12,6 +12,25 @@ use crate::scan;
 pub(super) const MAX_AGENT_LOADED_SKILL_BYTES: u64 = 128 * 1024;
 
 #[derive(Debug)]
+pub(super) struct FindSnapshotChanged {
+    pub(super) expected_snapshot_id: ScanId,
+    pub(super) actual_snapshot_id: ScanId,
+    pub(super) retry_argv: Vec<String>,
+}
+
+impl std::fmt::Display for FindSnapshotChanged {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Find recovery expected Snapshot {} but latest is {}",
+            self.expected_snapshot_id, self.actual_snapshot_id
+        )
+    }
+}
+
+impl std::error::Error for FindSnapshotChanged {}
+
+#[derive(Debug)]
 pub(super) struct SkillLoadBlocked {
     pub(super) reason: &'static str,
     pub(super) skill_id: String,
@@ -21,6 +40,7 @@ pub(super) struct SkillLoadBlocked {
     pub(super) mutation_scopes: Vec<String>,
     pub(super) expected_digest: Option<String>,
     pub(super) actual_digest: Option<String>,
+    pub(super) retry_argv: Option<Vec<String>>,
 }
 
 impl std::fmt::Display for SkillLoadBlocked {
@@ -66,6 +86,43 @@ pub fn error_json_with_context(
     error: &(dyn std::error::Error + 'static),
     action_context: &ActionContext,
 ) -> String {
+    if let Some(changed) = error.downcast_ref::<FindSnapshotChanged>() {
+        let mut envelope = JsonEnvelope::<Value>::failure(
+            command,
+            ApiError {
+                code: "find_snapshot_changed".into(),
+                message: error.to_string(),
+                retryable: true,
+                relevant_ids: vec![
+                    changed.expected_snapshot_id.to_string(),
+                    changed.actual_snapshot_id.to_string(),
+                ],
+                paths: Vec::new(),
+                details: Some(json!({
+                    "expected_snapshot_id": changed.expected_snapshot_id,
+                    "actual_snapshot_id": changed.actual_snapshot_id,
+                    "files_changed": false,
+                    "state_files_changed": false,
+                    "next_action": "rerun_find_on_latest_snapshot",
+                })),
+            },
+        );
+        let argv = changed
+            .retry_argv
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        envelope.suggested_actions = vec![action(
+            "rerun_find_on_latest_snapshot",
+            &argv,
+            false,
+            false,
+            "find_snapshot_changed",
+        )];
+        action_context.apply(&mut envelope.suggested_actions);
+        return serde_json::to_string(&envelope)
+            .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into());
+    }
     if let Some(rescan) = error.downcast_ref::<ContentIdentityRescanRequired>() {
         let mut envelope = JsonEnvelope::<Value>::failure(
             command,
@@ -140,28 +197,33 @@ pub fn error_json_with_context(
             },
         );
         let safe_retry = match blocked.reason {
-            "same_name_variants_ambiguous" | "no_routable_match" => Some((
+            "same_name_variants_ambiguous" => blocked.retry_argv.clone().map(|argv| {
+                (
+                    "inspect_same_name_variants",
+                    argv,
+                    "same_name_variants_ambiguous",
+                )
+            }),
+            "no_routable_match" => Some((
                 "inspect_current_report",
-                vec!["report", "--summary", "--json"],
+                vec!["report".into(), "--summary".into(), "--json".into()],
+                "verified_skill_load_blocked",
             )),
             "placement_missing_from_snapshot"
             | "package_fingerprint_incomplete"
             | "legacy_snapshot_requires_rescan"
             | "eligible_placement_missing"
             | "entrypoint_content_drift"
-            | "package_identity_drift" => {
-                Some(("refresh_snapshot", vec!["scan", "--summary", "--json"]))
-            }
+            | "package_identity_drift" => Some((
+                "refresh_snapshot",
+                vec!["scan".into(), "--summary".into(), "--json".into()],
+                "verified_skill_load_blocked",
+            )),
             _ => None,
         };
-        if let Some((name, argv)) = safe_retry {
-            envelope.suggested_actions = vec![action(
-                name,
-                &argv,
-                false,
-                false,
-                "verified_skill_load_blocked",
-            )];
+        if let Some((name, argv, reason_code)) = safe_retry {
+            let argv = argv.iter().map(String::as_str).collect::<Vec<_>>();
+            envelope.suggested_actions = vec![action(name, &argv, false, false, reason_code)];
             action_context.apply(&mut envelope.suggested_actions);
         }
         return serde_json::to_string(&envelope)
@@ -319,7 +381,7 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
     if let Some(blocker) = error.downcast_ref::<SkillLoadBlocked>() {
         let (next_action, retry_mode) = match blocker.reason {
             "same_name_variants_ambiguous" => {
-                ("inspect_variant_finding", "read_only_command_available")
+                ("inspect_same_name_variants", "read_only_command_available")
             }
             "variant_selector_requires_load" => (
                 "add_load_or_remove_variant_selector",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -217,6 +217,10 @@ pub struct FindArgs {
     /// Load one exact identity from an ambiguous Top-1 same-name group.
     #[arg(long, value_name = "SKILL_ID")]
     pub variant_skill_id: Option<String>,
+
+    /// Fail closed unless the latest Snapshot still matches this opaque ID.
+    #[arg(long, value_name = "SCAN_ID")]
+    pub require_snapshot: Option<String>,
 }
 
 pub const MAX_FIND_RESULTS: u16 = 100;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3262,6 +3262,12 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
                 .is_file()
         );
     }
+    let routing =
+        fs::read_to_string(bootstrap.parent().unwrap().join("references/routing.md")).unwrap();
+    assert!(routing.contains("inspect_same_name_variants"));
+    assert!(routing.contains("find_snapshot_changed"));
+    assert!(routing.contains("rerun_find_on_latest_snapshot"));
+    assert!(routing.contains("Do not reconstruct or rerun Find"));
     let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_eq!(current["result"]["state"], "up_to_date");
     assert!(current["result"]["plan_id"].is_null());
@@ -3372,7 +3378,7 @@ fn setup_upgrades_the_public_v1_8_23_package_and_undo_restores_every_file() {
         ),
         (
             "references/routing.md",
-            include_str!("../skill/skillroster/references/routing.md").to_owned(),
+            include_str!("fixtures/bootstrap-routing-v1.8.23.md").to_owned(),
         ),
         (
             "references/governance.md",
@@ -3409,13 +3415,13 @@ fn setup_upgrades_the_public_v1_8_23_package_and_undo_restores_every_file() {
         preview["result"]["targets"][0]["installed_version"],
         "1.8.23"
     );
-    assert_eq!(preview["result"]["operation_groups"]["replace_file"], 2);
+    assert_eq!(preview["result"]["operation_groups"]["replace_file"], 3);
     assert_eq!(preview["result"]["files_changed"], false);
 
     let plan_id = preview["result"]["plan_id"].as_str().unwrap();
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
     assert_eq!(applied["result"]["verification"], "passed");
-    assert_eq!(applied["result"]["changed_path_count"], 2);
+    assert_eq!(applied["result"]["changed_path_count"], 3);
     for (relative_path, expected) in [
         ("SKILL.md", include_str!("../skill/skillroster/SKILL.md")),
         (
@@ -7996,6 +8002,7 @@ fn archived_same_name_identity_cannot_return_through_active_variant() {
     ];
     let scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
     let snapshot = scan["result"]["snapshot_id"].as_str().unwrap();
+    json_output(&run(&[&common[..], &["report"]].concat(), None));
     let before = json_output(&run(
         &[&common[..], &["find", "active search marker"]].concat(),
         None,
@@ -8004,7 +8011,15 @@ fn archived_same_name_identity_cannot_return_through_active_variant() {
     let ambiguous_load = run(
         &[
             &common[..],
-            &["find", "active search marker", "--load", "--limit", "1"],
+            &[
+                "find",
+                "active search marker",
+                "--hint",
+                "inspect active identity",
+                "--load",
+                "--limit",
+                "1",
+            ],
         ]
         .concat(),
         None,
@@ -8015,16 +8030,75 @@ fn archived_same_name_identity_cannot_return_through_active_variant() {
         ambiguous_load["error"]["details"]["reason"],
         "same_name_variants_ambiguous"
     );
-    let retry_argv = ambiguous_load["suggested_actions"][0]["argv"]
-        .as_array()
-        .unwrap();
     assert_eq!(
-        &retry_argv[retry_argv.len() - 3..],
-        &[json!("report"), json!("--summary"), json!("--json")]
+        ambiguous_load["error"]["details"]["next_action"],
+        "inspect_same_name_variants"
     );
     assert_eq!(
-        ambiguous_load["suggested_actions"][0]["requires_confirmation"],
-        false
+        ambiguous_load["suggested_actions"][0],
+        json!({
+            "action": "inspect_same_name_variants",
+            "description": "inspect_same_name_variants",
+            "argv": [
+                "skillroster",
+                "--state-dir",
+                state,
+                "--home",
+                home,
+                "find",
+                "active search marker",
+                "--hint",
+                "inspect active identity",
+                "--limit",
+                "1",
+                "--require-snapshot",
+                snapshot,
+                "--json"
+            ],
+            "mutates": false,
+            "requires_confirmation": false,
+            "reason_code": "same_name_variants_ambiguous"
+        })
+    );
+    let variants = json_output(&run_suggested_action(
+        &ambiguous_load["suggested_actions"][0],
+    ));
+    assert_eq!(variants["result"]["matches"][0]["variant_count"], 2);
+    assert_eq!(
+        variants["result"]["matches"][0]["variant_finding"]["state"],
+        "available"
+    );
+    assert_eq!(
+        variants["result"]["matches"][0]["variant_finding"]["snapshot_id"],
+        snapshot
+    );
+    assert!(
+        variants["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|action| action["action"] == "inspect_variant_finding")
+    );
+    assert_eq!(
+        variants["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|action| action["action"] == "load_exact_variant_for_comparison")
+            .count(),
+        2
+    );
+    assert!(
+        variants["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|action| action["action"] == "load_exact_variant_for_comparison")
+            .all(|action| action["argv"]
+                .as_array()
+                .unwrap()
+                .windows(2)
+                .any(|pair| { pair == [json!("--require-snapshot"), json!(snapshot)] }))
     );
 
     let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
@@ -8118,6 +8192,52 @@ fn archived_same_name_identity_cannot_return_through_active_variant() {
         .concat(),
         None,
     ));
+
+    let newer_scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let stale_retry = run_suggested_action(&ambiguous_load["suggested_actions"][0]);
+    assert!(!stale_retry.status.success());
+    let stale_retry: Value = serde_json::from_slice(&stale_retry.stdout).unwrap();
+    assert_eq!(stale_retry["error"]["code"], "find_snapshot_changed");
+    assert_eq!(
+        stale_retry["error"]["details"]["expected_snapshot_id"],
+        snapshot
+    );
+    assert_eq!(
+        stale_retry["error"]["details"]["actual_snapshot_id"],
+        newer_scan["result"]["snapshot_id"]
+    );
+    assert_eq!(stale_retry["error"]["details"]["files_changed"], false);
+    assert!(stale_retry["result"].is_null());
+    let fresh_snapshot = newer_scan["result"]["snapshot_id"].as_str().unwrap();
+    let fresh_retry = &stale_retry["suggested_actions"][0];
+    assert_eq!(fresh_retry["action"], "rerun_find_on_latest_snapshot");
+    assert!(
+        fresh_retry["argv"]
+            .as_array()
+            .unwrap()
+            .windows(2)
+            .any(|pair| pair == [json!("--require-snapshot"), json!(fresh_snapshot)])
+    );
+
+    let fresh_variants = json_output(&run_suggested_action(fresh_retry));
+    assert_eq!(
+        fresh_variants["result"]["matches"][0]["variant_finding"]["snapshot_id"],
+        fresh_snapshot
+    );
+    let fresh_load_actions = fresh_variants["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|action| action["action"] == "load_exact_variant_for_comparison")
+        .collect::<Vec<_>>();
+    assert_eq!(fresh_load_actions.len(), 2);
+    assert!(fresh_load_actions.iter().all(|action| {
+        action["argv"]
+            .as_array()
+            .unwrap()
+            .windows(2)
+            .any(|pair| pair == [json!("--require-snapshot"), json!(fresh_snapshot)])
+    }));
 }
 
 #[test]

--- a/tests/fixtures/bootstrap-routing-v1.8.23.md
+++ b/tests/fixtures/bootstrap-routing-v1.8.23.md
@@ -12,19 +12,15 @@ and `augmented_channel_rank` to distinguish native task evidence from
 hint-expanded evidence. Retry at most once, only for an empty or wrong-domain
 result. Change only the hint; an English task may add one on its retry.
 
-When the blocker reason is `same_name_variants_ambiguous`, execute its returned
-read-only `inspect_same_name_variants` action. Do not reconstruct or rerun Find:
-the action preserves the original task and hint and binds the recovery to the
-same Snapshot. Keep each path and provider together. Materialize the current
-Report only when the returned result says `report_required`, then inspect that
-exact Finding. Use only the returned `load_exact_variant_for_comparison`
-actions to load the exact identities under comparison. If the recovery fails
-with `find_snapshot_changed`, execute only its returned read-only
-`rerun_find_on_latest_snapshot` action, then use the new result's Snapshot-bound
-exact variant actions. Require the requested and loaded Skill IDs to match and
-retain each identity's content, path, provider, and governance facts together.
-Compare the complete entrypoint instructions semantically and treat any choice
-as model-owned. Identical entrypoint digests do not resolve a divergent package
+When the blocker reason is `same_name_variants_ambiguous`, use the ordinary
+Find result and its read-only `variant_finding.argv`; keep each path and provider
+together. Materialize the current Report only when the result says
+`report_required`, then inspect that exact Finding. Use only the returned
+`load_exact_variant_for_comparison` actions to load the exact identities under
+comparison. Require the requested and loaded Skill IDs to match and retain each
+identity's content, path, provider, and governance facts together. Compare the
+complete entrypoint instructions semantically and treat any choice as
+model-owned. Identical entrypoint digests do not resolve a divergent package
 fingerprint; report the remaining package ambiguity instead of choosing a
 canonical identity. Exact loading does not canonicalize content, modify a
 Roster, or authorize a later Plan.


### PR DESCRIPTION
## Problem

A one-call Find load that was blocked by same-name variants told Agents to inspect variants, but did not return a directly executable recovery path. Recovery could also drift to a newer Scan between actions and silently change the evidence being compared.

## Solution

- return an inspect_same_name_variants read-only action that preserves task, hints, roots, limit, and Snapshot
- add require-snapshot as a public optimistic read boundary
- fail closed with find_snapshot_changed when the latest Scan changes
- bind each recovery retry and exact variant load to the latest observed Snapshot
- update product, Agent, and Bootstrap routing contracts
- freeze the historical v1.8.23 routing fixture so Bootstrap upgrades remain exact and reversible

## Verification

- bash scripts/ci-full-check.sh
- bash scripts/ci-change-scope.sh --self-test
- git diff --check
- independent Spec review: no findings
- independent Standards review: no findings

Closes #267