### PR TITLE
fix: bootstrap a detected Agent first Skill root

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -56,6 +56,7 @@ The Agent selects one primary action from current state:
 | Applied | Show verification and Receipt | 完成 |
 | Undo available | Show reverse impact on request | 撤销上次应用 |
 | Recovery required | Stop unrelated writes | 处理恢复 |
+| Agent detected, first Skill root missing | Show the fixed Bootstrap creation Plan and read-only boundary | 安装 Bootstrap |
 | Bootstrap modified | Show affected targets and ask retain/adopt | 保留本地 or 采用当前版 |
 | Bootstrap target unsupported | Explain the preserved link/non-file | 检查目标 |
 
@@ -276,6 +277,17 @@ After a CLI upgrade, the Agent runs `setup`. Exact official older bootstrap
 content produces a recoverable upgrade Plan. Locally modified content produces
 no Plan until the person explicitly chooses retain or adopt; unsupported
 targets remain untouched.
+
+### First Bootstrap install
+
+When the current Snapshot includes a supported Agent's session root but its
+fixed Skill root is missing, `setup` returns a read-only creation Plan for that
+adapter only and names `included_session_root` as the detection basis. The
+Agent shows the fixed directory and four-file impact before asking for Apply.
+Apply returns a Receipt, and Undo removes the newly created package and empty
+parent directories without touching the observed session root. With no
+included Skill or session root, Setup remains `no_supported_agent` and does not
+invent an Agent installation.
 
 ### Partial Evidence
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -254,6 +254,16 @@ bounded decision fields is not equivalent: it remains immutable and auditable,
 while Setup creates one decision-complete replacement. Both can temporarily
 appear as pending; the Agent presents only the newly returned Plan ID.
 
+Detection is Snapshot-bound and explicit. `existing_skill_root` means the
+Agent's fixed Skill root already exists. `included_session_root` means the
+current completed Snapshot included that Agent's fixed session root while its
+Skill root was genuinely missing. In the latter case Setup may plan only the
+fixed missing parent chain, Bootstrap package directories, and four managed
+files for that same adapter. A completely empty Home does not establish Agent
+presence and remains `no_supported_agent`. Planning is read-only; Apply still
+requires confirmation and produces a Receipt whose Undo restores both files
+and newly created directories.
+
 `find` preserves the user's original task and accepts repeatable Agent-authored
 retrieval hints. Hints let the semantic caller supply a cross-language or
 capability paraphrase while the CLI remains a deterministic local lexical

--- a/src/app.rs
+++ b/src/app.rs
@@ -5538,6 +5538,7 @@ fn plan_command(
         PlanOrigin::Agent,
         None,
         action_argv_prefix,
+        None,
     )
 }
 
