### PR TITLE
fix: make Home route from current state

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -62,6 +62,12 @@ The Agent selects one primary action from current state:
 
 The Agent never manufactures a problem so that an Apply action exists.
 
+The default no-subcommand Home is the Agent's bounded readiness router. It and
+Status share one action-priority decision: recovery, missing-Snapshot Scan,
+invalidated-Snapshot Scan, Ready Plan inspection, then no required
+continuation. Home never calls a stale Snapshot ready, and its human surface
+prints the same exact argv returned in the JSON suggested action.
+
 ## 4. First-screen information
 
 The initial response should fit roughly one conversation viewport. It contains:
@@ -170,10 +176,10 @@ the original Snapshot becomes current again. If a newer Scan already observed
 the applied state, Undo returns another required Scan before current-inventory
 decisions resume.
 
-While facts are invalid, Status names `snapshot_state: rescan_required`, binds
-the invalidating Receipt ID, and returns the same read-only Scan continuation.
-The Agent follows recovery first when required, then stale-fact refresh, then
-ordinary pending-Plan inspection.
+While facts are invalid, Home and Status name `snapshot_state:
+rescan_required`, bind the invalidating Receipt ID, and return the same
+read-only Scan continuation. The Agent follows recovery first when required,
+then stale-fact refresh, then ordinary pending-Plan inspection.
 
 ## 7. Drill-down behavior
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -194,6 +194,7 @@ SkillRoster records source, revision, and content hash when available. A source-
 The first complete command surface is:
 
 ```bash
+skillroster [--json]
 skillroster scan [--summary] [--json]
 skillroster report [--summary | --full | --findings [--category <category>] [--severity <severity>] | --finding <id> [--full]] [--limit <n>] [--offset <n>] [--json]
 skillroster find <task> [--hint <text>]... [--limit <n>] [--load] [--variant-skill-id <skill-id>] [--require-snapshot <scan-id>] [--json]
@@ -207,6 +208,14 @@ skillroster source-root inspect [--json]
 skillroster source-root revoke <permission-id> [--json]
 skillroster setup [--modified-choice retain-local|adopt-current] [--json]
 ```
+
+The no-subcommand Home is the bounded readiness projection for Agents. It does
+not maintain an independent readiness heuristic. Home and `status` use one
+continuation selector with this priority: recovery inspection, missing-Snapshot
+Scan, invalidated-Snapshot Scan, actionable Ready Plan inspection, then no
+required continuation. Home exposes `recovery_required`, `no_snapshot`,
+`rescan_required`, `plan_ready`, or `ready`; its JSON action and human argv are
+the same generated continuation with the original discovery context preserved.
 
 Finding lists and full Finding records default to 20 rows per page. Compact
 `report --finding <id>` detail defaults to five rows so an Agent receives the
@@ -475,6 +484,10 @@ SkillRoster uses one SQLite database at `~/.skillroster/skillroster.db`, includi
 - Plans and Receipts remain until explicitly purged.
 - Overflow source-confirmation details are versioned local artifacts retained until explicitly purged or local state is deleted.
 - `status` exposes storage location, retention state, and retained source-confirmation artifact counts and bytes.
+- Home is a bounded projection of the same current-state and continuation
+  decision used by `status`. It never reports `ready` merely because a completed
+  but invalidated Snapshot exists, and it never leaves a missing Snapshot or
+  recovery state without the exact read-only continuation.
 - `status` remains read-only and available when current inventory facts are
   invalid. It exposes typed `snapshot_state`, the invalidating Receipt ID, and
   the required Scan continuation. Recovery inspection remains higher priority;

