### PR TITLE
release: prepare v1.8.32 candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.31"
+version = "1.8.32"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.31"
+version = "1.8.32"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/docs/acceptance/release-v1.8.29-candidate.md
+++ b/docs/acceptance/release-v1.8.29-candidate.md
@@ -30,12 +30,14 @@ the product model to the public package built from current `main`.
   and exact Undo. These are controlled-fixture outcomes, not token, labor,
   performance, model-quality, or universal-superiority claims.
 
-The release keeps SQLite schema 10, JSON envelope schema 1, local-only
-operation, explicit confirmation, and Receipt-bounded Apply/Undo. Strict JSON
-consumers must continue to tolerate additive typed error and coverage fields.
-Snapshots created before the Unicode identity contract require a new complete
-Scan before exact identity decisions. Existing user-owned Skill contents are
-not migrated or deleted by upgrading the binary.
+The release upgrades the local state database from SQLite schema 10 to schema
+12 through the sequential v11 and v12 migrations. JSON envelope schema 1,
+local-only operation, explicit confirmation, and Receipt-bounded Apply/Undo
+remain unchanged. Strict JSON consumers must continue to tolerate additive
+typed error and coverage fields. Snapshots created before the Unicode identity
+contract require a new complete Scan before exact identity decisions. The
+database migration does not migrate or delete existing user-owned Skill
+contents.
 
 ## Release evidence
 

--- a/docs/acceptance/release-v1.8.30-candidate.md
+++ b/docs/acceptance/release-v1.8.30-candidate.md
@@ -12,7 +12,7 @@ callers without weakening recovery.
 - The persisted Receipt journal still contains the complete changed-path set,
   and Undo continues to use that complete recovery record.
 
-This patch release keeps SQLite schema 10 and JSON envelope schema 1. Strict
+This patch release keeps SQLite schema 12 and JSON envelope schema 1. Strict
 JSON consumers must tolerate the new additive field. There is no migration and
 no change to the local-only, explicit-confirmation, fail-closed mutation model.
 The bundled Bootstrap instructions are unchanged at content version 1.8.29, so

--- a/docs/acceptance/release-v1.8.31-candidate.md
+++ b/docs/acceptance/release-v1.8.31-candidate.md
@@ -11,7 +11,7 @@ SkillRoster 1.8.31 closes an Evidence-scope hole in raw Roster planning.
 - Relevant Skill Evidence and Placement Evidence remain accepted, and
   Finding-derived Roster planning keeps its existing behavior.
 
-This patch release keeps SQLite schema 10 and JSON envelope schema 1. There is
+This patch release keeps SQLite schema 12 and JSON envelope schema 1. There is
 no migration and no change to the local-only, explicit-confirmation,
 Receipt-backed mutation model. The bundled Bootstrap instructions remain at
 content version 1.8.29, so upgrading the CLI does not cause an unnecessary

