### PR TITLE
fix: explain hinted rank adjustments

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -309,7 +309,10 @@ index. Without hints, Find uses one lexical channel. With hints, it ranks the
 original task and the task-plus-hints expansion independently, then applies
 deterministic reciprocal-rank fusion over a bounded candidate pool. The JSON
 `ranking_strategy`, `task_channel_rank`, and `augmented_channel_rank` facts make
-that decision inspectable. Rank position remains discriminating within these
+that decision inspectable. When the post-fusion protection rule moves the
+strongest original-task match, that exact match also carries
+`ranking_adjustments: ["protected_original_task_match"]`; unadjusted matches
+omit the field. Rank position remains discriminating within these
 small candidate pools: a high-ranked Agent hint match outranks weak lexical
 overlap that merely appears in both channels, while the strongest original-task
 match remains within the default top three when it has protectable evidence.

--- a/skill/skillroster/references/routing.md
+++ b/skill/skillroster/references/routing.md
@@ -9,8 +9,12 @@ guess a Skill name.
 With a hint, require
 `ranking_strategy: task_hint_reciprocal_rank_fusion`. Use `task_channel_rank`
 and `augmented_channel_rank` to distinguish native task evidence from
-hint-expanded evidence. Retry at most once, only for an empty or wrong-domain
-result. Change only the hint; an English task may add one on its retry.
+hint-expanded evidence. A match with
+`ranking_adjustments: ["protected_original_task_match"]` was deliberately moved
+by the documented original-task protection rule after fusion; interpret its
+rank/score order through that adjustment. Retry at most once, only for an empty
+or wrong-domain result. Change only the hint; an English task may add one on its
+retry.
 
 When the blocker reason is `same_name_variants_ambiguous`, execute its returned
 read-only `inspect_same_name_variants` action. Do not reconstruct or rerun Find:

--- a/src/query.rs
+++ b/src/query.rs
@@ -310,6 +310,12 @@ pub struct Report {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RankingAdjustment {
+    ProtectedOriginalTaskMatch,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FindMatch {
     pub rank: usize,
     pub skill_id: String,
@@ -338,6 +344,9 @@ pub struct FindMatch {
     pub task_channel_rank: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub augmented_channel_rank: Option<usize>,
+    /// Policy adjustments applied after reciprocal-rank fusion.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ranking_adjustments: Vec<RankingAdjustment>,
     pub evidence_quality: EvidenceQuality,
     /// Same declared name with distinct Skill identities is one ambiguous capability result.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -2082,6 +2091,7 @@ pub(crate) fn find_matching(
                 match_reasons: reasons,
                 task_channel_rank: None,
                 augmented_channel_rank: None,
+                ranking_adjustments: Vec::new(),
                 evidence_quality: if observed_usage {
                     EvidenceQuality::Observed
                 } else {
@@ -2265,6 +2275,9 @@ pub(crate) fn fuse_retrieval_channels(
         if index > protected_rank_index {
             let matched = fused.remove(index);
             fused.insert(protected_rank_index, matched);
+            fused[protected_rank_index]
+                .ranking_adjustments
+                .push(RankingAdjustment::ProtectedOriginalTaskMatch);
         }
     }
     fused.truncate(limit);
@@ -2586,6 +2599,7 @@ mod tests {
             match_reasons: reasons.iter().map(|reason| (*reason).into()).collect(),
             task_channel_rank: None,
             augmented_channel_rank: None,
+            ranking_adjustments: Vec::new(),
             evidence_quality: EvidenceQuality::Inferred,
             variant_skill_ids: Vec::new(),
             variants: Vec::new(),
@@ -3427,6 +3441,16 @@ mod tests {
         assert_eq!(fused[0].name, "native-task");
         assert_eq!(fused[0].task_channel_rank, Some(1));
         assert_eq!(fused[0].augmented_channel_rank, Some(3));
+        assert!(matches!(
+            fused[0].ranking_adjustments.as_slice(),
+            [RankingAdjustment::ProtectedOriginalTaskMatch]
+        ));
+        assert_eq!(
+            serde_json::to_value(&fused[0]).unwrap()["ranking_adjustments"],
+            serde_json::json!(["protected_original_task_match"])
+        );
+        assert!(fused[1].ranking_adjustments.is_empty());
+        assert!(fused[2].ranking_adjustments.is_empty());
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1293,6 +1293,7 @@ fn public_find_hints_do_not_erase_a_native_task_match() {
     assert_eq!(native["rank"], 1);
     assert_eq!(native["task_channel_rank"], 1);
     assert!(native["augmented_channel_rank"].is_number());
+    assert!(native.get("ranking_adjustments").is_none());
     assert_eq!(
         hinted["result"]["ranking_strategy"],
         "task_hint_reciprocal_rank_fusion"


### PR DESCRIPTION
Closes #291

## Why

Hinted Find deliberately protects a strong original-task match after reciprocal-rank fusion. When that policy moves a lower fused-score match ahead of a higher-score hint match, the JSON previously exposed the final rank and score without identifying the post-fusion adjustment.

## What

- add a typed `RankingAdjustment` protocol enum
- emit `protected_original_task_match` only on a match that is actually moved by the protection rule
- omit the field for unadjusted matches
- document the field in the product contract and the routed Agent reference
- cover the positive serialized path and the ordinary omitted path

The ranking algorithm, scores, protection threshold, and prefix behavior are unchanged.

## Evidence

- red test first: the new field did not exist
- real isolated dogfood reproduced rank 1 score 500 ahead of rank 2 score 1500, then showed the exact adjustment on rank 1 with `files_changed: false`
- `bash scripts/ci-full-check.sh`: 318 unit + 8 acceptance + 95 CLI + 137 Node, strict Clippy and fmt included
- `git diff --check`
- change-scope self-test and classification: full checks required
- independent Spec review: Clean
- independent Standards review found the initial stringly-typed field; changed it to the typed serde enum; final Standards and Spec reviews: Clean

No release, source-root permission, Agent-file mutation, or lifecycle operation is included.