### PR TITLE
release: prepare v1.8.30 candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.29"
+version = "1.8.30"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.29"
+version = "1.8.30"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/docs/acceptance/release-v1.8.30-candidate.md
+++ b/docs/acceptance/release-v1.8.30-candidate.md
@@ -1,0 +1,48 @@
+# SkillRoster v1.8.30 candidate
+
+## Release notes draft
+
+SkillRoster 1.8.30 keeps large Apply and Undo responses bounded for Agent
+callers without weakening recovery.
+
+- Ordinary mutation JSON now returns at most ten deterministically ordered
+  changed-path previews.
+- `changed_path_count` still reports the exact total, while the additive
+  `changed_paths_truncated` field states whether the preview is incomplete.
+- The persisted Receipt journal still contains the complete changed-path set,
+  and Undo continues to use that complete recovery record.
+
+This patch release keeps SQLite schema 10 and JSON envelope schema 1. Strict
+JSON consumers must tolerate the new additive field. There is no migration and
+no change to the local-only, explicit-confirmation, fail-closed mutation model.
+The bundled Bootstrap instructions are unchanged at content version 1.8.29, so
+upgrading the CLI does not cause an unnecessary Bootstrap replacement Plan.
+
+## Preparation evidence
+
+The public baseline is v1.8.29. Candidate preparation starts from exact
+`origin/main` revision `3b471620445285c9f97eacbdeca211e1bee07c7c`, after
+[#300](https://github.com/tt-a1i/skillroster/pull/300) merged with its Linux,
+Windows, macOS arm64, macOS x86_64, change-scope, and aggregate CI gates green.
+That change closed [#299](https://github.com/tt-a1i/skillroster/issues/299).
+
+The source candidate and Cargo package are versioned as 1.8.30. Public install
+examples, the checked-in Formula, website current-release label, and README
+release evidence deliberately remain at v1.8.29 until the v1.8.30 tag,
+artifacts, checksums, and Homebrew package actually exist.
+
+## Candidate gates
+
+The candidate is not accepted until one exact final source revision passes:
+
+- `cargo fmt --all --check`;
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
+- `cargo test --locked --all-targets --all-features`;
+- the public CLI acceptance suite and both Node routing harnesses;
+- `git diff --check`, installation-surface validation, and the CI change-scope
+  self-test;
+- four platform build and governance jobs plus the WSL2 governance smoke.
+
+Candidate preparation does not create or push a tag, publish a GitHub Release,
+update Homebrew, or mutate any public release asset. Those steps are recorded
+only after their external evidence exists.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,7 +93,7 @@ skillroster setup --json
 ```
 
 Published CLI v1.8.29 bundles Bootstrap content version 1.8.29.
-The source tree is **v1.8.29**.
+The source tree is **v1.8.30**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap
 instructions.

--- a/website/index.html
+++ b/website/index.html
@@ -1496,7 +1496,7 @@ footer { overflow: hidden; }
       </div>
     </div>
     <div class="footer-rule">
-      <span>SOURCE TREE v1.8.29 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
+      <span>SOURCE TREE v1.8.30 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
       <span>NO DAEMON · NO CLOUD · NO TELEMETRY</span>
     </div>
   </div>


### PR DESCRIPTION
## 解决什么问题

为已合并的 #299 准备一个可验证、可发布的 v1.8.30 patch candidate。

## 价值

大型 Apply/Undo 不再把全部绝对路径塞进 Agent 响应，同时完整 Receipt 与 Undo 恢复能力不受影响。

## 发布边界

- Cargo/source candidate: 1.8.30
- Bundled Bootstrap content: 1.8.29（内容未变，不触发无意义升级）
- Formula / README / public install commands / website current release: 暂留已发布 v1.8.29，等新产物真实存在后更新
- 新增候选记录，明确区分已验证和待发布证据

## 验证

- `bash scripts/ci-full-check.sh`
- `bash scripts/verify-installation-surface.sh`
- Rust: 319 unit + 8 acceptance + 95 CLI
- Node harness: 137
- 发布规格复审：Clean
- 工程标准复审：Clean

Release publication follows only after this exact candidate merges and the tagged SHA passes the release workflow.