### PR TITLE
release: prepare v1.8.31 candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.30"
+version = "1.8.31"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.30"
+version = "1.8.31"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/docs/acceptance/release-v1.8.31-candidate.md
+++ b/docs/acceptance/release-v1.8.31-candidate.md
@@ -1,0 +1,49 @@
+# SkillRoster v1.8.31 candidate
+
+## Release notes draft
+
+SkillRoster 1.8.31 closes an Evidence-scope hole in raw Roster planning.
+
+- A raw `roster_changes` request now fails closed unless its cited Evidence
+  covers every Skill or Placement being changed.
+- Rejection uses the stable, bounded `plan_evidence_scope_mismatch` error and
+  reports `files_changed=false`; no applicable Plan is created.
+- Relevant Skill Evidence and Placement Evidence remain accepted, and
+  Finding-derived Roster planning keeps its existing behavior.
+
+This patch release keeps SQLite schema 10 and JSON envelope schema 1. There is
+no migration and no change to the local-only, explicit-confirmation,
+Receipt-backed mutation model. The bundled Bootstrap instructions remain at
+content version 1.8.29, so upgrading the CLI does not cause an unnecessary
+Bootstrap replacement Plan.
+
+## Preparation evidence
+
+The public baseline is v1.8.30. Candidate preparation starts from exact
+`origin/main` revision `bf82dfbaccaceedcd048284a4261bc692c0a34f6`, after
+[#304](https://github.com/tt-a1i/skillroster/pull/304) merged the Evidence-scope
+fix and [#305](https://github.com/tt-a1i/skillroster/pull/305) merged the
+privacy-safe packaged first-use acceptance record. Both pull requests passed
+their Linux, Windows, macOS arm64, macOS x86_64, change-scope, and aggregate CI
+gates.
+
+The source candidate and Cargo package are versioned as 1.8.31. Public install
+examples, the checked-in Formula, website current-release label, and README
+release evidence deliberately remain at v1.8.30 until the v1.8.31 tag,
+artifacts, checksums, and Homebrew package actually exist.
+
+## Candidate gates
+
+The candidate is not accepted until one exact final source revision passes:
+
+- `cargo fmt --all --check`;
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
+- `cargo test --locked --all-targets --all-features`;
+- the public CLI acceptance suite and both Node routing harnesses;
+- `git diff --check`, installation-surface validation, and the CI change-scope
+  self-test;
+- four platform build and governance jobs plus the WSL2 governance smoke.
+
+Candidate preparation does not create or push a tag, publish a GitHub Release,
+update Homebrew, or mutate any public release asset. Those steps are recorded
+only after their external evidence exists.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,7 +93,7 @@ skillroster setup --json
 ```
 
 Published CLI v1.8.30 bundles Bootstrap content version 1.8.29.
-The source tree is **v1.8.30**.
+The source tree is **v1.8.31**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap
 instructions.

--- a/website/index.html
+++ b/website/index.html
@@ -1496,7 +1496,7 @@ footer { overflow: hidden; }
       </div>
     </div>
     <div class="footer-rule">
-      <span>SOURCE TREE v1.8.30 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
+      <span>SOURCE TREE v1.8.31 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
       <span>NO DAEMON · NO CLOUD · NO TELEMETRY</span>
     </div>
   </div>


### PR DESCRIPTION
## 解决什么问题

把已合入的 #303 Evidence-scope fail-closed 修复准备成一个可验证、可发布的 v1.8.31 patch candidate。

## 价值

raw Roster Plan 不能再借用与目标 Skill/Placement 无关的 Evidence 伪装成“有证据的治理变更”；不相关 Evidence 会稳定拒绝且不创建可 Apply 的 Plan。

## 发布边界

- Cargo/source candidate: 1.8.31
- Bundled Bootstrap content: 1.8.29（内容未变）
- Formula / README / public install commands / website current release: 暂留已发布 v1.8.30，等新产物真实存在后更新
- #259 packaged first-use record作为发布可信度证据，不宣称为新功能

## 验证

- `bash scripts/ci-full-check.sh`
  - Rust: 319 unit + 8 acceptance + 96 CLI
  - Node harness: 137
- `bash scripts/verify-readme-value.sh`
- `bash scripts/verify-installation-surface.sh`
- `bash scripts/ci-change-scope.sh --self-test`
- `cargo metadata --locked` version assertion
- `git diff --check`

合并后将只从精确 main SHA dispatch Release candidate workflow；四平台与 WSL2 全绿后才会创建正式 tag。
