### PR TITLE
fix: invalidate stale snapshots after mutation

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -155,11 +155,25 @@ The precise wording adapts to the user's language and the host Agent, but the fa
 - 验证：目标、链接和索引均符合方案
 - Receipt：rcpt_01M...
 - Canonical Skill 删除：0
+- 当前事实：需执行返回的只读 Scan 后再使用 Report 或 Find
 
-如需恢复，回复“撤销这次整理”。
+先执行返回的 Scan 刷新事实；如需恢复，Receipt 的撤销入口仍然可用。
 ```
 
 If Apply failed but compensation succeeded, say that no planned state remains and identify the Receipt. If recovery is required, lead with that state, list the unresolved target, and do not offer another Apply.
+
+After a verified Apply, the Agent follows the returned read-only Scan action
+before using Report, Find, Plan, Setup, or another current-inventory decision.
+It does not hide this required continuation or infer it from prose. Status and
+the exact Receipt Undo remain usable. If exact Undo verifies before a new Scan,
+the original Snapshot becomes current again. If a newer Scan already observed
+the applied state, Undo returns another required Scan before current-inventory
+decisions resume.
+
+While facts are invalid, Status names `snapshot_state: rescan_required`, binds
+the invalidating Receipt ID, and returns the same read-only Scan continuation.
+The Agent follows recovery first when required, then stale-fact refresh, then
+ordinary pending-Plan inspection.
 
 ## 7. Drill-down behavior
 
@@ -199,6 +213,8 @@ The single `skillroster` bootstrap Skill must instruct every supported Agent to:
 - require one explicit user confirmation for Apply or Undo;
 - never use `--force`, `--yes`, hidden shell writes, or direct filesystem substitutes;
 - preserve the same report/Snapshot across follow-up questions;
+- after verified Apply, follow the returned Scan before using current inventory
+  facts; keep the exact Receipt Undo available while that Snapshot is stale;
 - state whether files changed in every final response;
 - stop when drift, ambiguity, unsupported scope, or recovery-required state appears.
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -156,6 +156,20 @@ Agent callers never need to parse the human message.
 
 Apply fails closed when paths, fingerprints, links, or configuration have drifted. Every successful mutation writes a Receipt. `undo <receipt-id>` is bounded to that Receipt and refuses ambiguous restoration. Canonical deletion is outside normal Apply, requires separate confirmation, and should prefer recoverable archive.
 
+A verified Applied Receipt invalidates the completed Snapshot on which its Plan
+was based because the mutation changed inventory facts after that observation.
+Until a newer Scan completes, commands that require current inventory facts
+fail with typed `snapshot_rescan_required` details and one read-only Scan
+continuation. Apply returns `rescan_required: true` and keeps both the required
+Scan and exact Receipt Undo actions visible. Status, lifecycle recovery, and
+Undo remain available while facts are stale. If no newer Scan completed after
+Apply, verified exact Undo consumes the Applied Receipt and restores the
+pre-Apply state, so that original Snapshot is current again without a redundant
+Scan. If a newer Scan observed the applied state, Undo invalidates that newer
+Snapshot and returns its own required Scan continuation. Failed-and-compensated
+Apply never invalidates a Snapshot; recovery-required state keeps its existing
+recovery boundary.
+
 File replacement copies the original through an exclusively created staging
 handle and restores its platform permissions before publication. Unix
 permission bits and Windows file attributes, including readonly, must therefore
@@ -461,17 +475,29 @@ SkillRoster uses one SQLite database at `~/.skillroster/skillroster.db`, includi
 - Plans and Receipts remain until explicitly purged.
 - Overflow source-confirmation details are versioned local artifacts retained until explicitly purged or local state is deleted.
 - `status` exposes storage location, retention state, and retained source-confirmation artifact counts and bytes.
+- `status` remains read-only and available when current inventory facts are
+  invalid. It exposes typed `snapshot_state`, the invalidating Receipt ID, and
+  the required Scan continuation. Recovery inspection remains higher priority;
+  stale-Snapshot refresh remains higher priority than inspecting another Ready
+  Plan derived from those stale facts.
+- The v11 migration backfills mutation invalidations from legacy second-resolution
+  timestamps. When a legacy Undo and the latest Scan completed in the same
+  second, their exact order is unknowable; migration fails closed and requires
+  one fresh Scan. New v11 mutations persist the exact invalidation relation and
+  do not use this timestamp inference.
 - `status.pending_plans` contains only actionable Ready Plans for the latest
   Snapshot plus any Applying or Recovery-required Plans. Ready Plans from older
   Snapshots remain inspectable history but are not presented as pending work.
   The total count remains exact while the returned list is capped and reports
   whether additional pending Plans were truncated.
-- When pending work exists, `status` routes the Agent to inspect the first Plan
-  from that deterministic bounded ordering before considering a new Scan.
-  Recovery inspection remains higher priority, and the action is read-only.
-- `status` suggests Scan only when no completed Snapshot exists. A healthy
-  state with a Snapshot exposes its timestamp and leaves refresh judgment to
-  the Agent instead of creating an unconditional Status-to-Scan loop.
+- When `snapshot_state == current` and pending work exists, `status` routes the
+  Agent to inspect the first Plan from that deterministic bounded ordering
+  before considering a new Scan. Recovery inspection remains higher priority,
+  and the action is read-only.
+- When `snapshot_state == current`, `status` does not suggest an unconditional
+  Scan. A healthy state exposes the Snapshot timestamp and leaves refresh
+  judgment to the Agent. Missing or invalidated Snapshots instead expose the
+  required Scan continuation described above.
 - Users can inspect, export, purge, or delete retained local state and rebuild inventory by scanning again.
 
 Reports may identify structural and provenance risks—unknown source, changed content, executable scripts, declaration mismatch, and escaping links—but must not claim malware detection or runtime safety.

--- a/skill/skillroster/references/mutation.md
+++ b/skill/skillroster/references/mutation.md
@@ -23,6 +23,15 @@ and obtain one explicit confirmation. Do not replace the Plan with filesystem
 commands or bypass drift checks. Report verification, changed-path count,
 Receipt ID, and canonical deletion count.
 
+A verified Apply returns `rescan_required: true`. Follow its read-only Scan
+action before Report, Find, Plan, Setup, source confirmation, or another Apply;
+the Plan's Snapshot predates the verified mutation and is no longer current.
+Keep the exact Receipt Undo action available. Status, recovery inspection, and
+Undo remain valid before that Scan. If exact Undo verifies first, the original
+Snapshot is current again and no redundant Scan is required. If a newer Scan
+already observed the applied state, verified Undo returns its own required Scan
+action; follow it before using current inventory facts.
+
 “Complete” means every affected Agent, Skill, placement, operation group,
 exclusion, risk, and before/after delta is accounted for by count. It does not
 mean dumping every internal operation. Load stored Plan detail only for exact

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,7 +37,7 @@ mod error;
 
 use error::{
     ContentIdentityRescanRequired, FindSnapshotChanged, LibraryRootConflict,
-    MAX_AGENT_LOADED_SKILL_BYTES, PlanSnapshotDrift, SkillLoadBlocked,
+    MAX_AGENT_LOADED_SKILL_BYTES, PlanSnapshotDrift, SkillLoadBlocked, SnapshotRescanRequired,
     StoredFindingCoverageInvalid, incomplete_fingerprint_blocker,
 };
 pub use error::{error_json, error_json_with_context};
@@ -135,6 +135,8 @@ pub fn run(cli: Cli) -> Result<Output> {
                     false,
                     "snapshot_required",
                 )]
+            } else if result["snapshot_state"] == "rescan_required" {
+                vec![snapshot_rescan_action()]
             } else if let Some(plan_id) = result["pending_plans"]
                 .as_array()
                 .and_then(|plans| plans.first())
@@ -365,24 +367,27 @@ pub fn run(cli: Cli) -> Result<Output> {
                 }
             }
             let progress = crate::present::ProgressGuard::start("apply", cli.json);
-            let result = apply_command(&store, &args.id, &state_lock)?;
+            let mut result = apply_command(&store, &args.id, &state_lock)?;
             progress.finish();
             let id = result["receipt_id"]
                 .as_str()
                 .unwrap_or_default()
                 .to_string();
-            (
-                "apply",
-                result,
-                vec![],
-                vec![action(
-                    "undo",
-                    &["undo", &id, "--json"],
-                    true,
-                    true,
-                    "receipt_undoable",
-                )],
-            )
+            let rescan_required = result["verification"].as_str() == Some("passed")
+                && result["status"].as_str() == Some("applied");
+            result["rescan_required"] = json!(rescan_required);
+            let mut actions = Vec::new();
+            if rescan_required {
+                actions.push(snapshot_rescan_action());
+            }
+            actions.push(action(
+                "undo",
+                &["undo", &id, "--json"],
+                true,
+                true,
+                "receipt_undoable",
+            ));
+            ("apply", result, vec![], actions)
         }
         Some(Command::Undo(args)) => {
             if !cli.json {
@@ -397,7 +402,12 @@ pub fn run(cli: Cli) -> Result<Output> {
             let progress = crate::present::ProgressGuard::start("undo", cli.json);
             let result = undo_command(&store, &args.id, &state_lock)?;
             progress.finish();
-            ("undo", result, vec![], vec![])
+            let actions = if result["rescan_required"].as_bool() == Some(true) {
+                vec![snapshot_rescan_action()]
+            } else {
+                Vec::new()
+            };
+            ("undo", result, vec![], actions)
         }
         Some(Command::Lifecycle(args)) => match args.command {
             LifecycleCommand::Inspect => (
@@ -722,8 +732,22 @@ fn home_result(store: &StateStore, state_dir: &Path) -> Result<Value> {
 fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> Result<Value> {
     let latest = store.latest_completed_scan()?;
     let latest_scan_id = latest.as_ref().map(|scan| &scan.id);
+    let invalidating_receipt_id = latest_scan_id
+        .map(|scan_id| store.snapshot_invalidating_receipt(scan_id))
+        .transpose()?
+        .flatten();
+    let snapshot_state = if latest_scan_id.is_none() {
+        "missing"
+    } else if invalidating_receipt_id.is_some() {
+        "rescan_required"
+    } else {
+        "current"
+    };
+    let actionable_scan_id = (snapshot_state == "current")
+        .then_some(latest_scan_id)
+        .flatten();
     let (pending_plan_count, pending_plans) =
-        store.pending_plans(latest_scan_id, STATUS_PENDING_PLAN_LIMIT)?;
+        store.pending_plans(actionable_scan_id, STATUS_PENDING_PLAN_LIMIT)?;
     let pending_plans = pending_plans
         .into_iter()
         .map(|plan| {
@@ -748,7 +772,9 @@ fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> 
         "database_path": database_path,
         "schema_version": store.schema_version()?,
         "latest_snapshot_id": latest.as_ref().map(|scan| scan.id.to_string()),
-        "latest_snapshot_at": latest.and_then(|scan| scan.completed_at),
+        "latest_snapshot_at": latest.as_ref().and_then(|scan| scan.completed_at),
+        "snapshot_state": snapshot_state,
+        "snapshot_invalidated_by_receipt_id": invalidating_receipt_id,
         "pending_plan_count": pending_plan_count,
         "pending_plans_returned": pending_plans.len(),
         "pending_plans_truncated": pending_plan_count > pending_plans.len(),
@@ -2054,6 +2080,11 @@ fn report_command(
         offset,
     } = request
     {
+        let latest_scan_id = store
+            .latest_completed_scan()?
+            .ok_or_else(|| anyhow!("no completed Snapshot exists"))?
+            .id;
+        require_snapshot_current(store, &latest_scan_id)?;
         let limit = finding_page_limit(full, limit);
         let id = FindingId::parse(id.to_string())?;
         let stored = store
@@ -2085,10 +2116,6 @@ fn report_command(
                 "coverage".into(),
                 finding_coverage_facts(coverage_basis, evidence_quality, &scan),
             );
-            let latest_scan_id = store
-                .latest_completed_scan()?
-                .ok_or_else(|| anyhow!("no completed Snapshot exists"))?
-                .id;
             if let Some(planning) =
                 finding_library_planning(&stored, &report.scan_id, &latest_scan_id, &scan)
             {
@@ -7524,6 +7551,12 @@ fn undo_command(store: &StateStore, id: &str, state_lock: &change::StateLock) ->
     if let Some(reverse) = store.reverse_receipt_for(&id)? {
         bail!("Receipt {id} was already undone by {reverse}");
     }
+    let plan = store
+        .get_plan(&record.plan_id)?
+        .ok_or_else(|| anyhow!("Plan {} does not exist", record.plan_id))?;
+    let latest_snapshot_id = store
+        .latest_scan_payload::<Value>()?
+        .map(|(scan_id, _)| scan_id);
     let original: ChangeReceipt =
         serde_json::from_value(record.verification["change_receipt"].clone())?;
     require_clear_journals(store, &original.state_dir)?;
@@ -7560,9 +7593,10 @@ fn undo_command(store: &StateStore, id: &str, state_lock: &change::StateLock) ->
             "after": record.verification["library_state"]["before"]
         }),
     )?;
+    let invalidates_snapshot_id = latest_snapshot_id.filter(|scan_id| scan_id != &plan.scan_id);
     if outcome.verification_passed {
         store
-            .save_undo_receipt(&id, &receipt)
+            .save_undo_receipt(&id, &receipt, invalidates_snapshot_id.as_ref())
             .with_context(|| {
                 format!(
                     "Undo journal {} is durable but SQLite finalization failed; run lifecycle recovery --json",
@@ -7572,7 +7606,10 @@ fn undo_command(store: &StateStore, id: &str, state_lock: &change::StateLock) ->
     } else {
         store.save_receipt(&receipt)?;
     }
-    Ok(mutation_result(&outcome, &receipt, Some(id)))
+    let mut result = mutation_result(&outcome, &receipt, Some(id));
+    result["rescan_required"] =
+        json!(outcome.verification_passed && invalidates_snapshot_id.is_some());
+    Ok(result)
 }
 
 const LEGACY_SINGLE_FILE_BOOTSTRAPS: &[(&str, &str)] = &[
@@ -7930,6 +7967,7 @@ fn setup_command_with_manifests<'a>(
             "next": "skillroster scan --summary --json"
         }));
     };
+    require_snapshot_current(store, &snapshot_id)?;
     let current_package = current_bootstrap_package();
     let mut detected = Vec::new();
     let mut targets = Vec::new();
@@ -8965,9 +9003,22 @@ fn restore_library_state(store: &StateStore, before: &Value) -> Result<()> {
 }
 
 fn latest_scan(store: &StateStore) -> Result<(ScanId, ScanResult)> {
-    store
+    let scan = store
         .latest_scan_payload()?
-        .ok_or_else(|| anyhow!("no completed Snapshot; run skillroster scan first"))
+        .ok_or_else(|| anyhow!("no completed Snapshot; run skillroster scan first"))?;
+    require_snapshot_current(store, &scan.0)?;
+    Ok(scan)
+}
+
+fn require_snapshot_current(store: &StateStore, scan_id: &ScanId) -> Result<()> {
+    if let Some(receipt_id) = store.snapshot_invalidating_receipt(scan_id)? {
+        return Err(SnapshotRescanRequired {
+            snapshot_id: scan_id.clone(),
+            receipt_id,
+        }
+        .into());
+    }
+    Ok(())
 }
 
 fn require_content_identity(scan: &ScanResult) -> Result<()> {
@@ -9315,6 +9366,16 @@ fn action(
         requires_confirmation: confirmation,
         reason_code: reason.into(),
     }
+}
+
+fn snapshot_rescan_action() -> SuggestedAction {
+    action(
+        "scan",
+        &["scan", "--summary", "--json"],
+        false,
+        false,
+        "verified_mutation_requires_rescan",
+    )
 }
 
 #[cfg(test)]

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 
 use serde_json::{Value, json};
 
-use super::action;
+use super::{action, snapshot_rescan_action};
 use crate::action_context::ActionContext;
-use crate::model::{ApiError, FindingId, JsonEnvelope, PlanId, ScanId};
+use crate::model::{ApiError, FindingId, JsonEnvelope, PlanId, ReceiptId, ScanId};
 use crate::scan;
 
 /// Agent tool-result transport bound, deliberately narrower than the 2 MiB
@@ -77,6 +77,24 @@ impl std::fmt::Display for ContentIdentityRescanRequired {
 
 impl std::error::Error for ContentIdentityRescanRequired {}
 
+#[derive(Debug)]
+pub(super) struct SnapshotRescanRequired {
+    pub(super) snapshot_id: ScanId,
+    pub(super) receipt_id: ReceiptId,
+}
+
+impl std::fmt::Display for SnapshotRescanRequired {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Snapshot {} predates verified Receipt {}; run skillroster scan --summary --json before using current inventory facts",
+            self.snapshot_id, self.receipt_id
+        )
+    }
+}
+
+impl std::error::Error for SnapshotRescanRequired {}
+
 pub fn error_json(command: &str, error: &(dyn std::error::Error + 'static)) -> String {
     error_json_with_context(command, error, &ActionContext::default())
 }
@@ -86,6 +104,33 @@ pub fn error_json_with_context(
     error: &(dyn std::error::Error + 'static),
     action_context: &ActionContext,
 ) -> String {
+    if let Some(required) = error.downcast_ref::<SnapshotRescanRequired>() {
+        let mut envelope = JsonEnvelope::<Value>::failure(
+            command,
+            ApiError {
+                code: "snapshot_rescan_required".into(),
+                message: error.to_string(),
+                retryable: true,
+                relevant_ids: vec![
+                    required.snapshot_id.to_string(),
+                    required.receipt_id.to_string(),
+                ],
+                paths: Vec::new(),
+                details: Some(json!({
+                    "reason": "verified_mutation_after_snapshot",
+                    "snapshot_id": required.snapshot_id,
+                    "receipt_id": required.receipt_id,
+                    "files_changed": false,
+                    "state_files_changed": false,
+                    "next_action": "scan"
+                })),
+            },
+        );
+        envelope.suggested_actions = vec![snapshot_rescan_action()];
+        action_context.apply(&mut envelope.suggested_actions);
+        return serde_json::to_string(&envelope)
+            .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into());
+    }
     if let Some(changed) = error.downcast_ref::<FindSnapshotChanged>() {
         let mut envelope = JsonEnvelope::<Value>::failure(
             command,

--- a/src/present.rs
+++ b/src/present.rs
@@ -337,6 +337,7 @@ fn status(value: &Value, lines: &mut Vec<String>, width: usize) {
         "Snapshot age",
         age(value.get("latest_snapshot_at").and_then(Value::as_i64)),
     );
+    fact(lines, "Snapshot state", text(value, "snapshot_state"));
     fact(lines, "Pending Plans", text(value, "pending_plan_count"));
     let pending_plan = value
         .get("pending_plans")
@@ -373,6 +374,8 @@ fn status(value: &Value, lines: &mut Vec<String>, width: usize) {
         "Next: skillroster lifecycle recovery".to_owned()
     } else if value.get("latest_snapshot_id").is_none_or(Value::is_null) {
         "Next: skillroster scan".to_owned()
+    } else if value["snapshot_state"] == "rescan_required" {
+        "Next: skillroster scan --summary --json".to_owned()
     } else if pending_plan.is_some() {
         "Next: inspect the Review Plan above".to_owned()
     } else {
@@ -1507,6 +1510,10 @@ fn mutation(value: &Value, lines: &mut Vec<String>) {
     fact(lines, "Changed paths", text(value, "changed_path_count"));
     fact(lines, "Verification", text(value, "verification"));
     fact(lines, "Undo available", text(value, "undo_available"));
+    if value.get("rescan_required").and_then(Value::as_bool) == Some(true) {
+        fact(lines, "Current facts", "Scan required");
+        fact(lines, "Continue", "skillroster scan --summary --json");
+    }
     if value
         .get("files_changed")
         .and_then(Value::as_bool)
@@ -1514,7 +1521,11 @@ fn mutation(value: &Value, lines: &mut Vec<String>) {
     {
         lines.extend(summary(
             "Changed · bounded by the Receipt",
-            "Use the Receipt ID to inspect or undo",
+            if value.get("rescan_required").and_then(Value::as_bool) == Some(true) {
+                "Run the Scan continuation before Report or Find; Undo remains available"
+            } else {
+                "Use the Receipt ID to inspect or undo"
+            },
         ));
     } else {
         lines.extend(summary(
@@ -1924,6 +1935,7 @@ mod tests {
             "schema_version": 9,
             "latest_snapshot_id": "scan_current",
             "latest_snapshot_at": 1,
+            "snapshot_state": "current",
             "pending_plan_count": 1,
             "pending_plans": [{
                 "plan_id": "plan_01M0QDAC102GEXKCMHVP97GF2V",
@@ -1965,8 +1977,15 @@ mod tests {
 
         let mut missing_snapshot = base.clone();
         missing_snapshot["latest_snapshot_id"] = Value::Null;
+        missing_snapshot["snapshot_state"] = json!("missing");
         let missing_snapshot = render("status", &missing_snapshot, options);
         assert!(missing_snapshot.contains("Next: skillroster scan"));
+
+        let mut stale = base.clone();
+        stale["snapshot_state"] = json!("rescan_required");
+        let stale = render("status", &stale, options);
+        assert!(stale.contains("Snapshot state         rescan_required"));
+        assert!(stale.contains("Next: skillroster scan --summary --json"));
 
         let mut healthy = base;
         healthy["pending_plan_count"] = json!(0);
@@ -2009,6 +2028,33 @@ mod tests {
         );
         assert!(output.contains("Verified · no files changed"));
         assert!(!output.contains("Changed · bounded"));
+    }
+
+    #[test]
+    fn verified_apply_tells_humans_to_refresh_current_facts() {
+        let output = render(
+            "apply",
+            &json!({
+                "plan_id": "plan_1",
+                "receipt_id": "receipt_1",
+                "changed_path_count": 4,
+                "verification": "passed",
+                "undo_available": true,
+                "rescan_required": true,
+                "files_changed": true
+            }),
+            RenderOptions {
+                width: 80,
+                styled: false,
+            },
+        );
+        assert!(output.contains("Current facts          Scan required"));
+        assert!(output.contains("Continue               skillroster scan --summary --json"));
+        assert!(
+            output.contains(
+                "Run the Scan continuation before Report or Find; Undo remains available"
+            )
+        );
     }
 
     #[test]

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -12,7 +12,7 @@ use crate::model::{
 use crate::source_policy::{RootIdentity, SourcePermissionId, SourceRootPermission};
 use crate::state_security;
 
-const SCHEMA_VERSION: i64 = 10;
+const SCHEMA_VERSION: i64 = 11;
 
 fn sqlite_nofollow_path(path: &Path) -> StorageResult<PathBuf> {
     let parent = path.parent().ok_or_else(|| {
@@ -146,6 +146,7 @@ const MIGRATIONS: [(i64, Migration); SCHEMA_VERSION as usize] = [
     (8, migration_v8),
     (9, migration_v9),
     (10, migration_v10),
+    (11, migration_v11),
 ];
 
 fn validate_migrations(migrations: &[(i64, Migration)], schema_version: i64) -> StorageResult<()> {
@@ -503,6 +504,27 @@ impl StateStore {
             .optional()?;
         stored
             .map(|(id, payload)| Ok((ScanId::parse(id).map_err(invalid_id)?, from_json(&payload)?)))
+            .transpose()
+    }
+
+    pub fn snapshot_invalidating_receipt(
+        &self,
+        scan_id: &ScanId,
+    ) -> StorageResult<Option<ReceiptId>> {
+        self.connection
+            .query_row(
+                "SELECT r.id FROM snapshot_invalidations i
+                 JOIN receipts r ON r.id = i.receipt_id
+                 WHERE i.snapshot_id = ?1
+                   AND ((r.reverses_receipt_id IS NULL AND r.status = 'applied')
+                     OR (r.reverses_receipt_id IS NOT NULL AND r.status = 'undone'))
+                 ORDER BY i.created_at DESC, i.rowid DESC
+                 LIMIT 1",
+                [scan_id.as_str()],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|id| ReceiptId::parse(id).map_err(invalid_id))
             .transpose()
     }
 
@@ -1382,6 +1404,18 @@ impl StateStore {
         }
         let transaction = self.connection.unchecked_transaction()?;
         save_receipt_transaction(&transaction, receipt)?;
+        if next == PlanStatus::Applied && receipt.status == ReceiptStatus::Applied {
+            let changed = transaction.execute(
+                "INSERT INTO snapshot_invalidations (snapshot_id, receipt_id, created_at)
+                 SELECT scan_id, ?1, ?2 FROM plans WHERE id = ?3",
+                params![receipt.id.as_str(), receipt.created_at, plan.as_str()],
+            )?;
+            if changed != 1 {
+                return Err(StorageError::InvalidData(format!(
+                    "plan {plan} has no Snapshot to invalidate"
+                )));
+            }
+        }
         for source in trusted_sources {
             let changed = transaction.execute(
                 "INSERT INTO source_baselines
@@ -1429,6 +1463,7 @@ impl StateStore {
         &self,
         original: &ReceiptId,
         receipt: &ReceiptRecord,
+        invalidates_snapshot_id: Option<&ScanId>,
     ) -> StorageResult<()> {
         if receipt.reverses_receipt_id.as_ref() != Some(original)
             || receipt.status != ReceiptStatus::Undone
@@ -1439,6 +1474,17 @@ impl StateStore {
         }
         let transaction = self.connection.unchecked_transaction()?;
         save_receipt_transaction(&transaction, receipt)?;
+        if let Some(snapshot_id) = invalidates_snapshot_id {
+            transaction.execute(
+                "INSERT INTO snapshot_invalidations (snapshot_id, receipt_id, created_at)
+                 VALUES (?1, ?2, ?3)",
+                params![
+                    snapshot_id.as_str(),
+                    receipt.id.as_str(),
+                    receipt.created_at
+                ],
+            )?;
+        }
         let changed = transaction.execute(
             "UPDATE receipts SET status = 'undone', completed_at = ?1
              WHERE id = ?2 AND status = 'applied'",
@@ -1935,6 +1981,7 @@ impl StateStore {
              WHERE trusted_by_receipt_id IS NOT NULL",
             [],
         )?;
+        transaction.execute("DELETE FROM snapshot_invalidations", [])?;
         transaction.execute("DELETE FROM receipt_operations", [])?;
         transaction.execute("DELETE FROM receipts", [])?;
         transaction.execute("DELETE FROM plan_operations", [])?;
@@ -2282,6 +2329,36 @@ fn migration_v10(transaction: &Transaction<'_>) -> StorageResult<()> {
     Ok(())
 }
 
+fn migration_v11(transaction: &Transaction<'_>) -> StorageResult<()> {
+    transaction.execute_batch(
+        "CREATE TABLE snapshot_invalidations (
+            snapshot_id TEXT NOT NULL REFERENCES scans(id),
+            receipt_id TEXT NOT NULL REFERENCES receipts(id),
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY(snapshot_id, receipt_id)
+         );
+         INSERT INTO snapshot_invalidations (snapshot_id, receipt_id, created_at)
+         SELECT p.scan_id, r.id, r.created_at
+         FROM receipts r JOIN plans p ON p.id = r.plan_id
+         WHERE r.status = 'applied' AND r.reverses_receipt_id IS NULL;
+         INSERT OR IGNORE INTO snapshot_invalidations (snapshot_id, receipt_id, created_at)
+         SELECT latest.id, reverse.id, reverse.created_at
+         FROM receipts reverse
+         JOIN plans p ON p.id = reverse.plan_id
+         JOIN scans latest ON latest.id = (
+             SELECT s.id FROM scans s
+             WHERE s.status = 'completed'
+             ORDER BY s.completed_at DESC, s.started_at DESC, s.rowid DESC
+             LIMIT 1
+         )
+         WHERE reverse.status = 'undone'
+           AND reverse.reverses_receipt_id IS NOT NULL
+           AND latest.id != p.scan_id
+           AND reverse.completed_at >= latest.completed_at;",
+    )?;
+    Ok(())
+}
+
 fn table_count(connection: &Connection, table: &str) -> StorageResult<u64> {
     let query = format!("SELECT COUNT(*) FROM {table}");
     Ok(connection.query_row(&query, [], |row| row.get(0))?)
@@ -2589,7 +2666,7 @@ mod tests {
 
     #[test]
     fn migration_upgrades_prior_states_sequentially() {
-        for starting_version in [1_i64, 2, 3, 4, 5, 6, 7, 8, 9] {
+        for starting_version in [1_i64, 2, 3, 4, 5, 6, 7, 8, 9, 10] {
             let mut connection = Connection::open_in_memory().unwrap();
             let transaction = connection.transaction().unwrap();
             migration_v1(&transaction).unwrap();
@@ -2617,6 +2694,9 @@ mod tests {
             if starting_version >= 9 {
                 migration_v9(&transaction).unwrap();
             }
+            if starting_version >= 10 {
+                migration_v10(&transaction).unwrap();
+            }
             transaction
                 .pragma_update(None, "user_version", starting_version)
                 .unwrap();
@@ -2634,13 +2714,107 @@ mod tests {
         let path = temp.path().join("skillroster.db");
         assert!(StateStore::requires_migration(&path).unwrap());
 
-        let connection = Connection::open(&path).unwrap();
-        connection.pragma_update(None, "user_version", 9).unwrap();
+        let mut connection = Connection::open(&path).unwrap();
+        let transaction = connection.transaction().unwrap();
+        for migration in [
+            migration_v1 as Migration,
+            migration_v2,
+            migration_v3,
+            migration_v4,
+            migration_v5,
+            migration_v6,
+            migration_v7,
+            migration_v8,
+            migration_v9,
+            migration_v10,
+        ] {
+            migration(&transaction).unwrap();
+        }
+        transaction.pragma_update(None, "user_version", 10).unwrap();
+        transaction.commit().unwrap();
         drop(connection);
         assert!(StateStore::requires_migration(&path).unwrap());
 
         drop(StateStore::open(&path).unwrap());
         assert!(!StateStore::requires_migration(&path).unwrap());
+    }
+
+    #[test]
+    fn snapshot_invalidation_migration_backfills_applied_and_later_undo_receipts() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let transaction = connection.transaction().unwrap();
+        for (_, migration) in &MIGRATIONS[..10] {
+            migration(&transaction).unwrap();
+        }
+        transaction
+            .execute_batch(
+                "INSERT INTO scans VALUES
+                    ('scan_a', 1, 10, 'completed', '[]'),
+                    ('scan_b', 11, 20, 'completed', '[]');
+                 INSERT INTO plans VALUES
+                    ('plan_a', 'scan_a', NULL, 2, 'applied', '{}', 'a', '{}'),
+                    ('plan_b', 'scan_b', NULL, 12, 'applied', '{}', 'b', '{}');
+                 INSERT INTO receipts VALUES
+                    ('receipt_original', 'plan_a', NULL, 3, 4, 'undone', '{}'),
+                    ('receipt_reverse', 'plan_a', 'receipt_original', 21, 22, 'undone', '{}'),
+                    ('receipt_applied', 'plan_b', NULL, 13, 14, 'applied', '{}');",
+            )
+            .unwrap();
+
+        migration_v11(&transaction).unwrap();
+
+        let rows = transaction
+            .prepare(
+                "SELECT snapshot_id, receipt_id FROM snapshot_invalidations
+                 ORDER BY receipt_id",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("scan_b".to_owned(), "receipt_applied".to_owned()),
+                ("scan_b".to_owned(), "receipt_reverse".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn snapshot_invalidation_migration_fails_closed_for_ambiguous_same_second_order() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let transaction = connection.transaction().unwrap();
+        for (_, migration) in &MIGRATIONS[..10] {
+            migration(&transaction).unwrap();
+        }
+        transaction
+            .execute_batch(
+                "INSERT INTO scans VALUES
+                    ('scan_before', 1, 10, 'completed', '[]'),
+                    ('scan_after', 20, 20, 'completed', '[]');
+                 INSERT INTO plans VALUES
+                    ('plan_a', 'scan_before', NULL, 2, 'applied', '{}', 'a', '{}');
+                 INSERT INTO receipts VALUES
+                    ('receipt_original', 'plan_a', NULL, 3, 4, 'undone', '{}'),
+                    ('receipt_reverse', 'plan_a', 'receipt_original', 19, 20, 'undone', '{}');",
+            )
+            .unwrap();
+
+        migration_v11(&transaction).unwrap();
+
+        let reverse_invalidations: i64 = transaction
+            .query_row(
+                "SELECT COUNT(*) FROM snapshot_invalidations
+                 WHERE receipt_id = 'receipt_reverse'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(reverse_invalidations, 1);
     }
 
     #[test]
@@ -2931,7 +3105,12 @@ mod tests {
             verification: serde_json::json!({}),
             operation_results: vec![],
         };
-        store.save_receipt(&original).unwrap();
+        store
+            .update_plan_status(&plan.id, PlanStatus::Applying)
+            .unwrap();
+        store
+            .save_apply_receipt(&plan.id, PlanStatus::Applied, &original)
+            .unwrap();
         let reverse = ReceiptRecord {
             id: ReceiptId::new(),
             plan_id: plan.id,
@@ -2942,7 +3121,9 @@ mod tests {
             verification: serde_json::json!({}),
             operation_results: vec![],
         };
-        store.save_undo_receipt(&original.id, &reverse).unwrap();
+        store
+            .save_undo_receipt(&original.id, &reverse, None)
+            .unwrap();
         assert_eq!(
             store.get_receipt(&original.id).unwrap().unwrap().status,
             ReceiptStatus::Undone
@@ -2956,8 +3137,99 @@ mod tests {
             id: ReceiptId::new(),
             ..reverse
         };
-        assert!(store.save_undo_receipt(&original.id, &duplicate).is_err());
+        assert!(
+            store
+                .save_undo_receipt(&original.id, &duplicate, None)
+                .is_err()
+        );
         assert!(!store.receipt_exists(&duplicate.id).unwrap());
+    }
+
+    #[test]
+    fn applied_and_undo_receipts_invalidate_only_the_snapshot_they_changed() {
+        let store = StateStore::open_in_memory().unwrap();
+        let original_scan = scan();
+        store.save_scan(&original_scan).unwrap();
+        let plan = PlanRecord {
+            id: PlanId::new(),
+            scan_id: original_scan.id.clone(),
+            report_id: None,
+            created_at: 30,
+            status: PlanStatus::Ready,
+            input: serde_json::json!({}),
+            fingerprint: "plan-sha256".to_owned(),
+            operations: vec![],
+        };
+        store.save_plan(&plan).unwrap();
+        let original = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id.clone(),
+            reverses_receipt_id: None,
+            created_at: 31,
+            completed_at: Some(32),
+            status: ReceiptStatus::Applied,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+
+        assert!(
+            store
+                .snapshot_invalidating_receipt(&original_scan.id)
+                .unwrap()
+                .is_none()
+        );
+        store
+            .update_plan_status(&plan.id, PlanStatus::Applying)
+            .unwrap();
+        store
+            .save_apply_receipt(&plan.id, PlanStatus::Applied, &original)
+            .unwrap();
+        assert_eq!(
+            store
+                .snapshot_invalidating_receipt(&original_scan.id)
+                .unwrap(),
+            Some(original.id.clone())
+        );
+        let newer_scan = scan();
+        store.save_scan(&newer_scan).unwrap();
+        assert!(
+            store
+                .snapshot_invalidating_receipt(&newer_scan.id)
+                .unwrap()
+                .is_none()
+        );
+
+        let reverse = ReceiptRecord {
+            id: ReceiptId::new(),
+            plan_id: plan.id,
+            reverses_receipt_id: Some(original.id.clone()),
+            created_at: 33,
+            completed_at: Some(34),
+            status: ReceiptStatus::Undone,
+            verification: serde_json::json!({}),
+            operation_results: vec![],
+        };
+        store
+            .save_undo_receipt(&original.id, &reverse, Some(&newer_scan.id))
+            .unwrap();
+        assert!(
+            store
+                .snapshot_invalidating_receipt(&original_scan.id)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            store.snapshot_invalidating_receipt(&newer_scan.id).unwrap(),
+            Some(reverse.id)
+        );
+        let post_undo_scan = scan();
+        store.save_scan(&post_undo_scan).unwrap();
+        assert!(
+            store
+                .snapshot_invalidating_receipt(&post_undo_scan.id)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -812,6 +812,8 @@ fn maintained_routing_set_meets_top_three_and_governance_does_not_regress_succes
         None,
     );
     assert_eq!(applied["result"]["verification"], "passed");
+    let refreshed = cli_json(&home, &state, &["scan", "--summary"], None);
+    assert_eq!(refreshed["result"]["placement_count"], names.len());
 
     let (after_routed, after_succeeded) = evaluate_capabilities(&home, &state, &routes);
     assert_eq!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3268,6 +3268,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert!(routing.contains("find_snapshot_changed"));
     assert!(routing.contains("rerun_find_on_latest_snapshot"));
     assert!(routing.contains("Do not reconstruct or rerun Find"));
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_eq!(current["result"]["state"], "up_to_date");
     assert!(current["result"]["plan_id"].is_null());
@@ -3351,6 +3352,7 @@ fn setup_upgrades_an_exact_official_legacy_bootstrap_and_undo_restores_it() {
             fs::read_to_string(&bootstrap).unwrap(),
             include_str!("../skill/skillroster/SKILL.md").replace("\r\n", "\n")
         );
+        json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
         let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
         assert_eq!(current["result"]["state"], "up_to_date");
 
@@ -3444,6 +3446,7 @@ fn setup_upgrades_the_public_v1_8_23_package_and_undo_restores_every_file() {
             expected.replace("\r\n", "\n")
         );
     }
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let current = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_eq!(current["result"]["state"], "up_to_date");
     assert_eq!(
@@ -3487,6 +3490,7 @@ fn setup_manages_the_fixed_bootstrap_package_and_preserves_unmanaged_files() {
         .concat(),
         None,
     ));
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let package = root.join("skillroster");
     let routing = package.join("references/routing.md");
     let unmanaged = package.join("notes.local.md");
@@ -3530,6 +3534,7 @@ fn setup_manages_the_fixed_bootstrap_package_and_preserves_unmanaged_files() {
         include_str!("../skill/skillroster/references/routing.md").replace("\r\n", "\n")
     );
     assert_eq!(fs::read_to_string(&unmanaged).unwrap(), "keep me\n");
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let healthy = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     assert_eq!(healthy["result"]["state"], "up_to_date");
     assert_eq!(healthy["result"]["targets"][0]["managed_file_count"], 4);
@@ -3574,6 +3579,7 @@ fn setup_does_not_report_a_package_with_a_missing_reference_as_current() {
         .concat(),
         None,
     ));
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     fs::remove_file(root.join("skillroster/references/governance.md")).unwrap();
 
     let result = json_output(&run(&[&common[..], &["setup"]].concat(), None));
@@ -3699,6 +3705,7 @@ fn setup_rejects_a_symlinked_managed_reference() {
         .concat(),
         None,
     ));
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let routing = root.join("skillroster/references/routing.md");
     fs::remove_file(&routing).unwrap();
     symlink(root.join("skillroster/SKILL.md"), &routing).unwrap();
@@ -4169,6 +4176,236 @@ fn setup_bootstraps_a_detected_agent_before_its_first_skill_root_exists() {
     assert_eq!(undone["result"]["verification"], "passed");
     assert!(!skill_root.exists());
     assert!(sessions.is_dir());
+}
+
+#[test]
+fn verified_apply_invalidates_inventory_until_scan_or_exact_undo() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    fs::create_dir_all(home.join(".codex/sessions")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    let original_scan = json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+    assert_eq!(original_scan["result"]["placement_count"], 0);
+    let pre_apply_report = json_output(&run(&[&common[..], &["report", "--full"]].concat(), None));
+    let finding_id = pre_apply_report["result"]["findings"]
+        .as_array()
+        .and_then(|findings| findings.first())
+        .and_then(|finding| finding["id"].as_str())
+        .expect("the known-missing-root Snapshot exposes a Finding")
+        .to_owned();
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    let plan_id = setup["result"]["plan_id"].as_str().unwrap();
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let immutable: String = database
+        .query_row(
+            "SELECT immutable_json FROM plans WHERE id = ?1",
+            [plan_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut alternative: Value = serde_json::from_str(&immutable).unwrap();
+    alternative["id"] = json!("plan_alternative_ready");
+    database
+        .execute(
+            "INSERT INTO plans
+                (id, scan_id, report_id, created_at, status, input_json, fingerprint, immutable_json)
+             SELECT 'plan_alternative_ready', scan_id, report_id, created_at + 1,
+                    status, input_json, fingerprint, ?1
+             FROM plans WHERE id = ?2",
+            rusqlite::params![alternative.to_string(), plan_id],
+        )
+        .unwrap();
+    let ready_status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(ready_status["result"]["pending_plan_count"], 2);
+    let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+
+    assert_eq!(applied["result"]["verification"], "passed");
+    assert_eq!(applied["result"]["rescan_required"], true);
+    assert_eq!(applied["suggested_actions"].as_array().unwrap().len(), 2);
+    assert_eq!(applied["suggested_actions"][0]["action"], "scan");
+    assert_eq!(
+        applied["suggested_actions"][0]["argv"],
+        context_action_argv(&home, &state, &["scan", "--summary", "--json"])
+    );
+    assert_eq!(applied["suggested_actions"][0]["mutates"], false);
+    assert_eq!(
+        applied["suggested_actions"][0]["requires_confirmation"],
+        false
+    );
+    assert_eq!(applied["suggested_actions"][1]["action"], "undo");
+
+    for command in [
+        vec!["report", "--summary"],
+        vec!["find", "help me govern skills", "--load", "--limit", "1"],
+        vec!["setup"],
+    ] {
+        let blocked = run(&[&common[..], &command].concat(), None);
+        assert!(!blocked.status.success());
+        let blocked: Value = serde_json::from_slice(&blocked.stdout).unwrap();
+        assert_eq!(blocked["error"]["code"], "snapshot_rescan_required");
+        assert_eq!(blocked["error"]["retryable"], true);
+        assert_eq!(
+            blocked["error"]["details"]["reason"],
+            "verified_mutation_after_snapshot"
+        );
+        assert_eq!(
+            blocked["error"]["details"]["snapshot_id"],
+            original_scan["result"]["snapshot_id"]
+        );
+        assert_eq!(blocked["error"]["details"]["files_changed"], false);
+        assert_eq!(blocked["suggested_actions"].as_array().unwrap().len(), 1);
+        assert_eq!(blocked["suggested_actions"][0]["action"], "scan");
+        assert_eq!(
+            blocked["suggested_actions"][0]["argv"],
+            context_action_argv(&home, &state, &["scan", "--summary", "--json"])
+        );
+    }
+    let blocked_plan = run(&[&common[..], &["plan", "--stdin"]].concat(), Some("{}"));
+    assert!(!blocked_plan.status.success());
+    let blocked_plan: Value = serde_json::from_slice(&blocked_plan.stdout).unwrap();
+    assert_eq!(blocked_plan["error"]["code"], "snapshot_rescan_required");
+    assert_eq!(blocked_plan["suggested_actions"][0]["action"], "scan");
+    let blocked_finding = run(
+        &[&common[..], &["report", "--finding", &finding_id]].concat(),
+        None,
+    );
+    assert!(!blocked_finding.status.success());
+    let blocked_finding: Value = serde_json::from_slice(&blocked_finding.stdout).unwrap();
+    assert_eq!(blocked_finding["error"]["code"], "snapshot_rescan_required");
+
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["recovery_state"], "clear");
+    assert_eq!(status["result"]["snapshot_state"], "rescan_required");
+    assert_eq!(
+        status["result"]["snapshot_invalidated_by_receipt_id"],
+        applied["result"]["receipt_id"]
+    );
+    assert_eq!(status["result"]["pending_plan_count"], 0);
+    assert_eq!(status["result"]["pending_plans"], json!([]));
+    assert_eq!(status["suggested_actions"].as_array().unwrap().len(), 1);
+    assert_eq!(status["suggested_actions"][0]["action"], "scan");
+    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+    assert_eq!(undone["result"]["verification"], "passed");
+    let restored = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    assert_eq!(
+        restored["result"]["snapshot_id"],
+        original_scan["result"]["snapshot_id"]
+    );
+    assert_eq!(restored["result"]["placement_count"], 0);
+}
+
+#[test]
+fn suggested_scan_refreshes_inventory_after_verified_apply() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    fs::create_dir_all(home.join(".codex/sessions")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    let original_scan = json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    let applied = json_output(&run(
+        &[
+            &common[..],
+            &["apply", setup["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+
+    let refreshed = json_output(&run_suggested_action(&applied["suggested_actions"][0]));
+    assert_ne!(
+        refreshed["result"]["snapshot_id"],
+        original_scan["result"]["snapshot_id"]
+    );
+    assert_eq!(refreshed["result"]["placement_count"], 1);
+    let report = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    assert_eq!(
+        report["result"]["snapshot_id"],
+        refreshed["result"]["snapshot_id"]
+    );
+    assert_eq!(report["result"]["placement_count"], 1);
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &["find", "help me govern skills", "--load", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(found["result"]["loaded_skill"]["selection"]["rank"], 1);
+    assert_eq!(found["result"]["loaded_skill"]["content"]["complete"], true);
+}
+
+#[test]
+fn exact_undo_invalidates_a_newer_post_apply_snapshot() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    fs::create_dir_all(home.join(".codex/sessions")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    let applied = json_output(&run(
+        &[
+            &common[..],
+            &["apply", setup["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    let post_apply_scan = json_output(&run_suggested_action(&applied["suggested_actions"][0]));
+    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert_eq!(undone["result"]["rescan_required"], true);
+    assert_eq!(undone["suggested_actions"].as_array().unwrap().len(), 1);
+    assert_eq!(undone["suggested_actions"][0]["action"], "scan");
+    let blocked = run(&[&common[..], &["report", "--summary"]].concat(), None);
+    assert!(!blocked.status.success());
+    let blocked: Value = serde_json::from_slice(&blocked.stdout).unwrap();
+    assert_eq!(blocked["error"]["code"], "snapshot_rescan_required");
+    assert_eq!(
+        blocked["error"]["details"]["snapshot_id"],
+        post_apply_scan["result"]["snapshot_id"]
+    );
+
+    let refreshed = json_output(&run_suggested_action(&undone["suggested_actions"][0]));
+    assert_eq!(refreshed["result"]["placement_count"], 0);
+    let report = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    assert_eq!(report["result"]["placement_count"], 0);
 }
 
 #[test]
@@ -5290,6 +5527,7 @@ fn library_governance_managed_and_hosted_round_trip_and_refuse_drift() {
         )
         .unwrap();
     assert_eq!(governance_state, "hosted");
+    let hosted_rescan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
     let hosted_find = json_output(&run(&[&common[..], &["find", "shared"]].concat(), None));
     assert_eq!(
         hosted_find["result"]["matches"][0]["roster_state"],
@@ -5305,7 +5543,6 @@ fn library_governance_managed_and_hosted_round_trip_and_refuse_drift() {
             .any(|path| fs::canonicalize(path.as_str().unwrap())
                 .is_ok_and(|actual| actual == expected_library_entry))
     );
-    let hosted_rescan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
     let hosted_snapshot = hosted_rescan["result"]["snapshot_id"].as_str().unwrap();
     let hosted_payload: String = database
         .query_row(
@@ -5347,6 +5584,7 @@ fn library_governance_managed_and_hosted_round_trip_and_refuse_drift() {
     assert!(!state.join("plan-backups").exists());
     assert!(codex_skill.join("SKILL.md").is_file());
     assert!(claude_skill.join("SKILL.md").is_file());
+    let restored_scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
     let restored_find = json_output(&run(&[&common[..], &["find", "shared"]].concat(), None));
     assert_find_paths_are_readable(&restored_find);
     assert!(
@@ -5357,7 +5595,6 @@ fn library_governance_managed_and_hosted_round_trip_and_refuse_drift() {
             .all(|path| !path.as_str().unwrap().contains("/library/"))
     );
 
-    let restored_scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
     let restored_snapshot = restored_scan["result"]["snapshot_id"].as_str().unwrap();
     let restored_evidence_id: String = database
         .query_row(
@@ -7865,6 +8102,7 @@ fn large_roster_apply_reduces_exposure_and_undo_restores_every_skill() {
     ));
     assert_eq!(fs::read_dir(&root).unwrap().count(), 0);
     assert_eq!(fs::read_dir(state.join("library")).unwrap().count(), 101);
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let governed_find = json_output(&run(&[&common[..], &["find", "skill-000"]].concat(), None));
     assert_eq!(
         governed_find["result"]["matches"][0]["roster_state"],
@@ -7894,6 +8132,7 @@ fn large_roster_apply_reduces_exposure_and_undo_restores_every_skill() {
     for index in 0..101 {
         assert!(root.join(format!("skill-{index:03}/SKILL.md")).is_file());
     }
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let restored_find = json_output(&run(&[&common[..], &["find", "skill-000"]].concat(), None));
     assert_eq!(
         restored_find["result"]["matches"][0]["roster_state"],
@@ -7971,6 +8210,7 @@ fn core_roster_adds_verified_link_and_undo_restores_absence() {
         fs::canonicalize(&linked).unwrap(),
         fs::canonicalize(&canonical).unwrap()
     );
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let core_find = json_output(&run(&[&common[..], &["find", "shared"]].concat(), None));
     assert_eq!(core_find["result"]["matches"][0]["roster_state"], "core");
     assert_find_paths_are_readable(&core_find);
@@ -7992,6 +8232,7 @@ fn core_roster_adds_verified_link_and_undo_restores_absence() {
     assert_eq!(undone["result"]["verification"], "passed");
     assert!(!linked.exists());
     assert!(canonical.join("SKILL.md").is_file());
+    let restored_scan = json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let restored_find = json_output(&run(&[&common[..], &["find", "shared"]].concat(), None));
     assert_eq!(
         restored_find["result"]["matches"][0]["roster_state"],
@@ -8006,9 +8247,20 @@ fn core_roster_adds_verified_link_and_undo_restores_absence() {
             .all(|path| path != linked.join("SKILL.md").to_str().unwrap())
     );
 
+    let restored_snapshot = restored_scan["result"]["snapshot_id"].as_str().unwrap();
+    let restored_evidence_id: String = database
+        .query_row(
+            "SELECT id FROM evidence WHERE scan_id = ?1 ORDER BY id LIMIT 1",
+            [restored_snapshot],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut drift_request = request.clone();
+    drift_request["scan_id"] = json!(restored_snapshot);
+    drift_request["evidence_ids"] = json!([restored_evidence_id]);
     let drift_plan = json_output(&run(
         &[&common[..], &["plan", "--stdin"]].concat(),
-        Some(&request.to_string()),
+        Some(&drift_request.to_string()),
     ));
     fs::write(
         canonical.join("SKILL.md"),
@@ -8092,6 +8344,7 @@ fn public_find_uses_full_fts_body_and_archive_undo_restores_routing() {
         .concat(),
         None,
     ));
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let archived = json_output(&run(
         &[&common[..], &["find", "phosphorescent reconciliation"]].concat(),
         None,
@@ -8130,6 +8383,7 @@ fn public_find_uses_full_fts_body_and_archive_undo_restores_routing() {
         .concat(),
         None,
     ));
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
     let restored = json_output(&run(
         &[&common[..], &["find", "phosphorescent reconciliation"]].concat(),
         None,
@@ -8310,6 +8564,8 @@ fn archived_same_name_identity_cannot_return_through_active_variant() {
         .concat(),
         None,
     ));
+
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
 
     let after = json_output(&run(
         &[&common[..], &["find", "active search marker"]].concat(),


### PR DESCRIPTION
## Problem

A verified `apply` changed Agent files but left the Plan's completed Snapshot looking current. `report`, `find`, `plan`, and `setup` could therefore consume pre-mutation facts until an Agent inferred and ran an undocumented Scan.

## Solution

- persist an explicit Snapshot-to-Receipt invalidation relation atomically with verified Apply and Undo receipts
- reject current-inventory commands with typed, retryable `snapshot_rescan_required`
- expose the same exact Scan continuation in JSON and human output
- keep Status, lifecycle, recovery, and exact Undo available
- restore the original Snapshot after exact Undo when no newer Scan intervened
- invalidate a newer post-Apply Snapshot when Undo changes the files it observed
- hide stale Ready Plans from Status while retaining Applying and Recovery-required lifecycle entries
- migrate v10 data fail-closed when second-resolution ordering is ambiguous

## Verification

- `bash scripts/ci-full-check.sh`
  - Rust: 300 unit, 8 acceptance, 80 CLI
  - Node harness: 137
- `git diff --check`
- independent Spec review: no findings
- independent Standards/simplification review: no findings

This is source-only. It does not publish a tag, GitHub Release, or Homebrew update.

Closes #271
