### PR TITLE
fix: preserve option-shaped Find tasks

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -163,7 +163,7 @@ skillroster scan --summary --json
 skillroster report --findings --limit 20 --json
 
 # Retrieve one complete, fingerprint-verified Skill
-skillroster find "review this pull request" --load --limit 1 --json
+skillroster find --load --limit 1 --json -- "review this pull request"
 
 # Preview bootstrap installation across detected agents
 skillroster setup --json

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ skillroster scan --summary --json
 skillroster report --findings --limit 20 --json
 
 # 检索并完整加载一份经过指纹校验的 Skill
-skillroster find "审查这个 Pull Request" --load --limit 1 --json
+skillroster find --load --limit 1 --json -- "审查这个 Pull Request"
 
 # 预览为已检测 Agent 安装引导 Skill 的方案
 skillroster setup --json

--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -232,7 +232,9 @@ The single `skillroster` bootstrap Skill must instruct every supported Agent to:
 
 - route a task through `skillroster find` before acting when its required
   specialized instructions are not already visible, using `--load --limit 1`
-  to receive the selected complete verified `SKILL.md` in the same result;
+  to receive the selected complete verified `SKILL.md` in the same result, and
+  place every Find option before a `--` boundary with the verbatim task as the
+  final argv value so option-shaped user text remains opaque;
 - invoke commands with explicit `--json`;
 - validate `schema_version` and `ok` before reading `result`;
 - set `schema_version: 1` on every declarative Plan request;

--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -136,6 +136,9 @@ Show ranked matches with Skill name, current Roster state, source, concise match
 reasons, and same-name variant count. Preserve the original task separately
 from repeatable `--hint` retrieval text. A CJK task without hints receives an
 actionable lexical-retrieval warning when English metadata may be missed.
+The canonical Agent argv puts all Find options before `--` and the verbatim
+task after it. Generated continuations use the same shape, so a task beginning
+with `-` or matching an option name is never reinterpreted as CLI syntax.
 Hints describe the desired surface, object, operation, and state. Results below
 the deterministic confidence floor are omitted instead of filling the first
 view with incidental body-token matches. Empty results are calm, successful

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -208,7 +208,7 @@ The first complete command surface is:
 skillroster [--json]
 skillroster scan [--summary] [--json]
 skillroster report [--summary | --full | --findings [--category <category>] [--severity <severity>] | --finding <id> [--full]] [--limit <n>] [--offset <n>] [--json]
-skillroster find <task> [--hint <text>]... [--limit <n>] [--load] [--variant-skill-id <skill-id>] [--require-snapshot <scan-id>] [--json]
+skillroster find [--hint <text>]... [--limit <n>] [--load] [--variant-skill-id <skill-id>] [--require-snapshot <scan-id>] [--json] -- <task>
 skillroster plan --stdin [--json]
 skillroster plan --show <plan-id> [--json]
 skillroster apply <plan-id> [--json]

