### PR TITLE
docs: record v1.8.29 release

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "37ef503b39f2d9f8e31fc0aa532c51eb4f4dbbf9"
-  version "1.8.28"
+      revision: "b996c7e52bd849243ce7772cff30602a00c4270b"
+  version "1.8.29"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.28", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.29", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,16 +214,14 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.28 implements the complete local governance loop. `main` is
-preparing the v1.8.29 candidate so the security and reliability hardening merged
-since that release reaches installed users. The loop includes discovery,
-normalized inventory, conservative usage evidence, bounded reporting, local
-retrieval, immutable planning, Apply/Undo, recovery, lifecycle controls, and
-eight direct agent adapters.
+Public release v1.8.29 implements the complete local governance loop and ships
+the filesystem, security, and recovery hardening merged since v1.8.28. The loop
+includes discovery, normalized inventory, conservative usage evidence, bounded
+reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
+controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [Release and platform evidence](docs/acceptance/release-v1.8.28-candidate.md)
-- [v1.8.29 candidate notes](docs/acceptance/release-v1.8.29-candidate.md)
+- [v1.8.29 release and platform evidence](docs/acceptance/release-v1.8.29-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,13 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.28 已实现完整的本地治理闭环；当前 `main` 正在准备 v1.8.29 候选版，
-把后续合并的安全与可靠性加固交付给安装用户。能力包括发现、标准化 Inventory、保守的
+公开版本 v1.8.29 已实现完整的本地治理闭环，并交付了文件系统、安全与恢复边界加固。
+能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [发布与平台证据](docs/acceptance/release-v1.8.28-candidate.md)
-- [v1.8.29 候选版说明](docs/acceptance/release-v1.8.29-candidate.md)
+- [v1.8.29 发布与平台证据](docs/acceptance/release-v1.8.29-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.29-candidate.md
+++ b/docs/acceptance/release-v1.8.29-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.29 candidate
+# SkillRoster v1.8.29 release receipt
 
-## Release notes draft
+## Release notes
 
 SkillRoster 1.8.29 brings the fail-closed and reversible boundaries promised by
 the product model to the public package built from current `main`.
@@ -37,22 +37,20 @@ Snapshots created before the Unicode identity contract require a new complete
 Scan before exact identity decisions. Existing user-owned Skill contents are
 not migrated or deleted by upgrading the binary.
 
-## Preparation evidence
+## Release evidence
 
-The public baseline is v1.8.28. Candidate preparation starts from exact
-`origin/main` revision `b7f6d47d9746dc3d6735b9e328748a467d603085` in a clean
-worktree. Cargo, installation examples, presentation fixtures, the website
-source, and bundled Bootstrap content are versioned as 1.8.29. The checked-in
-Homebrew Formula remains at the last published release until v1.8.29 artifacts
-exist and their independently verified checksum is available.
+The annotated `v1.8.29` tag resolves exactly to
+`b996c7e52bd849243ce7772cff30602a00c4270b`. The official tag workflow
+[run 33197816927](https://github.com/tt-a1i/skillroster/actions/runs/33197816927)
+passed the strict repository gate, Linux, Windows, macOS arm64 and x86_64
+build/governance jobs, and the WSL2 Linux governance smoke.
 
-The implementation already merged after v1.8.28 is represented by pull requests
-#233, #235, #237, #239, #241, #243, #245, #247, #249, #251, and #253. The
-outcome-first README clarification in #254 is also part of this candidate.
+The release delta is recorded in first-parent history from #233 through #297.
+That includes the security fixes, typed-module simplification, first-value
+acceptance work, routing and recovery corrections found during review, and the
+final WSL capability boundary.
 
-## Candidate gates
-
-The candidate is not accepted until one exact final source revision passes:
+The exact tagged revision passed:
 
 - `cargo fmt --all --check`;
 - `cargo clippy --locked --all-targets --all-features -- -D warnings`;
@@ -60,12 +58,20 @@ The candidate is not accepted until one exact final source revision passes:
 - the public CLI acceptance suite and both Node routing harnesses;
 - `git diff --check` and the CI change-scope self-test.
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-change the Homebrew tap, or mutate any public release asset. Those remain a
-separate explicitly authorized publication gate. Final candidate SHA, CI run,
-four-platform archives, adjacent checksums, WSL evidence, anonymous download
-readback, governance smoke, and Homebrew installation evidence will be recorded
-only after they exist.
+The [public GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.29)
+contains four platform archives and four adjacent checksum files. All eight
+assets were downloaded through their unauthenticated public URLs; every
+checksum passed. The public macOS arm64 archive reported `skillroster 1.8.29`,
+rendered help, and passed the complete synthetic Scan, Setup, Apply, Receipt,
+Undo, recovery-clear, and retained-ID governance smoke.
+
+The [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster) publishes
+v1.8.29 arm64 macOS and x86_64 Linux bottles. Both Homebrew test-bot jobs passed
+in [run 33198038445](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33198038445),
+and `brew pr-pull` published the bottles in
+[run 33199481374](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33199481374).
+The public macOS arm64 bottle was independently downloaded, matched the Formula
+checksum, reported `skillroster 1.8.29`, and passed the same governance smoke.
 
 The release WSL boundary is WSL2. WSL1 rejects Apply and Undo when its kernel
 cannot provide atomic no-replace rename; SkillRoster does not substitute a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,10 +4,8 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.28**. The source tree may contain a newer
-candidate before publication; candidate identity is not an installable tag.
-The examples below deliberately remain on the public release until its Formula,
-tag, archives, and checksums are all available.
+The current public release is **v1.8.29**. Its Formula, annotated tag, four
+platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
 no-replace rename primitive required for safe Apply and Undo, so mutation fails
@@ -36,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.28
+SKILLROSTER_VERSION=1.8.29
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -60,7 +58,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.28 skillroster
+  --tag v1.8.29 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -94,8 +92,8 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.28 bundles Bootstrap content version 1.8.28. The current
-source-tree candidate is **v1.8.29**.
+Published CLI v1.8.29 bundles Bootstrap content version 1.8.29.
+The source tree is **v1.8.29**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap
 instructions.

--- a/scripts/verify-installation-surface.sh
+++ b/scripts/verify-installation-surface.sh
@@ -46,7 +46,7 @@ require_literal "$installation" "The current public release is **v${published_ve
 require_literal "$installation" "SKILLROSTER_VERSION=${published_version}"
 require_literal "$installation" "--tag v${published_version} skillroster"
 require_literal "$installation" "Published CLI v${published_version} bundles Bootstrap content version ${published_version}."
-require_literal "$installation" "source-tree candidate is **v${candidate_version}**"
+require_literal "$installation" "The source tree is **v${candidate_version}**."
 require_literal "$installation" "Its bundled Bootstrap content version is ${bootstrap_version}."
 
 require_literal "$website" "CURRENT RELEASE v${published_version}"

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.28 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.29 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.28 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.29 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.28 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.28 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.29 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.29 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Records the completed v1.8.29 release boundary.

- updates bilingual project status, installation examples, website, and checked-in Formula
- converts the candidate note into an evidence-backed release receipt
- records exact tag workflow, public asset readback, WSL2, and Homebrew bottle evidence
- keeps the installation-surface verifier version-derived

Validation on the committed bytes before push:
- `bash scripts/ci-full-check.sh` (319 unit + 8 acceptance + 95 CLI + 137 Node)
- strict Clippy and rustfmt
- installation-surface verification
- `git diff --check`