### PR TITLE
fix: preserve Scan-to-Report continuation through Home

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -64,9 +64,10 @@ The Agent never manufactures a problem so that an Apply action exists.
 
 The default no-subcommand Home is the Agent's bounded readiness router. It and
 Status share one action-priority decision: recovery, missing-Snapshot Scan,
-invalidated-Snapshot Scan, Ready Plan inspection, then no required
-continuation. Home never calls a stale Snapshot ready, and its human surface
-prints the same exact argv returned in the JSON suggested action.
+invalidated-Snapshot Scan, Ready Plan inspection, missing current-Snapshot
+Report, then no required continuation. Home never calls a stale or unanalyzed
+Snapshot ready, and its human surface prints the same exact argv returned in
+the JSON suggested action.
 
 ## 4. First-screen information
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -212,10 +212,14 @@ skillroster setup [--modified-choice retain-local|adopt-current] [--json]
 The no-subcommand Home is the bounded readiness projection for Agents. It does
 not maintain an independent readiness heuristic. Home and `status` use one
 continuation selector with this priority: recovery inspection, missing-Snapshot
-Scan, invalidated-Snapshot Scan, actionable Ready Plan inspection, then no
-required continuation. Home exposes `recovery_required`, `no_snapshot`,
-`rescan_required`, `plan_ready`, or `ready`; its JSON action and human argv are
-the same generated continuation with the original discovery context preserved.
+Scan, invalidated-Snapshot Scan, actionable Ready Plan inspection, a missing
+Report for the current Snapshot, then no required continuation. Home exposes
+`recovery_required`, `no_snapshot`, `rescan_required`, `plan_ready`,
+`report_required`, or `ready`; its JSON action and human argv are the same
+generated continuation with the original discovery context preserved. A
+current Snapshot proves inventory freshness, not completed analysis: Home and
+`status` remain resumable through `report --json` until that Snapshot has a
+persisted Report.
 
 Finding lists and full Finding records default to 20 rows per page. Compact
 `report --finding <id>` detail defaults to five rows so an Agent receives the

--- a/src/app.rs
+++ b/src/app.rs
@@ -258,18 +258,7 @@ pub fn run(cli: Cli) -> Result<Output> {
                 parse_source_roots(&cli.source_roots)?,
                 args.summary,
             )?;
-            (
-                "scan",
-                result,
-                warnings,
-                vec![action(
-                    "report",
-                    &["report", "--json"],
-                    false,
-                    false,
-                    "scan_complete",
-                )],
-            )
+            ("scan", result, warnings, vec![report_action()])
         }
         Some(Command::Report(args)) => {
             let request = if let Some(id) = args.finding.as_deref() {
@@ -813,16 +802,7 @@ fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessD
         .transpose()?
         .unwrap_or(false)
     {
-        (
-            ReadinessState::ReportRequired,
-            Some(action(
-                "report",
-                &["report", "--json"],
-                false,
-                false,
-                "scan_complete",
-            )),
-        )
+        (ReadinessState::ReportRequired, Some(report_action()))
     } else {
         (ReadinessState::Ready, None)
     };
@@ -9477,6 +9457,16 @@ fn action(
         requires_confirmation: confirmation,
         reason_code: reason.into(),
     }
+}
+
+fn report_action() -> SuggestedAction {
+    action(
+        "report",
+        &["report", "--json"],
+        false,
+        false,
+        "scan_complete",
+    )
 }
 
 fn snapshot_rescan_action() -> SuggestedAction {

--- a/src/app.rs
+++ b/src/app.rs
@@ -720,6 +720,7 @@ enum ReadinessState {
     NoSnapshot,
     RescanRequired,
     PlanReady,
+    ReportRequired,
     Ready,
 }
 
@@ -730,6 +731,7 @@ impl ReadinessState {
             Self::NoSnapshot => "no_snapshot",
             Self::RescanRequired => "rescan_required",
             Self::PlanReady => "plan_ready",
+            Self::ReportRequired => "report_required",
             Self::Ready => "ready",
         }
     }
@@ -806,6 +808,21 @@ fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessD
                 "pending_plan_requires_review",
             )),
         )
+    } else if !latest_scan_id
+        .map(|scan_id| store.report_exists_for_scan(scan_id))
+        .transpose()?
+        .unwrap_or(false)
+    {
+        (
+            ReadinessState::ReportRequired,
+            Some(action(
+                "report",
+                &["report", "--json"],
+                false,
+                false,
+                "scan_complete",
+            )),
+        )
     } else {
         (ReadinessState::Ready, None)
     };
