### PR TITLE
fix: keep exact Undo discoverable after Apply resumption

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -179,7 +179,10 @@ decisions resume.
 
 While facts are invalid, Home and Status name `snapshot_state:
 rescan_required`, bind the invalidating Receipt ID, and return the same
-read-only Scan continuation. The Agent follows recovery first when required,
+read-only Scan continuation as the primary action. When a verified Applied
+Receipt caused the invalidation, they also return that exact confirmed Undo as
+a secondary action; an Undo-created invalidation remains Scan-only. The Agent
+follows recovery first when required,
 then stale-fact refresh, then ordinary pending-Plan inspection.
 
 ## 7. Drill-down behavior

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -170,6 +170,12 @@ Snapshot and returns its own required Scan continuation. Failed-and-compensated
 Apply never invalidates a Snapshot; recovery-required state keeps its existing
 recovery boundary.
 
+When Home or Status resumes an ordinary invalidated-Snapshot state, the
+read-only Scan remains the primary `next_action`. An original, still-Applied
+invalidating Receipt also supplies its exact Undo as a secondary suggested
+action; an Undo Receipt cannot itself be undone and keeps only the Scan.
+Recovery-required state suppresses both behind lifecycle recovery inspection.
+
 File replacement copies the original through an exclusively created staging
 handle and restores its platform permissions before publication. Unix
 permission bits and Windows file attributes, including readonly, must therefore

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,7 @@ use crate::model::{
     ScanStatus, Severity, SkillId, SkillRecord, SuggestedAction, UsageEvent, UsageStage,
 };
 use crate::scan::{self, ExplicitSkillRoot, RootKind, ScanOptions, ScanResult};
-use crate::sqlite::StateStore;
+use crate::sqlite::{SnapshotInvalidationKind, StateStore};
 use crate::state_security;
 
 pub use crate::action_context::ActionContext;
