### PR TITLE
docs: record v1.8.30 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install Rust 1.85

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Record exact release SHA

--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "b996c7e52bd849243ce7772cff30602a00c4270b"
-  version "1.8.29"
+      revision: "2891c383e3beca999788b0c54b044eb4f91f52a5"
+  version "1.8.30"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.29", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.30", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,14 +214,15 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.29 implements the complete local governance loop and ships
-the filesystem, security, and recovery hardening merged since v1.8.28. The loop
+Public release v1.8.30 implements the complete local governance loop and keeps
+large Apply/Undo Agent JSON bounded without weakening complete Receipts or exact
+recovery. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
 reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.29 release and platform evidence](docs/acceptance/release-v1.8.29-candidate.md)
+- [v1.8.30 release and platform evidence](docs/acceptance/release-v1.8.30-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,13 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.29 已实现完整的本地治理闭环，并交付了文件系统、安全与恢复边界加固。
+公开版本 v1.8.30 已实现完整的本地治理闭环，并让大型 Apply/Undo 的 Agent JSON
+保持有界，同时保留完整 Receipt 和精确恢复能力。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.29 发布与平台证据](docs/acceptance/release-v1.8.29-candidate.md)
+- [v1.8.30 发布与平台证据](docs/acceptance/release-v1.8.30-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.30-candidate.md
+++ b/docs/acceptance/release-v1.8.30-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.30 candidate
+# SkillRoster v1.8.30 release receipt
 
-## Release notes draft
+## Release notes
 
 SkillRoster 1.8.30 keeps large Apply and Undo responses bounded for Agent
 callers without weakening recovery.
@@ -18,22 +18,38 @@ no change to the local-only, explicit-confirmation, fail-closed mutation model.
 The bundled Bootstrap instructions are unchanged at content version 1.8.29, so
 upgrading the CLI does not cause an unnecessary Bootstrap replacement Plan.
 
-## Preparation evidence
+## Release evidence
 
-The public baseline is v1.8.29. Candidate preparation starts from exact
+The public baseline was v1.8.29. Candidate preparation started from exact
 `origin/main` revision `3b471620445285c9f97eacbdeca211e1bee07c7c`, after
 [#300](https://github.com/tt-a1i/skillroster/pull/300) merged with its Linux,
 Windows, macOS arm64, macOS x86_64, change-scope, and aggregate CI gates green.
 That change closed [#299](https://github.com/tt-a1i/skillroster/issues/299).
 
-The source candidate and Cargo package are versioned as 1.8.30. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.29 until the v1.8.30 tag,
-artifacts, checksums, and Homebrew package actually exist.
+The annotated `v1.8.30` tag resolves exactly to
+`2891c383e3beca999788b0c54b044eb4f91f52a5`. The official tag workflow
+[run 33256760259](https://github.com/tt-a1i/skillroster/actions/runs/33256760259)
+passed the strict repository gate, Linux, Windows, macOS arm64 and x86_64
+build/governance jobs, and the WSL2 Linux governance smoke.
 
-## Candidate gates
+The [public GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.30)
+contains four platform archives and four adjacent checksum files. All eight
+workflow artifacts passed their adjacent checksums before publication. The
+public macOS arm64 archive was then downloaded through its anonymous URL,
+matched its published checksum, reported `skillroster 1.8.30`, and passed the
+complete synthetic release governance smoke.
 
-The candidate is not accepted until one exact final source revision passes:
+The [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster) publishes
+v1.8.30 macOS arm64 and x86_64 Linux bottles. Both Homebrew test-bot jobs passed
+in [run 33257348384](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33257348384),
+and exact-head `brew pr-pull` published the bottles in
+[run 33257632463](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33257632463).
+The public macOS arm64 bottle was downloaded anonymously, matched the Formula
+checksum, reported `skillroster 1.8.30`, and passed the same governance smoke.
+
+## Accepted gates
+
+The exact tagged revision passed:
 
 - `cargo fmt --all --check`;
 - `cargo clippy --locked --all-targets --all-features -- -D warnings`;
@@ -43,6 +59,6 @@ The candidate is not accepted until one exact final source revision passes:
   self-test;
 - four platform build and governance jobs plus the WSL2 governance smoke.
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate any public release asset. Those steps are recorded
-only after their external evidence exists.
+The release WSL boundary remains WSL2. WSL1 mutation fails closed when its
+kernel cannot provide the atomic no-replace rename required by SkillRoster's
+handle-bound recovery model.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.29**. Its Formula, annotated tag, four
+The current public release is **v1.8.30**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.29
+SKILLROSTER_VERSION=1.8.30
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -58,7 +58,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.29 skillroster
+  --tag v1.8.30 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -92,7 +92,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.29 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.30 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.30**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/scripts/verify-installation-surface.sh
+++ b/scripts/verify-installation-surface.sh
@@ -10,6 +10,7 @@ website="website/index.html"
 published_version="$(awk -F '"' '/^[[:space:]]*version "/ { print $2; exit }' "$formula")"
 candidate_version="$(awk -F '"' '/^version = "/ { print $2; exit }' "$manifest")"
 bootstrap_version="$(awk -F '"' '/^[[:space:]]*bootstrap-version:/ { print $2; exit }' "$bootstrap")"
+published_revision="$(awk -F '"' '/^[[:space:]]*revision:/ { print $2; exit }' "$formula")"
 
 [[ "$published_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
   echo "could not derive the published version from $formula" >&2
@@ -21,6 +22,22 @@ bootstrap_version="$(awk -F '"' '/^[[:space:]]*bootstrap-version:/ { print $2; e
 }
 [[ "$bootstrap_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
   echo "could not derive the bundled Bootstrap version from $bootstrap" >&2
+  exit 1
+}
+[[ "$published_revision" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "could not derive the published revision from $formula" >&2
+  exit 1
+}
+git cat-file -e "$published_revision^{commit}" 2>/dev/null || {
+  echo "$formula revision $published_revision is unavailable; fetch repository history" >&2
+  exit 1
+}
+published_bootstrap_version="$(
+  git show "$published_revision:$bootstrap" |
+    awk -F '"' '/^[[:space:]]*bootstrap-version:/ { print $2; exit }'
+)"
+[[ "$published_bootstrap_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "could not derive the published Bootstrap version at $published_revision" >&2
   exit 1
 }
 
@@ -45,7 +62,7 @@ reject_literal() {
 require_literal "$installation" "The current public release is **v${published_version}**."
 require_literal "$installation" "SKILLROSTER_VERSION=${published_version}"
 require_literal "$installation" "--tag v${published_version} skillroster"
-require_literal "$installation" "Published CLI v${published_version} bundles Bootstrap content version ${published_version}."
+require_literal "$installation" "Published CLI v${published_version} bundles Bootstrap content version ${published_bootstrap_version}."
 require_literal "$installation" "The source tree is **v${candidate_version}**."
 require_literal "$installation" "Its bundled Bootstrap content version is ${bootstrap_version}."
 

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.29 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.30 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.29 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.30 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.29 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.29 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.30 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.30 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 解决什么问题

把已经真实发布的 v1.8.30 Tag、GitHub Release、Homebrew bottles 和安装面同步回主仓库，并保存可追溯证据。

## 价值

用户看到的 README、网站、安装命令和 Formula 与真实公开版本一致；后续候选还能正确区分 CLI 版本和 Bootstrap 内容版本。

## 内容

- README / website / installation / checked-in Formula 更新到公开 v1.8.30
- 发布收据记录 exact tag SHA、四平台+WSL2 run、8 个 Release assets、Homebrew test-bot/pr-pull 与匿名 smoke
- installation verifier 从 Formula 精确 revision 派生公开 Bootstrap 版本
- CI Linux 与 release validate 使用完整历史，以支持 fail-closed revision 校验

## 验证

- 匿名 GitHub archive checksum + governance smoke
- 匿名 Homebrew bottle checksum + governance smoke
- `bash scripts/ci-full-check.sh`
- `bash scripts/verify-installation-surface.sh`
- Rust 319 unit + 8 acceptance + 95 CLI；Node 137
- Spec review: Clean
- Standards review: 两轮发现已修复，最终 Clean