--- a/scripts/ci-change-scope.sh
+++ b/scripts/ci-change-scope.sh
@@ -13,7 +13,7 @@ classify_paths() {
     [[ -z "$path" ]] && continue
     saw_path=true
     case "$path" in
-      skill/skillroster/*)
+      skill/skillroster/*|tests/fixtures/*)
         full=true
         ;;
       LICENSE|*.md)
@@ -38,6 +38,7 @@ self_test() {
     'skill/skillroster/SKILL.md' \
     'skill/skillroster/references/routing.md' \
     'skill/skillroster/manifest.json' \
+    'tests/fixtures/bootstrap-v1.8.23.md' \
     'src/bootstrap.rs'; do
     actual="$(printf '%s\n' "$runtime_path" | classify_paths)"
     [[ "$actual" == true ]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -5152,7 +5152,7 @@ fn find_command(
                 task,
                 &retrieval_hints,
                 found,
-                required_snapshot_id.map(|_| &scan_id),
+                Some(&scan_id),
             ));
         }
     }
@@ -5245,7 +5245,7 @@ fn find_action_argv(
     kind: FindActionKind<'_>,
     required_snapshot_id: Option<&ScanId>,
 ) -> Vec<String> {
-    let mut argv = vec!["find".to_owned(), task.to_owned()];
+    let mut argv = vec!["find".to_owned()];
     for hint in hints {
         argv.extend(["--hint".to_owned(), hint.clone()]);
     }
@@ -5265,6 +5265,7 @@ fn find_action_argv(
         argv.extend(["--require-snapshot".to_owned(), snapshot_id.to_string()]);
     }
     argv.push("--json".to_owned());
+    argv.extend(["--".to_owned(), task.to_owned()]);
     argv
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -201,6 +201,7 @@ impl ReportSeverity {
 
 #[derive(Debug, Args)]
 pub struct FindArgs {
+    #[arg(allow_hyphen_values = true, value_parser = parse_non_empty_task)]
     pub task: String,
 
     /// Add an Agent-authored lexical retrieval hint while preserving TASK. Repeatable.
@@ -224,6 +225,14 @@ pub struct FindArgs {
 }
 
 pub const MAX_FIND_RESULTS: u16 = 100;
+
+fn parse_non_empty_task(value: &str) -> Result<String, String> {
+    if value.is_empty() {
+        Err("TASK must not be empty".into())
+    } else {
+        Ok(value.to_owned())
+    }
+}
 
 #[derive(Debug, Args)]
 pub struct PlanArgs {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3668,10 +3668,7 @@ fn setup_upgrades_the_public_v1_8_23_package_and_undo_restores_every_file() {
     let legacy_files = [
         (
             "SKILL.md",
-            include_str!("../skill/skillroster/SKILL.md").replace(
-                "bootstrap-version: \"1.8.29\"",
-                "bootstrap-version: \"1.8.23\"",
-            ),
+            include_str!("fixtures/bootstrap-v1.8.23.md").to_owned(),
         ),
         (
             "references/routing.md",
@@ -9540,14 +9537,15 @@ fn archived_same_name_identity_cannot_return_through_active_variant() {
                 "--home",
                 home,
                 "find",
-                "active search marker",
                 "--hint",
                 "inspect active identity",
                 "--limit",
                 "1",
                 "--require-snapshot",
                 snapshot,
-                "--json"
+                "--json",
+                "--",
+                "active search marker"
             ],
             "mutates": false,
             "requires_confirmation": false,
@@ -10184,6 +10182,135 @@ fn non_unicode_identity_coverage_blocks_exact_snapshot_consumers() {
             "non_unicode_identity_coverage_incomplete"
         );
     }
+}
+
+#[test]
+fn find_preserves_leading_hyphen_tasks_and_replayable_variant_actions() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let codex = home.join(".codex/skills/hyphen-route");
+    let claude = home.join(".claude/skills/hyphen-route");
+    fs::create_dir_all(&codex).unwrap();
+    fs::create_dir_all(&claude).unwrap();
+    fs::write(
+        codex.join("SKILL.md"),
+        "---\nname: hyphen-route\ndescription: Review a leading hyphen route\n---\ncodex variant\n",
+    )
+    .unwrap();
+    fs::write(
+        claude.join("SKILL.md"),
+        "---\nname: hyphen-route\ndescription: Review a leading hyphen route\n---\nclaude variant\n",
+    )
+    .unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    let task = "--review leading hyphen route";
+    let hint = "review route";
+
+    for tail in [&["find"][..], &["find", "--", ""][..]] {
+        let rejected = run(&[&common[..], tail].concat(), None);
+        assert!(!rejected.status.success());
+        let rejected: Value = serde_json::from_slice(&rejected.stdout).unwrap();
+        assert_eq!(rejected["error"]["code"], "invalid_cli_arguments");
+    }
+
+    let scan = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let snapshot = scan["result"]["snapshot_id"].as_str().unwrap();
+    json_output(&run(&[&common[..], &["report"]].concat(), None));
+    let found = json_output(&run(
+        &[&common[..], &["find", task, "--hint", hint, "--limit", "1"]].concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["task"], task);
+    assert_eq!(found["result"]["retrieval_hints"], json!([hint]));
+    assert_eq!(found["result"]["matches"][0]["name"], "hyphen-route");
+    assert_eq!(found["result"]["matches"][0]["variant_count"], 2);
+    let load_action = found["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|action| action["action"] == "load_exact_variant_for_comparison")
+        .unwrap();
+    assert!(
+        load_action["argv"]
+            .as_array()
+            .unwrap()
+            .contains(&json!(task))
+    );
+    assert_eq!(
+        &load_action["argv"].as_array().unwrap()
+            [load_action["argv"].as_array().unwrap().len() - 2..],
+        &[json!("--"), json!(task)]
+    );
+    assert!(
+        load_action["argv"]
+            .as_array()
+            .unwrap()
+            .windows(2)
+            .any(|pair| pair == [json!("--require-snapshot"), json!(snapshot)])
+    );
+
+    let loaded = json_output(&run_suggested_action(load_action));
+    assert_eq!(loaded["result"]["task"], task);
+    assert_eq!(loaded["result"]["retrieval_hints"], json!([hint]));
+    assert_eq!(
+        loaded["result"]["loaded_skill"]["selection"]["name"],
+        "hyphen-route"
+    );
+    assert_eq!(
+        loaded["result"]["loaded_skill"]["verification"]["identity_matches_snapshot"],
+        true
+    );
+
+    let refreshed = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    assert_ne!(refreshed["result"]["snapshot_id"], snapshot);
+    let stale = run_suggested_action(load_action);
+    assert!(!stale.status.success());
+    let stale: Value = serde_json::from_slice(&stale.stdout).unwrap();
+    assert_eq!(stale["error"]["code"], "find_snapshot_changed");
+    assert_eq!(stale["error"]["details"]["expected_snapshot_id"], snapshot);
+    assert_eq!(
+        stale["error"]["details"]["actual_snapshot_id"],
+        refreshed["result"]["snapshot_id"]
+    );
+
+    let option_shaped_task = "--json";
+    let reserved = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "--hint",
+                hint,
+                "--limit",
+                "1",
+                "--",
+                option_shaped_task,
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(reserved["result"]["task"], option_shaped_task);
+    assert_eq!(reserved["result"]["matches"][0]["name"], "hyphen-route");
+    assert!(
+        reserved["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|action| action["action"] == "load_exact_variant_for_comparison")
+            .all(|action| {
+                let argv = action["argv"].as_array().unwrap();
+                argv[argv.len() - 2..] == [json!("--"), json!(option_shaped_task)]
+            })
+    );
 }
 
 #[test]

--- a/tests/fixtures/bootstrap-v1.8.23.md
+++ b/tests/fixtures/bootstrap-v1.8.23.md
@@ -5,7 +5,7 @@ description: >
   local Skill roster. Before reading or changing the workspace for a task that
   may need instructions not already visible, preserve the complete user message
   verbatim as TASK. For non-English or mixed input, run
-  `skillroster find --hint "ONE FAITHFUL ENGLISH CAPABILITY PARAPHRASE" --load --limit 1 --json -- "TASK"`;
+  `skillroster find "TASK" --hint "ONE FAITHFUL ENGLISH CAPABILITY PARAPHRASE" --load --limit 1 --json`;
   for English input omit `--hint`. Follow the complete verified SKILL.md in
   `result.loaded_skill.content.text`. Also use
   for inventory, usage evidence, duplicates, broken links, Core/On-demand
@@ -13,7 +13,7 @@ description: >
   third-party Skills or migrating, distributing, synchronizing, or repairing shared
   Skill-manager directories.
 metadata:
-  bootstrap-version: "1.8.29"
+  bootstrap-version: "1.8.23"
   skillroster-routing-triggers: "route task to local Skill; inventory installed Agent Skills; analyze duplicate or unused Agent Skills; govern a Skill Roster; prepare or apply approved Skill Plan; create or undo Skill Receipt"
 ---
 
@@ -43,10 +43,8 @@ change the workspace and do not execute a non-routing command:
    capability paraphrase as `HINT`. It supplements `TASK`; it never replaces it.
 3. Invoke the fixed SkillRoster executable with `TASK` and `HINT` as separate,
    literal argv values; never interpolate either into shell syntax. Use:
-   - English: `skillroster find --load --limit 1 --json -- "TASK"`
-   - Otherwise: `skillroster find --hint "HINT" --load --limit 1 --json -- "TASK"`
-   The `--` boundary is required even when `TASK` does not begin with `-`; it
-   keeps opaque user text from being parsed as a SkillRoster option.
+   - English: `skillroster find "TASK" --load --limit 1 --json`
+   - Otherwise: `skillroster find "TASK" --hint "HINT" --load --limit 1 --json`
 4. When `HINT` was used, first require
    `ranking_strategy: task_hint_reciprocal_rank_fusion`.
 5. Require `loaded_skill.selection.rank: 1`, `content.complete: true`, and all

--- a/tests/harness/codex-cold-routing/driver.mjs
+++ b/tests/harness/codex-cold-routing/driver.mjs
@@ -960,7 +960,7 @@ function parseEnvelope(stdout, command) {
 }
 
 export function skillRosterScanArgs(paths, sourceRoot) { return ["--home", paths.home, "--state-dir", paths.state, "--json", "scan", "--source-root", sourceRoot]; }
-export function skillRosterFindArgs(paths, task) { return ["--home", paths.home, "--state-dir", paths.state, "--json", "find", task.prompt, "--hint", task.hint, ...(task.one_call_load ? ["--load", "--limit", "1"] : [])]; }
+export function skillRosterFindArgs(paths, task) { return ["--home", paths.home, "--state-dir", paths.state, "--json", "find", "--hint", task.hint, ...(task.one_call_load ? ["--load", "--limit", "1"] : []), "--", task.prompt]; }
 
 export function findWrapperSource(oneCallLoad = false) {
   return `#!/usr/bin/env node
@@ -970,15 +970,15 @@ import { resolve } from "node:path";
 import { realpathSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 const sha = (value) => createHash("sha256").update(value).digest("hex");
-const args = process.argv.slice(2); const separator = args.indexOf("--hint");
-const task = args[0] === "find" ? (args[1] ?? "") : "";
+const args = process.argv.slice(2); const separator = args.indexOf("--");
+const task = args[0] === "find" && separator === args.length - 2 ? (args[separator + 1] ?? "") : "";
 const hints = []; for (let i = 0; i < args.length; i += 1) if (args[i] === "--hint" && args[i + 1] !== undefined) hints.push(args[i + 1]);
 const oneCallLoad = ${JSON.stringify(oneCallLoad)};
-let result = { status: 64, stdout: "", stderr: oneCallLoad ? "wrapper permits only: skillroster find TASK --hint HINT --load --limit 1 --json\\n" : "wrapper permits only: skillroster find TASK --hint HINT --json\\n" };
+let result = { status: 64, stdout: "", stderr: oneCallLoad ? "wrapper permits only: skillroster find --hint HINT --load --limit 1 --json -- TASK\\n" : "wrapper permits only: skillroster find --hint HINT --json -- TASK\\n" };
 const argvShapeValid = oneCallLoad
-  ? args.length === 8 && args[0] === "find" && args[2] === "--hint" && args[4] === "--load" && args[5] === "--limit" && args[6] === "1" && args[7] === "--json"
-  : args.length === 5 && args[0] === "find" && args[2] === "--hint" && args[4] === "--json";
-if (argvShapeValid) result = spawnSync(process.env.SKILLROSTER_REAL_CLI, ["--home", process.env.SKILLROSTER_TEST_HOME, "--state-dir", process.env.SKILLROSTER_TEST_STATE, "--json", ...args.slice(0, oneCallLoad ? 7 : 4)], { encoding: "utf8", shell: false });
+  ? args.length === 9 && args[0] === "find" && args[1] === "--hint" && args[3] === "--load" && args[4] === "--limit" && args[5] === "1" && args[6] === "--json" && args[7] === "--" && task.length > 0
+  : args.length === 6 && args[0] === "find" && args[1] === "--hint" && args[3] === "--json" && args[4] === "--" && task.length > 0;
+if (argvShapeValid) result = spawnSync(process.env.SKILLROSTER_REAL_CLI, ["--home", process.env.SKILLROSTER_TEST_HOME, "--state-dir", process.env.SKILLROSTER_TEST_STATE, "--json", ...args], { encoding: "utf8", shell: false });
 let top1 = {}; let envelopeValid = false; let loadedContentComplete = false; let loadedContentSha256 = null; try { const value = JSON.parse(result.stdout ?? ""); envelopeValid = value?.schema_version === 1 && value?.ok === true && value?.command === "find" && value?.result?.ranking_strategy === "task_hint_reciprocal_rank_fusion"; const top = envelopeValid ? value?.result?.matches?.[0] ?? {} : {}; top1 = { skill: top.name ?? null, path: top.paths?.[0] ?? null }; const loaded = value?.result?.loaded_skill; loadedContentComplete = !oneCallLoad || (loaded?.selection?.rank === 1 && loaded?.content?.complete === true && typeof loaded?.content?.text === "string" && loaded?.content?.byte_length === Buffer.byteLength(loaded.content.text, "utf8") && loaded?.content?.sha256 === sha(loaded.content.text) && loaded?.verification?.identity_matches_snapshot === true && loaded?.verification?.entrypoint_digest_matches_snapshot === true && loaded?.verification?.package_fingerprint_matches_snapshot === true && loaded?.verification?.package_fingerprint_complete === true && loaded?.task_success === "not_evaluated"); loadedContentSha256 = loadedContentComplete && oneCallLoad ? sha(loaded.content.text) : null; envelopeValid = envelopeValid && (!oneCallLoad || loadedContentComplete); } catch {}
 let canonicalTopPath = null; try { canonicalTopPath = top1.path ? realpathSync(top1.path) : null; } catch { canonicalTopPath = top1.path ? resolve(top1.path) : null; }
 appendFileSync(process.env.SKILLROSTER_FIND_AUDIT, JSON.stringify({ kind: "find_call", argv_count: args.length, argv_shape_valid: argvShapeValid, envelope_valid: envelopeValid, task_sha256: sha(task), hint_count: hints.length, hint_nonempty: hints.length > 0 && hints.every((hint) => hint.trim().length > 0), hint_sha256: hints.map(sha), separator_index: separator, exit_code: result.status, top1_skill: top1.skill ?? null, top1_path_sha256: canonicalTopPath ? sha(canonicalTopPath) : null, loaded_content_complete: loadedContentComplete, loaded_content_sha256: loadedContentSha256 }) + "\\n", { mode: 0o600 });

--- a/tests/harness/codex-cold-routing/driver.test.mjs
+++ b/tests/harness/codex-cold-routing/driver.test.mjs
@@ -372,8 +372,8 @@ test("SkillRoster seam uses the real envelope and global-option ordering", () =>
   assert.throws(() => parseFindEnvelope(JSON.stringify({ schema_version: 1, ok: true, command: "find", result: { ranking_strategy: "single_lexical_channel", matches: [] } })), /reciprocal_rank_fusion/u);
   const paths = { home: "/tmp/home", state: "/tmp/state" }; const task = { prompt: "完整任务", hint: "agent hint" };
   assert.deepEqual(skillRosterScanArgs(paths, "/tmp/source"), ["--home", "/tmp/home", "--state-dir", "/tmp/state", "--json", "scan", "--source-root", "/tmp/source"]);
-  assert.deepEqual(skillRosterFindArgs(paths, task), ["--home", "/tmp/home", "--state-dir", "/tmp/state", "--json", "find", "完整任务", "--hint", "agent hint"]);
-  assert.deepEqual(skillRosterFindArgs(paths, { ...task, one_call_load: true }), ["--home", "/tmp/home", "--state-dir", "/tmp/state", "--json", "find", "完整任务", "--hint", "agent hint", "--load", "--limit", "1"]);
+  assert.deepEqual(skillRosterFindArgs(paths, task), ["--home", "/tmp/home", "--state-dir", "/tmp/state", "--json", "find", "--hint", "agent hint", "--", "完整任务"]);
+  assert.deepEqual(skillRosterFindArgs(paths, { ...task, one_call_load: true }), ["--home", "/tmp/home", "--state-dir", "/tmp/state", "--json", "find", "--hint", "agent hint", "--load", "--limit", "1", "--", "完整任务"]);
 });
 
 test("Find audit preserves exact argument mismatch and retry classification", async () => {

--- a/tests/harness/pi-cold-routing/gate.test.mjs
+++ b/tests/harness/pi-cold-routing/gate.test.mjs
@@ -118,9 +118,17 @@ test("only the exact injected Bootstrap path is eligible for route-order classif
 });
 
 test("find parser accepts quoted tasks and rejects aliases and shell syntax", () => {
-  assert.deepEqual(parseFindCommand('skillroster find "中文 task" --hint "English hint" --json'), {
+  assert.deepEqual(parseFindCommand('skillroster find --hint "English hint" --json -- "中文 task"'), {
     task: "中文 task",
     hints: ["English hint"],
+  });
+  assert.deepEqual(parseFindCommand('skillroster find --hint "option shaped" --json -- "--json"'), {
+    task: "--json",
+    hints: ["option shaped"],
+  });
+  assert.deepEqual(parseFindCommand('skillroster find "legacy task" --hint "legacy hint" --json'), {
+    task: "legacy task",
+    hints: ["legacy hint"],
   });
   assert.throws(() => parseFindCommand('/tmp/skillroster find "task" --json'), /literal/);
   assert.throws(() => parseFindCommand('skillroster find "task" --json; touch /tmp/pwned'), /shell syntax/);
@@ -130,7 +138,7 @@ test("find parser accepts quoted tasks and rejects aliases and shell syntax", ()
 });
 
 test("quoted natural punctuation is literal while unquoted operators remain unsafe", () => {
-  const natural = 'skillroster find "为什么失败?! $() [草稿]*" --hint "中文?!" --json';
+  const natural = 'skillroster find --hint "中文?!" --json -- "为什么失败?! $() [草稿]*"';
   assert.equal(containsUnquotedShellSyntax(natural), false);
   assert.deepEqual(parseFindCommand(natural), { task: "为什么失败?! $() [草稿]*", hints: ["中文?!"] });
   assert.equal(containsUnquotedShellSyntax('skillroster find "safe" --json && whoami'), true);

--- a/tests/harness/pi-cold-routing/gate.ts
+++ b/tests/harness/pi-cold-routing/gate.ts
@@ -164,9 +164,14 @@ export function parseFindCommand(command: string): { task: string; hints: string
     throw new Error("only the literal skillroster find command is allowed");
   }
 
-  const positional: string[] = [];
+  const separator = words.indexOf("--", 2);
+  if (separator !== -1 && separator !== words.length - 2) {
+    throw new Error("find requires exactly one task after --");
+  }
+  const optionEnd = separator === -1 ? words.length : separator;
+  const positional: string[] = separator === -1 ? [] : [words[separator + 1]];
   const hints: string[] = [];
-  for (let index = 2; index < words.length; index += 1) {
+  for (let index = 2; index < optionEnd; index += 1) {
     const value = words[index];
     if (value === "--json") continue;
     if (value === "--hint") {
@@ -177,6 +182,7 @@ export function parseFindCommand(command: string): { task: string; hints: string
       continue;
     }
     if (value.startsWith("--")) throw new Error(`unsupported find option: ${value}`);
+    if (separator !== -1) throw new Error("task must follow the -- boundary");
     positional.push(value);
   }
   if (positional.length !== 1 || positional[0].length === 0) {

--- a/tests/harness/pi-cold-routing/runner.mjs
+++ b/tests/harness/pi-cold-routing/runner.mjs
@@ -752,7 +752,7 @@ function runArm(options, manifest, task, arm, snapshot) {
     assertPiIdentity(options.piIdentity);
     const common = ["--home", home, "--state-dir", state, "--json"];
     const scan = runJson(snapshot.paths.cli, common, ["scan"], undefined, join(artifacts, "scan.json"), artifactBudget);
-    const initialFind = runJson(snapshot.paths.cli, common, ["find", task.prompt, "--hint", task.family], undefined, join(artifacts, "find-before.json"), artifactBudget);
+    const initialFind = runJson(snapshot.paths.cli, common, ["find", "--hint", task.family, "--", task.prompt], undefined, join(artifacts, "find-before.json"), artifactBudget);
     const target = initialFind.result.matches.find((match) => match.name === task.expected_skill); if (!target) fail(`preflight find did not return ${task.expected_skill}`);
     const report = runJson(snapshot.paths.cli, common, ["report", "--full"], undefined, join(artifacts, "report-full.json"), artifactBudget);
     const finding = report.result.findings.find((item) => item.affected_skill_ids?.includes(target.skill_id)); const evidenceId = finding?.evidence_ids?.[0]; if (!evidenceId) fail(`no Evidence supports ${task.expected_skill}`);
@@ -761,7 +761,7 @@ function runArm(options, manifest, task, arm, snapshot) {
     const plan = runJson(snapshot.paths.cli, common, ["plan", "--stdin"], JSON.stringify(request), join(artifacts, "plan.json"), artifactBudget);
     const apply = runJson(snapshot.paths.cli, common, ["apply", plan.result.plan_id], undefined, join(artifacts, "apply.json"), artifactBudget); if (apply.result.verification !== "passed") fail("Apply did not verify");
     const governedScan = runJson(snapshot.paths.cli, common, ["scan"], undefined, join(artifacts, "scan-governed.json"), artifactBudget);
-    const governed = runJson(snapshot.paths.cli, common, ["find", task.prompt, "--hint", task.family], undefined, join(artifacts, "find-governed.json"), artifactBudget);
+    const governed = runJson(snapshot.paths.cli, common, ["find", "--hint", task.family, "--", task.prompt], undefined, join(artifacts, "find-governed.json"), artifactBudget);
     const governedTarget = governed.result.matches.find((match) => match.name === task.expected_skill); if (!governedTarget || governedTarget.roster_state !== arm) fail(`governed find did not prove ${arm}`);
     const governedReport = runJson(snapshot.paths.cli, common, ["report", "--full"], undefined, join(artifacts, "report-governed.json"), artifactBudget);
     const actualExposure = governedReport.result.default_exposure; const expectedExposure = arm === "on_demand" ? 0 : 1; if (actualExposure !== expectedExposure) fail(`default exposure ${actualExposure}, expected ${expectedExposure}`);


### PR DESCRIPTION
Closes #287

## Why

`find` promises to preserve an Agent's opaque TASK, but option-shaped tasks such as `--help me review code` were parsed as CLI syntax unless callers knew to add a boundary marker.

## What changed

- accept non-empty option-shaped TASK values without trimming or rewriting them
- emit canonical replay actions as `find [options] -- TASK`
- bind every exact-variant load action to the observed Scan snapshot and fail closed after drift
- update Bootstrap, public docs, and Codex/Pi cold-routing harnesses to the same argv contract
- freeze the historical v1.8.23 Bootstrap fixture and classify fixture changes as full CI inputs

## Evidence

- `bash scripts/ci-full-check.sh`
  - Rust unit: 318/318
  - acceptance: 8/8
  - CLI: 94/94
  - Node: 137/137
  - formatting and strict Clippy: passed
- `bash scripts/ci-change-scope.sh --self-test`: passed
- independent Standards review: clean
- independent Spec review: clean

No release tag, GitHub Release, Homebrew update, or real Agent-file Apply is included.
