### PR TITLE
fix: fail closed on unsupported Linux rename

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -189,7 +189,7 @@ jobs:
           if ($actual -ne "9b2f7730dc68227dd04a9f3e5eab86ad85caf556b8606ad94f1f29ff5c4fd3f5") {
             throw "Ubuntu WSL image checksum mismatch: $actual"
           }
-          wsl --import SkillRosterAcceptance $install $image --version 1
+          wsl --import SkillRosterAcceptance $install $image --version 2
           if ($LASTEXITCODE -ne 0) { throw "WSL import failed with exit code $LASTEXITCODE" }
           try {
             function Convert-ToWslPath([string]$Path) {

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -165,7 +165,7 @@ release binaries, always against synthetic temporary homes:
   governance smoke checks.
 
 WSL is tested as Linux in the release workflow by importing a checksum-pinned
-Canonical Ubuntu 24.04 image into WSL1 on the Windows runner, then executing the
+Canonical Ubuntu 24.04 image into WSL2 on the Windows runner, then executing the
 packaged Linux binary through the same governance loop. The final successful
 candidate and official tag run are the release record; a failed or skipped WSL
 job does not count as support.

--- a/docs/acceptance/release-v1.8.29-candidate.md
+++ b/docs/acceptance/release-v1.8.29-candidate.md
@@ -66,3 +66,7 @@ separate explicitly authorized publication gate. Final candidate SHA, CI run,
 four-platform archives, adjacent checksums, WSL evidence, anonymous download
 readback, governance smoke, and Homebrew installation evidence will be recorded
 only after they exist.
+
+The release WSL boundary is WSL2. WSL1 rejects Apply and Undo when its kernel
+cannot provide atomic no-replace rename; SkillRoster does not substitute a
+race-prone check-then-rename fallback.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,6 +9,10 @@ candidate before publication; candidate identity is not an installable tag.
 The examples below deliberately remain on the public release until its Formula,
 tag, archives, and checksums are all available.
 
+WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
+no-replace rename primitive required for safe Apply and Undo, so mutation fails
+closed there instead of falling back to a race-prone path operation.
+
 ## GitHub Release binaries
 
 Download the archive and matching `.sha256` file for your platform from the

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -26,7 +26,11 @@ The first complete release directly supports:
 - Gemini CLI
 - GitHub Copilot
 
-Supported platforms are macOS, Linux, and Windows. WSL is treated as Linux. A platform or Agent is not declared supported until its adapter passes fixtures and a real-environment acceptance run.
+Supported platforms are macOS, Linux, and Windows. WSL2 is treated as Linux;
+WSL1 mutation fails closed because it does not provide the no-replace rename
+primitive required by SkillRoster's handle-bound recovery model. A platform or
+Agent is not declared supported until its adapter passes fixtures and a
+real-environment acceptance run.
 
 SkillRoster scans only known directories for these eight Agents, the active SkillRoster-owned Library root, Skill roots from Codex plugins proven by either explicit local enablement or a valid local remote-plugin install marker, plus paths explicitly provided by the user. It never crawls the entire home directory or treats an arbitrary plugin cache as installed. Explicitly disabled plugins remain excluded. Discovered Codex plugin Skills are Observed, searchable, and provider-managed read-only: they cannot become mutation targets or canonical Library sources. Invalid install markers and ambiguous cached plugin versions fail closed. Every new Snapshot records two orthogonal placement facts: `owned_by_agent` describes only whether the placement path is structurally inside an Agent root, while `mutation_scope` is `mutable`, `provider_read_only`, `durable_read_only`, or `untrusted_external`. Placement-path ownership never endorses linked source content. Compatibility field `governable` is true exactly for `mutable`; missing authority fields in legacy Snapshots remain unknown and cannot authorize mutation. Every Scan reports included, excluded, missing, and inaccessible roots. `--root AGENT=PATH` is an Agent placement root and contributes to exposure; `--source-root PATH` is an approved canonical source with no Agent identity and no default exposure. Source trust is explicit and scoped to the resolved canonical directory; a path and a symlink alias to that same directory have identical trust semantics.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,7 +18,7 @@ other user data.
 4. Download all four workflow artifacts and verify every adjacent `.sha256`
    file. The workflow smoke-tests `skillroster --version` and a fixture-backed
    Plan/Apply/Undo cycle on each operating system, then runs the Linux archive
-   inside checksum-pinned Ubuntu WSL. Unix packaging also runs the staged
+   inside checksum-pinned Ubuntu WSL2. Unix packaging also runs the staged
    archive binary through the synthetic retained-ID collision regression before
    the archive is created. Review all five successful jobs.
 

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -31,6 +31,8 @@ thread_local! {
         std::cell::RefCell::new(None);
     static BEFORE_RENAME_NOREPLACE_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
         std::cell::RefCell::new(None);
+    static FORCE_ATOMIC_NOREPLACE_UNSUPPORTED: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
 }
 
 #[cfg(test)]
@@ -81,6 +83,11 @@ pub(crate) fn set_after_renamed_entry_first_check_hook(hook: impl FnOnce() + 'st
 #[cfg(all(test, any(unix, windows)))]
 pub(crate) fn set_before_rename_noreplace_hook(hook: impl FnOnce() + 'static) {
     BEFORE_RENAME_NOREPLACE_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(test)]
+pub(crate) fn force_atomic_noreplace_unsupported_once() {
+    FORCE_ATOMIC_NOREPLACE_UNSUPPORTED.with(|forced| forced.set(true));
 }
 
 #[cfg(test)]
@@ -203,6 +210,16 @@ fn run_before_rename_noreplace_hook() {
 #[cfg(not(test))]
 fn run_before_rename_noreplace_hook() {}
 
+#[cfg(test)]
+fn take_forced_atomic_noreplace_unsupported() -> bool {
+    FORCE_ATOMIC_NOREPLACE_UNSUPPORTED.with(|forced| forced.replace(false))
+}
+
+#[cfg(not(test))]
+fn take_forced_atomic_noreplace_unsupported() -> bool {
+    false
+}
+
 struct Anchor {
     path: PathBuf,
     dir: Dir,
@@ -263,14 +280,20 @@ fn parent_dir_and_name(anchor: &Anchor, relative: &Path) -> io::Result<(Dir, OsS
     Ok((anchor.dir.open_dir(parent)?, name.to_os_string()))
 }
 
+fn unsupported_atomic_noreplace_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "atomic no-replace rename is unavailable; mutation requires Linux or WSL2 with RENAME_NOREPLACE support",
+    )
+}
+
 #[cfg(target_os = "linux")]
 fn classify_atomic_noreplace_probe(error: io::Error) -> io::Result<()> {
     match error.raw_os_error() {
         Some(libc::ENOENT) => Ok(()),
-        Some(libc::EINVAL) | Some(libc::ENOSYS) | Some(libc::EOPNOTSUPP) => Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "atomic no-replace rename is unavailable; mutation requires Linux or WSL2 with RENAME_NOREPLACE support",
-        )),
+        Some(libc::EINVAL) | Some(libc::ENOSYS) | Some(libc::EOPNOTSUPP) => {
+            Err(unsupported_atomic_noreplace_error())
+        }
         _ => Err(error),
     }
 }
@@ -537,6 +560,10 @@ impl<'a> AnchoredFs<'a> {
     pub(crate) fn require_atomic_noreplace_rename(&self) -> io::Result<()> {
         use std::os::fd::AsRawFd as _;
 
+        if take_forced_atomic_noreplace_unsupported() {
+            return Err(unsupported_atomic_noreplace_error());
+        }
+
         let state = self
             .anchors
             .iter()
@@ -562,7 +589,11 @@ impl<'a> AnchoredFs<'a> {
 
     #[cfg(not(target_os = "linux"))]
     pub(crate) fn require_atomic_noreplace_rename(&self) -> io::Result<()> {
-        Ok(())
+        if take_forced_atomic_noreplace_unsupported() {
+            Err(unsupported_atomic_noreplace_error())
+        } else {
+            Ok(())
+        }
     }
 
     pub(crate) fn open(

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -264,6 +264,18 @@ fn parent_dir_and_name(anchor: &Anchor, relative: &Path) -> io::Result<(Dir, OsS
 }
 
 #[cfg(target_os = "linux")]
+fn classify_atomic_noreplace_probe(error: io::Error) -> io::Result<()> {
+    match error.raw_os_error() {
+        Some(libc::ENOENT) => Ok(()),
+        Some(libc::EINVAL) | Some(libc::ENOSYS) | Some(libc::EOPNOTSUPP) => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "atomic no-replace rename is unavailable; mutation requires Linux or WSL2 with RENAME_NOREPLACE support",
+        )),
+        _ => Err(error),
+    }
+}
+
+#[cfg(target_os = "linux")]
 fn rename_noreplace(
     from_anchor: &Anchor,
     from: &Path,
@@ -515,6 +527,42 @@ impl<'a> AnchoredFs<'a> {
         let retained = retained.dir.try_clone()?.into_std_file();
         let candidate = candidate.dir.into_std_file();
         same_file_identity(&retained, &candidate)
+    }
+
+    /// Refuse mutation before the first write when the filesystem cannot
+    /// provide an atomic descriptor-relative no-replace rename. An empty
+    /// source name makes this probe mutation-free: supported kernels return
+    /// ENOENT, while WSL1 and unsupported filesystems reject the flag.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn require_atomic_noreplace_rename(&self) -> io::Result<()> {
+        use std::os::fd::AsRawFd as _;
+
+        let state = self
+            .anchors
+            .iter()
+            .find(|anchor| anchor.path == self.state_path)
+            .ok_or_else(|| io::Error::other("state capability is missing"))?;
+        let empty = c"";
+        let result = unsafe {
+            libc::renameat2(
+                state.dir.as_raw_fd(),
+                empty.as_ptr(),
+                state.dir.as_raw_fd(),
+                empty.as_ptr(),
+                libc::RENAME_NOREPLACE,
+            )
+        };
+        if result == 0 {
+            return Err(io::Error::other(
+                "atomic no-replace rename probe unexpectedly mutated an empty path",
+            ));
+        }
+        classify_atomic_noreplace_probe(io::Error::last_os_error())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub(crate) fn require_atomic_noreplace_rename(&self) -> io::Result<()> {
+        Ok(())
     }
 
     pub(crate) fn open(
@@ -1601,4 +1649,43 @@ fn same_file_identity(left: &fs::File, right: &fs::File) -> io::Result<bool> {
     }
 
     Ok(identity(left.as_raw_handle())? == identity(right.as_raw_handle())?)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod linux_probe_tests {
+    use super::classify_atomic_noreplace_probe;
+    use std::io;
+
+    #[test]
+    fn atomic_noreplace_probe_accepts_missing_source() {
+        assert!(
+            classify_atomic_noreplace_probe(io::Error::from_raw_os_error(libc::ENOENT)).is_ok()
+        );
+    }
+
+    #[test]
+    fn running_kernel_accepts_the_mutation_free_probe() {
+        let empty = c"";
+        let result = unsafe {
+            libc::renameat2(
+                libc::AT_FDCWD,
+                empty.as_ptr(),
+                libc::AT_FDCWD,
+                empty.as_ptr(),
+                libc::RENAME_NOREPLACE,
+            )
+        };
+        assert_eq!(result, -1);
+        classify_atomic_noreplace_probe(io::Error::last_os_error())
+            .expect("the test kernel must support atomic no-replace rename");
+    }
+
+    #[test]
+    fn atomic_noreplace_probe_rejects_unsupported_kernel_or_filesystem() {
+        for code in [libc::EINVAL, libc::ENOSYS, libc::EOPNOTSUPP] {
+            let error = classify_atomic_noreplace_probe(io::Error::from_raw_os_error(code))
+                .expect_err("unsupported no-replace rename must fail closed");
+            assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+        }
+    }
 }

--- a/src/change.rs
+++ b/src/change.rs
@@ -636,6 +636,9 @@ fn apply_locked_with_anchored(
     run_before_sequence_validation_hook();
     validate_operation_sequence_anchored(&plan.operations, &anchored)?;
     reject_unresolved_recovery_except(&anchored, &plan.state_dir, "")?;
+    anchored
+        .require_atomic_noreplace_rename()
+        .map_err(|error| ChangeError::io("validate mutation filesystem", &plan.state_dir, error))?;
 
     let receipt_id = format!("receipt_{}", ulid::Ulid::new());
     let mut receipt = ChangeReceipt {
@@ -826,6 +829,11 @@ fn undo_locked_with_anchored(
         ));
     }
     reject_unresolved_recovery_except(&anchored, &receipt.state_dir, &receipt.id)?;
+    anchored
+        .require_atomic_noreplace_rename()
+        .map_err(|error| {
+            ChangeError::io("validate mutation filesystem", &receipt.state_dir, error)
+        })?;
     if reverse_receipt_exists(&anchored, &receipt.state_dir, &receipt.id)? {
         return Err(ChangeError::new(
             "receipt_already_undone",

--- a/src/change.rs
+++ b/src/change.rs
@@ -3303,6 +3303,25 @@ mod tests {
     }
 
     #[test]
+    fn unsupported_atomic_rename_is_rejected_before_mutation_or_receipt() {
+        let (_temp, root, state) = fixture();
+        let target = root.join("not-created.md");
+        let plan = prepared_write(&root, &state, &target);
+        crate::anchored_fs::force_atomic_noreplace_unsupported_once();
+
+        let error = apply(&plan).unwrap_err();
+
+        assert_eq!(error.code, "filesystem_error");
+        assert!(
+            error
+                .message
+                .contains("atomic no-replace rename is unavailable")
+        );
+        assert!(!target.exists());
+        assert!(!state.join("receipts").exists());
+    }
+
+    #[test]
     fn journal_reuses_an_owned_temp_left_by_an_interrupted_write() {
         let (_temp, root, state) = fixture();
         let receipt = ChangeReceipt {


### PR DESCRIPTION
## What changed

- probe `RENAME_NOREPLACE` through the retained state-directory handle before Apply or Undo performs its first write
- treat `EINVAL`, `ENOSYS`, and `EOPNOTSUPP` as an unsupported mutation filesystem instead of entering a partially reversible operation
- add a regression proving unsupported capability is rejected before target mutation or Receipt creation
- move the supported WSL release boundary from WSL1 to WSL2
- document why WSL1 mutation is refused instead of using a race-prone check-then-rename fallback

## Evidence

The v1.8.29 candidate and an exact-artifact rerun both reached Undo on WSL1 and returned `EINVAL` from `renameat2(..., RENAME_NOREPLACE)`. The diagnostic candidate exposed the precise recovery receipt in #295.

## Validation

- `bash scripts/ci-full-check.sh`: 319 unit + 8 acceptance + 95 CLI + 137 Node
- strict Clippy and formatting
- `git diff --check`
- fresh branch candidate required to prove the Linux kernel probe and WSL2 packaged governance loop

Related to #295 and #258.
