### PR TITLE
test: prove packaged fresh-user governance journey

### DIFF
--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -191,6 +191,18 @@ authorization for the synthetic scope, then verified Apply, Receipt, Undo, and
 recovery-clear Status. The bootstrap Skill separately requires an explicit user
 confirmation before any real Apply or Undo and never asks per-file questions.
 
+## Packaged fresh-user governance journey
+
+The [v1.8.29 packaged fresh-user journey](acceptance/packaged-fresh-user-governance-v1.8.29.md)
+starts from an anonymously downloaded, checksum-verified public macOS arm64
+archive rather than a source-tree binary. Two fresh isolated runs separately
+recorded installation, Bootstrap preview and Apply, diagnosis, one exact Roster Plan
+authorization, verified Apply and Receipt, recovery-clear Status, rank-one
+On-demand exact load, and verified Undo. In both runs the governed Codex and
+Claude Code fixture returned to the same 76-record byte ledger with zero added,
+removed, or changed records. The redacted machine ledger contains no real-home
+paths, raw conversations, Skill bodies, credentials, or opaque local IDs.
+
 ## Agent-led Finding drilldown evidence
 
 Before the 1.3 release, the Agent reused one immutable read-only Snapshot from

--- a/docs/acceptance/artifacts/packaged-fresh-user-governance-v1.8.29.json
+++ b/docs/acceptance/artifacts/packaged-fresh-user-governance-v1.8.29.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "suite_id": "packaged-fresh-user-governance-v1.8.29",
+  "issue": 259,
+  "status": "passed_twice_on_reference_platform",
+  "source": {
+    "release_tag": "v1.8.29",
+    "release_commit": "b996c7e52bd849243ce7772cff30602a00c4270b",
+    "artifact": "skillroster-1.8.29-aarch64-apple-darwin.tar.gz",
+    "artifact_sha256": "e79376eafc6541d80b27ccb861f041fca38e1ccf51b42cd130af191df872de09",
+    "binary_sha256": "1d03390f5f5fb06e0cb0687c0604c2b2c8ff80339c78b8b254b593e98b5b42f5",
+    "binary_version": "skillroster 1.8.29",
+    "anonymous_download": true,
+    "adjacent_checksum_verified": true,
+    "source_tree_binary_used": false,
+    "bootstrap_content_version": "1.8.29",
+    "bootstrap_skill_sha256": "c62bc41e54000a6191c781b45d082440cb5930bc26a1511dafc000cb1c1af5e3"
+  },
+  "request": {
+    "kind": "natural_language_agent_governance_request",
+    "projection": "inspect and improve SkillRoster by governing only an isolated synthetic fixture",
+    "raw_text_persisted": false,
+    "entrypoint": "installed_bootstrap_then_public_cli"
+  },
+  "isolation": {
+    "reference_platform": "macos_arm64",
+    "fresh_run_count": 2,
+    "preliminary_run_count": 2,
+    "fresh_home_per_run": true,
+    "fresh_state_per_run": true,
+    "isolated_agent_roots_per_run": true,
+    "synthetic_skills": 19,
+    "synthetic_cross_agent_copies": 12,
+    "real_user_directories_read": false,
+    "real_user_directories_written": false,
+    "repository_files_mutated_by_product": false
+  },
+  "runs": [
+    {
+      "run": 1,
+      "stages": {
+        "installation": {"status": "passed", "published_artifact_only": true},
+        "bootstrap": {"status": "passed", "preview_ready": true, "agents": ["claude-code", "codex"], "authorization_status": "authorized_under_approved_synthetic_ticket_scope", "apply_verification": "passed", "changed_path_count": 12, "canonical_deletion_count": 0, "receipt_present": true, "bootstrap_read_complete": true, "governance_reference_read_complete": true, "mutation_reference_read_complete": true},
+        "diagnosis": {"status": "passed", "independent_skills": 20, "placements": 33, "default_exposure": 33, "exact_duplicate_skills": 13, "exact_duplicate_placements": 26, "usage_coverage": "missing_for_all_8_supported_agents", "unused_claim_made": false, "files_changed": false},
+        "plan": {"status": "ready", "target": "agent-session-miner", "target_agent": "codex", "target_state": "on_demand", "before_default_exposure": 33, "after_default_exposure": 32, "operation_count": 2, "canonical_deletion_count": 0, "files_changed": false, "full_detail_reviewed": true},
+        "confirmation": {"status": "authorized_once_for_ticket_scoped_synthetic_plan", "per_operation_prompts": 0, "raw_text_persisted": false},
+        "apply": {"status": "passed", "authorization_status": "covered_by_roster_plan_confirmation", "verification": "passed", "changed_path_count": 2, "canonical_deletion_count": 0},
+        "receipt": {"status": "present", "opaque_id_persisted": false, "undo_available": true},
+        "recovery": {"status": "clear", "journal_issue_count": 0},
+        "on_demand_retrieval": {"status": "passed", "rank": 1, "loaded_name": "agent-session-miner", "roster_state": "on_demand", "identity_matches_snapshot": true, "package_fingerprint_matches_snapshot": true},
+        "undo": {"status": "passed", "authorization_status": "authorized_under_approved_synthetic_ticket_scope", "verification": "passed", "changed_path_count": 2},
+        "byte_ledger": {"status": "equal", "record_count": 76, "regular_file_count": 39, "directory_count": 37, "regular_file_bytes": 43889, "digest_before": "4c1674f8dbfa10c35641b8beb238b9c8d923ebfb0167d672000b6d464486f282", "digest_after": "4c1674f8dbfa10c35641b8beb238b9c8d923ebfb0167d672000b6d464486f282", "added_records": 0, "removed_records": 0, "changed_records": 0}
+      }
+    },
+    {
+      "run": 2,
+      "stages": {
+        "installation": {"status": "passed", "published_artifact_only": true},
+        "bootstrap": {"status": "passed", "preview_ready": true, "agents": ["claude-code", "codex"], "authorization_status": "authorized_under_approved_synthetic_ticket_scope", "apply_verification": "passed", "changed_path_count": 12, "canonical_deletion_count": 0, "receipt_present": true, "bootstrap_read_complete": true, "governance_reference_read_complete": true, "mutation_reference_read_complete": true},
+        "diagnosis": {"status": "passed", "independent_skills": 20, "placements": 33, "default_exposure": 33, "exact_duplicate_skills": 13, "exact_duplicate_placements": 26, "usage_coverage": "missing_for_all_8_supported_agents", "unused_claim_made": false, "files_changed": false},
+        "plan": {"status": "ready", "target": "agent-session-miner", "target_agent": "codex", "target_state": "on_demand", "before_default_exposure": 33, "after_default_exposure": 32, "operation_count": 2, "canonical_deletion_count": 0, "files_changed": false, "full_detail_reviewed": true},
+        "confirmation": {"status": "authorized_once_for_ticket_scoped_synthetic_plan", "per_operation_prompts": 0, "raw_text_persisted": false},
+        "apply": {"status": "passed", "authorization_status": "covered_by_roster_plan_confirmation", "verification": "passed", "changed_path_count": 2, "canonical_deletion_count": 0},
+        "receipt": {"status": "present", "opaque_id_persisted": false, "undo_available": true},
+        "recovery": {"status": "clear", "journal_issue_count": 0},
+        "on_demand_retrieval": {"status": "passed", "rank": 1, "loaded_name": "agent-session-miner", "roster_state": "on_demand", "identity_matches_snapshot": true, "package_fingerprint_matches_snapshot": true},
+        "undo": {"status": "passed", "authorization_status": "authorized_under_approved_synthetic_ticket_scope", "verification": "passed", "changed_path_count": 2},
+        "byte_ledger": {"status": "equal", "record_count": 76, "regular_file_count": 39, "directory_count": 37, "regular_file_bytes": 43889, "digest_before": "4c1674f8dbfa10c35641b8beb238b9c8d923ebfb0167d672000b6d464486f282", "digest_after": "4c1674f8dbfa10c35641b8beb238b9c8d923ebfb0167d672000b6d464486f282", "added_records": 0, "removed_records": 0, "changed_records": 0}
+      }
+    }
+  ],
+  "repeatability": {
+    "same_stage_outcomes": true,
+    "same_bootstrap_bytes": true,
+    "same_plan_impact": true,
+    "same_ledger_digest": true,
+    "accepted_sequence_frozen_before_run": true,
+    "accepted_runs_started_from_complete_bootstrap_read": true,
+    "preliminary_parser_corrections": 3,
+    "preliminary_parser_corrections_caused_governance_mutation": false,
+    "preliminary_runs_used_for_acceptance_claim": false
+  },
+  "privacy": {
+    "absolute_paths": false,
+    "opaque_local_ids": false,
+    "skill_bodies": false,
+    "raw_conversation": false,
+    "credentials": false,
+    "raw_command_output": false,
+    "raw_evidence_location": "external_temporary_directory_not_committed"
+  },
+  "limitations": {
+    "independent_new_user_tested": false,
+    "platforms_in_this_journey": ["macos_arm64"],
+    "relevant_evidence_used_for_raw_roster_plan": true,
+    "unrelated_raw_evidence_rejection_proven_by_this_artifact": false,
+    "later_unrelated_evidence_fix": "issue_303_merged_to_main_after_v1.8.30",
+    "recommendation_quality_claim": false,
+    "token_savings_claim": false,
+    "labor_savings_claim": false,
+    "model_quality_claim": false,
+    "universal_core_on_demand_superiority_claim": false
+  }
+}