--- a/src/app.rs
+++ b/src/app.rs
@@ -114,44 +114,16 @@ pub fn run(cli: Cli) -> Result<Output> {
     state_security::secure_state_layout(&state_dir)
         .with_context(|| format!("cannot secure state layout {}", state_dir.display()))?;
 
-    let (command, mut result, warnings, actions) = match cli.command {
-        None => ("home", home_result(&store, &state_dir)?, vec![], vec![]),
+    let (command, mut result, warnings, mut actions) = match cli.command {
+        None => {
+            let status = status_result(&store, &database_path, &state_dir)?;
+            let actions = status_actions(&status);
+            let result = home_result(&status, actions.first());
+            ("home", result, vec![], actions)
+        }
         Some(Command::Status) => {
             let result = status_result(&store, &database_path, &state_dir)?;
-            let recovery_required = result["recovery_state"] == "required";
-            let actions = if recovery_required {
-                vec![action(
-                    "inspect_recovery",
-                    &["lifecycle", "recovery", "--json"],
-                    false,
-                    false,
-                    "recovery_required",
-                )]
-            } else if result["latest_snapshot_id"].is_null() {
-                vec![action(
-                    "scan",
-                    &["scan", "--summary", "--json"],
-                    false,
-                    false,
-                    "snapshot_required",
-                )]
-            } else if result["snapshot_state"] == "rescan_required" {
-                vec![snapshot_rescan_action()]
-            } else if let Some(plan_id) = result["pending_plans"]
-                .as_array()
-                .and_then(|plans| plans.first())
-                .and_then(|plan| plan["plan_id"].as_str())
-            {
-                vec![action(
-                    "inspect_pending_plan",
-                    &["plan", "--show", plan_id, "--json"],
-                    false,
-                    false,
-                    "pending_plan_requires_review",
-                )]
-            } else {
-                Vec::new()
-            };
+            let actions = status_actions(&result);
             ("status", result, vec![], actions)
         }
         Some(Command::SourceRoot(args)) => match args.command {
@@ -516,10 +488,13 @@ pub fn run(cli: Cli) -> Result<Output> {
     action_context.apply_result(command, &mut result);
     state_security::secure_state_layout(&state_dir)
         .with_context(|| format!("cannot secure state layout {}", state_dir.display()))?;
+    action_context.apply(&mut actions);
+    if matches!(command, "home" | "status") {
+        result["next_action"] = json!(actions.first());
+    }
     let mut envelope = JsonEnvelope::success(command, result.clone());
     envelope.warnings = warnings;
     envelope.suggested_actions = actions;
-    action_context.apply(&mut envelope.suggested_actions);
     Ok(Output {
         json: serde_json::to_string(&envelope)?,
         human: crate::present::human(command, &result),
@@ -721,12 +696,59 @@ fn parse_agent_kind(value: &str) -> Result<AgentKind> {
         .ok_or_else(|| anyhow!("unsupported Agent: {value}"))
 }
 
-fn home_result(store: &StateStore, state_dir: &Path) -> Result<Value> {
-    Ok(json!({
-        "state": if store.latest_completed_scan()?.is_some() { "ready" } else { "no_snapshot" },
-        "recovery_state": recovery_text(store, state_dir)?,
+fn home_result(status: &Value, next_action: Option<&SuggestedAction>) -> Value {
+    let state = match next_action.map(|action| action.reason_code.as_str()) {
+        Some("recovery_required") => "recovery_required",
+        Some("snapshot_required") => "no_snapshot",
+        Some("verified_mutation_requires_rescan") => "rescan_required",
+        Some("pending_plan_requires_review") => "plan_ready",
+        Some(_) | None => "ready",
+    };
+    json!({
+        "state": state,
+        "snapshot_state": status["snapshot_state"],
+        "latest_snapshot_id": status["latest_snapshot_id"],
+        "snapshot_invalidated_by_receipt_id": status["snapshot_invalidated_by_receipt_id"],
+        "pending_plan_count": status["pending_plan_count"],
+        "recovery_state": status["recovery_state"],
         "files_changed": false
-    }))
+    })
+}
+
+fn status_actions(result: &Value) -> Vec<SuggestedAction> {
+    if result["recovery_state"] == "required" {
+        vec![action(
+            "inspect_recovery",
+            &["lifecycle", "recovery", "--json"],
+            false,
+            false,
+            "recovery_required",
+        )]
+    } else if result["latest_snapshot_id"].is_null() {
+        vec![action(
+            "scan",
+            &["scan", "--summary", "--json"],
+            false,
+            false,
+            "snapshot_required",
+        )]
+    } else if result["snapshot_state"] == "rescan_required" {
+        vec![snapshot_rescan_action()]
+    } else if let Some(plan_id) = result["pending_plans"]
+        .as_array()
+        .and_then(|plans| plans.first())
+        .and_then(|plan| plan["plan_id"].as_str())
+    {
+        vec![action(
+            "inspect_pending_plan",
+            &["plan", "--show", plan_id, "--json"],
+            false,
+            false,
+            "pending_plan_requires_review",
+        )]
+    } else {
+        Vec::new()
+    }
 }
 
 fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> Result<Value> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -116,14 +116,15 @@ pub fn run(cli: Cli) -> Result<Output> {
 
     let (command, mut result, warnings, mut actions) = match cli.command {
         None => {
-            let status = status_result(&store, &database_path, &state_dir)?;
-            let actions = status_actions(&status);
-            let result = home_result(&status, actions.first());
+            let readiness = readiness_decision(&store, &state_dir)?;
+            let actions = readiness.continuation.clone().into_iter().collect();
+            let result = home_result(&readiness);
             ("home", result, vec![], actions)
         }
         Some(Command::Status) => {
-            let result = status_result(&store, &database_path, &state_dir)?;
-            let actions = status_actions(&result);
+            let readiness = readiness_decision(&store, &state_dir)?;
+            let actions = readiness.continuation.clone().into_iter().collect();
+            let result = status_result(&store, &database_path, &state_dir, &readiness)?;
             ("status", result, vec![], actions)
         }
         Some(Command::SourceRoot(args)) => match args.command {
@@ -696,87 +697,157 @@ fn parse_agent_kind(value: &str) -> Result<AgentKind> {
         .ok_or_else(|| anyhow!("unsupported Agent: {value}"))
 }
 
-fn home_result(status: &Value, next_action: Option<&SuggestedAction>) -> Value {
-    let state = match next_action.map(|action| action.reason_code.as_str()) {
-        Some("recovery_required") => "recovery_required",
-        Some("snapshot_required") => "no_snapshot",
-        Some("verified_mutation_requires_rescan") => "rescan_required",
-        Some("pending_plan_requires_review") => "plan_ready",
-        Some(_) | None => "ready",
-    };
-    json!({
-        "state": state,
-        "snapshot_state": status["snapshot_state"],
-        "latest_snapshot_id": status["latest_snapshot_id"],
-        "snapshot_invalidated_by_receipt_id": status["snapshot_invalidated_by_receipt_id"],
-        "pending_plan_count": status["pending_plan_count"],
-        "recovery_state": status["recovery_state"],
-        "files_changed": false
-    })
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SnapshotState {
+    Missing,
+    Current,
+    RescanRequired,
 }
 
-fn status_actions(result: &Value) -> Vec<SuggestedAction> {
-    if result["recovery_state"] == "required" {
-        vec![action(
-            "inspect_recovery",
-            &["lifecycle", "recovery", "--json"],
-            false,
-            false,
-            "recovery_required",
-        )]
-    } else if result["latest_snapshot_id"].is_null() {
-        vec![action(
-            "scan",
-            &["scan", "--summary", "--json"],
-            false,
-            false,
-            "snapshot_required",
-        )]
-    } else if result["snapshot_state"] == "rescan_required" {
-        vec![snapshot_rescan_action()]
-    } else if let Some(plan_id) = result["pending_plans"]
-        .as_array()
-        .and_then(|plans| plans.first())
-        .and_then(|plan| plan["plan_id"].as_str())
-    {
-        vec![action(
-            "inspect_pending_plan",
-            &["plan", "--show", plan_id, "--json"],
-            false,
-            false,
-            "pending_plan_requires_review",
-        )]
-    } else {
-        Vec::new()
+impl SnapshotState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::Current => "current",
+            Self::RescanRequired => "rescan_required",
+        }
     }
 }
 
-fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> Result<Value> {
-    let latest = store.latest_completed_scan()?;
-    let latest_scan_id = latest.as_ref().map(|scan| &scan.id);
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReadinessState {
+    RecoveryRequired,
+    NoSnapshot,
+    RescanRequired,
+    PlanReady,
+    Ready,
+}
+
+impl ReadinessState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::RecoveryRequired => "recovery_required",
+            Self::NoSnapshot => "no_snapshot",
+            Self::RescanRequired => "rescan_required",
+            Self::PlanReady => "plan_ready",
+            Self::Ready => "ready",
+        }
+    }
+}
+
+struct ReadinessDecision {
+    state: ReadinessState,
+    snapshot_state: SnapshotState,
+    latest_snapshot: Option<ScanRun>,
+    invalidating_receipt_id: Option<ReceiptId>,
+    pending_plan_count: usize,
+    pending_plans: Vec<PlanRecord>,
+    recovery_required: bool,
+    journal_issues: Vec<Value>,
+    continuation: Option<SuggestedAction>,
+}
+
+fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessDecision> {
+    let latest_snapshot = store.latest_completed_scan()?;
+    let latest_scan_id = latest_snapshot.as_ref().map(|scan| &scan.id);
     let invalidating_receipt_id = latest_scan_id
         .map(|scan_id| store.snapshot_invalidating_receipt(scan_id))
         .transpose()?
         .flatten();
     let snapshot_state = if latest_scan_id.is_none() {
-        "missing"
+        SnapshotState::Missing
     } else if invalidating_receipt_id.is_some() {
-        "rescan_required"
+        SnapshotState::RescanRequired
     } else {
-        "current"
+        SnapshotState::Current
     };
-    let actionable_scan_id = (snapshot_state == "current")
+    let actionable_scan_id = (snapshot_state == SnapshotState::Current)
         .then_some(latest_scan_id)
         .flatten();
     let (pending_plan_count, pending_plans) =
         store.pending_plans(actionable_scan_id, STATUS_PENDING_PLAN_LIMIT)?;
-    let pending_plans = pending_plans
-        .into_iter()
+    let journal_issues = journal_issues(store, state_dir)?;
+    let recovery_required = store.recovery_required()? || !journal_issues.is_empty();
+    let (state, continuation) = if recovery_required {
+        (
+            ReadinessState::RecoveryRequired,
+            Some(action(
+                "inspect_recovery",
+                &["lifecycle", "recovery", "--json"],
+                false,
+                false,
+                "recovery_required",
+            )),
+        )
+    } else if snapshot_state == SnapshotState::Missing {
+        (
+            ReadinessState::NoSnapshot,
+            Some(action(
+                "scan",
+                &["scan", "--summary", "--json"],
+                false,
+                false,
+                "snapshot_required",
+            )),
+        )
+    } else if snapshot_state == SnapshotState::RescanRequired {
+        (
+            ReadinessState::RescanRequired,
+            Some(snapshot_rescan_action()),
+        )
+    } else if let Some(plan) = pending_plans.first() {
+        (
+            ReadinessState::PlanReady,
+            Some(action(
+                "inspect_pending_plan",
+                &["plan", "--show", plan.id.as_str(), "--json"],
+                false,
+                false,
+                "pending_plan_requires_review",
+            )),
+        )
+    } else {
+        (ReadinessState::Ready, None)
+    };
+    Ok(ReadinessDecision {
+        state,
+        snapshot_state,
+        latest_snapshot,
+        invalidating_receipt_id,
+        pending_plan_count,
+        pending_plans,
+        recovery_required,
+        journal_issues,
+        continuation,
+    })
+}
+
+fn home_result(readiness: &ReadinessDecision) -> Value {
+    json!({
+        "state": readiness.state.as_str(),
+        "snapshot_state": readiness.snapshot_state.as_str(),
+        "latest_snapshot_id": readiness.latest_snapshot.as_ref().map(|scan| scan.id.to_string()),
+        "snapshot_invalidated_by_receipt_id": &readiness.invalidating_receipt_id,
+        "pending_plan_count": readiness.pending_plan_count,
+        "recovery_state": if readiness.recovery_required { "required" } else { "clear" },
+        "files_changed": false
+    })
+}
+
+fn status_result(
+    store: &StateStore,
+    database_path: &Path,
+    state_dir: &Path,
+    readiness: &ReadinessDecision,
+) -> Result<Value> {
+    let pending_plans = readiness
+        .pending_plans
+        .iter()
         .map(|plan| {
             json!({
-                "plan_id": plan.id,
-                "snapshot_id": plan.scan_id,
-                "status": plan.status,
+                "plan_id": &plan.id,
+                "snapshot_id": &plan.scan_id,
+                "status": &plan.status,
                 "created_at": plan.created_at,
             })
         })
@@ -793,17 +864,17 @@ fn status_result(store: &StateStore, database_path: &Path, state_dir: &Path) -> 
     Ok(json!({
         "database_path": database_path,
         "schema_version": store.schema_version()?,
-        "latest_snapshot_id": latest.as_ref().map(|scan| scan.id.to_string()),
-        "latest_snapshot_at": latest.as_ref().and_then(|scan| scan.completed_at),
-        "snapshot_state": snapshot_state,
-        "snapshot_invalidated_by_receipt_id": invalidating_receipt_id,
-        "pending_plan_count": pending_plan_count,
+        "latest_snapshot_id": readiness.latest_snapshot.as_ref().map(|scan| scan.id.to_string()),
+        "latest_snapshot_at": readiness.latest_snapshot.as_ref().and_then(|scan| scan.completed_at),
+        "snapshot_state": readiness.snapshot_state.as_str(),
+        "snapshot_invalidated_by_receipt_id": &readiness.invalidating_receipt_id,
+        "pending_plan_count": readiness.pending_plan_count,
         "pending_plans_returned": pending_plans.len(),
-        "pending_plans_truncated": pending_plan_count > pending_plans.len(),
+        "pending_plans_truncated": readiness.pending_plan_count > pending_plans.len(),
         "pending_plans": pending_plans,
         "last_receipt": last_receipt,
-        "recovery_state": recovery_text(store, state_dir)?,
-        "journal_issues": journal_issues(store, state_dir)?,
+        "recovery_state": if readiness.recovery_required { "required" } else { "clear" },
+        "journal_issues": &readiness.journal_issues,
         "retention": {
             "raw_usage_days": 180,
             "older_usage": "monthly_aggregates_retained",

--- a/src/present.rs
+++ b/src/present.rs
@@ -169,7 +169,7 @@ fn render(command: &str, result: &Value, options: RenderOptions) -> String {
         "lifecycle" => lifecycle(result, &mut lines),
         "source-root" => source_root(result, &mut lines),
         "setup" => setup(result, &mut lines, options.width),
-        _ => home(result, &mut lines),
+        _ => home(result, &mut lines, options.width),
     }
     if styled {
         for line in &mut lines {
@@ -329,7 +329,14 @@ fn fact_items(lines: &mut Vec<String>, label: &str, items: Vec<String>, width: u
 }
 
 fn status(value: &Value, lines: &mut Vec<String>, width: usize) {
-    fact(lines, "Database", text(value, "database_path"));
+    fact(
+        lines,
+        "Database",
+        middle_truncate(
+            &text(value, "database_path"),
+            width.saturating_sub(25).max(1),
+        ),
+    );
     fact(lines, "Schema", text(value, "schema_version"));
     fact(lines, "Latest Snapshot", text(value, "latest_snapshot_id"));
     fact(
@@ -372,7 +379,7 @@ fn status(value: &Value, lines: &mut Vec<String>, width: usize) {
     fact(lines, "Recovery", text(value, "recovery_state"));
     lines.push(String::new());
     lines.push("Read-only · no Agent files changed".into());
-    continuation(value, lines);
+    continuation(value, lines, width);
 }
 
 fn scan(value: &Value, lines: &mut Vec<String>) {
@@ -1758,21 +1765,66 @@ fn source_root(value: &Value, lines: &mut Vec<String>) {
     ));
 }
 
-fn home(value: &Value, lines: &mut Vec<String>) {
+fn home(value: &Value, lines: &mut Vec<String>, width: usize) {
     fact(lines, "State", text(value, "state"));
     fact(lines, "Snapshot state", text(value, "snapshot_state"));
     fact(lines, "Recovery", text(value, "recovery_state"));
     lines.push(String::new());
-    continuation(value, lines);
+    continuation(value, lines, width);
 }
 
-fn continuation(value: &Value, lines: &mut Vec<String>) {
+fn continuation(value: &Value, lines: &mut Vec<String>, width: usize) {
     if let Some(action) = value.get("next_action").filter(|action| !action.is_null()) {
-        let argv = serde_json::to_string(&action["argv"]).unwrap_or_else(|_| "[]".to_owned());
-        lines.push(format!("Continue argv: {argv}"));
+        lines.push("Continue argv:".into());
+        for (index, argument) in action["argv"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .enumerate()
+        {
+            let prefix = format!("  [{index}] ");
+            let indent = " ".repeat(display_width(&prefix));
+            let budget = width.saturating_sub(display_width(&prefix) + 2).max(8);
+            let chunks = exact_json_string_chunks(argument, budget);
+            let last = chunks.len().saturating_sub(1);
+            for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+                lines.push(format!(
+                    "{}{}{}",
+                    if chunk_index == 0 { &prefix } else { &indent },
+                    chunk,
+                    if chunk_index < last { " +" } else { "" }
+                ));
+            }
+        }
     } else {
         lines.push("No required continuation".into());
     }
+}
+
+fn exact_json_string_chunks(value: &str, budget: usize) -> Vec<String> {
+    if value.is_empty() {
+        return vec!["\"\"".into()];
+    }
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    for character in value.chars() {
+        current.push(character);
+        let encoded = serde_json::to_string(&current).unwrap_or_else(|_| "\"\"".into());
+        if display_width(&encoded) <= budget {
+            continue;
+        }
+        current.pop();
+        if !current.is_empty() {
+            chunks.push(serde_json::to_string(&current).unwrap_or_else(|_| "\"\"".into()));
+        }
+        current.clear();
+        current.push(character);
+    }
+    if !current.is_empty() {
+        chunks.push(serde_json::to_string(&current).unwrap_or_else(|_| "\"\"".into()));
+    }
+    chunks
 }
 
 fn summary(safety: &str, next: &str) -> Vec<String> {
@@ -1952,13 +2004,14 @@ mod tests {
 
         let pending = render("status", &base, options);
         assert!(pending.contains("Review Plan            plan_01M0QDAC102GEXKCMHVP97GF2V"));
-        let exact = "Continue argv: [\"skillroster\",\"plan\",\"--show\",\"plan_01M0QDAC102GEXKCMHVP97GF2V\",\"--json\"]";
-        assert!(pending.contains(exact));
+        assert!(pending.contains("Continue argv:\n  [0] \"skillroster\"\n  [1] \"plan\""));
+        assert!(pending.contains("  [3] \"plan_01M0QDAC102GEXKCMHVP97GF2V\""));
+        assert!(pending.lines().all(|line| display_width(line) <= 80));
 
         let mut recovery = base.clone();
         recovery["recovery_state"] = json!("required");
         let recovery = render("status", &recovery, options);
-        assert!(recovery.contains(exact));
+        assert!(recovery.contains("  [3] \"plan_01M0QDAC102GEXKCMHVP97GF2V\""));
 
         let mut healthy = base;
         healthy["pending_plan_count"] = json!(0);
@@ -1966,6 +2019,49 @@ mod tests {
         healthy["next_action"] = Value::Null;
         let healthy = render("status", &healthy, options);
         assert!(healthy.contains("No required continuation"));
+    }
+
+    #[test]
+    fn continuation_wraps_exact_json_chunks_to_the_requested_width() {
+        let value = json!({
+            "next_action": {
+                "argv": [
+                    "skillroster",
+                    "--state-dir",
+                    "/a state directory with spaces/and/a/very/long/path/that/must/not/be/truncated"
+                ]
+            }
+        });
+        let output = render(
+            "home",
+            &value,
+            RenderOptions {
+                width: 40,
+                styled: false,
+            },
+        );
+        assert!(output.lines().all(|line| display_width(line) <= 40));
+        assert!(output.contains(" +\n      \""));
+        let chunks = output
+            .lines()
+            .skip_while(|line| *line != "Continue argv:")
+            .skip(1)
+            .filter_map(|line| {
+                let trimmed = line.trim_start();
+                let payload = trimmed
+                    .find(']')
+                    .map(|close| trimmed[close + 1..].trim_start())
+                    .unwrap_or(trimmed);
+                payload
+                    .starts_with('"')
+                    .then(|| payload.strip_suffix(" +").unwrap_or(payload))
+            })
+            .map(|chunk| serde_json::from_str::<String>(chunk).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            chunks.concat(),
+            "skillroster--state-dir/a state directory with spaces/and/a/very/long/path/that/must/not/be/truncated"
+        );
     }
 
     #[test]

--- a/src/present.rs
+++ b/src/present.rs
@@ -370,24 +370,9 @@ fn status(value: &Value, lines: &mut Vec<String>, width: usize) {
         fact(lines, "Last Receipt", "none");
     }
     fact(lines, "Recovery", text(value, "recovery_state"));
-    let next = if value["recovery_state"] == "required" {
-        "Next: skillroster lifecycle recovery".to_owned()
-    } else if value.get("latest_snapshot_id").is_none_or(Value::is_null) {
-        "Next: skillroster scan".to_owned()
-    } else if value["snapshot_state"] == "rescan_required" {
-        "Next: skillroster scan --summary --json".to_owned()
-    } else if pending_plan.is_some() {
-        "Next: inspect the Review Plan above".to_owned()
-    } else {
-        "Next: scan only when fresher inventory is needed".to_owned()
-    };
     lines.push(String::new());
     lines.push("Read-only · no Agent files changed".into());
-    if display_width(&next) > width {
-        lines.push(middle_truncate(&next, width));
-    } else {
-        lines.push(next);
-    }
+    continuation(value, lines);
 }
 
 fn scan(value: &Value, lines: &mut Vec<String>) {
@@ -1775,9 +1760,19 @@ fn source_root(value: &Value, lines: &mut Vec<String>) {
 
 fn home(value: &Value, lines: &mut Vec<String>) {
     fact(lines, "State", text(value, "state"));
+    fact(lines, "Snapshot state", text(value, "snapshot_state"));
     fact(lines, "Recovery", text(value, "recovery_state"));
     lines.push(String::new());
-    lines.push("Next: skillroster scan | report | status".into());
+    continuation(value, lines);
+}
+
+fn continuation(value: &Value, lines: &mut Vec<String>) {
+    if let Some(action) = value.get("next_action").filter(|action| !action.is_null()) {
+        let argv = serde_json::to_string(&action["argv"]).unwrap_or_else(|_| "[]".to_owned());
+        lines.push(format!("Continue argv: {argv}"));
+    } else {
+        lines.push("No required continuation".into());
+    }
 }
 
 fn summary(safety: &str, next: &str) -> Vec<String> {
@@ -1929,7 +1924,7 @@ mod tests {
     }
 
     #[test]
-    fn status_routes_to_the_highest_priority_read_only_decision() {
+    fn status_renders_the_provided_continuation_without_reinterpreting_state() {
         let base = json!({
             "database_path": "/db",
             "schema_version": 9,
@@ -1944,7 +1939,11 @@ mod tests {
                 "created_at": 1
             }],
             "last_receipt": null,
-            "recovery_state": "clear"
+            "recovery_state": "clear",
+            "next_action": {
+                "action": "inspect_pending_plan",
+                "argv": ["skillroster", "plan", "--show", "plan_01M0QDAC102GEXKCMHVP97GF2V", "--json"]
+            }
         });
         let options = RenderOptions {
             width: 80,
@@ -1953,45 +1952,20 @@ mod tests {
 
         let pending = render("status", &base, options);
         assert!(pending.contains("Review Plan            plan_01M0QDAC102GEXKCMHVP97GF2V"));
-        assert!(pending.contains("Next: inspect the Review Plan above"));
-        assert!(!pending.contains("Next: skillroster scan"));
-
-        let narrow = render(
-            "status",
-            &base,
-            RenderOptions {
-                width: 40,
-                styled: false,
-            },
-        );
-        assert!(narrow.contains("Review Plan"));
-        assert!(narrow.contains("\n    plan_01M0QDAC102GEXKCMHVP97GF2V"));
-        assert!(!narrow.contains("Review Plan            plan_"));
-        assert!(narrow.contains("Next: inspect the Review Plan above"));
-        assert!(narrow.lines().all(|line| display_width(line) <= 40));
+        let exact = "Continue argv: [\"skillroster\",\"plan\",\"--show\",\"plan_01M0QDAC102GEXKCMHVP97GF2V\",\"--json\"]";
+        assert!(pending.contains(exact));
 
         let mut recovery = base.clone();
         recovery["recovery_state"] = json!("required");
         let recovery = render("status", &recovery, options);
-        assert!(recovery.contains("Next: skillroster lifecycle recovery"));
-
-        let mut missing_snapshot = base.clone();
-        missing_snapshot["latest_snapshot_id"] = Value::Null;
-        missing_snapshot["snapshot_state"] = json!("missing");
-        let missing_snapshot = render("status", &missing_snapshot, options);
-        assert!(missing_snapshot.contains("Next: skillroster scan"));
-
-        let mut stale = base.clone();
-        stale["snapshot_state"] = json!("rescan_required");
-        let stale = render("status", &stale, options);
-        assert!(stale.contains("Snapshot state         rescan_required"));
-        assert!(stale.contains("Next: skillroster scan --summary --json"));
+        assert!(recovery.contains(exact));
 
         let mut healthy = base;
         healthy["pending_plan_count"] = json!(0);
         healthy["pending_plans"] = json!([]);
+        healthy["next_action"] = Value::Null;
         let healthy = render("status", &healthy, options);
-        assert!(healthy.contains("Next: scan only when fresher inventory is needed"));
+        assert!(healthy.contains("No required continuation"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -819,6 +819,157 @@ fn healthy_status_does_not_suggest_an_unconditional_rescan() {
 }
 
 #[test]
+fn home_and_status_share_the_missing_snapshot_scan_continuation() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home with spaces");
+    let state = temp.path().join("state with spaces");
+    fs::create_dir_all(&home).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    let home_result = json_output(&run(&common, None));
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    let expected = context_action_argv(&home, &state, &["scan", "--summary", "--json"]);
+
+    assert_eq!(home_result["result"]["state"], "no_snapshot");
+    assert_eq!(home_result["result"]["snapshot_state"], "missing");
+    assert_eq!(
+        home_result["suggested_actions"],
+        status["suggested_actions"]
+    );
+    assert_eq!(home_result["suggested_actions"][0]["argv"], expected);
+    assert_eq!(home_result["suggested_actions"][0]["mutates"], false);
+    assert_eq!(
+        home_result["suggested_actions"][0]["requires_confirmation"],
+        false
+    );
+
+    let human = run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+        ],
+        None,
+    );
+    assert!(human.status.success());
+    let human = String::from_utf8(human.stdout).unwrap();
+    assert!(human.contains(&serde_json::to_string(&expected).unwrap()));
+    let human_status = run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "status",
+        ],
+        None,
+    );
+    assert!(human_status.status.success());
+    let human_status = String::from_utf8(human_status.stdout).unwrap();
+    assert!(human_status.contains(&serde_json::to_string(&expected).unwrap()));
+}
+
+#[test]
+fn home_routes_a_current_snapshot_only_when_a_ready_plan_exists() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    fs::create_dir_all(home.join(".codex/sessions")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let healthy = json_output(&run(&common, None));
+    assert_eq!(healthy["result"]["state"], "ready");
+    assert_eq!(healthy["result"]["snapshot_state"], "current");
+    assert_eq!(healthy["suggested_actions"], json!([]));
+
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    let plan_ready = json_output(&run(&common, None));
+    assert_eq!(plan_ready["result"]["state"], "plan_ready");
+    assert_eq!(plan_ready["result"]["snapshot_state"], "current");
+    assert_eq!(plan_ready["result"]["pending_plan_count"], 1);
+    assert_eq!(plan_ready["suggested_actions"], status["suggested_actions"]);
+    assert_eq!(
+        plan_ready["suggested_actions"][0]["argv"],
+        context_action_argv(
+            &home,
+            &state,
+            &[
+                "plan",
+                "--show",
+                setup["result"]["plan_id"].as_str().unwrap(),
+                "--json"
+            ]
+        )
+    );
+}
+
+#[test]
+fn home_and_status_prioritize_recovery_over_an_invalidated_snapshot() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    fs::create_dir_all(home.join(".codex/sessions")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    let applied = json_output(&run(
+        &[
+            &common[..],
+            &["apply", setup["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    database
+        .execute(
+            "UPDATE receipts SET status = 'recovery_required' WHERE id = ?1",
+            [applied["result"]["receipt_id"].as_str().unwrap()],
+        )
+        .unwrap();
+    drop(database);
+
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    let home_result = json_output(&run(&common, None));
+    assert_eq!(home_result["result"]["state"], "recovery_required");
+    assert_eq!(home_result["result"]["recovery_state"], "required");
+    assert_eq!(
+        home_result["suggested_actions"],
+        status["suggested_actions"]
+    );
+    assert_eq!(
+        home_result["suggested_actions"][0]["argv"],
+        context_action_argv(&home, &state, &["lifecycle", "recovery", "--json"])
+    );
+    assert_eq!(
+        home_result["suggested_actions"][0]["reason_code"],
+        "recovery_required"
+    );
+}
+
+#[test]
 fn public_cli_exits_quietly_when_the_output_consumer_closes() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
@@ -4292,6 +4443,17 @@ fn verified_apply_invalidates_inventory_until_scan_or_exact_undo() {
     assert_eq!(status["result"]["pending_plans"], json!([]));
     assert_eq!(status["suggested_actions"].as_array().unwrap().len(), 1);
     assert_eq!(status["suggested_actions"][0]["action"], "scan");
+    let home_result = json_output(&run(&common, None));
+    assert_eq!(home_result["result"]["state"], "rescan_required");
+    assert_eq!(home_result["result"]["snapshot_state"], "rescan_required");
+    assert_eq!(
+        home_result["result"]["snapshot_invalidated_by_receipt_id"],
+        applied["result"]["receipt_id"]
+    );
+    assert_eq!(
+        home_result["suggested_actions"],
+        status["suggested_actions"]
+    );
     let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
     let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
     assert_eq!(undone["result"]["verification"], "passed");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -36,6 +36,51 @@ fn run(args: &[&str], stdin: Option<&str>) -> std::process::Output {
     child.wait_with_output().unwrap()
 }
 
+fn run_with_columns(args: &[&str], columns: usize) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_skillroster"))
+        .args(args)
+        .env("COLUMNS", columns.to_string())
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap()
+}
+
+fn continuation_argv(output: &str) -> Vec<String> {
+    let mut argv = Vec::new();
+    let mut current = None::<String>;
+    let mut in_continuation = false;
+    for line in output.lines() {
+        if line == "Continue argv:" {
+            in_continuation = true;
+            continue;
+        }
+        if !in_continuation || line.trim().is_empty() {
+            continue;
+        }
+        let trimmed = line.trim_start();
+        let payload = if let Some(close) = trimmed
+            .strip_prefix('[')
+            .and_then(|line| line.find(']').map(|close| (line, close)))
+        {
+            if let Some(argument) = current.take() {
+                argv.push(argument);
+            }
+            close.0[close.1 + 1..].trim_start()
+        } else if trimmed.starts_with('"') {
+            trimmed
+        } else {
+            break;
+        };
+        let chunk = payload.strip_suffix(" +").unwrap_or(payload);
+        let decoded: String = serde_json::from_str(chunk).unwrap();
+        current.get_or_insert_with(String::new).push_str(&decoded);
+    }
+    if let Some(argument) = current {
+        argv.push(argument);
+    }
+    argv
+}
+
 #[cfg(unix)]
 fn run_with_umask(args: &[&str], umask: libc::mode_t) -> std::process::Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_skillroster"));
@@ -849,19 +894,26 @@ fn home_and_status_share_the_missing_snapshot_scan_continuation() {
         false
     );
 
-    let human = run(
+    let human = run_with_columns(
         &[
             "--home",
             home.to_str().unwrap(),
             "--state-dir",
             state.to_str().unwrap(),
         ],
-        None,
+        60,
     );
     assert!(human.status.success());
     let human = String::from_utf8(human.stdout).unwrap();
-    assert!(human.contains(&serde_json::to_string(&expected).unwrap()));
-    let human_status = run(
+    let expected_argv = expected
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|argument| argument.as_str().unwrap().to_owned())
+        .collect::<Vec<_>>();
+    assert_eq!(continuation_argv(&human), expected_argv);
+    assert!(human.lines().all(|line| line.chars().count() <= 60));
+    let human_status = run_with_columns(
         &[
             "--home",
             home.to_str().unwrap(),
@@ -869,11 +921,15 @@ fn home_and_status_share_the_missing_snapshot_scan_continuation() {
             state.to_str().unwrap(),
             "status",
         ],
-        None,
+        60,
     );
     assert!(human_status.status.success());
     let human_status = String::from_utf8(human_status.stdout).unwrap();
-    assert!(human_status.contains(&serde_json::to_string(&expected).unwrap()));
+    assert_eq!(continuation_argv(&human_status), expected_argv);
+    assert!(
+        human_status.lines().all(|line| line.chars().count() <= 60),
+        "line exceeded 60 columns:\n{human_status}"
+    );
 }
 
 #[test]
@@ -942,18 +998,29 @@ fn home_and_status_prioritize_recovery_over_an_invalidated_snapshot() {
         .concat(),
         None,
     ));
-    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
-    database
-        .execute(
-            "UPDATE receipts SET status = 'recovery_required' WHERE id = ?1",
-            [applied["result"]["receipt_id"].as_str().unwrap()],
-        )
-        .unwrap();
-    drop(database);
+    let applied_receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let applied_journal = state
+        .join("receipts")
+        .join(format!("{applied_receipt_id}.json"));
+    let mut orphan: Value = serde_json::from_slice(&fs::read(applied_journal).unwrap()).unwrap();
+    let orphan_id = "receipt_00000000000000000000000000";
+    orphan["id"] = json!(orphan_id);
+    orphan["status"] = json!("recovery_required");
+    fs::write(
+        state.join("receipts").join(format!("{orphan_id}.json")),
+        serde_json::to_vec_pretty(&orphan).unwrap(),
+    )
+    .unwrap();
 
     let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
     let home_result = json_output(&run(&common, None));
     assert_eq!(home_result["result"]["state"], "recovery_required");
+    assert_eq!(home_result["result"]["snapshot_state"], "rescan_required");
+    assert_eq!(status["result"]["snapshot_state"], "rescan_required");
+    assert_eq!(
+        status["result"]["snapshot_invalidated_by_receipt_id"],
+        applied_receipt_id
+    );
     assert_eq!(home_result["result"]["recovery_state"], "required");
     assert_eq!(
         home_result["suggested_actions"],


### PR DESCRIPTION
## Summary
- make bare Home expose the authoritative readiness state and one exact continuation
- centralize Home and Status routing in one typed readiness decision
- keep human continuation argv exact and bounded on narrow terminals

## Verification
- `bash scripts/ci-full-check.sh`
- Rust: 301 unit, 8 acceptance, 83 CLI
- Node harness: 137
- independent specification review: no findings
- independent repository-standards review: no findings

Closes #273