@@ -117,13 +117,13 @@ pub fn run(cli: Cli) -> Result<Output> {
     let (command, mut result, warnings, mut actions) = match cli.command {
         None => {
             let readiness = readiness_decision(&store, &state_dir)?;
-            let actions = readiness.continuation.clone().into_iter().collect();
+            let actions = readiness.actions.clone();
             let result = home_result(&readiness);
             ("home", result, vec![], actions)
         }
         Some(Command::Status) => {
             let readiness = readiness_decision(&store, &state_dir)?;
-            let actions = readiness.continuation.clone().into_iter().collect();
+            let actions = readiness.actions.clone();
             let result = status_result(&store, &database_path, &state_dir, &readiness)?;
             ("status", result, vec![], actions)
         }
@@ -342,13 +342,7 @@ pub fn run(cli: Cli) -> Result<Output> {
             if rescan_required {
                 actions.push(snapshot_rescan_action());
             }
-            actions.push(action(
-                "undo",
-                &["undo", &id, "--json"],
-                true,
-                true,
-                "receipt_undoable",
-            ));
+            actions.push(receipt_undo_action(&id));
             ("apply", result, vec![], actions)
         }
         Some(Command::Undo(args)) => {
@@ -735,16 +729,19 @@ struct ReadinessDecision {
     pending_plans: Vec<PlanRecord>,
     recovery_required: bool,
     journal_issues: Vec<Value>,
-    continuation: Option<SuggestedAction>,
+    actions: Vec<SuggestedAction>,
 }
 
 fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessDecision> {
     let latest_snapshot = store.latest_completed_scan()?;
     let latest_scan_id = latest_snapshot.as_ref().map(|scan| &scan.id);
-    let invalidating_receipt_id = latest_scan_id
+    let invalidation = latest_scan_id
         .map(|scan_id| store.snapshot_invalidating_receipt(scan_id))
         .transpose()?
         .flatten();
+    let invalidating_receipt_id = invalidation
+        .as_ref()
+        .map(|invalidation| invalidation.receipt_id.clone());
     let snapshot_state = if latest_scan_id.is_none() {
         SnapshotState::Missing
     } else if invalidating_receipt_id.is_some() {
@@ -759,52 +756,53 @@ fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessD
         store.pending_plans(actionable_scan_id, STATUS_PENDING_PLAN_LIMIT)?;
     let journal_issues = journal_issues(store, state_dir)?;
     let recovery_required = store.recovery_required()? || !journal_issues.is_empty();
-    let (state, continuation) = if recovery_required {
+    let (state, actions) = if recovery_required {
         (
             ReadinessState::RecoveryRequired,
-            Some(action(
+            vec![action(
                 "inspect_recovery",
                 &["lifecycle", "recovery", "--json"],
                 false,
                 false,
                 "recovery_required",
-            )),
+            )],
         )
     } else if snapshot_state == SnapshotState::Missing {
         (
             ReadinessState::NoSnapshot,
-            Some(action(
+            vec![action(
                 "scan",
                 &["scan", "--summary", "--json"],
                 false,
                 false,
                 "snapshot_required",
-            )),
+            )],
         )
-    } else if snapshot_state == SnapshotState::RescanRequired {
-        (
-            ReadinessState::RescanRequired,
-            Some(snapshot_rescan_action()),
-        )
+    } else if let Some(invalidation) = invalidation {
+        let mut actions = vec![snapshot_rescan_action()];
+        if invalidation.kind == SnapshotInvalidationKind::AppliedReceipt {
+            actions.push(receipt_undo_action(invalidation.receipt_id.as_str()));
+        }
+        (ReadinessState::RescanRequired, actions)
     } else if let Some(plan) = pending_plans.first() {
         (
             ReadinessState::PlanReady,
-            Some(action(
+            vec![action(
                 "inspect_pending_plan",
                 &["plan", "--show", plan.id.as_str(), "--json"],
                 false,
                 false,
                 "pending_plan_requires_review",
-            )),
+            )],
         )
     } else if !latest_scan_id
         .map(|scan_id| store.report_exists_for_scan(scan_id))
         .transpose()?
         .unwrap_or(false)
     {
-        (ReadinessState::ReportRequired, Some(report_action()))
+        (ReadinessState::ReportRequired, vec![report_action()])
     } else {
-        (ReadinessState::Ready, None)
+        (ReadinessState::Ready, Vec::new())
     };
     Ok(ReadinessDecision {
         state,
@@ -815,7 +813,7 @@ fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessD
         pending_plans,
         recovery_required,
         journal_issues,
-        continuation,
+        actions,
     })
 }
 
@@ -9102,10 +9100,10 @@ fn latest_scan(store: &StateStore) -> Result<(ScanId, ScanResult)> {
 }
 
 fn require_snapshot_current(store: &StateStore, scan_id: &ScanId) -> Result<()> {
-    if let Some(receipt_id) = store.snapshot_invalidating_receipt(scan_id)? {
+    if let Some(invalidation) = store.snapshot_invalidating_receipt(scan_id)? {
         return Err(SnapshotRescanRequired {
             snapshot_id: scan_id.clone(),
-            receipt_id,
+            receipt_id: invalidation.receipt_id,
         }
         .into());
     }
@@ -9476,6 +9474,16 @@ fn snapshot_rescan_action() -> SuggestedAction {
         false,
         false,
         "verified_mutation_requires_rescan",
+    )
+}
+
+fn receipt_undo_action(receipt_id: &str) -> SuggestedAction {
+    action(
+        "undo",
+        &["undo", receipt_id, "--json"],
+        true,
+        true,
+        "receipt_undoable",
     )
 }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -58,6 +58,18 @@ pub struct LifecycleCounts {
     pub source_root_permissions: u64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SnapshotInvalidationKind {
+    AppliedReceipt,
+    UndoReceipt,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SnapshotInvalidation {
+    pub receipt_id: ReceiptId,
+    pub kind: SnapshotInvalidationKind,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct PurgeCounts {
     pub aggregated_raw_usage_rows: u64,
@@ -516,10 +528,10 @@ impl StateStore {
     pub fn snapshot_invalidating_receipt(
         &self,
         scan_id: &ScanId,
-    ) -> StorageResult<Option<ReceiptId>> {
+    ) -> StorageResult<Option<SnapshotInvalidation>> {
         self.connection
             .query_row(
-                "SELECT r.id FROM snapshot_invalidations i
+                "SELECT r.id, r.reverses_receipt_id IS NOT NULL FROM snapshot_invalidations i
                  JOIN receipts r ON r.id = i.receipt_id
                  WHERE i.snapshot_id = ?1
                    AND ((r.reverses_receipt_id IS NULL AND r.status = 'applied')
@@ -527,10 +539,19 @@ impl StateStore {
                  ORDER BY i.created_at DESC, i.rowid DESC
                  LIMIT 1",
                 [scan_id.as_str()],
-                |row| row.get::<_, String>(0),
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, bool>(1)?)),
             )
             .optional()?
-            .map(|id| ReceiptId::parse(id).map_err(invalid_id))
+            .map(|(id, is_undo)| {
+                Ok(SnapshotInvalidation {
+                    receipt_id: ReceiptId::parse(id).map_err(invalid_id)?,
+                    kind: if is_undo {
+                        SnapshotInvalidationKind::UndoReceipt
+                    } else {
+                        SnapshotInvalidationKind::AppliedReceipt
+                    },
+                })
+            })
             .transpose()
     }
 
@@ -3266,11 +3287,14 @@ mod tests {
         store
             .save_apply_receipt(&plan.id, PlanStatus::Applied, &original)
             .unwrap();
+        let applied_invalidation = store
+            .snapshot_invalidating_receipt(&original_scan.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(applied_invalidation.receipt_id, original.id.clone());
         assert_eq!(
-            store
-                .snapshot_invalidating_receipt(&original_scan.id)
-                .unwrap(),
-            Some(original.id.clone())
+            applied_invalidation.kind,
+            SnapshotInvalidationKind::AppliedReceipt
         );
         let newer_scan = scan();
         store.save_scan(&newer_scan).unwrap();
@@ -3300,9 +3324,14 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+        let undo_invalidation = store
+            .snapshot_invalidating_receipt(&newer_scan.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(undo_invalidation.receipt_id, reverse.id);
         assert_eq!(
-            store.snapshot_invalidating_receipt(&newer_scan.id).unwrap(),
-            Some(reverse.id)
+            undo_invalidation.kind,
+            SnapshotInvalidationKind::UndoReceipt
         );
         let post_undo_scan = scan();
         store.save_scan(&post_undo_scan).unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1096,6 +1096,14 @@ fn home_and_status_prioritize_recovery_over_an_invalidated_snapshot() {
         status["suggested_actions"]
     );
     assert_eq!(
+        home_result["suggested_actions"].as_array().unwrap().len(),
+        1
+    );
+    assert_eq!(
+        home_result["result"]["next_action"],
+        home_result["suggested_actions"][0]
+    );
+    assert_eq!(
         home_result["suggested_actions"][0]["argv"],
         context_action_argv(&home, &state, &["lifecycle", "recovery", "--json"])
     );
@@ -4513,8 +4521,10 @@ fn verified_apply_invalidates_inventory_until_scan_or_exact_undo() {
     let ready_status = json_output(&run(&[&common[..], &["status"]].concat(), None));
     assert_eq!(ready_status["result"]["pending_plan_count"], 2);
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+    let bootstrap = home.join(".codex/skills/skillroster");
 
     assert_eq!(applied["result"]["verification"], "passed");
+    assert!(bootstrap.is_dir());
     assert_eq!(applied["result"]["rescan_required"], true);
     assert_eq!(applied["suggested_actions"].as_array().unwrap().len(), 2);
     assert_eq!(applied["suggested_actions"][0]["action"], "scan");
@@ -4577,8 +4587,34 @@ fn verified_apply_invalidates_inventory_until_scan_or_exact_undo() {
     );
     assert_eq!(status["result"]["pending_plan_count"], 0);
     assert_eq!(status["result"]["pending_plans"], json!([]));
-    assert_eq!(status["suggested_actions"].as_array().unwrap().len(), 1);
+    assert_eq!(status["suggested_actions"].as_array().unwrap().len(), 2);
     assert_eq!(status["suggested_actions"][0]["action"], "scan");
+    assert_eq!(
+        status["result"]["next_action"],
+        status["suggested_actions"][0]
+    );
+    assert_eq!(status["suggested_actions"][1]["action"], "undo");
+    assert_eq!(
+        status["suggested_actions"][1]["argv"],
+        context_action_argv(
+            &home,
+            &state,
+            &[
+                "undo",
+                applied["result"]["receipt_id"].as_str().unwrap(),
+                "--json",
+            ],
+        )
+    );
+    assert_eq!(status["suggested_actions"][1]["mutates"], true);
+    assert_eq!(
+        status["suggested_actions"][1]["reason_code"],
+        "receipt_undoable"
+    );
+    assert_eq!(
+        status["suggested_actions"][1]["requires_confirmation"],
+        true
+    );
     let home_result = json_output(&run(&common, None));
     assert_eq!(home_result["result"]["state"], "rescan_required");
     assert_eq!(home_result["result"]["snapshot_state"], "rescan_required");
@@ -4590,9 +4626,13 @@ fn verified_apply_invalidates_inventory_until_scan_or_exact_undo() {
         home_result["suggested_actions"],
         status["suggested_actions"]
     );
-    let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
-    let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
+    let undone = json_output(&run_suggested_action(&home_result["suggested_actions"][1]));
     assert_eq!(undone["result"]["verification"], "passed");
+    assert_eq!(
+        undone["result"]["reverses_receipt_id"],
+        applied["result"]["receipt_id"]
+    );
+    assert!(!bootstrap.exists());
     let restored = json_output(&run(
         &[&common[..], &["report", "--summary"]].concat(),
         None,
@@ -4696,6 +4736,17 @@ fn exact_undo_invalidates_a_newer_post_apply_snapshot() {
         blocked["error"]["details"]["snapshot_id"],
         post_apply_scan["result"]["snapshot_id"]
     );
+    let resumed_home = json_output(&run(&common, None));
+    let resumed_status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(
+        resumed_home["suggested_actions"],
+        resumed_status["suggested_actions"]
+    );
+    assert_eq!(
+        resumed_home["suggested_actions"].as_array().unwrap().len(),
+        1
+    );
+    assert_eq!(resumed_home["suggested_actions"][0]["action"], "scan");
 
     let refreshed = json_output(&run_suggested_action(&undone["suggested_actions"][0]));
     assert_eq!(refreshed["result"]["placement_count"], 0);


### PR DESCRIPTION
## Summary

- keep Home and Status primary `next_action` as the required read-only Scan after Apply
- retain the exact confirmed Undo as a secondary action only for an original still-Applied invalidating Receipt
- type Snapshot invalidation at the SQLite boundary so Undo-created invalidation remains Scan-only
- share exact Undo action construction across Apply and readiness, with strict recovery suppression

## Evidence

- isolated real CLI dogfood reproduced Apply returning `[scan, undo]` but resumed Home/Status losing Undo
- TDD regression directly replays the resumed Home Undo action, verifies reverse Receipt binding, and proves filesystem restoration
- Apply → Scan → Undo → Home/Status proves reverse invalidation offers Scan only
- recovery-required proves exactly one lifecycle recovery action
- `bash scripts/ci-full-check.sh` passed: 304 unit, 8 acceptance, 84 CLI, 137 Node; strict Clippy/format/diff checks passed
- independent spec review: no findings after fixes
- independent standards/simplification review: no findings after fixes

Closes #277

No release, tag, or Homebrew change.