--- a/docs/acceptance/packaged-fresh-user-governance-v1.8.29.md
+++ b/docs/acceptance/packaged-fresh-user-governance-v1.8.29.md
@@ -1,0 +1,103 @@
+# Packaged fresh-user governance journey — v1.8.29
+
+Date: 2026-08-29 (Asia/Shanghai)
+
+Issue: [#259](https://github.com/tt-a1i/skillroster/issues/259)
+
+Published release: [v1.8.29](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.29)
+
+## Question
+
+Can an Agent start from the published package and a natural-language governance
+request, install the Bootstrap through a previewed Plan, diagnose a fresh
+synthetic estate, prepare one decision-complete Roster Plan, Apply it after one
+Roster Plan authorization, retrieve an On-demand Skill exactly, and Undo the governed estate
+byte-for-byte?
+
+This is a packaged first-use proof, not a source-tree smoke. It records the
+installation, Bootstrap, diagnosis, Plan, confirmation, Apply, Receipt,
+recovery, On-demand retrieval, and Undo boundaries separately.
+
+## Frozen boundary
+
+- The macOS arm64 archive was downloaded anonymously from the v1.8.29 Release.
+  Its adjacent checksum verified archive digest
+  `e79376eafc6541d80b27ccb861f041fca38e1ccf51b42cd130af191df872de09`.
+- The extracted binary reported `skillroster 1.8.29`; no source-tree binary ran.
+  The archive contained only `LICENSE`, `README.md`, and the binary under its
+  target directory.
+- Each run used a fresh temporary Home, state directory, Codex root, Claude Code
+  root, raw-output directory, and evidence directory. The fixture contained 19
+  repository-owned synthetic Skills and 12 same-content cross-Agent copies.
+- After Setup, the Agent read the installed 83-line Bootstrap, 132-line
+  governance reference, and 51-line mutation/recovery reference completely
+  before continuing. Both accepted runs used the same verified Bootstrap bytes.
+- The active natural-language Agent request authorized governance only inside
+  that synthetic scope. The public record stores a bounded projection of the
+  request, not the raw conversation.
+- No real Agent, Skill, session, configuration, or state directory was supplied
+  to the product. Raw command envelopes and opaque local IDs stayed in the
+  external temporary evidence directory.
+
+## Stage result
+
+The frozen complete journey passed twice on fresh isolated state:
+
+| Stage | Run 1 | Run 2 |
+| --- | --- | --- |
+| Installation | Published v1.8.29 checksum and version passed | Same artifact passed |
+| Bootstrap | Preview then confirmed, verified Apply to Codex and Claude Code; Receipt present; Bootstrap and required references read to EOF | Same |
+| Diagnosis | 20 Skills, 33 placements, 33 default exposures | Same |
+| Evidence boundary | All eight session roots missing; no unused claim | Same |
+| Plan | Ready; complete detail reviewed; Codex `agent-session-miner` On-demand; 33 → 32; 2 operations | Same |
+| Roster Plan confirmation | One ticket-scoped authorization for the exact synthetic Plan; zero per-operation prompts | Same |
+| Apply / Receipt | Verified; 2 changed paths; zero canonical deletion; Undo available | Same |
+| On-demand retrieval | Rank 1 exact load; identity and package fingerprint matched | Same |
+| Recovery | Clear; zero journal issues | Same |
+| Undo | Confirmed and verified; 2 changed paths | Same |
+| Byte ledger | 76/76 records identical; zero add/remove/change | Same digest |
+
+The ledger baseline was captured after the Bootstrap was installed and before
+the Roster Apply. It therefore proves exact restoration of the governed Agent
+estate, while the Bootstrap installation remains a separately reported,
+Receipt-backed first-use stage. Both before and after digests were
+`4c1674f8dbfa10c35641b8beb238b9c8d923ebfb0167d672000b6d464486f282`.
+
+## Agent friction and decision
+
+Two preliminary isolated runs froze the acceptance protocol and are disclosed
+but excluded from the pass claim. The first stopped three times before its
+Roster Apply because the Agent assumed remembered response shapes instead of
+reading the v1.8.29 envelopes: Setup correctly installed Bootstrap for both
+detected Agents, Find used `loaded_skill`, and Plan used flat `impact` fields.
+Those corrections caused no governance mutation. A second preliminary run
+confirmed the corrected field contract. The two accepted runs then started
+from fresh state, read the installed Bootstrap and required references to EOF,
+and completed the frozen sequence without correction.
+
+This is useful integration feedback, but it does not justify another runtime
+feature: the Bootstrap already requires callers to validate `schema_version`,
+`ok`, and the returned typed result instead of scraping prose or assuming a
+newer schema. The durable gap was the missing privacy-safe, stage-separated
+acceptance record; this document and its machine ledger close that gap without
+adding a workflow engine or duplicate harness.
+
+## Evidence and limitations
+
+The privacy-safe machine record is
+[`packaged-fresh-user-governance-v1.8.29.json`](artifacts/packaged-fresh-user-governance-v1.8.29.json).
+It contains no absolute paths, Skill bodies, raw conversation, credentials,
+opaque local IDs, or raw command output.
+
+The run proves the packaged macOS arm64 first-use path on deterministic
+synthetic data and one repeated reference-platform execution. Cross-platform
+package smokes remain separate release evidence. It does not prove independent
+new-user comprehension, recommendation preference, token or labor savings,
+model-quality improvement, or universal Core-versus-On-demand superiority.
+
+The raw Roster Plan in each accepted run cited Evidence that covered the
+changed Skill. This journey does not
+prove that v1.8.29 rejects unrelated Evidence in a raw Roster request. That
+separate defect was reproduced from a later public package and fixed by
+[#303](https://github.com/tt-a1i/skillroster/issues/303) on `main` after
+v1.8.30; it is not retroactively claimed for the v1.8.29 bytes tested here.


### PR DESCRIPTION
## Outcome

Proves the published v1.8.29 first-use governance journey twice from a fresh, isolated synthetic environment, without using a source-tree binary.

## Value

- Binds the product's first-use claim to a privacy-safe, stage-separated machine ledger.
- Records checksum-verified installation, confirmed Bootstrap Apply, diagnosis, one exact Roster Plan confirmation, verified Apply/Receipt, exact On-demand retrieval, recovery-clear Status, confirmed Undo, and byte-exact restoration.
- Keeps the claim bounded to macOS arm64 synthetic evidence and explicitly excludes independent-user, token, labor, model-quality, and universal recommendation claims.

## Evidence

- Two accepted fresh runs with identical outcomes.
- 20 Skills / 33 placements / 33 default exposures diagnosed per run.
- Roster Plan changed one Codex Skill to On-demand: 33 -> 32, 2 operations, zero canonical deletion.
- Exact On-demand load ranked first and matched identity/package fingerprints.
- Undo restored all 76 ledger records with zero add/remove/change.
- Published v1.8.29 archive, binary, and Bootstrap hashes recorded; raw paths, IDs, prompts, credentials, and command envelopes remain outside Git.

## Checks

- `bash scripts/ci-full-check.sh`
- `bash scripts/verify-readme-value.sh`
- `bash scripts/verify-installation-surface.sh`
- `bash scripts/ci-change-scope.sh --self-test`
- JSON schema/assertion and privacy scans
- `git diff --check origin/main...HEAD`
- Independent Standards and Spec review

Closes #259
