### PR TITLE
fix: bound Apply and Undo changed-path JSON

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -43,6 +43,7 @@ use error::{
 pub use error::{error_json, error_json_with_context};
 
 const STATUS_PENDING_PLAN_LIMIT: usize = 20;
+const MUTATION_CHANGED_PATH_PREVIEW_LIMIT: usize = 10;
 const SETUP_PLAN_SUMMARY_FIELDS: &[&str] = &[
     "snapshot_id",
     "digest",
@@ -9668,13 +9669,19 @@ fn mutation_result(
     receipt: &ReceiptRecord,
     reverses: Option<ReceiptId>,
 ) -> Value {
+    let changed_path_count = outcome.receipt.changed_paths.len();
+    let mut changed_paths = outcome.receipt.changed_paths.clone();
+    changed_paths.sort();
+    changed_paths.truncate(MUTATION_CHANGED_PATH_PREVIEW_LIMIT);
+
     json!({
         "plan_id": receipt.plan_id,
         "receipt_id": receipt.id,
         "reverses_receipt_id": reverses,
         "status": receipt.status,
-        "changed_path_count": outcome.receipt.changed_paths.len(),
-        "changed_paths": outcome.receipt.changed_paths,
+        "changed_path_count": changed_path_count,
+        "changed_paths": changed_paths,
+        "changed_paths_truncated": changed_path_count > MUTATION_CHANGED_PATH_PREVIEW_LIMIT,
         "verification": if outcome.verification_passed { "passed" } else { "failed" },
         "canonical_deletion_count": 0,
         "undo_available": outcome.receipt.status == change::ReceiptStatus::Applied,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3719,6 +3719,11 @@ fn setup_upgrades_the_public_v1_8_23_package_and_undo_restores_every_file() {
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
     assert_eq!(applied["result"]["verification"], "passed");
     assert_eq!(applied["result"]["changed_path_count"], 4);
+    assert_eq!(
+        applied["result"]["changed_paths"].as_array().unwrap().len(),
+        4
+    );
+    assert_eq!(applied["result"]["changed_paths_truncated"], false);
     for (relative_path, expected) in [
         ("SKILL.md", include_str!("../skill/skillroster/SKILL.md")),
         (
@@ -3752,6 +3757,12 @@ fn setup_upgrades_the_public_v1_8_23_package_and_undo_restores_every_file() {
     let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
     let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
     assert_eq!(undone["result"]["verification"], "passed");
+    assert_eq!(undone["result"]["changed_path_count"], 4);
+    assert_eq!(
+        undone["result"]["changed_paths"].as_array().unwrap().len(),
+        4
+    );
+    assert_eq!(undone["result"]["changed_paths_truncated"], false);
     for (relative_path, expected) in legacy_files {
         assert_eq!(
             fs::read_to_string(package.join(relative_path)).unwrap(),
@@ -4123,6 +4134,18 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
     assert_eq!(status["result"]["recovery_state"], "clear");
 
     let applied = json_output(&run(&[&common[..], &["apply", plan_id]].concat(), None));
+    assert_eq!(applied["result"]["changed_path_count"], 36);
+    assert_eq!(
+        applied["result"]["changed_paths"].as_array().unwrap().len(),
+        10
+    );
+    assert_eq!(applied["result"]["changed_paths_truncated"], true);
+    let applied_paths = applied["result"]["changed_paths"].as_array().unwrap();
+    assert!(
+        applied_paths
+            .windows(2)
+            .all(|pair| { pair[0].as_str().unwrap() <= pair[1].as_str().unwrap() })
+    );
     for root in physical_roots {
         assert!(root.join("skillroster/SKILL.md").is_file());
         assert!(root.join("skillroster/references/routing.md").is_file());
@@ -4130,8 +4153,22 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
         assert!(root.join("skillroster/references/mutation.md").is_file());
     }
     let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
+    let persisted_receipt: Value = serde_json::from_slice(
+        &fs::read(state.join("receipts").join(format!("{receipt_id}.json"))).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        persisted_receipt["changed_paths"].as_array().unwrap().len(),
+        36
+    );
     let undone = json_output(&run(&[&common[..], &["undo", receipt_id]].concat(), None));
     assert_eq!(undone["result"]["verification"], "passed");
+    assert_eq!(undone["result"]["changed_path_count"], 36);
+    assert_eq!(
+        undone["result"]["changed_paths"].as_array().unwrap().len(),
+        10
+    );
+    assert_eq!(undone["result"]["changed_paths_truncated"], true);
     for root in physical_roots {
         assert!(!root.join("skillroster").exists());
     }


### PR DESCRIPTION
## 解决什么问题

大型 Apply/Undo 会把所有绝对变更路径线性塞进普通 JSON 响应，放大 Agent 上下文、路径暴露和响应尺寸。

## 价值

保留精确变更总数和完整可恢复 Receipt，同时把面向 Agent 的普通响应限制为稳定的 10 条预览，并明确告诉调用方是否截断。

## 方法

- Apply/Undo 共用一个命名预览上限
- 对预览路径确定性排序后截断
- 保留精确 `changed_path_count`，新增 additive `changed_paths_truncated`
- 不裁剪 journal/Receipt，Undo 仍基于完整路径集合
- 覆盖 4 路径和 36 路径两组公共 CLI 回归

## 验证

- `bash scripts/ci-full-check.sh`
- Rust: 319 unit + 8 acceptance + 95 CLI
- Node harness: 137
- 两轴代码复审：Spec Clean / Standards Clean

Closes #299