### PR TITLE
docs: record v1.8.32 release

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "aa688e265a0541cbe40548d847ac9349676fc02f"
-  version "1.8.31"
+      revision: "4329cf2a2b476aafa6d77fc6edcfb6b31cd604ed"
+  version "1.8.32"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.31", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.32", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,15 +214,15 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.31 implements the complete local governance loop. A raw
-Roster Plan now fails closed unless its Evidence covers every target Skill or
-Placement. The loop
+Public release v1.8.32 implements the complete local governance loop. Every
+Agent continuation stays bound to the SkillRoster executable that emitted it
+instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
 reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.31 release and platform evidence](docs/acceptance/release-v1.8.31-candidate.md)
+- [v1.8.32 release and platform evidence](docs/acceptance/release-v1.8.32-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.31 已实现完整的本地治理闭环；raw Roster Plan 只有在 Evidence
-覆盖每个目标 Skill 或 Placement 时才会成立，不相关证据会 fail closed。
+公开版本 v1.8.32 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.31 发布与平台证据](docs/acceptance/release-v1.8.31-candidate.md)
+- [v1.8.32 发布与平台证据](docs/acceptance/release-v1.8.32-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.32-candidate.md
+++ b/docs/acceptance/release-v1.8.32-candidate.md
@@ -1,9 +1,9 @@
-# SkillRoster v1.8.32 candidate
+# SkillRoster v1.8.32 release receipt
 
-## Release notes draft
+## Release notes
 
 SkillRoster 1.8.32 keeps every Agent continuation bound to the executable that
-created the current local state.
+emitted it.
 
 - Home, Scan, Report, Plan, Apply, Undo, recovery, and nested suggested actions
   now start with the exact absolute path of the running SkillRoster binary.
@@ -20,9 +20,9 @@ Receipt-backed mutation model. The bundled Bootstrap instructions remain at
 content version 1.8.29, so upgrading the CLI does not cause an unnecessary
 Bootstrap replacement Plan.
 
-## Preparation evidence
+## Release evidence
 
-The public baseline is v1.8.31. Candidate preparation starts from exact
+The public baseline was v1.8.31. Candidate preparation started from exact
 `origin/main` revision `52aa0cdd089127a6f1a99c9cb84e26a8b538055d`, after
 [#309](https://github.com/tt-a1i/skillroster/pull/309) merged the executable
 binding fix and closed
@@ -37,14 +37,51 @@ v1.8.28, and the next command failed because schema 12 was newer than schema
 while PATH still selected v1.8.28; every emitted argv stayed bound to the current
 release binary and no Agent files changed.
 
-The source candidate and Cargo package are versioned as 1.8.32. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.31 until the v1.8.32 tag,
-artifacts, checksums, and Homebrew package actually exist.
+[#310](https://github.com/tt-a1i/skillroster/pull/310) prepared the release from
+that exact baseline and passed Linux, Windows, macOS arm64, macOS x86_64,
+change-scope, and aggregate CI gates. Candidate
+[run 33265583930](https://github.com/tt-a1i/skillroster/actions/runs/33265583930)
+then passed the exact-SHA repository gate, all four build/governance jobs, and
+the WSL2 Linux archive smoke.
 
-## Candidate gates
+The annotated `v1.8.32` tag object
+`9fade7229270ec27871445c3d7a595932f0df450` resolves exactly to
+`4329cf2a2b476aafa6d77fc6edcfb6b31cd604ed`. The official tag workflow
+[run 33265997530](https://github.com/tt-a1i/skillroster/actions/runs/33265997530)
+passed the same strict repository gate, Linux, Windows, macOS arm64 and x86_64
+build/governance jobs, and the WSL2 Linux governance smoke.
 
-The candidate is not accepted until one exact final source revision passes:
+The [public GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.32)
+contains four platform archives and four adjacent checksum files:
+
+- macOS arm64:
+  `15eaac54a3348e6d04e95ae20680283e4900ba1e9a03cc3b8806a40dfe998b8d`;
+- macOS x86_64:
+  `336f9e4a0c4ad7a21f71fc569aaa313e5bb3f60394f9058f1be98139bb2136e8`;
+- Windows x86_64:
+  `e471f4bd3e7a6b1537937546afddce780a9296e8410073490d6870aa70ecf673`;
+- Linux x86_64:
+  `860a1545e2c0f10937fbffd7ad620a9579a48984bf88862d317f05996ad41ff6`.
+
+All eight tag-workflow artifacts passed their adjacent checksums before
+publication. The public macOS arm64 archive was then downloaded anonymously,
+matched its published checksum, reported `skillroster 1.8.32`, and passed the
+complete synthetic release governance smoke.
+
+The [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster) publishes
+v1.8.32 macOS arm64 and x86_64 Linux bottles. Both Homebrew test-bot jobs passed
+in [run 33266757082](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33266757082),
+and exact-head `brew pr-pull` published the bottles in
+[run 33267024232](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33267024232).
+Tap `main` reached `e2e9c4026d383aa7123bc4d4d921d0269058a125`.
+The public macOS arm64 bottle was downloaded anonymously, matched Formula
+checksum
+`71f7a2b694161a6cd7f0f2f9d555cf5b91476ad507c506161a731c6b752d1308`,
+reported `skillroster 1.8.32`, and passed the same governance smoke.
+
+## Accepted gates
+
+The exact tagged revision passed:
 
 - `cargo fmt --all --check`;
 - `cargo clippy --locked --all-targets --all-features -- -D warnings`;
@@ -54,6 +91,6 @@ The candidate is not accepted until one exact final source revision passes:
   self-test;
 - four platform build and governance jobs plus the WSL2 governance smoke.
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate any public release asset. Those steps are recorded
-only after their external evidence exists.
+The release WSL boundary remains WSL2. WSL1 mutation fails closed when its
+kernel cannot provide the atomic no-replace rename required by SkillRoster's
+handle-bound recovery model.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.31**. Its Formula, annotated tag, four
+The current public release is **v1.8.32**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.31
+SKILLROSTER_VERSION=1.8.32
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -58,7 +58,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.31 skillroster
+  --tag v1.8.32 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -92,7 +92,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.31 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.32 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.32**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.31 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.32 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.31 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.32 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.31 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.31 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.32 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.32 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Records the completed v1.8.32 publication after all external evidence exists.

- advances the checked-in Formula, bilingual README status, installation guide, and website to public v1.8.32
- records the exact candidate/tag workflows, annotated tag target, four archive checksums, public GitHub Release, Homebrew test-bot/pr-pull runs, tap commit, and bottle checksum
- documents anonymous archive and bottle governance smoke evidence

Validation:
- `bash scripts/ci-full-check.sh` (321 unit, 8 acceptance, 97 CLI, 137 Node)
- `bash scripts/verify-installation-surface.sh`
- `bash scripts/ci-change-scope.sh --self-test`
- `git diff --check`
- independent spec and standards reviews: Clean after one wording precision fix