@@ -862,6 +879,7 @@ fn status_result(
     });
     let lifecycle = store.lifecycle_counts()?;
     Ok(json!({
+        "state": readiness.state.as_str(),
         "database_path": database_path,
         "schema_version": store.schema_version()?,
         "latest_snapshot_id": readiness.latest_snapshot.as_ref().map(|scan| scan.id.to_string()),

--- a/src/app.rs
+++ b/src/app.rs
@@ -10067,6 +10067,7 @@ mod recovery_tests {
                 coverage_notes: Vec::new(),
             })
             .unwrap();
+        store.save_scan_payload(&scan_id, &json!({})).unwrap();
         let roster = source_reference_fixture_roster(&report_id);
         let escaping = source_reference_fixture_finding(
             "finding_197_source",
@@ -10118,6 +10119,7 @@ mod recovery_tests {
                 })
                 .unwrap();
         }
+        store.save_scan_payload(&scan_id, &json!({})).unwrap();
         let roster = source_reference_fixture_roster(&report_id);
         let first = source_reference_fixture_finding(
             "finding_197_source_a",

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -13,6 +13,11 @@ use crate::source_policy::{RootIdentity, SourcePermissionId, SourceRootPermissio
 use crate::state_security;
 
 const SCHEMA_VERSION: i64 = 12;
+const REPORT_EXISTS_FOR_SCAN_SQL: &str = "SELECT EXISTS(
+        SELECT 1 FROM reports r
+        JOIN scan_payloads p ON p.scan_id = r.scan_id
+        WHERE r.scan_id = ?1 AND r.scan_payload_updated_at = p.updated_at
+    )";
 
 fn sqlite_nofollow_path(path: &Path) -> StorageResult<PathBuf> {
     let parent = path.parent().ok_or_else(|| {
@@ -485,7 +490,7 @@ impl StateStore {
             "INSERT INTO scan_payloads (scan_id, payload_json, updated_at)
              VALUES (?1, ?2, CAST(strftime('%s', 'now') AS INTEGER))
              ON CONFLICT(scan_id) DO UPDATE SET payload_json = excluded.payload_json,
-                 updated_at = excluded.updated_at",
+                 updated_at = MAX(scan_payloads.updated_at + 1, excluded.updated_at)",
             params![id.as_str(), json(payload)?],
         )?;
         Ok(())
@@ -573,15 +578,9 @@ impl StateStore {
     }
 
     pub fn report_exists_for_scan(&self, id: &ScanId) -> StorageResult<bool> {
-        Ok(self.connection.query_row(
-            "SELECT EXISTS(
-                SELECT 1 FROM reports r
-                JOIN scan_payloads p ON p.scan_id = r.scan_id
-                WHERE r.scan_id = ?1 AND r.scan_payload_updated_at = p.updated_at
-            )",
-            [id.as_str()],
-            |row| row.get(0),
-        )?)
+        Ok(self
+            .connection
+            .query_row(REPORT_EXISTS_FOR_SCAN_SQL, [id.as_str()], |row| row.get(0))?)
     }
 
     pub fn save_agent(&self, agent: &AgentRecord) -> StorageResult<AgentId> {
@@ -1970,7 +1969,10 @@ impl StateStore {
                             scan_payloads.updated_at) >= ?1
                     ), json('[]'))
                  ),
-                 updated_at = CAST(strftime('%s', 'now') AS INTEGER) + 1
+                 updated_at = MAX(
+                    scan_payloads.updated_at + 1,
+                    CAST(strftime('%s', 'now') AS INTEGER)
+                 )
              WHERE EXISTS (
                 SELECT 1 FROM json_each(scan_payloads.payload_json, '$.usage') AS usage
                 WHERE COALESCE(
@@ -3952,9 +3954,12 @@ mod tests {
         store
             .connection
             .execute(
-                "UPDATE scan_payloads SET updated_at = 200 WHERE scan_id = ?1",
+                "UPDATE scan_payloads SET updated_at = 10000000000 WHERE scan_id = ?1",
                 [scan.id.as_str()],
             )
+            .unwrap();
+        store
+            .save_scan_payload(&scan.id, &serde_json::json!({"version": 1}))
             .unwrap();
         let first = ReportRecord {
             id: ReportId::parse("report_00000000000000000000000000000001").unwrap(),
@@ -3965,13 +3970,26 @@ mod tests {
         store.save_report(&first, &[]).unwrap();
         assert!(store.report_exists_for_scan(&scan.id).unwrap());
 
-        store
+        let first_version: i64 = store
             .connection
-            .execute(
-                "UPDATE scan_payloads SET updated_at = 201 WHERE scan_id = ?1",
+            .query_row(
+                "SELECT updated_at FROM scan_payloads WHERE scan_id = ?1",
                 [scan.id.as_str()],
+                |row| row.get(0),
             )
             .unwrap();
+        store
+            .save_scan_payload(&scan.id, &serde_json::json!({"version": 2}))
+            .unwrap();
+        let second_version: i64 = store
+            .connection
+            .query_row(
+                "SELECT updated_at FROM scan_payloads WHERE scan_id = ?1",
+                [scan.id.as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(second_version, first_version + 1);
         assert!(!store.report_exists_for_scan(&scan.id).unwrap());
         assert!(store.latest_report().unwrap().is_none());
 
@@ -3991,14 +4009,7 @@ mod tests {
         let store = StateStore::open_in_memory().unwrap();
         let details = store
             .connection
-            .prepare(
-                "EXPLAIN QUERY PLAN
-                 SELECT EXISTS(
-                    SELECT 1 FROM reports r
-                    JOIN scan_payloads p ON p.scan_id = r.scan_id
-                    WHERE r.scan_id = ?1 AND r.scan_payload_updated_at = p.updated_at
-                 )",
-            )
+            .prepare(&format!("EXPLAIN QUERY PLAN {REPORT_EXISTS_FOR_SCAN_SQL}"))
             .unwrap()
             .query_map(["scan_any"], |row| row.get::<_, String>(3))
             .unwrap()
@@ -4033,6 +4044,13 @@ mod tests {
                     }],
                     "coverage": [{"agent": "codex", "denominator_reliable": false}]
                 }),
+            )
+            .unwrap();
+        store
+            .connection
+            .execute(
+                "UPDATE scan_payloads SET updated_at = 10000000000 WHERE scan_id = ?1",
+                [scan.id.as_str()],
             )
             .unwrap();
         let agent = AgentRecord {
@@ -4086,6 +4104,15 @@ mod tests {
         assert_eq!(result.deleted_raw_usage_rows, 1);
         assert_eq!(result.deleted_evidence_rows, 1);
         assert_eq!(result.deleted_payload_usage_summaries, 1);
+        let payload_version: i64 = store
+            .connection
+            .query_row(
+                "SELECT updated_at FROM scan_payloads WHERE scan_id = ?1",
+                [scan.id.as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(payload_version, 10000000001);
         let counts = store.lifecycle_counts().unwrap();
         assert_eq!(counts.raw_usage_rows, 0);
         assert_eq!(counts.monthly_usage_rows, 1);

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -12,7 +12,7 @@ use crate::model::{
 use crate::source_policy::{RootIdentity, SourcePermissionId, SourceRootPermission};
 use crate::state_security;
 
-const SCHEMA_VERSION: i64 = 11;
+const SCHEMA_VERSION: i64 = 12;
 
 fn sqlite_nofollow_path(path: &Path) -> StorageResult<PathBuf> {
     let parent = path.parent().ok_or_else(|| {
@@ -147,6 +147,7 @@ const MIGRATIONS: [(i64, Migration); SCHEMA_VERSION as usize] = [
     (9, migration_v9),
     (10, migration_v10),
     (11, migration_v11),
+    (12, migration_v12),
 ];
 
 fn validate_migrations(migrations: &[(i64, Migration)], schema_version: i64) -> StorageResult<()> {
@@ -546,7 +547,7 @@ impl StateStore {
             .query_row(
                 "SELECT r.id, r.scan_id, r.created_at, r.summary_json FROM reports r
                  JOIN scan_payloads p ON p.scan_id = r.scan_id
-                 WHERE r.created_at >= p.updated_at
+                 WHERE r.scan_payload_updated_at = p.updated_at
                  ORDER BY r.created_at DESC, r.rowid DESC LIMIT 1",
                 [],
                 |row| {
@@ -576,7 +577,7 @@ impl StateStore {
             "SELECT EXISTS(
                 SELECT 1 FROM reports r
                 JOIN scan_payloads p ON p.scan_id = r.scan_id
-                WHERE r.scan_id = ?1 AND r.created_at >= p.updated_at
+                WHERE r.scan_id = ?1 AND r.scan_payload_updated_at = p.updated_at
             )",
             [id.as_str()],
             |row| row.get(0),
@@ -1143,8 +1144,11 @@ impl StateStore {
         findings: &[FindingRecord],
     ) -> StorageResult<()> {
         let transaction = self.connection.unchecked_transaction()?;
-        transaction.execute(
-            "INSERT INTO reports (id, scan_id, created_at, summary_json) VALUES (?1, ?2, ?3, ?4)",
+        let inserted = transaction.execute(
+            "INSERT INTO reports
+                (id, scan_id, created_at, scan_payload_updated_at, summary_json)
+             SELECT ?1, ?2, ?3, p.updated_at, ?4
+             FROM scan_payloads p WHERE p.scan_id = ?2",
             params![
                 report.id.as_str(),
                 report.scan_id.as_str(),
@@ -1152,6 +1156,12 @@ impl StateStore {
                 json(&report.summary)?,
             ],
         )?;
+        if inserted != 1 {
+            return Err(StorageError::InvalidData(format!(
+                "Report {} has no persisted Snapshot payload",
+                report.id
+            )));
+        }
         for finding in findings {
             save_finding(&transaction, finding)?;
         }
@@ -2371,6 +2381,23 @@ fn migration_v11(transaction: &Transaction<'_>) -> StorageResult<()> {
     Ok(())
 }
 
+fn migration_v12(transaction: &Transaction<'_>) -> StorageResult<()> {
+    transaction.execute_batch(
+        "ALTER TABLE reports ADD COLUMN scan_payload_updated_at INTEGER;
+         UPDATE reports
+         SET scan_payload_updated_at = (
+             SELECT p.updated_at FROM scan_payloads p WHERE p.scan_id = reports.scan_id
+         )
+         WHERE EXISTS (
+             SELECT 1 FROM scan_payloads p
+             WHERE p.scan_id = reports.scan_id AND reports.created_at >= p.updated_at
+         );
+         CREATE INDEX reports_scan_payload_version
+            ON reports(scan_id, scan_payload_updated_at);",
+    )?;
+    Ok(())
+}
+
 fn table_count(connection: &Connection, table: &str) -> StorageResult<u64> {
     let query = format!("SELECT COUNT(*) FROM {table}");
     Ok(connection.query_row(&query, [], |row| row.get(0))?)
@@ -2678,7 +2705,7 @@ mod tests {
 
     #[test]
     fn migration_upgrades_prior_states_sequentially() {
-        for starting_version in [1_i64, 2, 3, 4, 5, 6, 7, 8, 9, 10] {
+        for starting_version in [1_i64, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] {
             let mut connection = Connection::open_in_memory().unwrap();
             let transaction = connection.transaction().unwrap();
             migration_v1(&transaction).unwrap();
@@ -2708,6 +2735,9 @@ mod tests {
             }
             if starting_version >= 10 {
                 migration_v10(&transaction).unwrap();
+            }
+            if starting_version >= 11 {
+                migration_v11(&transaction).unwrap();
             }
             transaction
                 .pragma_update(None, "user_version", starting_version)
@@ -2827,6 +2857,44 @@ mod tests {
             )
             .unwrap();
         assert_eq!(reverse_invalidations, 1);
+    }
+
+    #[test]
+    fn report_payload_version_migration_backfills_only_previously_fresh_reports() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let transaction = connection.transaction().unwrap();
+        for (_, migration) in &MIGRATIONS[..11] {
+            migration(&transaction).unwrap();
+        }
+        transaction
+            .execute_batch(
+                "INSERT INTO scans VALUES ('scan_a', 1, 2, 'completed', '[]');
+                 INSERT INTO scan_payloads VALUES ('scan_a', '{}', 100);
+                 INSERT INTO reports VALUES
+                    ('report_stale', 'scan_a', 99, '{}'),
+                    ('report_fresh', 'scan_a', 100, '{}');",
+            )
+            .unwrap();
+
+        migration_v12(&transaction).unwrap();
+
+        let bound = transaction
+            .prepare("SELECT id FROM reports WHERE scan_payload_updated_at IS NOT NULL ORDER BY id")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(bound, vec!["report_fresh"]);
+        let indexed: i64 = transaction
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type = 'index' AND name = 'reports_scan_payload_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(indexed, 1);
     }
 
     #[test]
@@ -3871,6 +3939,77 @@ mod tests {
         let latest = store.latest_report().unwrap().unwrap();
         assert_eq!(latest.id, second_report.id);
         assert_eq!(latest.summary["order"], 2);
+    }
+
+    #[test]
+    fn report_freshness_binds_the_exact_payload_version_without_timestamp_ordering() {
+        let store = StateStore::open_in_memory().unwrap();
+        let scan = scan();
+        store.save_scan(&scan).unwrap();
+        store
+            .save_scan_payload(&scan.id, &serde_json::json!({"version": 1}))
+            .unwrap();
+        store
+            .connection
+            .execute(
+                "UPDATE scan_payloads SET updated_at = 200 WHERE scan_id = ?1",
+                [scan.id.as_str()],
+            )
+            .unwrap();
+        let first = ReportRecord {
+            id: ReportId::parse("report_00000000000000000000000000000001").unwrap(),
+            scan_id: scan.id.clone(),
+            created_at: 100,
+            summary: serde_json::json!({"version": 1}),
+        };
+        store.save_report(&first, &[]).unwrap();
+        assert!(store.report_exists_for_scan(&scan.id).unwrap());
+
+        store
+            .connection
+            .execute(
+                "UPDATE scan_payloads SET updated_at = 201 WHERE scan_id = ?1",
+                [scan.id.as_str()],
+            )
+            .unwrap();
+        assert!(!store.report_exists_for_scan(&scan.id).unwrap());
+        assert!(store.latest_report().unwrap().is_none());
+
+        let second = ReportRecord {
+            id: ReportId::parse("report_00000000000000000000000000000002").unwrap(),
+            created_at: 100,
+            summary: serde_json::json!({"version": 2}),
+            ..first
+        };
+        store.save_report(&second, &[]).unwrap();
+        assert!(store.report_exists_for_scan(&scan.id).unwrap());
+        assert_eq!(store.latest_report().unwrap().unwrap().id, second.id);
+    }
+
+    #[test]
+    fn report_freshness_query_uses_the_payload_version_index() {
+        let store = StateStore::open_in_memory().unwrap();
+        let details = store
+            .connection
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 SELECT EXISTS(
+                    SELECT 1 FROM reports r
+                    JOIN scan_payloads p ON p.scan_id = r.scan_id
+                    WHERE r.scan_id = ?1 AND r.scan_payload_updated_at = p.updated_at
+                 )",
+            )
+            .unwrap()
+            .query_map(["scan_any"], |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail.contains("reports_scan_payload_version")),
+            "query plan did not use the Report freshness index: {details:?}"
+        );
     }
 
     #[test]

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -571,6 +571,18 @@ impl StateStore {
             .transpose()
     }
 
+    pub fn report_exists_for_scan(&self, id: &ScanId) -> StorageResult<bool> {
+        Ok(self.connection.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM reports r
+                JOIN scan_payloads p ON p.scan_id = r.scan_id
+                WHERE r.scan_id = ?1 AND r.created_at >= p.updated_at
+            )",
+            [id.as_str()],
+            |row| row.get(0),
+        )?)
+    }
+
     pub fn save_agent(&self, agent: &AgentRecord) -> StorageResult<AgentId> {
         let kind = enum_text(&agent.kind)?;
         if let Some(id) = self

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -958,7 +958,8 @@ fn home_and_status_resume_the_first_value_flow_until_the_current_report_exists()
         initial["suggested_actions"][0]["argv"],
         context_action_argv(&home, &state, &["scan", "--summary", "--json"])
     );
-    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+    let scan = json_output(&run_suggested_action(&initial["suggested_actions"][0]));
+    assert_eq!(scan["result"]["files_changed"], false);
 
     let resumed_home = json_output(&run(&common, None));
     let resumed_status = json_output(&run(&[&common[..], &["status"]].concat(), None));
@@ -977,7 +978,12 @@ fn home_and_status_resume_the_first_value_flow_until_the_current_report_exists()
     assert_eq!(resumed_home["result"]["files_changed"], false);
     assert_eq!(resumed_status["result"]["files_changed"], false);
 
-    json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let report = json_output(&run_suggested_action(&resumed_home["suggested_actions"][0]));
+    assert_eq!(
+        report["result"]["snapshot_id"],
+        scan["result"]["snapshot_id"]
+    );
+    assert_eq!(report["result"]["files_changed"], false);
     let complete = json_output(&run(&common, None));
     assert_eq!(complete["result"]["state"], "ready");
     assert_eq!(complete["suggested_actions"], json!([]));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -987,6 +987,20 @@ fn home_and_status_resume_the_first_value_flow_until_the_current_report_exists()
     let complete = json_output(&run(&common, None));
     assert_eq!(complete["result"]["state"], "ready");
     assert_eq!(complete["suggested_actions"], json!([]));
+
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    database
+        .execute("UPDATE scan_payloads SET updated_at = updated_at + 1", [])
+        .unwrap();
+    drop(database);
+    let payload_changed = json_output(&run(&common, None));
+    assert_eq!(payload_changed["result"]["state"], "report_required");
+    json_output(&run_suggested_action(
+        &payload_changed["suggested_actions"][0],
+    ));
+    let rebuilt = json_output(&run(&common, None));
+    assert_eq!(rebuilt["result"]["state"], "ready");
+    assert_eq!(rebuilt["suggested_actions"], json!([]));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -857,6 +857,7 @@ fn healthy_status_does_not_suggest_an_unconditional_rescan() {
     );
 
     json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    json_output(&run(&[&common[..], &["report"]].concat(), None));
     let healthy = json_output(&run(&[&common[..], &["status"]].concat(), None));
     assert!(healthy["result"]["latest_snapshot_id"].is_string());
     assert_eq!(healthy["result"]["recovery_state"], "clear");
@@ -933,6 +934,56 @@ fn home_and_status_share_the_missing_snapshot_scan_continuation() {
 }
 
 #[test]
+fn home_and_status_resume_the_first_value_flow_until_the_current_report_exists() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home with spaces");
+    let state = temp.path().join("state with spaces");
+    fs::create_dir_all(home.join(".codex/skills/example")).unwrap();
+    fs::write(
+        home.join(".codex/skills/example/SKILL.md"),
+        "---\nname: example\ndescription: Example Skill\n---\n",
+    )
+    .unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    let initial = json_output(&run(&common, None));
+    assert_eq!(initial["result"]["state"], "no_snapshot");
+    assert_eq!(
+        initial["suggested_actions"][0]["argv"],
+        context_action_argv(&home, &state, &["scan", "--summary", "--json"])
+    );
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+
+    let resumed_home = json_output(&run(&common, None));
+    let resumed_status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    let expected_report = context_action_argv(&home, &state, &["report", "--json"]);
+    assert_eq!(resumed_home["result"]["state"], "report_required");
+    assert_eq!(resumed_status["result"]["state"], "report_required");
+    assert_eq!(
+        resumed_home["suggested_actions"],
+        resumed_status["suggested_actions"]
+    );
+    assert_eq!(
+        resumed_home["suggested_actions"][0]["argv"],
+        expected_report
+    );
+    assert_eq!(resumed_home["suggested_actions"][0]["mutates"], false);
+    assert_eq!(resumed_home["result"]["files_changed"], false);
+    assert_eq!(resumed_status["result"]["files_changed"], false);
+
+    json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let complete = json_output(&run(&common, None));
+    assert_eq!(complete["result"]["state"], "ready");
+    assert_eq!(complete["suggested_actions"], json!([]));
+}
+
+#[test]
 fn home_routes_a_current_snapshot_only_when_a_ready_plan_exists() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
@@ -947,10 +998,8 @@ fn home_routes_a_current_snapshot_only_when_a_ready_plan_exists() {
     ];
 
     json_output(&run(&[&common[..], &["scan"]].concat(), None));
-    let healthy = json_output(&run(&common, None));
-    assert_eq!(healthy["result"]["state"], "ready");
-    assert_eq!(healthy["result"]["snapshot_state"], "current");
-    assert_eq!(healthy["suggested_actions"], json!([]));
+    let report_required = json_output(&run(&common, None));
+    assert_eq!(report_required["result"]["state"], "report_required");
 
     let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
     let status = json_output(&run(&[&common[..], &["status"]].concat(), None));


### PR DESCRIPTION
## Summary
- keep Home and Status resumable from a current Snapshot through its evidence-backed Report
- bind Report freshness to a strictly monotonic payload version instead of timestamp ordering
- add the Report freshness index and v12 migration while preserving previously fresh history
- keep Scan and resumed Home on one shared Report action contract

## Verification
- `bash scripts/ci-full-check.sh`
- Rust: 304 unit, 8 acceptance, 84 CLI
- Node harness: 137
- real isolated Home → exact Scan → resumed Home/Status → exact Report → Ready dogfood
- independent specification review: no findings
- independent repository-standards review: no findings

Closes #275