### PR TITLE
fix: keep package support out of Skill discovery

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -54,7 +54,7 @@ Use this placement test for every capability: local truth, stable identity, repr
 
 ### 4.1 Inventory and identity
 
-A read-only Scan discovers Skill roots, `SKILL.md` entry points, source metadata, links, configuration exposure, and supported local session sources. It normalizes paths without following links outside approved roots silently.
+A read-only Scan discovers Skill roots, `SKILL.md` entry points, source metadata, links, configuration exposure, and supported local session sources. It normalizes paths without following links outside approved roots silently. Entrypoint discovery traverses root and category directories within its depth bound. Once a directory declares `SKILL.md`, arbitrary descendants are package support content rather than more entrypoint search space; only direct child directories that also declare `SKILL.md` continue the nested-Skill chain. Repository and build trees `.git`, `target`, and `node_modules` are excluded from entrypoint discovery. These exclusions do not weaken package fingerprints: support files remain identity- and drift-bearing under the independent fingerprint bounds.
 
 The immutable Scan payload is the historical Snapshot record. SQLite's
 normalized placement table is the current projection: when a stable placement

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1340,6 +1340,12 @@ fn discover_entrypoints(
         let path = entry.path();
         let metadata = fs::symlink_metadata(&path)?;
         let file_name = entry.file_name();
+        if ENTRYPOINT_DISCOVERY_EXCLUDED_DIRS
+            .iter()
+            .any(|excluded| file_name == *excluded)
+        {
+            continue;
+        }
         if file_name == "SKILL.md" {
             let (target, link_status) = inspect_link(approved_roots, &path, &metadata);
             let expected_physical_entrypoint = fs::canonicalize(&path)
@@ -1359,12 +1365,6 @@ fn discover_entrypoints(
                 default_exposed,
             });
         } else if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
-            if ENTRYPOINT_DISCOVERY_EXCLUDED_DIRS
-                .iter()
-                .any(|excluded| file_name == *excluded)
-            {
-                continue;
-            }
             if directory_has_skill && !directory_declares_skill(&path)? {
                 continue;
             }