@@ -5944,6 +5945,11 @@ enum PlanOrigin {
     BootstrapSetup,
     SourceUpdate,
     LibraryGovernance,
+}
+
+struct BootstrapPlanScope {
+    anchor_roots: Vec<PathBuf>,
+    missing_skill_roots: Vec<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
@@ -7142,6 +7148,7 @@ fn prepare_plan(
     origin: PlanOrigin,
     reuse_identity: Option<Value>,
     action_argv_prefix: &[String],
+    bootstrap_scope: Option<&BootstrapPlanScope>,
 ) -> Result<Value> {
     if store.recovery_required()? {
         bail!("recovery is required before another Plan can be prepared");
@@ -7196,6 +7203,11 @@ fn prepare_plan(
         &PrepareContext {
             approved_roots: {
                 let mut roots = approved_roots(&scan);
+                roots.extend(
+                    bootstrap_scope
+                        .into_iter()
+                        .flat_map(|scope| scope.anchor_roots.iter().cloned()),
+                );
                 roots.push(canonical_state_dir.join("library"));
                 roots.push(canonical_state_dir.join("plan-backups"));
                 roots
@@ -7204,7 +7216,11 @@ fn prepare_plan(
             operation_policy: match effective_origin {
                 PlanOrigin::Agent => OperationPolicy::GovernanceOnly,
                 PlanOrigin::RosterGovernance => OperationPolicy::LibraryGovernance,
-                PlanOrigin::BootstrapSetup => OperationPolicy::BootstrapSetup,
+                PlanOrigin::BootstrapSetup => OperationPolicy::BootstrapSetup {
+                    missing_skill_roots: bootstrap_scope
+                        .map(|scope| scope.missing_skill_roots.clone())
+                        .unwrap_or_default(),
+                },
                 PlanOrigin::SourceUpdate => OperationPolicy::SourceUpdate,
                 PlanOrigin::LibraryGovernance => OperationPolicy::LibraryGovernance,
             },
@@ -7892,7 +7908,7 @@ fn setup_command_with_manifests<'a>(
 ) -> Result<Value> {
     let bootstrap_content_version = content_version()
         .context("bundled Bootstrap Skill is missing metadata.bootstrap-version")?;
-    let Some(snapshot) = store.latest_completed_scan()? else {
+    let Some((snapshot_id, snapshot)) = store.latest_scan_payload::<ScanResult>()? else {
         return Ok(json!({
             "detected_agents": [],
             "targets": [],
@@ -7927,17 +7943,57 @@ fn setup_command_with_manifests<'a>(
     let mut physical_targets = BTreeSet::new();
     let mut planned_directories = BTreeSet::new();
     let mut planned_files = BTreeSet::new();
+    let mut bootstrap_anchor_roots = BTreeSet::new();
+    let mut bootstrap_missing_skill_roots = BTreeSet::new();
+    let physical_home = std::fs::canonicalize(home)
+        .with_context(|| format!("failed to resolve Home {}", home.display()))?;
+    let session_detected_agents = snapshot
+        .roots
+        .iter()
+        .filter(|root| root.kind == RootKind::Sessions && root.status == scan::RootStatus::Included)
+        .filter_map(|root| root.agent)
+        .collect::<BTreeSet<_>>();
     for roots in harness::known_agent_roots(home) {
-        for root in roots.skill_roots.into_iter().filter(|path| path.is_dir()) {
+        let agent = roots.agent;
+        let detected_by_session = session_detected_agents.contains(&agent);
+        let skill_roots = roots
+            .skill_roots
+            .into_iter()
+            .filter_map(|root| {
+                if root.is_dir() {
+                    return Some((root, "existing_skill_root"));
+                }
+                let missing = std::fs::symlink_metadata(&root)
+                    .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound);
+                (detected_by_session && missing).then_some((root, "included_session_root"))
+            })
+            .collect::<Vec<_>>();
+        for (root, detection_basis) in skill_roots {
             let directory = root.join("skillroster");
             let entrypoint = directory.join("SKILL.md");
-            let physical_root = std::fs::canonicalize(&root).with_context(|| {
-                format!("failed to resolve Agent Skill root {}", root.display())
-            })?;
+            let root_missing = !root.exists();
+            let physical_root = if root_missing {
+                let relative = root.strip_prefix(home).with_context(|| {
+                    format!("Agent Skill root {} is outside Home", root.display())
+                })?;
+                bootstrap_anchor_roots.insert(home.to_path_buf());
+                physical_home.join(relative)
+            } else {
+                std::fs::canonicalize(&root).with_context(|| {
+                    format!("failed to resolve Agent Skill root {}", root.display())
+                })?
+            };
             let physical_directory = physical_root.join("skillroster");
             let physical_entrypoint = physical_directory.join("SKILL.md");
             physical_targets.insert(physical_directory.clone());
-            detected.push(json!({"agent": roots.agent.id(), "target": entrypoint}));
+            if root_missing {
+                bootstrap_missing_skill_roots.insert(physical_root.clone());
+            }
+            detected.push(json!({
+                "agent": agent.id(),
+                "detection_basis": detection_basis,
+                "target": entrypoint
+            }));
             let directory_is_unsupported = match std::fs::symlink_metadata(&directory) {
                 Ok(metadata) => metadata.file_type().is_symlink() || !metadata.file_type().is_dir(),
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
@@ -8010,6 +8066,34 @@ fn setup_command_with_manifests<'a>(
                 || (package_status == "modified"
                     && matches!(modified_choice, Some(ModifiedBootstrapChoice::AdoptCurrent)));
             if should_install {
+                if root_missing {
+                    let mut missing_directories = Vec::new();
+                    let mut cursor = Some(root.as_path());
+                    while let Some(path) = cursor {
+                        if path.exists() {
+                            break;
+                        }
+                        if path == home {
+                            break;
+                        }
+                        missing_directories.push(path.to_path_buf());
+                        cursor = path.parent();
+                    }
+                    missing_directories.reverse();
+                    for target in missing_directories {
+                        let relative = target.strip_prefix(home).with_context(|| {
+                            format!("Bootstrap target {} is outside Home", target.display())
+                        })?;
+                        let physical_target = physical_home.join(relative);
+                        if planned_directories.insert(physical_target) {
+                            operations.push(json!({
+                                "kind": "create_directory",
+                                "target": target,
+                                "expected_fingerprint": "missing"
+                            }));
+                        }
+                    }
+                }
                 if package_missing && planned_directories.insert(physical_directory.clone()) {
                     operations.push(json!({
                         "kind": "create_directory",
@@ -8053,7 +8137,8 @@ fn setup_command_with_manifests<'a>(
                 }
             }
             targets.push(json!({
-                "agent": roots.agent.id(),
+                "agent": agent.id(),
+                "detection_basis": detection_basis,
                 "target": entrypoint,
                 "physical_target": physical_entrypoint,
                 "status": package_status,
@@ -8118,10 +8203,14 @@ fn setup_command_with_manifests<'a>(
         });
         return Ok(result);
     }
+    let bootstrap_scope = BootstrapPlanScope {
+        anchor_roots: bootstrap_anchor_roots.into_iter().collect(),
+        missing_skill_roots: bootstrap_missing_skill_roots.into_iter().collect(),
+    };
     let plan = prepare_plan(
         store,
         state_dir,
-        json!({"schema_version": 1, "scan_id": snapshot.id, "operations": operations}),
+        json!({"schema_version": 1, "scan_id": snapshot_id, "operations": operations}),
         PlanOrigin::BootstrapSetup,
         Some(json!({
             "modified_choice": match modified_choice {
@@ -8131,6 +8220,7 @@ fn setup_command_with_manifests<'a>(
             }
         })),
         &[],
+        Some(&bootstrap_scope),
     )?;
     let operation_count = plan["change_summary"]["operation_count"]
         .as_u64()

--- a/src/change.rs
+++ b/src/change.rs
@@ -123,10 +123,12 @@ pub struct PrepareContext {
     pub(crate) operation_policy: OperationPolicy,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum OperationPolicy {
     GovernanceOnly,
-    BootstrapSetup,
+    BootstrapSetup {
+        missing_skill_roots: Vec<PathBuf>,
+    },
     SourceUpdate,
     LibraryGovernance,
     #[cfg(test)]
@@ -411,14 +413,14 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
             "a plan must contain a filesystem operation or Roster change",
         ));
     }
-    match ctx.operation_policy {
+    match &ctx.operation_policy {
         OperationPolicy::GovernanceOnly if !input.operations.is_empty() => {
             return Err(ChangeError::new(
                 "operations_not_declarative",
                 "Agent-authored Plans may request Roster state changes only; filesystem operations are derived by trusted SkillRoster workflows",
             ));
         }
-        OperationPolicy::BootstrapSetup
+        OperationPolicy::BootstrapSetup { .. }
             if input.operations.iter().any(|operation| {
                 !matches!(
                     operation,
@@ -477,7 +479,11 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
     }
 
     let state_dir = canonical_directory(&ctx.state_dir, "state_dir")?;
-    let bootstrap_roots = if matches!(ctx.operation_policy, OperationPolicy::BootstrapSetup) {
+    let roots = normalize_roots(&ctx.approved_roots, &state_dir)?;
+    let bootstrap_roots = if matches!(
+        &ctx.operation_policy,
+        OperationPolicy::BootstrapSetup { .. }
+    ) {
         let roots = ctx
             .approved_roots
             .iter()
@@ -494,8 +500,19 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
     } else {
         Vec::new()
     };
-    let roots = normalize_roots(&ctx.approved_roots, &state_dir)?;
-    if roots.iter().any(|root| {
+    let bootstrap_missing_skill_roots = match &ctx.operation_policy {
+        OperationPolicy::BootstrapSetup {
+            missing_skill_roots,
+        } => missing_skill_roots
+            .iter()
+            .map(|root| normalize_target(root, &bootstrap_roots))
+            .collect::<Result<Vec<_>>>()?,
+        _ => Vec::new(),
+    };
+    if !matches!(
+        &ctx.operation_policy,
+        OperationPolicy::BootstrapSetup { .. }
+    ) && roots.iter().any(|root| {
         (state_dir.starts_with(root) || root.starts_with(&state_dir))
             && !is_controlled_state_root(root, &state_dir)
     }) {
@@ -512,10 +529,25 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
     let mut projected_fingerprints: HashMap<PathBuf, String> = HashMap::new();
     for raw in input.operations {
         let operation = normalize_operation(raw, &roots, &projected_present)?;
-        if matches!(ctx.operation_policy, OperationPolicy::BootstrapSetup) {
-            validate_bootstrap_operation_target(&operation, &bootstrap_roots)?;
+        if matches!(
+            &ctx.operation_policy,
+            OperationPolicy::BootstrapSetup { .. }
+        ) {
+            validate_bootstrap_operation_target(
+                &operation,
+                &bootstrap_roots,
+                &bootstrap_missing_skill_roots,
+            )?;
         }
         let target = operation.target().to_path_buf();
+        if (state_dir.starts_with(&target) || target.starts_with(&state_dir))
+            && !is_controlled_state_path(&target, &state_dir)
+        {
+            return Err(ChangeError::new(
+                "unsafe_state_directory",
+                "operation target must be separate from the state directory",
+            ));
+        }
         if !targets.insert(target.clone()) {
             return Err(ChangeError::new(
                 "ambiguous_target",
@@ -536,6 +568,19 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
             &mut projected_fingerprints,
         );
         operations.push(operation);
+    }
+    if matches!(
+        &ctx.operation_policy,
+        OperationPolicy::BootstrapSetup { .. }
+    ) && operations
+        .iter()
+        .filter_map(|operation| bootstrap_skill_root(operation.target()))
+        .any(|root| state_dir.starts_with(root) || root.starts_with(&state_dir))
+    {
+        return Err(ChangeError::new(
+            "unsafe_state_directory",
+            "state_dir must be separate from Bootstrap Skill roots",
+        ));
     }
 
     let digest_payload = serde_json::to_vec(&(
@@ -1124,21 +1169,44 @@ fn normalize_operation(
     Ok(normalized)
 }
 
-fn validate_bootstrap_operation_target(operation: &Operation, roots: &[PathBuf]) -> Result<()> {
+fn validate_bootstrap_operation_target(
+    operation: &Operation,
+    roots: &[PathBuf],
+    missing_skill_roots: &[PathBuf],
+) -> Result<()> {
     let allowed = roots.iter().any(|root| {
-        let Ok(relative) = operation.target().strip_prefix(root) else {
+        let target = operation.target();
+        let Ok(relative) = target.strip_prefix(root) else {
             return false;
         };
-        match operation {
+        let package_target_allowed = |relative_to_skill_root: &Path| match operation {
             Operation::CreateDirectory { .. } => {
-                relative == Path::new("skillroster")
-                    || relative == Path::new("skillroster/references")
+                relative_to_skill_root.as_os_str().is_empty()
+                    || relative_to_skill_root == Path::new("skillroster")
+                    || relative_to_skill_root == Path::new("skillroster/references")
             }
             Operation::WriteFile { .. } | Operation::ReplaceFile { .. } => {
-                crate::bootstrap::is_managed_target(relative)
+                crate::bootstrap::is_managed_target(relative_to_skill_root)
             }
             _ => false,
+        };
+        let is_anchor = missing_skill_roots
+            .iter()
+            .any(|skill_root| skill_root != root && skill_root.starts_with(root));
+        if !is_anchor && package_target_allowed(relative) {
+            return true;
         }
+        missing_skill_roots.iter().any(|skill_root| {
+            if matches!(operation, Operation::CreateDirectory { .. })
+                && target != root
+                && skill_root.starts_with(target)
+            {
+                return true;
+            }
+            target
+                .strip_prefix(skill_root)
+                .is_ok_and(package_target_allowed)
+        })
     });
     if !allowed {
         return Err(ChangeError::new(
@@ -1150,6 +1218,13 @@ fn validate_bootstrap_operation_target(operation: &Operation, roots: &[PathBuf])
         ));
     }
     Ok(())
+}
+
+fn bootstrap_skill_root(target: &Path) -> Option<&Path> {
+    target
+        .ancestors()
+        .find(|ancestor| ancestor.file_name() == Some(OsStr::new("skillroster")))
+        .and_then(Path::parent)
 }
 
 fn validate_current_state(operation: &Operation, roots: &[PathBuf]) -> Result<()> {
@@ -2015,6 +2090,10 @@ fn normalize_roots(roots: &[PathBuf], state_dir: &Path) -> Result<Vec<PathBuf>> 
 
 fn is_controlled_state_root(root: &Path, state_dir: &Path) -> bool {
     root == state_dir.join("library") || root == state_dir.join("plan-backups")
+}
+
+fn is_controlled_state_path(path: &Path, state_dir: &Path) -> bool {
+    path.starts_with(state_dir.join("library")) || path.starts_with(state_dir.join("plan-backups"))
 }
 
 fn canonical_directory(path: &Path, label: &str) -> Result<PathBuf> {
@@ -3005,7 +3084,9 @@ mod tests {
 
     #[test]
     fn bootstrap_setup_accepts_only_fixed_package_targets() {
-        let (_temp, root, state) = fixture();
+        let (_temp, home, state) = fixture();
+        let root = home.join(".codex/skills");
+        fs::create_dir_all(&root).unwrap();
         let library = state.join("library");
         let plan_backups = state.join("plan-backups");
         fs::create_dir(&library).unwrap();
@@ -3013,7 +3094,9 @@ mod tests {
         let context = PrepareContext {
             approved_roots: vec![root.clone(), library.clone(), plan_backups.clone()],
             state_dir: state,
-            operation_policy: OperationPolicy::BootstrapSetup,
+            operation_policy: OperationPolicy::BootstrapSetup {
+                missing_skill_roots: Vec::new(),
+            },
         };
         let allowed = serde_json::json!({
             "schema_version": 1,
@@ -3052,6 +3135,65 @@ mod tests {
         }
     }
 
+    #[test]
+    fn bootstrap_home_anchor_rejects_state_inside_the_fixed_skill_root() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let state = home.join(".codex/skills/state");
+        fs::create_dir_all(&state).unwrap();
+        let context = PrepareContext {
+            approved_roots: vec![home.clone()],
+            state_dir: state,
+            operation_policy: OperationPolicy::BootstrapSetup {
+                missing_skill_roots: vec![home.join(".codex/skills")],
+            },
+        };
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "write_file",
+                "target": home.join(".codex/skills/skillroster/SKILL.md"),
+                "content": "bootstrap",
+                "expected_fingerprint": "missing"
+            }]
+        })
+        .to_string();
+
+        assert_eq!(
+            prepare(&input, &context).unwrap_err().code,
+            "unsafe_state_directory"
+        );
+    }
+
+    #[test]
+    fn bootstrap_home_anchor_rejects_an_undetected_agent_root() {
+        let (_temp, home, state) = fixture();
+        let context = PrepareContext {
+            approved_roots: vec![home.clone()],
+            state_dir: state,
+            operation_policy: OperationPolicy::BootstrapSetup {
+                missing_skill_roots: vec![home.join(".codex/skills")],
+            },
+        };
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "write_file",
+                "target": home.join(".claude/skills/skillroster/SKILL.md"),
+                "content": "unexpected",
+                "expected_fingerprint": "missing"
+            }]
+        })
+        .to_string();
+
+        assert_eq!(
+            prepare(&input, &context).unwrap_err().code,
+            "invalid_setup_target"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn bootstrap_setup_rejects_agent_root_aliases_to_controlled_state_roots() {
@@ -3069,7 +3211,9 @@ mod tests {
         let context = PrepareContext {
             approved_roots: vec![library_alias.clone(), backups_alias.clone()],
             state_dir: state,
-            operation_policy: OperationPolicy::BootstrapSetup,
+            operation_policy: OperationPolicy::BootstrapSetup {
+                missing_skill_roots: Vec::new(),
+            },
         };
 
         for target in [

--- a/src/present.rs
+++ b/src/present.rs
@@ -1537,6 +1537,18 @@ fn setup(value: &Value, lines: &mut Vec<String>, width: usize) {
         "Detected Agents",
         array_len(value, "detected_agents"),
     );
+    let first_skill_roots = value
+        .get("detected_agents")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|agent| {
+            agent.get("detection_basis").and_then(Value::as_str) == Some("included_session_root")
+        })
+        .count();
+    if first_skill_roots > 0 {
+        fact(lines, "First Skill roots", first_skill_roots.to_string());
+    }
     fact(
         lines,
         "Physical targets",
@@ -2047,6 +2059,36 @@ mod tests {
         );
         assert!(unsupported.contains("unsupported bootstrap targets were preserved"));
         assert!(unsupported.contains("Unsupported            1"));
+    }
+
+    #[test]
+    fn setup_output_names_a_first_skill_root_plan() {
+        let output = render(
+            "setup",
+            &json!({
+                "state": "preview_ready",
+                "cli_version": "1.8.29",
+                "bootstrap_content_version": "1.8.29",
+                "detected_agents": [{
+                    "agent": "codex",
+                    "detection_basis": "included_session_root"
+                }],
+                "physical_target_count": 1,
+                "current_count": 0,
+                "missing_count": 1,
+                "outdated_count": 0,
+                "modified_count": 0,
+                "unsupported_count": 0,
+                "plan_id": "plan_1",
+                "targets": []
+            }),
+            RenderOptions {
+                width: 80,
+                styled: false,
+            },
+        );
+        assert!(output.contains("First Skill roots      1"));
+        assert!(output.contains("Preview only · no files changed"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3386,7 +3386,7 @@ fn setup_upgrades_the_public_v1_8_23_package_and_undo_restores_every_file() {
         ),
         (
             "references/mutation.md",
-            include_str!("../skill/skillroster/references/mutation.md").to_owned(),
+            include_str!("fixtures/bootstrap-mutation-v1.8.23.md").to_owned(),
         ),
     ];
     for (relative_path, content) in &legacy_files {
@@ -3415,13 +3415,13 @@ fn setup_upgrades_the_public_v1_8_23_package_and_undo_restores_every_file() {
         preview["result"]["targets"][0]["installed_version"],
         "1.8.23"
     );
-    assert_eq!(preview["result"]["operation_groups"]["replace_file"], 3);
+    assert_eq!(preview["result"]["operation_groups"]["replace_file"], 4);
     assert_eq!(preview["result"]["files_changed"], false);
 
     let plan_id = preview["result"]["plan_id"].as_str().unwrap();
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
     assert_eq!(applied["result"]["verification"], "passed");
-    assert_eq!(applied["result"]["changed_path_count"], 3);
+    assert_eq!(applied["result"]["changed_path_count"], 4);
     for (relative_path, expected) in [
         ("SKILL.md", include_str!("../skill/skillroster/SKILL.md")),
         (
@@ -4075,6 +4075,169 @@ fn setup_without_a_snapshot_returns_a_typed_scan_action() {
         output["suggested_actions"][0]["argv"],
         context_action_argv(&home, &state, &["scan", "--summary", "--json"])
     );
+}
+
+#[test]
+fn setup_bootstraps_a_detected_agent_before_its_first_skill_root_exists() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let sessions = home.join(".codex/sessions");
+    let skill_root = home.join(".codex/skills");
+    fs::create_dir_all(&sessions).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    let scan = json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+    assert_eq!(scan["result"]["placement_count"], 0);
+    assert_eq!(
+        scan["result"]["root_counts"],
+        json!([
+            {"count": 8, "kind": "skills", "status": "missing"},
+            {"count": 1, "kind": "sessions", "status": "included"},
+            {"count": 7, "kind": "sessions", "status": "missing"}
+        ])
+    );
+    assert!(!skill_root.exists());
+
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(setup["result"]["state"], "preview_ready");
+    assert_setup_versions(&setup);
+    assert_eq!(
+        setup["result"]["detected_agents"],
+        json!([{
+            "agent": "codex",
+            "detection_basis": "included_session_root",
+            "target": skill_root.join("skillroster/SKILL.md")
+        }])
+    );
+    assert_eq!(setup["result"]["missing_count"], 1);
+    assert_eq!(setup["result"]["physical_target_count"], 1);
+    assert_eq!(setup["result"]["operation_count"], 7);
+    assert_eq!(setup["result"]["operation_groups"]["create_directory"], 3);
+    assert_eq!(setup["result"]["operation_groups"]["write_file"], 4);
+    assert_eq!(setup["result"]["canonical_deletion_count"], 0);
+    assert_eq!(setup["result"]["files_changed"], false);
+    assert_eq!(setup["result"]["confirmation_required"], true);
+    assert!(!skill_root.exists());
+
+    let plan_id = setup["result"]["plan_id"].as_str().unwrap();
+    let detail = json_output(&run(
+        &[&common[..], &["plan", "--show", plan_id]].concat(),
+        None,
+    ));
+    let physical_skill_root = fs::canonicalize(skill_root.parent().unwrap())
+        .unwrap()
+        .join("skills");
+    assert!(
+        detail["result"]["operations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|operation| {
+                operation["kind"] == "create_directory"
+                    && operation["target"] == json!(physical_skill_root)
+            })
+    );
+
+    let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+    assert_eq!(applied["result"]["verification"], "passed");
+    assert!(skill_root.join("skillroster/SKILL.md").is_file());
+    assert!(
+        skill_root
+            .join("skillroster/references/routing.md")
+            .is_file()
+    );
+    assert!(
+        skill_root
+            .join("skillroster/references/governance.md")
+            .is_file()
+    );
+    assert!(
+        skill_root
+            .join("skillroster/references/mutation.md")
+            .is_file()
+    );
+
+    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert!(!skill_root.exists());
+    assert!(sessions.is_dir());
+}
+
+#[test]
+fn setup_builds_only_the_fixed_missing_skill_root_chain_for_a_detected_agent() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let sessions = home.join(".local/share/opencode/storage/session");
+    let config = home.join(".config");
+    let skill_root = config.join("opencode/skills");
+    fs::create_dir_all(&sessions).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(setup["result"]["state"], "preview_ready");
+    assert_eq!(
+        setup["result"]["detected_agents"],
+        json!([{
+            "agent": "opencode",
+            "detection_basis": "included_session_root",
+            "target": skill_root.join("skillroster/SKILL.md")
+        }])
+    );
+    assert_eq!(setup["result"]["operation_count"], 9);
+    assert_eq!(setup["result"]["operation_groups"]["create_directory"], 5);
+    assert_eq!(setup["result"]["operation_groups"]["write_file"], 4);
+    assert!(!config.exists());
+
+    let plan_id = setup["result"]["plan_id"].as_str().unwrap();
+    let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+    assert_eq!(applied["result"]["verification"], "passed");
+    assert!(skill_root.join("skillroster/SKILL.md").is_file());
+
+    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert!(!config.exists());
+    assert!(sessions.is_dir());
+}
+
+#[test]
+fn setup_does_not_invent_agent_presence_from_known_missing_roots() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(setup["result"]["state"], "no_supported_agent");
+    assert_eq!(setup["result"]["detected_agents"], json!([]));
+    assert!(setup["result"]["plan_id"].is_null());
+    assert_eq!(setup["result"]["files_changed"], false);
+    assert_eq!(setup["suggested_actions"], json!([]));
+    assert_eq!(fs::read_dir(&home).unwrap().count(), 0);
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4113,7 +4113,7 @@ fn setup_bootstraps_a_detected_agent_before_its_first_skill_root_exists() {
         json!([{
             "agent": "codex",
             "detection_basis": "included_session_root",
-            "target": skill_root.join("skillroster/SKILL.md")
+            "target": skill_root.join("skillroster").join("SKILL.md")
         }])
     );
     assert_eq!(setup["result"]["missing_count"], 1);
@@ -4196,7 +4196,7 @@ fn setup_builds_only_the_fixed_missing_skill_root_chain_for_a_detected_agent() {
         json!([{
             "agent": "opencode",
             "detection_basis": "included_session_root",
-            "target": skill_root.join("skillroster/SKILL.md")
+            "target": skill_root.join("skillroster").join("SKILL.md")
         }])
     );
     assert_eq!(setup["result"]["operation_count"], 9);

--- a/tests/fixtures/bootstrap-mutation-v1.8.23.md
+++ b/tests/fixtures/bootstrap-mutation-v1.8.23.md
@@ -8,14 +8,6 @@ package. An exact official older package produces a recoverable Plan. When
 `retain-local` or `adopt-current`; never choose for the user. Unsupported links
 or non-files remain blocked.
 
-Read each target's `detection_basis`. `existing_skill_root` means the fixed
-Agent Skill root already exists. `included_session_root` is current-Snapshot
-evidence that the same Agent is present before its first Skill root exists;
-show the fixed parent-directory and four-file Plan, and do not infer any other
-Agent. `no_supported_agent` means the Snapshot included neither a supported
-Skill root nor session root, so do not invent a target. Setup remains preview
-only until the person confirms the ordinary Apply action.
-
 ## Apply
 
 Before `skillroster apply PLAN_ID --json`, show the complete bounded Plan impact


### PR DESCRIPTION
## Summary

- let `setup` prepare the first Bootstrap Skill root when the current Snapshot includes that Agent's session root
- bind first-install validation to the exact Snapshot-detected missing Skill roots and keep empty Homes non-speculative
- preserve preview-only confirmation, Receipt, byte-exact Undo, shared-root deduplication, and state-directory isolation
- document `detection_basis` in the product, Agent experience, and Bootstrap mutation contracts
- freeze the released v1.8.23 mutation fixture so exact legacy upgrades remain testable

## Representative result

An isolated Home containing only `.codex/sessions` now returns `preview_ready` for Codex only, with `detection_basis: included_session_root`, 3 directory creations, 4 managed-file writes, `confirmation_required: true`, and `files_changed: false`. Apply verifies all 7 paths and returns a Receipt; Undo removes the created Skill root while preserving sessions.

## Checks

- `bash scripts/ci-full-check.sh`
  - Rust: 296 unit, 8 acceptance, 77 CLI
  - Node harness: 137
  - strict Clippy, rustfmt, README value, and installation-surface checks
- `git diff --check`
- two-axis review: Standards 0 findings, Spec 0 findings after fixing the exact-adapter validation gap
- isolated candidate dogfood: Scan → Setup → Apply → Receipt → Undo passed

Closes #269