--- a/docs/acceptance/release-v1.8.32-candidate.md
+++ b/docs/acceptance/release-v1.8.32-candidate.md
@@ -1,0 +1,59 @@
+# SkillRoster v1.8.32 candidate
+
+## Release notes draft
+
+SkillRoster 1.8.32 keeps every Agent continuation bound to the executable that
+created the current local state.
+
+- Home, Scan, Report, Plan, Apply, Undo, recovery, and nested suggested actions
+  now start with the exact absolute path of the running SkillRoster binary.
+- A release archive or explicitly selected binary therefore cannot silently
+  hand the next step to an older `skillroster` found on `PATH`.
+- Source-confirmation overflow details preserve the same executable and
+  discovery context in schema 4 while remaining compatible with schema 1-3.
+- A non-Unicode current executable path fails closed instead of falling back to
+  an ambiguous PATH lookup.
+
+This patch release keeps SQLite schema 12 and JSON envelope schema 1. There is
+no database migration and no change to the local-only, explicit-confirmation,
+Receipt-backed mutation model. The bundled Bootstrap instructions remain at
+content version 1.8.29, so upgrading the CLI does not cause an unnecessary
+Bootstrap replacement Plan.
+
+## Preparation evidence
+
+The public baseline is v1.8.31. Candidate preparation starts from exact
+`origin/main` revision `52aa0cdd089127a6f1a99c9cb84e26a8b538055d`, after
+[#309](https://github.com/tt-a1i/skillroster/pull/309) merged the executable
+binding fix and closed
+[#308](https://github.com/tt-a1i/skillroster/issues/308). The pull request passed
+Linux, Windows, macOS arm64, macOS x86_64, change-scope, and aggregate CI gates.
+Its Linux gate also ran the real non-Unicode executable process test.
+
+The original failure was reproduced with the official v1.8.31 macOS arm64
+archive: Home returned a bare `skillroster` continuation, PATH selected local
+v1.8.28, and the next command failed because schema 12 was newer than schema
+10. After the fix, a fresh real-home Home → Scan → Report journey completed
+while PATH still selected v1.8.28; every emitted argv stayed bound to the current
+release binary and no Agent files changed.
+
+The source candidate and Cargo package are versioned as 1.8.32. Public install
+examples, the checked-in Formula, website current-release label, and README
+release evidence deliberately remain at v1.8.31 until the v1.8.32 tag,
+artifacts, checksums, and Homebrew package actually exist.
+
+## Candidate gates
+
+The candidate is not accepted until one exact final source revision passes:
+
+- `cargo fmt --all --check`;
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
+- `cargo test --locked --all-targets --all-features`;
+- the public CLI acceptance suite and both Node routing harnesses;
+- `git diff --check`, installation-surface validation, and the CI change-scope
+  self-test;
+- four platform build and governance jobs plus the WSL2 governance smoke.
+
+Candidate preparation does not create or push a tag, publish a GitHub Release,
+update Homebrew, or mutate any public release asset. Those steps are recorded
+only after their external evidence exists.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,7 +93,7 @@ skillroster setup --json
 ```
 
 Published CLI v1.8.31 bundles Bootstrap content version 1.8.29.
-The source tree is **v1.8.31**.
+The source tree is **v1.8.32**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap
 instructions.

--- a/website/index.html
+++ b/website/index.html
@@ -1496,7 +1496,7 @@ footer { overflow: hidden; }
       </div>
     </div>
     <div class="footer-rule">
-      <span>SOURCE TREE v1.8.31 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
+      <span>SOURCE TREE v1.8.32 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
       <span>NO DAEMON · NO CLOUD · NO TELEMETRY</span>
     </div>
   </div>


### PR DESCRIPTION
## 解决什么问题

把 #308/#309 的 executable-bound continuation 修复准备为可验证、可发布的 v1.8.32 patch candidate。

## 价值

Agent 原样执行 SkillRoster 返回的 Home、Scan、Report、Plan、Apply、Undo 与恢复 argv 时，不会因为 PATH 指向旧版本而在同一治理旅程中静默切换 binary、SQLite schema 或信任边界。

## 发布边界

- Cargo/source candidate: 1.8.32
- SQLite schema: 12（无新迁移）
- JSON envelope: 1
- Bundled Bootstrap content: 1.8.29（内容未变）
- Formula / README / public install commands / website current release: 暂留已发布 v1.8.31，等新产物真实存在后更新
- 一并事实性更正 v1.8.29–v1.8.31 release receipts 的 SQLite schema 记录

## 验证

- `bash scripts/ci-full-check.sh`: 321 unit + 8 acceptance + 97 CLI + 137 Node
- `bash scripts/verify-readme-value.sh`
- `bash scripts/verify-installation-surface.sh`
- `bash scripts/ci-change-scope.sh --self-test`
- `cargo metadata --locked` version assertion
- `git diff --check`
- 独立 Spec review: Clean
- 独立 Standards review: finding 已修复后 Clean

合并后只从精确 main SHA dispatch Release candidate workflow；四平台与 WSL2 全绿后才创建正式 tag。