### PR TITLE
test: freeze privacy-safe Roster recommendation pilot

### DIFF
--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -490,6 +490,18 @@ ran all eight Core and On-demand arms. Cold retrieval and target loading passed
 4/4, while the overall task-success gate failed because two Core controls also
 failed. The result is preserved as a failed holdout rather than tuned or rerun.
 
+## Roster recommendation pilot protocol
+
+The [frozen privacy-safe protocol](research/roster-recommendation-pilot-v1.md)
+defines the separate authority, stage, recommendation, safety, and stop-rule
+boundaries for a future independent qualitative pilot. Its
+[synthetic dry run](acceptance/roster-recommendation-pilot-v1-dry-run.md)
+exercises three invented participants and five recommendation records,
+including an invocation failure, retrieval failure, rejection, and typed
+blocker. The strict ledger rejects extra or identifying fields, and its summary
+authorizes no ranking, embedding, model, or policy change. No real participant
+was recruited or observed.
+
 ## Evidence boundary
 
 These checks establish deterministic routing and safe local governance; they do

--- a/docs/acceptance/artifacts/roster-recommendation-pilot-v1.synthetic-summary.json
+++ b/docs/acceptance/artifacts/roster-recommendation-pilot-v1.synthetic-summary.json
@@ -1,0 +1,88 @@
+{
+  "format": "skillroster-roster-recommendation-pilot-summary",
+  "participants": {
+    "abandoned_before_observation": 0,
+    "observed": 3,
+    "reported": 3,
+    "required": 3
+  },
+  "participant_readiness": {
+    "decision_ready": 3,
+    "diagnosed": 3,
+    "required_decision_ready": 2
+  },
+  "product_change_authority": {
+    "embedding": false,
+    "model": false,
+    "policy": false,
+    "ranking": false,
+    "reason": "synthetic_evidence_cannot_authorize_product_change"
+  },
+  "reason_categories": {
+    "accepted_as_proposed": 1,
+    "insufficient_evidence": 1,
+    "not_evaluated": 2,
+    "personal_preference": 1
+  },
+  "recommendation_outcomes": {
+    "accepted": 1,
+    "blocked": 1,
+    "not_evaluated": 2,
+    "rejected": 1
+  },
+  "safety": {
+    "authority_unverified_observed_count": 0,
+    "identifying_path_persisted_count": 0,
+    "raw_conversation_persisted_count": 0,
+    "secret_persisted_count": 0,
+    "skill_content_persisted_count": 0,
+    "unapproved_write_count": 0,
+    "passed": true
+  },
+  "schema_version": 1,
+  "stage_results": {
+    "setup": {
+      "blocked": 0,
+      "failed": 0,
+      "not_evaluated": 0,
+      "passed": 5
+    },
+    "invocation": {
+      "blocked": 0,
+      "failed": 1,
+      "not_evaluated": 0,
+      "passed": 4
+    },
+    "diagnosis": {
+      "blocked": 0,
+      "failed": 0,
+      "not_evaluated": 1,
+      "passed": 4
+    },
+    "plan": {
+      "blocked": 1,
+      "failed": 0,
+      "not_evaluated": 1,
+      "passed": 3
+    },
+    "deterministic_retrieval": {
+      "blocked": 0,
+      "failed": 1,
+      "not_evaluated": 1,
+      "passed": 3
+    },
+    "recommendation_decision": {
+      "accepted": 1,
+      "blocked": 1,
+      "not_evaluated": 2,
+      "rejected": 1
+    },
+    "final_task": {
+      "blocked": 0,
+      "failed": 0,
+      "not_evaluated": 3,
+      "passed": 2
+    }
+  },
+  "synthetic": true
+}

