### PR TITLE
docs: record v1.8.33 release

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "4329cf2a2b476aafa6d77fc6edcfb6b31cd604ed"
-  version "1.8.32"
+      revision: "a9b649efbc0ca0b5c7a853e795ee6257c21629c8"
+  version "1.8.33"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.32", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.33", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.32 implements the complete local governance loop. Every
+Public release v1.8.33 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.32 release and platform evidence](docs/acceptance/release-v1.8.32-candidate.md)
+- [v1.8.33 release and platform evidence](docs/acceptance/release-v1.8.33-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.32 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.33 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.32 发布与平台证据](docs/acceptance/release-v1.8.32-candidate.md)
+- [v1.8.33 发布与平台证据](docs/acceptance/release-v1.8.33-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.33-candidate.md
+++ b/docs/acceptance/release-v1.8.33-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.33 candidate
+# SkillRoster v1.8.33 release receipt
 
-## Release notes draft
+## Release notes
 
 SkillRoster 1.8.33 publishes, in the public source tree, a
 [privacy-safe protocol](../research/roster-recommendation-pilot-v1.md) and
@@ -21,10 +21,16 @@ or reject proposed Core and On-demand Roster decisions.
   authorizes no ranking, embedding, model, or policy change. Its evidence is
   recorded in the [synthetic dry-run receipt](roster-recommendation-pilot-v1-dry-run.md).
 
-The four platform archives still contain only the Rust CLI binary and LICENSE;
-the installed `skillroster` command gains no pilot subcommand. Rust CLI behavior
-is unchanged apart from its version string. The protocol, harness, fixtures,
-and tests are available from a source checkout.
+The four platform archives contain the Rust CLI binary, `README.md`, and the
+Apache-2.0 `LICENSE`; the installed `skillroster` command gains no pilot
+subcommand. Rust CLI behavior is unchanged apart from its version string. The
+protocol, harness, fixtures, and tests are available from a source checkout.
+Because those immutable archives were built from the release-candidate tag,
+their packaged README still names v1.8.32 as the then-current public release
+and links its evidence. The v1.8.33 binary, tag, checksums, and public release
+metadata are unaffected. A later release must use version-neutral packaged
+copy or generate archive-specific release text before tagging; this follow-up
+is tracked by [#314](https://github.com/tt-a1i/skillroster/issues/314).
 
 This patch release keeps SQLite schema 12 and JSON envelope schema 1. There is
 no database migration and no change to the local-only, explicit-confirmation,
@@ -33,9 +39,9 @@ content version 1.8.29. The protocol authorizes no participant recruitment,
 messaging, real-environment read, or Apply; those remain separate #261
 boundaries.
 
-## Preparation evidence
+## Release evidence
 
-The public baseline is v1.8.32. Candidate preparation starts from exact
+The public baseline was v1.8.32. Candidate preparation started from exact
 `origin/main` revision `b16af99ef9171f6a7d5540c9e4c32f2a4fb3c665`, after
 [#312](https://github.com/tt-a1i/skillroster/pull/312) merged the frozen pilot
 protocol and closed
@@ -49,14 +55,53 @@ tests, and 152 Node harness tests. The frozen synthetic summary is reproduced
 exactly from its public fixture, and no real participant or environment data is
 present.
 
-The source candidate and Cargo package are versioned as 1.8.33. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.32 until the v1.8.33 tag,
-artifacts, checksums, and Homebrew package actually exist.
+[#313](https://github.com/tt-a1i/skillroster/pull/313) prepared the release from
+that exact baseline and passed Linux, Windows, macOS arm64, macOS x86_64,
+change-scope, and aggregate CI gates. Candidate
+[run 33269706239](https://github.com/tt-a1i/skillroster/actions/runs/33269706239)
+then passed the exact-SHA repository gate, all four build/governance jobs, and
+the WSL2 Linux archive smoke.
 
-## Candidate gates
+The annotated `v1.8.33` tag object
+`0cb502d7c14562387ab4e06ef46ed3767ec3e7dd` resolves exactly to
+`a9b649efbc0ca0b5c7a853e795ee6257c21629c8`. The official tag workflow
+[run 33270251405](https://github.com/tt-a1i/skillroster/actions/runs/33270251405)
+passed the same strict repository gate, Linux, Windows, macOS arm64 and x86_64
+build/governance jobs, and the WSL2 Linux governance smoke.
 
-The candidate is not accepted until one exact final source revision passes:
+The [public GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.33)
+contains four platform archives and four adjacent checksum files:
+
+- macOS arm64:
+  `20f3ab866390ad9eef631fef20ddf86618ba200ecbd9a523f65bcf50483e0211`;
+- macOS x86_64:
+  `5570010a87940251b1fdf49ec405ef49971de2acd199ab3c1635a40d324eb554`;
+- Windows x86_64:
+  `f10973adfb9fdd37e5da1b66c0cb59a28025e520d1bac4d870decf5aee57b8d1`;
+- Linux x86_64:
+  `f9f6aa4cfd07f620696976f8034fcf4fe97efe718dc6cfce9b6ac67040cb4907`.
+
+All eight tag-workflow artifacts passed their adjacent checksums before
+publication. The public macOS arm64 archive was then downloaded anonymously,
+matched its published checksum, reported `skillroster 1.8.33`, and passed the
+complete synthetic release governance smoke.
+
+The [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster) publishes
+v1.8.33 macOS arm64 and x86_64 Linux bottles. Both Homebrew test-bot jobs passed
+in [run 33270842211](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33270842211),
+and exact-head `brew pr-pull` published the bottles in
+[run 33271338074](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33271338074).
+Tap `main` reached `e9cf1d23cc78d53b6c7722d1e930f01e6bb18876`.
+The public macOS arm64 bottle was downloaded anonymously, matched Formula
+checksum
+`6f8e5789f5ec72cb0966c61e62927c7c9f4cf4c364e67cb7f4ff4c3e53371353`,
+reported `skillroster 1.8.33`, and passed the same governance smoke. The Linux
+x86_64 bottle checksum is
+`b1272a53f33cfa3fc4b901dd3359c80d1812d957d7f667b3b630a187625a6a20`.
+
+## Accepted gates
+
+The exact tagged revision passed:
 
 - `cargo fmt --all --check`;
 - `cargo clippy --locked --all-targets --all-features -- -D warnings`;
@@ -66,6 +111,6 @@ The candidate is not accepted until one exact final source revision passes:
   self-test;
 - four platform build and governance jobs plus the WSL2 governance smoke.
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate any public release asset. Those steps are recorded
-only after their external evidence exists.
+The release WSL boundary remains WSL2. WSL1 mutation fails closed when its
+kernel cannot provide the atomic no-replace rename required by SkillRoster's
+handle-bound recovery model.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.32**. Its Formula, annotated tag, four
+The current public release is **v1.8.33**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.32
+SKILLROSTER_VERSION=1.8.33
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -50,7 +50,8 @@ Agent, then restart that Agent so future sessions can resolve `skillroster`.
 On Windows, compare `Get-FileHash .\skillroster-*.zip -Algorithm SHA256` with
 the checksum file. Extract the archive, open its versioned directory, then
 place `skillroster.exe` in a directory on `PATH`. Every release archive also
-contains the complete Apache-2.0 `LICENSE` distributed with the binary.
+contains `README.md` and the complete Apache-2.0 `LICENSE` distributed with the
+binary.
 
 ## Build or install from source
 
@@ -58,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.32 skillroster
+  --tag v1.8.33 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -92,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.32 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.33 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.33**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.32 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.33 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.32 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.33 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.32 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.32 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.33 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.33 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What this records

- marks v1.8.33 as the current public release across both READMEs, installation guidance, website, and the checked-in source Formula
- turns the candidate note into an evidence-backed release receipt with exact tag, workflow, archive, checksum, and Homebrew bottle facts
- records anonymous public archive and bottle governance smokes
- discloses the immutable archive README version-text limitation and links #314 for the next-release packaging fix

## Validation

- full local gate: 321 Rust unit, 8 acceptance, 97 CLI, 152 Node harness tests
- cargo fmt and strict Clippy through the full gate
- installation-surface verifier
- README value verifier
- change-scope self-test
- ruby Formula syntax
- git diff --check
- independent Spec review: Clean
- independent Standards review: Clean after findings were fixed

## External evidence

- v1.8.33 Release: https://github.com/tt-a1i/skillroster/releases/tag/v1.8.33
- tag workflow: https://github.com/tt-a1i/skillroster/actions/runs/33270251405
- Homebrew test-bot: https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33270842211
- Homebrew pr-pull: https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33271338074