### PR TITLE
docs: record v1.8.31 release

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "2891c383e3beca999788b0c54b044eb4f91f52a5"
-  version "1.8.30"
+      revision: "aa688e265a0541cbe40548d847ac9349676fc02f"
+  version "1.8.31"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.30", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.31", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,15 +214,15 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.30 implements the complete local governance loop and keeps
-large Apply/Undo Agent JSON bounded without weakening complete Receipts or exact
-recovery. The loop
+Public release v1.8.31 implements the complete local governance loop. A raw
+Roster Plan now fails closed unless its Evidence covers every target Skill or
+Placement. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
 reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.30 release and platform evidence](docs/acceptance/release-v1.8.30-candidate.md)
+- [v1.8.31 release and platform evidence](docs/acceptance/release-v1.8.31-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.30 已实现完整的本地治理闭环，并让大型 Apply/Undo 的 Agent JSON
-保持有界，同时保留完整 Receipt 和精确恢复能力。
+公开版本 v1.8.31 已实现完整的本地治理闭环；raw Roster Plan 只有在 Evidence
+覆盖每个目标 Skill 或 Placement 时才会成立，不相关证据会 fail closed。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.30 发布与平台证据](docs/acceptance/release-v1.8.30-candidate.md)
+- [v1.8.31 发布与平台证据](docs/acceptance/release-v1.8.31-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.31-candidate.md
+++ b/docs/acceptance/release-v1.8.31-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.31 candidate
+# SkillRoster v1.8.31 release receipt
 
-## Release notes draft
+## Release notes
 
 SkillRoster 1.8.31 closes an Evidence-scope hole in raw Roster planning.
 
@@ -17,24 +17,57 @@ Receipt-backed mutation model. The bundled Bootstrap instructions remain at
 content version 1.8.29, so upgrading the CLI does not cause an unnecessary
 Bootstrap replacement Plan.
 
-## Preparation evidence
+## Release evidence
 
-The public baseline is v1.8.30. Candidate preparation starts from exact
+The public baseline was v1.8.30. Candidate preparation started from exact
 `origin/main` revision `bf82dfbaccaceedcd048284a4261bc692c0a34f6`, after
 [#304](https://github.com/tt-a1i/skillroster/pull/304) merged the Evidence-scope
 fix and [#305](https://github.com/tt-a1i/skillroster/pull/305) merged the
 privacy-safe packaged first-use acceptance record. Both pull requests passed
 their Linux, Windows, macOS arm64, macOS x86_64, change-scope, and aggregate CI
-gates.
+gates. Candidate
+[run 33260982973](https://github.com/tt-a1i/skillroster/actions/runs/33260982973)
+then passed the exact-SHA repository gate, all four build/governance jobs, and
+the WSL2 Linux archive smoke.
 
-The source candidate and Cargo package are versioned as 1.8.31. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.30 until the v1.8.31 tag,
-artifacts, checksums, and Homebrew package actually exist.
+The annotated `v1.8.31` tag object
+`e214a30028f13614319a1d100dd58e9cd1bae3ca` resolves exactly to
+`aa688e265a0541cbe40548d847ac9349676fc02f`. The official tag workflow
+[run 33261632527](https://github.com/tt-a1i/skillroster/actions/runs/33261632527)
+passed the same strict repository gate, Linux, Windows, macOS arm64 and x86_64
+build/governance jobs, and the WSL2 Linux governance smoke.
 
-## Candidate gates
+The [public GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.31)
+contains four platform archives and four adjacent checksum files:
 
-The candidate is not accepted until one exact final source revision passes:
+- macOS arm64:
+  `6cf0dbdff7f1f6e515cbd88434d6f3c219d7da405dcf3cfd00160807d5ff5e11`;
+- macOS x86_64:
+  `abac4e5b994bf4b6adfba9fb82d94ac471a2712881097708071c39b5747c1b23`;
+- Windows x86_64:
+  `e36db7f2d0b2fe768382c18574893e022e82d4baba9652eb2371c8eb7cd89c9c`;
+- Linux x86_64:
+  `292d4bd88c83860ea43516a0cafedd7aae3a8e74bed1579c055d434680ea5e08`.
+
+All eight tag-workflow artifacts passed their adjacent checksums before
+publication. The public macOS arm64 archive was then downloaded anonymously,
+matched its published checksum, reported `skillroster 1.8.31`, and passed the
+complete synthetic release governance smoke.
+
+The [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster) publishes
+v1.8.31 macOS arm64 and x86_64 Linux bottles. Both Homebrew test-bot jobs passed
+in [run 33262319710](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33262319710),
+and exact-head `brew pr-pull` published the bottles in
+[run 33262638714](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33262638714).
+Tap `main` reached `1841601539063f4e5a58a63cc778ca7cf5bea8b1`.
+The public macOS arm64 bottle was downloaded anonymously, matched Formula
+checksum
+`ef74fd693ac351db3cf138420345a8bea17bbbb28229b7e4cdc25182acfa275f`,
+reported `skillroster 1.8.31`, and passed the same governance smoke.
+
+## Accepted gates
+
+The exact tagged revision passed:
 
 - `cargo fmt --all --check`;
 - `cargo clippy --locked --all-targets --all-features -- -D warnings`;
@@ -44,6 +77,6 @@ The candidate is not accepted until one exact final source revision passes:
   self-test;
 - four platform build and governance jobs plus the WSL2 governance smoke.
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate any public release asset. Those steps are recorded
-only after their external evidence exists.
+The release WSL boundary remains WSL2. WSL1 mutation fails closed when its
+kernel cannot provide the atomic no-replace rename required by SkillRoster's
+handle-bound recovery model.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.30**. Its Formula, annotated tag, four
+The current public release is **v1.8.31**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.30
+SKILLROSTER_VERSION=1.8.31
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -58,7 +58,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.30 skillroster
+  --tag v1.8.31 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -92,7 +92,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.30 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.31 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.31**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.30 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.31 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.30 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.31 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.30 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.30 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.31 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.31 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 解决什么问题

把已真实发布的 v1.8.31 tag、GitHub Release、正式产物、Homebrew bottles 和匿名安装验收同步回主仓库。

## 价值

用户看到的 README、网站、安装命令和 checked-in Formula 与真实公开版本一致；发布收据能把候选、tag、Release、Homebrew 和匿名运行证明分开追溯。

## 内容

- README / website / installation / checked-in Formula 更新到公开 v1.8.31
- 发布收据记录 annotated tag object、exact release SHA、candidate/tag workflows、4 个 archive hashes、8 个 Release assets
- 记录 Homebrew test-bot、exact-head pr-pull、tap main、公开 bottle checksum
- 保持 Bootstrap content version 1.8.29 与 SQLite/JSON schema 边界不变

## 验证

- anonymous GitHub archive checksum + governance smoke
- anonymous Homebrew bottle checksum + governance smoke
- `bash scripts/ci-full-check.sh`
  - Rust: 319 unit + 8 acceptance + 96 CLI
  - Node harness: 137
- `bash scripts/verify-readme-value.sh`
- `bash scripts/verify-installation-surface.sh`
- `bash scripts/ci-change-scope.sh --self-test`
- `ruby -c Formula/skillroster.rb`
- `git diff --check`
