### PR TITLE
release: prepare v1.8.33 candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.32"
+version = "1.8.33"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.32"
+version = "1.8.33"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/docs/acceptance/release-v1.8.33-candidate.md
+++ b/docs/acceptance/release-v1.8.33-candidate.md
@@ -1,0 +1,71 @@
+# SkillRoster v1.8.33 candidate
+
+## Release notes draft
+
+SkillRoster 1.8.33 publishes, in the public source tree, a
+[privacy-safe protocol](../research/roster-recommendation-pilot-v1.md) and
+offline Node research harness for evaluating whether independent users accept
+or reject proposed Core and On-demand Roster decisions.
+
+- A strict offline ledger separates setup, Agent invocation, diagnosis, Plan,
+  deterministic retrieval, recommendation decision, and final-task outcomes.
+- Scheduled participants who leave before observation remain reported without
+  invented inventory, Agent, or recommendation facts.
+- The ledger excludes raw conversations, Skill contents, secrets, participant
+  identities, and identifying absolute paths; its summary emits only bounded
+  aggregate counts.
+- Input is read through one retained file descriptor, rejects symlinks and
+  non-regular files, and is limited to 1 MiB before JSON parsing.
+- A checked-in three-participant synthetic dry run exercises acceptance,
+  rejection, a typed blocker, invocation failure, and retrieval failure. It
+  authorizes no ranking, embedding, model, or policy change. Its evidence is
+  recorded in the [synthetic dry-run receipt](roster-recommendation-pilot-v1-dry-run.md).
+
+The four platform archives still contain only the Rust CLI binary and LICENSE;
+the installed `skillroster` command gains no pilot subcommand. Rust CLI behavior
+is unchanged apart from its version string. The protocol, harness, fixtures,
+and tests are available from a source checkout.
+
+This patch release keeps SQLite schema 12 and JSON envelope schema 1. There is
+no database migration and no change to the local-only, explicit-confirmation,
+Receipt-backed mutation model. The bundled Bootstrap instructions remain at
+content version 1.8.29. The protocol authorizes no participant recruitment,
+messaging, real-environment read, or Apply; those remain separate #261
+boundaries.
+
+## Preparation evidence
+
+The public baseline is v1.8.32. Candidate preparation starts from exact
+`origin/main` revision `b16af99ef9171f6a7d5540c9e4c32f2a4fb3c665`, after
+[#312](https://github.com/tt-a1i/skillroster/pull/312) merged the frozen pilot
+protocol and closed
+[#260](https://github.com/tt-a1i/skillroster/issues/260). That pull request
+passed change-scope, Linux, Windows, macOS arm64, macOS x86_64, and aggregate CI
+gates. Independent Spec and Standards reviews were Clean after the initial
+Standards findings were fixed.
+
+The local full gate passed 321 Rust unit tests, 8 acceptance tests, 97 CLI
+tests, and 152 Node harness tests. The frozen synthetic summary is reproduced
+exactly from its public fixture, and no real participant or environment data is
+present.
+
+The source candidate and Cargo package are versioned as 1.8.33. Public install
+examples, the checked-in Formula, website current-release label, and README
+release evidence deliberately remain at v1.8.32 until the v1.8.33 tag,
+artifacts, checksums, and Homebrew package actually exist.
+
+## Candidate gates
+
+The candidate is not accepted until one exact final source revision passes:
+
+- `cargo fmt --all --check`;
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
+- `cargo test --locked --all-targets --all-features`;
+- the public CLI acceptance suite and Node harnesses;
+- `git diff --check`, installation-surface validation, and the CI change-scope
+  self-test;
+- four platform build and governance jobs plus the WSL2 governance smoke.
+
+Candidate preparation does not create or push a tag, publish a GitHub Release,
+update Homebrew, or mutate any public release asset. Those steps are recorded
+only after their external evidence exists.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,7 +93,7 @@ skillroster setup --json
 ```
 
 Published CLI v1.8.32 bundles Bootstrap content version 1.8.29.
-The source tree is **v1.8.32**.
+The source tree is **v1.8.33**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap
 instructions.

--- a/website/index.html
+++ b/website/index.html
@@ -1496,7 +1496,7 @@ footer { overflow: hidden; }
       </div>
     </div>
     <div class="footer-rule">
-      <span>SOURCE TREE v1.8.32 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
+      <span>SOURCE TREE v1.8.33 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
       <span>NO DAEMON · NO CLOUD · NO TELEMETRY</span>
     </div>
   </div>


### PR DESCRIPTION
## 解决什么问题

把 #260/#312 的隐私安全推荐试点协议与源码研究 harness 准备为可验证的 v1.8.33 patch candidate，同时明确它不是安装后二进制的新命令。

## 价值

研究者可以从公开源码复现一套不保存私聊、Skill 内容、秘密和身份路径的定性试点；已排期但诊断前退出的参与者也能被诚实计入，不会漏报或伪造事实。

## 发布边界

- Cargo/source candidate: 1.8.33
- SQLite schema: 12（无迁移）
- JSON envelope: 1
- Bundled Bootstrap content: 1.8.29（未变）
- Rust CLI: 除 version string 外行为未变，无 pilot subcommand
- 四平台 archive: 仍仅 Rust binary + LICENSE
- Formula / README / public install commands / website current release: 暂留已发布 v1.8.32，等真实 artifact 后再更新
- 不授权 #261 的招募、消息、真实环境读取或 Apply

## 验证

- `bash scripts/ci-full-check.sh`: 321 unit + 8 acceptance + 97 CLI + 152 Node
- `bash scripts/verify-readme-value.sh`
- `bash scripts/verify-installation-surface.sh`
- `bash scripts/ci-change-scope.sh --self-test`
- Cargo metadata version assertion
- `git diff --check`
- independent Spec review: Clean
- independent Standards review: source/package boundary finding 修复后 Clean

合并后只从精确 main SHA dispatch Release candidate workflow；四平台与 WSL2 全绿后才创建正式 tag。