@@ -1387,11 +1387,15 @@ fn discover_entrypoints(
             // traversed recursively before the boundary has been evaluated.
             let linked_entrypoint = path.join("SKILL.md");
             let (target, status) = inspect_link(approved_roots, &path, &metadata);
+            let declares_skill = directory_declares_skill(&path)?;
+            if directory_has_skill && !declares_skill {
+                continue;
+            }
             let Some(child_name) = file_name.to_str() else {
                 outcome.non_unicode_skipped = outcome.non_unicode_skipped.saturating_add(1);
                 continue;
             };
-            if linked_entrypoint.exists() || status != LinkStatus::Valid {
+            if declares_skill || status != LinkStatus::Valid {
                 let expected_physical_entrypoint = fs::canonicalize(&linked_entrypoint)
                     .ok()
                     .filter(|path| path.to_str().is_some());
@@ -1423,7 +1427,14 @@ fn discover_entrypoints(
 fn directory_declares_skill(directory: &Path) -> io::Result<bool> {
     match fs::symlink_metadata(directory.join("SKILL.md")) {
         Ok(_) => Ok(true),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+            ) =>
+        {
+            Ok(false)
+        }
         Err(error) => Err(error),
     }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1335,7 +1335,7 @@ fn discover_entrypoints(
     let mut outcome = SkillDiscoveryOutcome::default();
     let mut entries = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
     entries.sort_by_key(|entry| entry.file_name());
-    let directory_has_skill = directory.join("SKILL.md").is_file();
+    let directory_has_skill = directory_declares_skill(directory)?;
     for entry in entries {
         let path = entry.path();
         let metadata = fs::symlink_metadata(&path)?;
@@ -1359,6 +1359,15 @@ fn discover_entrypoints(
                 default_exposed,
             });
         } else if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+            if ENTRYPOINT_DISCOVERY_EXCLUDED_DIRS
+                .iter()
+                .any(|excluded| file_name == *excluded)
+            {
+                continue;
+            }
+            if directory_has_skill && !directory_declares_skill(&path)? {
+                continue;
+            }
             let Some(child_name) = file_name.to_str() else {
                 outcome.non_unicode_skipped = outcome.non_unicode_skipped.saturating_add(1);
                 continue;
@@ -1411,14 +1420,22 @@ fn discover_entrypoints(
     Ok(outcome)
 }
 
+fn directory_declares_skill(directory: &Path) -> io::Result<bool> {
+    match fs::symlink_metadata(directory.join("SKILL.md")) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+const ENTRYPOINT_DISCOVERY_EXCLUDED_DIRS: &[&str] = &[".git", "target", "node_modules"];
+
 const HERMES_EXCLUDED_SKILL_DIRS: &[&str] = &[
-    ".git",
     ".github",
     ".hub",
     ".archive",
     ".venv",
     "venv",
-    "node_modules",
     "site-packages",
     "__pycache__",
     ".tox",
@@ -3839,6 +3856,36 @@ enabled = true
                 && placement.governable
         }));
         assert!(result.roots.iter().any(|seen| seen.explicit));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nested_broken_skill_entrypoint_remains_visible_as_unsafe() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_directory("nested-broken-entrypoint");
+        let parent = root.join("parent");
+        let child = parent.join("child");
+        fs::create_dir_all(&child).unwrap();
+        fs::write(parent.join("SKILL.md"), "---\nname: parent\n---\n").unwrap();
+        symlink(parent.join("missing.md"), child.join("SKILL.md")).unwrap();
+        let mut options = ScanOptions::for_home(root.join("empty-home"));
+        options.explicit_skill_roots.push(ExplicitSkillRoot {
+            agent: AgentKind::Codex,
+            path: root.clone(),
+        });
+        options.include_session_evidence = false;
+
+        let result = scan(&options).unwrap();
+
+        assert_eq!(result.placements.len(), 2);
+        let nested = result
+            .placements
+            .iter()
+            .find(|placement| placement.directory == child)
+            .unwrap();
+        assert_eq!(nested.link_status, LinkStatus::Broken);
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5152,6 +5152,84 @@ fn scan_keeps_repository_metadata_out_of_root_discovery_coverage() {
     assert!(observed["detail"].is_null());
 }
 
+#[cfg(unix)]
+#[test]
+fn scan_excludes_linked_repository_metadata_from_entrypoint_discovery() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("empty-home");
+    let state = temp.path().join("state");
+    let root = temp.path().join("skills");
+    let skill = root.join("example");
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(&skill).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(skill.join("SKILL.md"), "---\nname: example\n---\n").unwrap();
+    fs::write(outside.join("SKILL.md"), "---\nname: hidden\n---\n").unwrap();
+    symlink(&outside, root.join(".git")).unwrap();
+
+    let explicit_root = format!("codex={}", root.display());
+    let scan = json_output(&run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--root",
+            &explicit_root,
+            "--json",
+            "scan",
+        ],
+        None,
+    ));
+
+    assert_eq!(scan["result"]["skill_count"], 1);
+    assert_eq!(scan["result"]["placement_count"], 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn scan_ignores_linked_support_without_a_nested_skill_entrypoint() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("empty-home");
+    let state = temp.path().join("state");
+    let root = temp.path().join("skills");
+    let parent = root.join("parent");
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(&parent).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(parent.join("SKILL.md"), "---\nname: parent\n---\n").unwrap();
+    symlink(&outside, parent.join("references")).unwrap();
+
+    let explicit_root = format!("codex={}", root.display());
+    let scan = json_output(&run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--root",
+            &explicit_root,
+            "--json",
+            "scan",
+        ],
+        None,
+    ));
+
+    assert_eq!(scan["result"]["skill_count"], 1);
+    assert_eq!(scan["result"]["placement_count"], 1);
+    let observed = scan["result"]["roots"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|observed| observed["path"] == root.display().to_string())
+        .unwrap();
+    assert_eq!(observed["discovery_complete"], true);
+}
+
 #[test]
 fn source_confirmation_crash_temp_does_not_block_lifecycle_cleanup() {
     let temp = TempDir::new().unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5063,6 +5063,96 @@ fn explicit_roots_preserve_all_eight_agent_identities() {
 }
 
 #[test]
+fn scan_keeps_deep_package_support_out_of_root_discovery_coverage() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("empty-home");
+    let state = temp.path().join("state");
+    let root = temp.path().join("skills");
+    let parent = root.join("parent");
+    let child = parent.join("child");
+    fs::create_dir_all(&child).unwrap();
+    fs::write(
+        parent.join("SKILL.md"),
+        "---\nname: parent\ndescription: Parent skill\n---\n",
+    )
+    .unwrap();
+    fs::write(
+        child.join("SKILL.md"),
+        "---\nname: child\ndescription: Nested child skill\n---\n",
+    )
+    .unwrap();
+    fs::create_dir_all(parent.join("references/one/two/three/four/five")).unwrap();
+
+    let explicit_root = format!("codex={}", root.display());
+    let scan = json_output(&run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--root",
+            &explicit_root,
+            "--json",
+            "scan",
+        ],
+        None,
+    ));
+
+    assert_eq!(scan["result"]["skill_count"], 2);
+    assert_eq!(scan["result"]["placement_count"], 2);
+    let observed = scan["result"]["roots"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|observed| observed["path"] == root.display().to_string())
+        .unwrap();
+    assert_eq!(observed["status"], "included");
+    assert_eq!(observed["discovery_complete"], true);
+    assert!(observed["detail"].is_null());
+}
+
+#[test]
+fn scan_keeps_repository_metadata_out_of_root_discovery_coverage() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("empty-home");
+    let state = temp.path().join("state");
+    let root = temp.path().join("skills");
+    let skill = root.join("example");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: example\ndescription: Example skill\n---\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join(".git/logs/refs/remotes/origin/archive")).unwrap();
+
+    let explicit_root = format!("codex={}", root.display());
+    let scan = json_output(&run(
+        &[
+            "--home",
+            home.to_str().unwrap(),
+            "--state-dir",
+            state.to_str().unwrap(),
+            "--root",
+            &explicit_root,
+            "--json",
+            "scan",
+        ],
+        None,
+    ));
+
+    assert_eq!(scan["result"]["skill_count"], 1);
+    let observed = scan["result"]["roots"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|observed| observed["path"] == root.display().to_string())
+        .unwrap();
+    assert_eq!(observed["discovery_complete"], true);
+    assert!(observed["detail"].is_null());
+}
+
+#[test]
 fn source_confirmation_crash_temp_does_not_block_lifecycle_cleanup() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## Problem

Real dogfood found all 260 Skills / 1,030 placements, but deep package support content made six included roots look discovery-incomplete. That false coverage limitation blocked exact governance even though no entrypoint was missed.

## Solution

- Treat a directory declaring `SKILL.md` as an entrypoint-discovery package boundary.
- Preserve chains of directly nested Skill packages.
- Exclude `.git`, `target`, and `node_modules` for both real directories and links.
- Require package-internal linked directories to prove a direct `SKILL.md` before becoming a nested Skill.
- Keep package fingerprinting independent, so support files remain identity- and drift-bearing.
- Preserve broken linked Skill and non-Unicode fail-closed behavior.

## User-visible evidence

Fresh read-only Scan of the real user home with isolated temporary state:

- 260 Skills
- 1,030 Placements
- 21 included Skill roots
- 0 included roots marked discovery-incomplete (previously 6 false depth-limit warnings)

## Verification

- `bash scripts/ci-full-check.sh`
  - 305 Rust unit tests
  - 8 acceptance tests
  - 88 CLI tests
  - 137 Node tests
  - strict Clippy and formatting checks
- `git diff --check`
- independent Spec review: No findings
- independent Standards review: initial symlink-boundary P1 fixed; final review No findings

Closes #279