--- a/docs/acceptance/roster-recommendation-pilot-v1-dry-run.md
+++ b/docs/acceptance/roster-recommendation-pilot-v1-dry-run.md
@@ -1,0 +1,46 @@
+# Roster recommendation pilot v1 synthetic dry run
+
+## Result
+
+The frozen protocol's synthetic dry run passes. It uses three invented
+pseudonyms, aggregate fixture facts, five bounded recommendation records, and no
+real participant, Agent session, Skill body, secret, or identifying path.
+
+- participants reported: 3/3;
+- observed participants: 3; abandoned before observation: 0;
+- participants with a bounded diagnosis: 3;
+- participants reaching a decision-ready Plan or typed blocker: 3/2 required;
+- recommendation outcomes: 1 accepted, 1 rejected, 1 blocked, 2 not evaluated;
+- deliberately separate failures: 1 Agent invocation failure and 1
+  deterministic retrieval failure;
+- final-task results: 2 passed, 3 not evaluated;
+- safety gate: passed, with zero unapproved writes and all persisted-private-data
+  counters at zero;
+- ranking, embedding, model, and policy changes authorized: none.
+
+The machine summary is
+[`roster-recommendation-pilot-v1.synthetic-summary.json`](artifacts/roster-recommendation-pilot-v1.synthetic-summary.json).
+It is reproduced from
+[`roster-recommendation-pilot-v1.synthetic.json`](../../tests/fixtures/roster-recommendation-pilot-v1.synthetic.json)
+through the public research-harness command documented in the
+[frozen protocol](../research/roster-recommendation-pilot-v1.md).
+
+## Privacy and classification checks
+
+The validator rejects extra object fields, free-form recommendation identities,
+path-shaped categories, invalid Agent names, outcome/reason mismatches, duplicate
+pseudonyms or labels outside the bounded grammar, and
+stage sequences that claim later work after setup or invocation did not pass.
+The CLI also rejects symlink, non-regular, and larger-than-1-MiB inputs before
+unbounded JSON parsing. A scheduled participant who exits before observation
+can be retained with typed status and empty observation facts instead of being
+omitted or assigned invented zero values.
+Aggregation removes pseudonyms and reports setup, invocation, diagnosis, Plan,
+deterministic retrieval, recommendation decision, and final task independently.
+
+This run proves only that the protocol, validator, aggregation, redaction, and
+reporting path behave on synthetic input. It does not prove that an independent
+participant can use SkillRoster successfully or agrees with its recommendations.
+That external evidence remains owned by
+[#261](https://github.com/tt-a1i/skillroster/issues/261) and requires direct
+participant consent before any recruitment, messaging, or real-environment read.

--- a/docs/research/roster-recommendation-pilot-v1.md
+++ b/docs/research/roster-recommendation-pilot-v1.md
@@ -1,0 +1,130 @@
+# Roster recommendation pilot protocol v1
+
+Status: frozen protocol; synthetic dry run complete; no real participant has
+been recruited or observed.
+
+## Question and evidence boundary
+
+This qualitative pilot asks whether non-implementer participants can receive a
+bounded SkillRoster diagnosis and judge proposed Core and On-demand decisions
+without a maintainer composing the CLI workflow for them.
+
+It does not measure population-level preference, token or labor savings,
+production performance, model quality, or universal recommendation
+superiority. Recommendation agreement, deterministic retrieval, and final task
+success remain separate outcomes.
+
+## Participant and authority boundary
+
+- Schedule at least three participants who did not implement the tested
+  recommendation behavior. Report every scheduled participant, including an
+  abandoned or blocked run.
+- Obtain direct consent before messaging, reading a real environment, or
+  starting a run. Consent text, names, contact details, and conversation text
+  are not copied into the evidence ledger.
+- Agree on the supported Agent set and the exact read-only diagnostic scope
+  before Scan. The operator records only `authority_verified: true` after that
+  check succeeds.
+- Real Apply is optional, is not needed for pilot success, and requires a new
+  explicit authorization. Refusal to Apply is not a failed run.
+- Recruitment, participant messaging, real-home reads, and real Apply are
+  external boundaries. Freezing this protocol authorizes none of them.
+
+## Stage classification
+
+Each recommendation records the following stages independently:
+
+1. `setup`: the published package and Bootstrap path are available;
+2. `invocation`: the Agent successfully invokes the public SkillRoster path;
+3. `diagnosis`: the participant receives a bounded read-only diagnosis;
+4. `plan`: a decision-ready Plan or an accurate typed blocker is returned;
+5. `deterministic_retrieval`: the relevant On-demand Skill is deterministically
+   found and loaded when that check is applicable;
+6. `recommendation_decision`: the participant accepts, rejects, is blocked, or
+   does not evaluate the recommendation;
+7. `final_task`: the participant's task result, if evaluated.
+
+Setup, invocation, diagnosis, Plan, deterministic retrieval, recommendation,
+and final-task failures must not be relabelled as one another. A retrieval
+failure and a recommendation rejection may coexist; neither explains the
+other. Later stages remain `not_evaluated` when an earlier required stage did
+not run.
+
+## Bounded ledger
+
+The machine ledger format is
+`skillroster-roster-recommendation-pilot`, schema 1. It accepts 3–32 unique
+opaque pseudonyms and at most 64 recommendation records per participant.
+Participant records contain only:
+
+- `pseudonym`: a short opaque label not derived from a person's name;
+- `run_status`: either `observed` or `abandoned_before_observation`;
+- `supported_agents`: one or more of the eight supported Agent identifiers;
+- `aggregate_inventory`: non-negative `skill_count`, `placement_count`,
+  `default_exposure`, and a bounded `session_coverage` state;
+- `recommendations`: a bounded recommendation category, outcome, reason
+  category, and the seven stage results;
+- `safety_outcome`: authority verification and zero/false privacy and mutation
+  counters.
+
+An `abandoned_before_observation` record has `null` aggregate inventory and
+empty Agent and recommendation arrays. It remains in the participant total but
+cannot contribute diagnosis or Plan readiness. This records an early exit
+without inventing zero inventory, a recommendation, or authority that was never
+observed.
+
+Recommendation categories are `core_general`, `core_agent_specific`,
+`on_demand_general`, `on_demand_agent_specific`, `protected_existing`, and
+`source_blocked`. They deliberately omit Skill names, IDs, descriptions,
+contents, and paths.
+
+Outcomes are `accepted`, `rejected`, `blocked`, and `not_evaluated`. Reasons are
+bounded to `accepted_as_proposed`, `personal_preference`,
+`insufficient_evidence`, `incorrect_identity`, `unsuitable_source`,
+`other_bounded`, and `not_evaluated`. The validator rejects an outcome/reason
+mismatch instead of accepting free text.
+
+The ledger contains no raw conversation, prompt, Skill body, secret, absolute
+path, participant identity, contact detail, or open-ended explanation. Exact
+object-key validation rejects extra fields before aggregation. The summary
+contains only counts and never emits pseudonyms.
+
+## Safety gate and stop rules
+
+The safety gate passes only when every observed run records verified authority,
+every scheduled run records zero unapproved writes, and none persists raw
+conversation, Skill content, secret, or identifying path. An abandoned run may
+record unverified authority only when it also records no observation facts.
+
+- Stop and report the run if the safety gate fails. Do not hide it with a rerun.
+- Do not infer that missing usage Evidence means a Skill is unused.
+- Do not change ranking, add embeddings or model calls, or introduce persistent
+  preference policy because one participant disagrees with a recommendation.
+- A repeated preference category is only input to a separate product decision
+  and specification. The pilot summary always reports every product-change
+  authority flag as false.
+- At least three participants must receive a bounded diagnosis, and at least
+  two must reach a decision-ready Plan or typed blocker before the real pilot
+  can satisfy its readiness gates.
+
+## Reproduction
+
+The frozen synthetic input exercises acceptance, rejection, a typed blocker,
+an Agent invocation failure, and a deterministic retrieval failure without any
+real participant or environment data:
+
+```bash
+node scripts/recommendation-pilot.mjs summarize \
+  --input tests/fixtures/roster-recommendation-pilot-v1.synthetic.json
+
+node scripts/recommendation-pilot.mjs report \
+  --input tests/fixtures/roster-recommendation-pilot-v1.synthetic.json
+```
+
+The checked-in [dry-run receipt](../acceptance/roster-recommendation-pilot-v1-dry-run.md)
+records the accepted synthetic result. A real run requires the separate
+authority and participation boundary tracked by
+[#261](https://github.com/tt-a1i/skillroster/issues/261).
+
+The command accepts only a regular, non-symlink ledger file and reads at most
+1 MiB through its opened descriptor before JSON parsing.

--- a/scripts/ci-node-harness.sh
+++ b/scripts/ci-node-harness.sh
@@ -6,8 +6,11 @@ node --check tests/harness/pi-cold-routing/runner.mjs
 node --check tests/harness/codex-cold-routing/driver.mjs
 node --check tests/harness/byte-ledger/ledger.mjs
 node --check scripts/byte-ledger.mjs
+node --check scripts/recommendation-pilot.mjs
+node --check tests/harness/roster-recommendation-pilot/pilot.mjs
 node --experimental-strip-types --check tests/harness/pi-cold-routing/gate.ts
 node --test \
   tests/harness/pi-cold-routing/*.test.mjs \
   tests/harness/codex-cold-routing/*.test.mjs \
-  tests/harness/byte-ledger/*.test.mjs
+  tests/harness/byte-ledger/*.test.mjs \
+  tests/harness/roster-recommendation-pilot/*.test.mjs

--- a/scripts/recommendation-pilot.mjs
+++ b/scripts/recommendation-pilot.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readSync,
+} from "node:fs";
+
+import {
+  PilotError,
+  renderPilotReport,
+  summarizePilot,
+} from "../tests/harness/roster-recommendation-pilot/pilot.mjs";
+
+const failUsage = (message) => { throw new PilotError("invalid_arguments", message); };
+const MAX_INPUT_BYTES = 1024 * 1024;
+
+const parseArguments = (arguments_) => {
+  const [command, ...rest] = arguments_;
+  if (command !== "summarize" && command !== "report") {
+    failUsage("expected summarize or report");
+  }
+  if (rest.length !== 2 || rest[0] !== "--input" || !rest[1]) {
+    failUsage("expected exactly --input <ledger.json>");
+  }
+  return { command, input: rest[1] };
+};
+
+const readLedger = (input) => {
+  let descriptor;
+  try {
+    const pathIdentity = lstatSync(input);
+    if (!pathIdentity.isFile()) throw new PilotError("unreadable_input", "pilot ledger must be a regular file");
+    descriptor = openSync(input, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const openedIdentity = fstatSync(descriptor);
+    if (
+      !openedIdentity.isFile()
+      || (pathIdentity.ino !== 0 && openedIdentity.ino !== 0 && (
+        pathIdentity.dev !== openedIdentity.dev || pathIdentity.ino !== openedIdentity.ino
+      ))
+    ) {
+      throw new PilotError("unreadable_input", "pilot ledger identity changed before read");
+    }
+    if (openedIdentity.size > MAX_INPUT_BYTES) {
+      throw new PilotError("input_too_large", `pilot ledger exceeds ${MAX_INPUT_BYTES} bytes`);
+    }
+    const buffer = Buffer.allocUnsafe(MAX_INPUT_BYTES + 1);
+    let length = 0;
+    while (length <= MAX_INPUT_BYTES) {
+      const bytesRead = readSync(descriptor, buffer, length, buffer.length - length, null);
+      if (bytesRead === 0) break;
+      length += bytesRead;
+    }
+    if (length > MAX_INPUT_BYTES) {
+      throw new PilotError("input_too_large", `pilot ledger exceeds ${MAX_INPUT_BYTES} bytes`);
+    }
+    return JSON.parse(buffer.subarray(0, length).toString("utf8"));
+  } catch (error) {
+    if (error instanceof PilotError) throw error;
+    throw new PilotError("unreadable_input", "pilot ledger must be readable JSON");
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+};
+
+const main = () => {
+  const { command, input } = parseArguments(process.argv.slice(2));
+  const ledger = readLedger(input);
+  const summary = summarizePilot(ledger);
+  if (command === "report") process.stdout.write(renderPilotReport(summary));
+  else process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+};
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error.code ?? "pilot_error"}: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/tests/fixtures/roster-recommendation-pilot-v1.synthetic.json
+++ b/tests/fixtures/roster-recommendation-pilot-v1.synthetic.json
@@ -1,0 +1,140 @@
+{
+  "format": "skillroster-roster-recommendation-pilot",
+  "participants": [
+    {
+      "aggregate_inventory": {
+        "default_exposure": 36,
+        "placement_count": 120,
+        "session_coverage": "sampled_limited",
+        "skill_count": 64
+      },
+      "pseudonym": "synthetic-a",
+      "recommendations": [
+        {
+          "outcome": "accepted",
+          "reason_category": "accepted_as_proposed",
+          "recommendation_category": "core_general",
+          "stage_results": {
+            "diagnosis": "passed",
+            "deterministic_retrieval": "passed",
+            "final_task": "passed",
+            "invocation": "passed",
+            "plan": "passed",
+            "recommendation_decision": "accepted",
+            "setup": "passed"
+          }
+        }
+      ],
+      "run_status": "observed",
+      "safety_outcome": {
+        "authority_verified": true,
+        "identifying_path_persisted": false,
+        "raw_conversation_persisted": false,
+        "secret_persisted": false,
+        "skill_content_persisted": false,
+        "unapproved_write_count": 0
+      },
+      "supported_agents": ["codex"]
+    },
+    {
+      "aggregate_inventory": {
+        "default_exposure": 24,
+        "placement_count": 84,
+        "session_coverage": "complete",
+        "skill_count": 51
+      },
+      "pseudonym": "synthetic-b",
+      "recommendations": [
+        {
+          "outcome": "rejected",
+          "reason_category": "personal_preference",
+          "recommendation_category": "on_demand_agent_specific",
+          "stage_results": {
+            "diagnosis": "passed",
+            "deterministic_retrieval": "passed",
+            "final_task": "passed",
+            "invocation": "passed",
+            "plan": "passed",
+            "recommendation_decision": "rejected",
+            "setup": "passed"
+          }
+        }
+      ],
+      "run_status": "observed",
+      "safety_outcome": {
+        "authority_verified": true,
+        "identifying_path_persisted": false,
+        "raw_conversation_persisted": false,
+        "secret_persisted": false,
+        "skill_content_persisted": false,
+        "unapproved_write_count": 0
+      },
+      "supported_agents": ["claude-code", "codex"]
+    },
+    {
+      "aggregate_inventory": {
+        "default_exposure": 71,
+        "placement_count": 143,
+        "session_coverage": "sampled_limited",
+        "skill_count": 92
+      },
+      "pseudonym": "synthetic-c",
+      "recommendations": [
+        {
+          "outcome": "not_evaluated",
+          "reason_category": "not_evaluated",
+          "recommendation_category": "core_agent_specific",
+          "stage_results": {
+            "diagnosis": "not_evaluated",
+            "deterministic_retrieval": "not_evaluated",
+            "final_task": "not_evaluated",
+            "invocation": "failed",
+            "plan": "not_evaluated",
+            "recommendation_decision": "not_evaluated",
+            "setup": "passed"
+          }
+        },
+        {
+          "outcome": "not_evaluated",
+          "reason_category": "not_evaluated",
+          "recommendation_category": "on_demand_general",
+          "stage_results": {
+            "diagnosis": "passed",
+            "deterministic_retrieval": "failed",
+            "final_task": "not_evaluated",
+            "invocation": "passed",
+            "plan": "passed",
+            "recommendation_decision": "not_evaluated",
+            "setup": "passed"
+          }
+        },
+        {
+          "outcome": "blocked",
+          "reason_category": "insufficient_evidence",
+          "recommendation_category": "source_blocked",
+          "stage_results": {
+            "diagnosis": "passed",
+            "deterministic_retrieval": "passed",
+            "final_task": "not_evaluated",
+            "invocation": "passed",
+            "plan": "blocked",
+            "recommendation_decision": "blocked",
+            "setup": "passed"
+          }
+        }
+      ],
+      "run_status": "observed",
+      "safety_outcome": {
+        "authority_verified": true,
+        "identifying_path_persisted": false,
+        "raw_conversation_persisted": false,
+        "secret_persisted": false,
+        "skill_content_persisted": false,
+        "unapproved_write_count": 0
+      },
+      "supported_agents": ["hermes", "pi"]
+    }
+  ],
+  "schema_version": 1,
+  "synthetic": true
+}

--- a/tests/harness/roster-recommendation-pilot/pilot.mjs
+++ b/tests/harness/roster-recommendation-pilot/pilot.mjs
@@ -1,0 +1,286 @@
+const PARTICIPANT_REQUIREMENT = 3;
+const PARTICIPANT_LIMIT = 32;
+const RECOMMENDATION_LIMIT = 64;
+const RECOMMENDATION_CATEGORIES = new Set([
+  "core_agent_specific",
+  "core_general",
+  "on_demand_agent_specific",
+  "on_demand_general",
+  "protected_existing",
+  "source_blocked",
+]);
+const SUPPORTED_AGENTS = new Set([
+  "claude-code",
+  "codex",
+  "cursor",
+  "gemini-cli",
+  "github-copilot",
+  "hermes",
+  "opencode",
+  "pi",
+]);
+const OUTCOMES = new Set(["accepted", "blocked", "not_evaluated", "rejected"]);
+const REASONS_BY_OUTCOME = {
+  accepted: new Set(["accepted_as_proposed"]),
+  blocked: new Set(["incorrect_identity", "insufficient_evidence", "other_bounded", "unsuitable_source"]),
+  not_evaluated: new Set(["not_evaluated"]),
+  rejected: new Set(["incorrect_identity", "insufficient_evidence", "other_bounded", "personal_preference", "unsuitable_source"]),
+};
+const REASON_CATEGORIES = new Set(Object.values(REASONS_BY_OUTCOME).flatMap((reasons) => [...reasons]));
+const STAGE_STATES = new Set(["blocked", "failed", "not_evaluated", "passed"]);
+const STAGE_DEFINITIONS = {
+  setup: { prerequisites: [], states: STAGE_STATES },
+  invocation: { prerequisites: [["setup", ["passed"]]], states: STAGE_STATES },
+  diagnosis: { prerequisites: [["invocation", ["passed"]]], states: STAGE_STATES },
+  plan: { prerequisites: [["diagnosis", ["passed"]]], states: STAGE_STATES },
+  deterministic_retrieval: { prerequisites: [["invocation", ["passed"]]], states: STAGE_STATES },
+  recommendation_decision: {
+    prerequisites: [["diagnosis", ["passed"]], ["plan", ["blocked", "passed"]]],
+    states: OUTCOMES,
+  },
+  final_task: { prerequisites: [["invocation", ["passed"]]], states: STAGE_STATES },
+};
+const COVERAGE_STATES = new Set(["complete", "missing", "sampled_limited", "unavailable"]);
+const RUN_STATUSES = new Set(["abandoned_before_observation", "observed"]);
+
+export class PilotError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "PilotError";
+    this.code = code;
+  }
+}
+
+const fail = (message) => { throw new PilotError("invalid_ledger", message); };
+const exactKeys = (value, expected, label) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  const actual = Object.keys(value).sort();
+  if (actual.join("\0") !== [...expected].sort().join("\0")) fail(`${label} has an invalid shape`);
+};
+const nonNegativeInteger = (value, label) => {
+  if (!Number.isSafeInteger(value) || value < 0) fail(`${label} must be a non-negative integer`);
+};
+const boundedEnum = (value, vocabulary, label) => {
+  if (!vocabulary.has(value)) fail(`${label} is outside the bounded vocabulary`);
+};
+
+const validateLedger = (ledger) => {
+  exactKeys(ledger, ["format", "participants", "schema_version", "synthetic"], "ledger");
+  if (ledger.format !== "skillroster-roster-recommendation-pilot" || ledger.schema_version !== 1) {
+    fail("ledger has an unsupported format");
+  }
+  if (typeof ledger.synthetic !== "boolean") fail("ledger synthetic marker must be boolean");
+  if (
+    !Array.isArray(ledger.participants)
+    || ledger.participants.length < PARTICIPANT_REQUIREMENT
+    || ledger.participants.length > PARTICIPANT_LIMIT
+  ) {
+    fail(`ledger requires ${PARTICIPANT_REQUIREMENT} to ${PARTICIPANT_LIMIT} participants`);
+  }
+  const pseudonyms = new Set();
+  for (const participant of ledger.participants) {
+    exactKeys(
+      participant,
+      ["aggregate_inventory", "pseudonym", "recommendations", "run_status", "safety_outcome", "supported_agents"],
+      "participant",
+    );
+    if (typeof participant.pseudonym !== "string" || !/^[a-z0-9][a-z0-9-]{2,31}$/u.test(participant.pseudonym)) {
+      fail("participant pseudonym must be a bounded opaque label");
+    }
+    if (pseudonyms.has(participant.pseudonym)) fail("participant pseudonyms must be unique");
+    pseudonyms.add(participant.pseudonym);
+    boundedEnum(participant.run_status, RUN_STATUSES, "participant run status");
+    exactKeys(
+      participant.safety_outcome,
+      [
+        "authority_verified",
+        "identifying_path_persisted",
+        "raw_conversation_persisted",
+        "secret_persisted",
+        "skill_content_persisted",
+        "unapproved_write_count",
+      ],
+      "safety outcome",
+    );
+    for (const field of [
+      "authority_verified",
+      "identifying_path_persisted",
+      "raw_conversation_persisted",
+      "secret_persisted",
+      "skill_content_persisted",
+    ]) {
+      if (typeof participant.safety_outcome[field] !== "boolean") fail(`safety ${field} must be boolean`);
+    }
+    nonNegativeInteger(participant.safety_outcome.unapproved_write_count, "unapproved write count");
+    if (participant.run_status === "abandoned_before_observation") {
+      if (
+        participant.aggregate_inventory !== null
+        || !Array.isArray(participant.supported_agents)
+        || participant.supported_agents.length !== 0
+        || !Array.isArray(participant.recommendations)
+        || participant.recommendations.length !== 0
+      ) {
+        fail("an unobserved participant cannot contain invented observation facts");
+      }
+      continue;
+    }
+    if (!Array.isArray(participant.supported_agents) || participant.supported_agents.length === 0) {
+      fail("participant supported agents must be a non-empty array");
+    }
+    if (new Set(participant.supported_agents).size !== participant.supported_agents.length) {
+      fail("participant supported agents must be unique");
+    }
+    for (const agent of participant.supported_agents) boundedEnum(agent, SUPPORTED_AGENTS, "supported Agent");
+    exactKeys(
+      participant.aggregate_inventory,
+      ["default_exposure", "placement_count", "session_coverage", "skill_count"],
+      "aggregate inventory",
+    );
+    nonNegativeInteger(participant.aggregate_inventory.skill_count, "Skill count");
+    nonNegativeInteger(participant.aggregate_inventory.placement_count, "Placement count");
+    nonNegativeInteger(participant.aggregate_inventory.default_exposure, "default exposure");
+    boundedEnum(participant.aggregate_inventory.session_coverage, COVERAGE_STATES, "session coverage");
+    if (
+      !Array.isArray(participant.recommendations)
+      || participant.recommendations.length === 0
+      || participant.recommendations.length > RECOMMENDATION_LIMIT
+    ) {
+      fail("participant recommendations must be a bounded non-empty array");
+    }
+    for (const recommendation of participant.recommendations) {
+      exactKeys(
+        recommendation,
+        ["outcome", "reason_category", "recommendation_category", "stage_results"],
+        "recommendation",
+      );
+      if (!RECOMMENDATION_CATEGORIES.has(recommendation.recommendation_category)) {
+        fail("recommendation category is outside the bounded vocabulary");
+      }
+      boundedEnum(recommendation.outcome, OUTCOMES, "recommendation outcome");
+      boundedEnum(recommendation.reason_category, REASON_CATEGORIES, "reason category");
+      exactKeys(
+        recommendation.stage_results,
+        Object.keys(STAGE_DEFINITIONS),
+        "stage results",
+      );
+      for (const [stage, definition] of Object.entries(STAGE_DEFINITIONS)) {
+        boundedEnum(recommendation.stage_results[stage], definition.states, `${stage} result`);
+        if (
+          recommendation.stage_results[stage] !== "not_evaluated"
+          && definition.prerequisites.some(([prerequisite, allowed]) => (
+            !allowed.includes(recommendation.stage_results[prerequisite])
+          ))
+        ) {
+          fail(`${stage} must remain unevaluated until its prerequisites pass or block as specified`);
+        }
+      }
+      if (recommendation.outcome !== recommendation.stage_results.recommendation_decision) {
+        fail("recommendation outcome must match its stage result");
+      }
+      if (
+        recommendation.stage_results.plan === "blocked"
+        && recommendation.stage_results.recommendation_decision !== "blocked"
+      ) {
+        fail("a blocked Plan requires a blocked recommendation outcome");
+      }
+      if (!REASONS_BY_OUTCOME[recommendation.outcome].has(recommendation.reason_category)) {
+        fail("recommendation reason category does not match its outcome");
+      }
+    }
+  }
+  return ledger;
+};
+
+const countValues = (values, vocabulary) => Object.fromEntries(
+  vocabulary.map((value) => [value, values.filter((entry) => entry === value).length]),
+);
+
+export const summarizePilot = (ledger) => {
+  validateLedger(ledger);
+  const recommendations = ledger.participants.flatMap((participant) => participant.recommendations);
+  const safetyOutcomes = ledger.participants.map((participant) => participant.safety_outcome);
+  const reasonCategories = recommendations.map((recommendation) => recommendation.reason_category);
+  const observedParticipants = ledger.participants.filter((participant) => participant.run_status === "observed");
+
+  return {
+    format: "skillroster-roster-recommendation-pilot-summary",
+    participants: {
+      abandoned_before_observation: ledger.participants.length - observedParticipants.length,
+      observed: observedParticipants.length,
+      reported: ledger.participants.length,
+      required: PARTICIPANT_REQUIREMENT,
+    },
+    participant_readiness: {
+      decision_ready: ledger.participants.filter((participant) => participant.recommendations.some(
+        (recommendation) => recommendation.stage_results.diagnosis === "passed"
+          && ["blocked", "passed"].includes(recommendation.stage_results.plan),
+      )).length,
+      diagnosed: ledger.participants.filter((participant) => participant.recommendations.some(
+        (recommendation) => recommendation.stage_results.diagnosis === "passed",
+      )).length,
+      required_decision_ready: 2,
+    },
+    product_change_authority: {
+      embedding: false,
+      model: false,
+      policy: false,
+      ranking: false,
+      reason: ledger.synthetic
+        ? "synthetic_evidence_cannot_authorize_product_change"
+        : "pilot_evidence_requires_separate_product_decision",
+    },
+    reason_categories: Object.fromEntries(
+      [...new Set(reasonCategories)].sort().map((reason) => [
+        reason,
+        reasonCategories.filter((entry) => entry === reason).length,
+      ]),
+    ),
+    recommendation_outcomes: countValues(
+      recommendations.map((recommendation) => recommendation.outcome),
+      ["accepted", "blocked", "not_evaluated", "rejected"],
+    ),
+    safety: (() => {
+      const result = {
+        authority_unverified_observed_count: observedParticipants.filter(
+          (participant) => !participant.safety_outcome.authority_verified,
+        ).length,
+        identifying_path_persisted_count: safetyOutcomes.filter((outcome) => outcome.identifying_path_persisted).length,
+        raw_conversation_persisted_count: safetyOutcomes.filter((outcome) => outcome.raw_conversation_persisted).length,
+        secret_persisted_count: safetyOutcomes.filter((outcome) => outcome.secret_persisted).length,
+        skill_content_persisted_count: safetyOutcomes.filter((outcome) => outcome.skill_content_persisted).length,
+        unapproved_write_count: safetyOutcomes.reduce((sum, outcome) => sum + outcome.unapproved_write_count, 0),
+      };
+      return {
+        ...result,
+        passed: Object.values(result).every((value) => value === 0),
+      };
+    })(),
+    schema_version: 1,
+    stage_results: Object.fromEntries(Object.entries(STAGE_DEFINITIONS).map(([stage, definition]) => [
+      stage,
+      countValues(
+        recommendations.map((recommendation) => recommendation.stage_results[stage]),
+        [...definition.states],
+      ),
+    ])),
+    synthetic: ledger.synthetic,
+  };
+};
+
+export const renderPilotReport = (summary) => {
+  const outcomes = summary.recommendation_outcomes;
+  return [
+    "# Roster recommendation pilot",
+    "",
+    summary.synthetic ? "Status: Synthetic dry run" : "Status: Real pilot evidence",
+    `Participants reported: ${summary.participants.reported}/${summary.participants.required}`,
+    `Observed participants: ${summary.participants.observed}; abandoned before observation: ${summary.participants.abandoned_before_observation}`,
+    `Decision-ready participants: ${summary.participant_readiness.decision_ready}/${summary.participant_readiness.required_decision_ready} required`,
+    `Accepted: ${outcomes.accepted}; rejected: ${outcomes.rejected}; blocked: ${outcomes.blocked}; not evaluated: ${outcomes.not_evaluated}`,
+    `Safety gate: ${summary.safety.passed ? "passed" : "failed"}`,
+    "",
+    "This evidence does not authorize ranking, embedding, model, or policy changes.",
+    "A separate product decision must interpret completed real-pilot evidence.",
+    "",
+  ].join("\n");
+};

--- a/tests/harness/roster-recommendation-pilot/pilot.test.mjs
+++ b/tests/harness/roster-recommendation-pilot/pilot.test.mjs
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { PilotError, renderPilotReport, summarizePilot } from "./pilot.mjs";
+
+const safetyPass = {
+  authority_verified: true,
+  identifying_path_persisted: false,
+  raw_conversation_persisted: false,
+  secret_persisted: false,
+  skill_content_persisted: false,
+  unapproved_write_count: 0,
+};
+
+const stages = (recommendationDecision) => ({
+  diagnosis: "passed",
+  deterministic_retrieval: "passed",
+  final_task: "not_evaluated",
+  invocation: "passed",
+  plan: recommendationDecision === "blocked" ? "blocked" : "passed",
+  recommendation_decision: recommendationDecision,
+  setup: "passed",
+});
+
+const participant = (pseudonym, outcome, reasonCategory) => ({
+  aggregate_inventory: {
+    default_exposure: 36,
+    placement_count: 120,
+    session_coverage: "sampled_limited",
+    skill_count: 64,
+  },
+  pseudonym,
+  recommendations: [{
+    outcome,
+    reason_category: reasonCategory,
+    recommendation_category: "on_demand_general",
+    stage_results: stages(outcome),
+  }],
+  run_status: "observed",
+  safety_outcome: safetyPass,
+  supported_agents: ["codex"],
+});
+
+const ledger = {
+  format: "skillroster-roster-recommendation-pilot",
+  participants: [
+    participant("synthetic-a", "accepted", "accepted_as_proposed"),
+    participant("synthetic-b", "rejected", "personal_preference"),
+    participant("synthetic-c", "blocked", "insufficient_evidence"),
+  ],
+  schema_version: 1,
+  synthetic: true,
+};
+
+const script = fileURLToPath(new URL("../../../scripts/recommendation-pilot.mjs", import.meta.url));
+const syntheticFixture = fileURLToPath(new URL("../../fixtures/roster-recommendation-pilot-v1.synthetic.json", import.meta.url));
+const syntheticSummary = fileURLToPath(new URL("../../../docs/acceptance/artifacts/roster-recommendation-pilot-v1.synthetic-summary.json", import.meta.url));
+
+test("synthetic pilot keeps recommendation, stage, and safety outcomes separate", () => {
+  const summary = summarizePilot(ledger);
+
+  assert.deepEqual(summary.participants, {
+    abandoned_before_observation: 0,
+    observed: 3,
+    reported: 3,
+    required: 3,
+  });
+  assert.deepEqual(summary.recommendation_outcomes, {
+    accepted: 1,
+    blocked: 1,
+    not_evaluated: 0,
+    rejected: 1,
+  });
+  assert.deepEqual(summary.reason_categories, {
+    accepted_as_proposed: 1,
+    insufficient_evidence: 1,
+    personal_preference: 1,
+  });
+  assert.deepEqual(summary.stage_results.recommendation_decision, {
+    accepted: 1,
+    blocked: 1,
+    not_evaluated: 0,
+    rejected: 1,
+  });
+  assert.deepEqual(summary.safety, {
+    authority_unverified_observed_count: 0,
+    identifying_path_persisted_count: 0,
+    passed: true,
+    raw_conversation_persisted_count: 0,
+    secret_persisted_count: 0,
+    skill_content_persisted_count: 0,
+    unapproved_write_count: 0,
+  });
+  assert.deepEqual(summary.product_change_authority, {
+    embedding: false,
+    model: false,
+    policy: false,
+    ranking: false,
+    reason: "synthetic_evidence_cannot_authorize_product_change",
+  });
+  assert.equal(JSON.stringify(summary).includes("synthetic-a"), false);
+});
+
+test("pilot ledger rejects raw conversation fields before aggregation", () => {
+  const unsafe = structuredClone(ledger);
+  unsafe.participants[0].raw_conversation = "private participant message";
+
+  assert.throws(
+    () => summarizePilot(unsafe),
+    (error) => error instanceof PilotError && error.code === "invalid_ledger",
+  );
+});
+
+test("pilot ledger rejects identifying paths disguised as recommendation categories", () => {
+  const unsafe = structuredClone(ledger);
+  unsafe.participants[0].recommendations[0].recommendation_category = "/Users/alice/private-skill";
+
+  assert.throws(
+    () => summarizePilot(unsafe),
+    (error) => error instanceof PilotError && error.code === "invalid_ledger",
+  );
+});
+
+test("pilot ledger keeps retrieval failure independent from recommendation rejection", () => {
+  const independent = structuredClone(ledger);
+  const recommendation = independent.participants[1].recommendations[0];
+  recommendation.stage_results.deterministic_retrieval = "failed";
+
+  const summary = summarizePilot(independent);
+  assert.equal(summary.stage_results.deterministic_retrieval.failed, 1);
+  assert.equal(summary.stage_results.recommendation_decision.rejected, 1);
+});
+
+test("pilot stage ledger cannot skip an earlier failed setup", () => {
+  const confused = structuredClone(ledger);
+  const recommendation = confused.participants[0].recommendations[0];
+  recommendation.stage_results.setup = "failed";
+
+  assert.throws(
+    () => summarizePilot(confused),
+    (error) => error instanceof PilotError && error.code === "invalid_ledger",
+  );
+});
+
+test("pilot outcome cannot use a reason category from another decision state", () => {
+  const confused = structuredClone(ledger);
+  confused.participants[1].recommendations[0].reason_category = "accepted_as_proposed";
+
+  assert.throws(
+    () => summarizePilot(confused),
+    (error) => error instanceof PilotError && error.code === "invalid_ledger",
+  );
+});
+
+test("pilot ledger records diagnosis and Plan readiness as separate stages", () => {
+  const withReadiness = structuredClone(ledger);
+  for (const participantEntry of withReadiness.participants) {
+    for (const recommendation of participantEntry.recommendations) {
+      recommendation.stage_results.diagnosis = "passed";
+      recommendation.stage_results.plan = recommendation.outcome === "blocked" ? "blocked" : "passed";
+    }
+  }
+
+  const summary = summarizePilot(withReadiness);
+  assert.equal(summary.stage_results.diagnosis.passed, 3);
+  assert.equal(summary.stage_results.plan.passed, 2);
+  assert.equal(summary.stage_results.plan.blocked, 1);
+});
+
+test("pilot ledger keeps the qualitative participant set bounded", () => {
+  const oversized = structuredClone(ledger);
+  oversized.participants = Array.from({ length: 33 }, (_, index) => ({
+    ...structuredClone(ledger.participants[0]),
+    pseudonym: `synthetic-${String(index).padStart(2, "0")}`,
+  }));
+
+  assert.throws(
+    () => summarizePilot(oversized),
+    (error) => error instanceof PilotError && error.code === "invalid_ledger",
+  );
+});
+
+test("pilot ledger reports a participant who left before observation without invented facts", () => {
+  const withAbandonedRun = structuredClone(ledger);
+  withAbandonedRun.participants.push({
+    aggregate_inventory: null,
+    pseudonym: "synthetic-d",
+    recommendations: [],
+    run_status: "abandoned_before_observation",
+    safety_outcome: {
+      ...safetyPass,
+      authority_verified: false,
+    },
+    supported_agents: [],
+  });
+
+  const summary = summarizePilot(withAbandonedRun);
+  assert.deepEqual(summary.participants, {
+    abandoned_before_observation: 1,
+    observed: 3,
+    reported: 4,
+    required: 3,
+  });
+  assert.deepEqual(summary.participant_readiness, {
+    decision_ready: 3,
+    diagnosed: 3,
+    required_decision_ready: 2,
+  });
+  assert.equal(summary.safety.authority_unverified_observed_count, 0);
+  assert.equal(summary.safety.passed, true);
+  assert.match(renderPilotReport(summary), /Observed participants: 3; abandoned before observation: 1/u);
+});
+
+test("observed pilot runs cannot omit inventory or recommendations", () => {
+  const incomplete = structuredClone(ledger);
+  incomplete.participants[0].aggregate_inventory = null;
+  incomplete.participants[0].recommendations = [];
+
+  assert.throws(
+    () => summarizePilot(incomplete),
+    (error) => error instanceof PilotError && error.code === "invalid_ledger",
+  );
+});
+
+test("synthetic pilot report states the evidence and product-change boundary", () => {
+  const report = renderPilotReport(summarizePilot(ledger));
+
+  assert.match(report, /Synthetic dry run/u);
+  assert.match(report, /Participants reported: 3\/3/u);
+  assert.match(report, /Decision-ready participants: 3\/2 required/u);
+  assert.match(report, /Accepted: 1; rejected: 1; blocked: 1; not evaluated: 0/u);
+  assert.match(report, /Safety gate: passed/u);
+  assert.match(report, /does not authorize ranking, embedding, model, or policy changes/u);
+  assert.equal(report.includes("synthetic-a"), false);
+});
+
+test("pilot CLI validates one ledger and emits bounded JSON or Markdown", () => {
+  const root = mkdtempSync(join(resolve(tmpdir()), "skillroster-pilot-"));
+  const input = join(root, "synthetic.json");
+  writeFileSync(input, JSON.stringify(ledger));
+
+  const summary = spawnSync(process.execPath, [script, "summarize", "--input", input], { encoding: "utf8" });
+  assert.equal(summary.status, 0, summary.stderr);
+  assert.equal(JSON.parse(summary.stdout).participants.reported, 3);
+  assert.equal(summary.stdout.includes("synthetic-a"), false);
+
+  const report = spawnSync(process.execPath, [script, "report", "--input", input], { encoding: "utf8" });
+  assert.equal(report.status, 0, report.stderr);
+  assert.match(report.stdout, /Synthetic dry run/u);
+  assert.equal(report.stdout.includes("synthetic-a"), false);
+
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("pilot CLI refuses an oversized ledger before JSON parsing", () => {
+  const root = mkdtempSync(join(resolve(tmpdir()), "skillroster-pilot-large-"));
+  const input = join(root, "oversized.json");
+  writeFileSync(input, `{"padding":"${"x".repeat(1024 * 1024)}"}`);
+
+  const result = spawnSync(process.execPath, [script, "summarize", "--input", input], { encoding: "utf8" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /^input_too_large:/u);
+
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("frozen synthetic dry run keeps invocation, retrieval, disagreement, and blocker facts independent", () => {
+  const fixture = JSON.parse(readFileSync(syntheticFixture, "utf8"));
+  const summary = summarizePilot(fixture);
+
+  assert.deepEqual(summary.recommendation_outcomes, {
+    accepted: 1,
+    blocked: 1,
+    not_evaluated: 2,
+    rejected: 1,
+  });
+  assert.equal(summary.stage_results.invocation.failed, 1);
+  assert.equal(summary.stage_results.deterministic_retrieval.failed, 1);
+  assert.equal(summary.stage_results.recommendation_decision.rejected, 1);
+  assert.equal(summary.stage_results.final_task.passed, 2);
+  assert.deepEqual(summary.participant_readiness, {
+    decision_ready: 3,
+    diagnosed: 3,
+    required_decision_ready: 2,
+  });
+  assert.equal(summary.safety.passed, true);
+  assert.equal(summary.product_change_authority.ranking, false);
+  assert.equal(summary.product_change_authority.policy, false);
+});
+
+test("checked-in synthetic summary is reproduced exactly from the frozen fixture", () => {
+  const fixture = JSON.parse(readFileSync(syntheticFixture, "utf8"));
+  const recorded = JSON.parse(readFileSync(syntheticSummary, "utf8"));
+
+  assert.deepEqual(recorded, summarizePilot(fixture));
+});


### PR DESCRIPTION
## 解决什么问题

在邀请真实参与者之前，先冻结一套能诚实记录同意、退出、诊断、Plan、检索、推荐分歧、任务结果与安全边界的定性试点协议，避免把私聊、Skill 内容或本机路径变成研究数据。

## 价值

- 每个已排期参与者都能被报告，诊断前退出者不会被遗漏，也不会被伪造成零 Inventory 或虚构 Recommendation。
- Setup、Invocation、Diagnosis、Plan、Deterministic retrieval、Recommendation decision、Final task 分开计数，失败不会互相冒充。
- 汇总永远不授权 ranking、embedding、model 或 policy 变更；真实试点仍需 #261 的单独同意和权限。

## 方法

- 新增严格 schema 1 ledger、离线 summarize/report CLI 和 3 人 5 条记录的合成 fixture。
- exact-key + bounded enum 校验；输入通过固定 descriptor 读取，解析前限制为 1 MiB，并拒绝 symlink/非普通文件。
- `abandoned_before_observation` 只允许 null inventory、空 Agent/Recommendation 与 safety outcome。
- 单一 `STAGE_DEFINITIONS` 驱动 shape、词表、前置关系和聚合。
- 登记可精确复现的合成 machine summary 与 dry-run receipt。

## 验证

- `bash scripts/ci-full-check.sh`: 321 unit + 8 acceptance + 97 CLI + 152 Node
- pilot tests: 15/15
- synthetic summary exact reproduction
- `git diff --check`
- independent Spec review: Clean
- independent Standards review: 2 个阻断 finding + 1 个 smell 已修复后 Clean

Closes #260
