### PR TITLE
test: make release Undo failures diagnosable

### DIFF
--- a/scripts/release/smoke.sh
+++ b/scripts/release/smoke.sh
@@ -45,10 +45,18 @@ receipt_id="$(printf '%s' "$apply" | sed -n 's/.*"receipt_id":"\([^"]*\)".*/\1/p
 }
 
 undo="$(run_json undo "$receipt_id")"
-[[ "$undo" == *'"verification":"passed"'* && ! -e "$skill_root/skillroster" ]] || {
-  echo "release Undo did not restore the synthetic Agent root" >&2
+[[ "$undo" == *'"verification":"passed"'* ]] || {
+  echo "release Undo receipt did not report verification passed: $undo" >&2
   exit 1
 }
+if [[ -e "$skill_root/skillroster" || -L "$skill_root/skillroster" ]]; then
+  echo "release Undo left the synthetic bootstrap path in place" >&2
+  # The fixture is generated entirely by this script, so bounded metadata is
+  # safe to print and makes cross-runtime release failures actionable.
+  ls -ld "$skill_root/skillroster" >&2 || true
+  find "$skill_root/skillroster" -print 2>&1 | head -n 50 >&2 || true
+  exit 1
+fi
 
 status="$(run_json status)"
 [[ "$status" == *'"recovery_state":"clear"'* ]] || {


### PR DESCRIPTION
## What changed

- split Undo receipt verification from filesystem-restoration assertions in the release smoke
- print bounded metadata from the synthetic fixture when the bootstrap path remains
- keep diagnostics safe: the inspected path is generated entirely inside the release smoke fixture

## Why

The v1.8.29 candidate WSL gate failed with one combined error that could not distinguish a failed Undo receipt from a leftover path. This change creates the evidence needed to resolve the blocker without weakening the release gate.

## Validation

- `bash -n scripts/release/smoke.sh`
- `scripts/release/smoke.sh target/release/skillroster`
- `bash scripts/ci-full-check.sh`

Related to #295. Keep that issue open until a fresh candidate proves the WSL gate deterministic.
