### PR TITLE
fix: keep release archive README version-neutral

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 LICENSE text eol=lf
 skill/**/SKILL.md text eol=lf
 tests/fixtures/bootstrap-*.md text eol=lf
+docs/release-archive/README.md text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bash scripts/verify-readme-value.sh
           bash scripts/verify-installation-surface.sh
+          bash scripts/verify-release-archive-readme.sh
           bash scripts/ci-change-scope.sh --self-test
           full=true
           if [[ "$EVENT_NAME" != "workflow_dispatch" && -n "$BASE_SHA" && ! "$BASE_SHA" =~ ^0+$ ]] && git cat-file -e "$BASE_SHA^{commit}"; then
@@ -124,6 +125,22 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: bash scripts/ci-node-harness.sh
+
+      - name: Parse Windows release packager
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path "scripts/release/package-windows.ps1"),
+            [ref]$tokens,
+            [ref]$errors
+          ) | Out-Null
+          if ($errors.Count -ne 0) {
+            $errors | ForEach-Object { Write-Error $_.Message }
+            exit 1
+          }
 
   gate:
     name: CI gate

--- a/docs/release-archive/README.md
+++ b/docs/release-archive/README.md
@@ -1,0 +1,28 @@
+# SkillRoster release archive
+
+This immutable directory contains a platform-specific SkillRoster binary, this
+version-neutral guide, and the complete Apache-2.0 `LICENSE`.
+
+Verify the adjacent checksum before extracting the archive. Then run
+`skillroster --version` (or `skillroster.exe --version` on Windows) to identify
+the exact binary. Do not use this file to infer which release is currently the
+newest.
+
+- Releases, checksums, notes, and platform evidence:
+  <https://github.com/tt-a1i/skillroster/releases>
+- Current documentation and source:
+  <https://github.com/tt-a1i/skillroster>
+
+SkillRoster is local-only. It has no daemon, cloud service, or telemetry. Review
+every Plan before Apply; successful changes return a Receipt and can be undone
+through the recorded Receipt boundary.
+
+## 中文
+
+这是一个不可变的 SkillRoster 平台发布包，包含对应平台的二进制文件、本说明和
+完整的 Apache-2.0 `LICENSE`。
+
+解压前请校验相邻的 checksum。解压后运行 `skillroster --version`；Windows 使用
+`skillroster.exe --version`，以确认二进制的精确版本。不要根据本文件判断当前
+最新版本，最新发布、校验和、说明和平台证据请查看：
+<https://github.com/tt-a1i/skillroster/releases>。

--- a/docs/release.md
+++ b/docs/release.md
@@ -5,6 +5,13 @@ from the public source tree. Workflows must never upload local Skill libraries,
 agent sessions, inventories, plans, receipts, configuration, credentials, or
 other user data.
 
+Every archive packages `docs/release-archive/README.md` as its root
+`README.md`. That guide is intentionally version-neutral because an immutable
+candidate tag cannot truthfully claim which release is currently public. The
+packaging jobs on all four platforms verify that the archived README matches
+the checked-in source exactly; the normal full CI gate rejects a hard-coded
+release version in that source.
+
 ## Candidate build
 
 1. Update `Cargo.toml` and `Cargo.lock` to the intended version.

--- a/scripts/ci-change-scope.sh
+++ b/scripts/ci-change-scope.sh
@@ -16,6 +16,9 @@ classify_paths() {
       skill/skillroster/*|tests/fixtures/*)
         full=true
         ;;
+      docs/release-archive/README.md)
+        full=true
+        ;;
       LICENSE|*.md)
         ;;
       *)
@@ -38,6 +41,7 @@ self_test() {
     'skill/skillroster/SKILL.md' \
     'skill/skillroster/references/routing.md' \
     'skill/skillroster/manifest.json' \
+    'docs/release-archive/README.md' \
     'tests/fixtures/bootstrap-v1.8.23.md' \
     'src/bootstrap.rs'; do
     actual="$(printf '%s\n' "$runtime_path" | classify_paths)"

--- a/scripts/ci-full-check.sh
+++ b/scripts/ci-full-check.sh
@@ -7,3 +7,4 @@ cargo test --locked --all-targets --all-features
 bash scripts/ci-node-harness.sh
 bash scripts/verify-readme-value.sh
 bash scripts/verify-installation-surface.sh
+bash scripts/verify-release-archive-readme.sh

--- a/scripts/release/package-unix.sh
+++ b/scripts/release/package-unix.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 target="${1:?target is required}"
 version="${2:?version is required}"
+archive_readme="docs/release-archive/README.md"
 
 case "$target" in
   x86_64-unknown-linux-gnu|aarch64-apple-darwin|x86_64-apple-darwin) ;;
@@ -33,13 +34,15 @@ if [[ -e "$stage" || -L "$stage" || -e "$archive" || -L "$archive" || -e "$check
   exit 1
 fi
 
+bash scripts/verify-release-archive-readme.sh
+
 cleanup_stage() {
   if [[ -e "$stage" || -L "$stage" ]]; then rm -rf -- "$stage"; fi
 }
 trap cleanup_stage EXIT
 mkdir -p "$stage"
 install -m 0755 "target/${target}/release/skillroster" "$stage/skillroster"
-cp README.md "$stage/README.md"
+cp "$archive_readme" "$stage/README.md"
 cp LICENSE "$stage/LICENSE"
 scripts/release/smoke.sh "$stage/skillroster"
 tar -C "$dist_root" -czf "$archive" "$name"
@@ -48,6 +51,10 @@ trap - EXIT
 
 if ! tar -xOf "$archive" "$name/LICENSE" | cmp - LICENSE; then
   echo "release archive does not contain the repository LICENSE" >&2
+  exit 1
+fi
+if ! tar -xOf "$archive" "$name/README.md" | cmp - "$archive_readme"; then
+  echo "release archive README differs from the version-neutral source" >&2
   exit 1
 fi
 

--- a/scripts/release/package-windows.ps1
+++ b/scripts/release/package-windows.ps1
@@ -4,11 +4,52 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$RepoRoot = [System.IO.Path]::GetFullPath((Get-Location).Path)
+$ArchiveReadmeRelative = "docs/release-archive/README.md"
+$DocsRoot = [System.IO.Path]::GetFullPath((Join-Path $RepoRoot "docs"))
+$ExpectedArchiveParent = [System.IO.Path]::GetFullPath(
+    (Join-Path $DocsRoot "release-archive")
+)
+$ArchiveReadme = [System.IO.Path]::GetFullPath(
+    (Join-Path $RepoRoot $ArchiveReadmeRelative)
+)
 if ($Target -ne "x86_64-pc-windows-msvc") {
     throw "Unsupported release target: $Target"
 }
 if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$' -or $Version.Contains("..")) {
     throw "Version must be SemVer without build metadata"
+}
+foreach ($DirectoryPath in @($RepoRoot, $DocsRoot, $ExpectedArchiveParent)) {
+    if (-not (Test-Path -LiteralPath $DirectoryPath -PathType Container)) {
+        throw "Release archive README directory is missing: $DirectoryPath"
+    }
+    $DirectoryItem = Get-Item -LiteralPath $DirectoryPath -Force
+    if (($DirectoryItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Release archive README ancestors must not be reparse points: $DirectoryPath"
+    }
+}
+if (-not (Test-Path -LiteralPath $ArchiveReadme -PathType Leaf)) {
+    throw "Release archive README is missing: $ArchiveReadme"
+}
+$ArchiveReadmeItem = Get-Item -LiteralPath $ArchiveReadme -Force
+if (($ArchiveReadmeItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+    throw "Release archive README must not be a reparse point"
+}
+$ResolvedArchiveParent = [System.IO.Path]::GetFullPath(
+    (Resolve-Path -LiteralPath (Split-Path -Parent $ArchiveReadme)).Path
+)
+if (-not $ResolvedArchiveParent.Equals($ExpectedArchiveParent, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Release archive README parent must not resolve outside its fixed repository path"
+}
+$ResolvedArchiveReadme = [System.IO.Path]::GetFullPath(
+    (Resolve-Path -LiteralPath $ArchiveReadme).Path
+)
+if (-not $ResolvedArchiveReadme.Equals($ArchiveReadme, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Release archive README must not resolve outside its fixed repository path"
+}
+$ArchiveReadmeText = [System.IO.File]::ReadAllText($ArchiveReadme)
+if ($ArchiveReadmeText -match '(^|[^0-9])[vV]?[0-9]+\.[0-9]+\.[0-9]+([^0-9]|$)') {
+    throw "Release archive README must not hard-code a release version"
 }
 
 $Name = "skillroster-$Version-$Target"
@@ -32,7 +73,7 @@ if ((Test-Path -LiteralPath $Stage) -or (Test-Path -LiteralPath $Archive) -or (T
 }
 New-Item -ItemType Directory -Force -Path $Stage | Out-Null
 Copy-Item "target/$Target/release/skillroster.exe" (Join-Path $Stage "skillroster.exe")
-Copy-Item "README.md" (Join-Path $Stage "README.md")
+Copy-Item $ArchiveReadme (Join-Path $Stage "README.md")
 Copy-Item "LICENSE" (Join-Path $Stage "LICENSE")
 Compress-Archive -Path $Stage -DestinationPath $Archive -Force
 Remove-Item $Stage -Recurse -Force
@@ -40,13 +81,22 @@ Remove-Item $Stage -Recurse -Force
 try {
     Expand-Archive -LiteralPath $Archive -DestinationPath $VerifyRoot
     $BundledLicense = Join-Path (Join-Path $VerifyRoot $Name) "LICENSE"
+    $BundledReadme = Join-Path (Join-Path $VerifyRoot $Name) "README.md"
     if (-not (Test-Path -LiteralPath $BundledLicense -PathType Leaf)) {
         throw "Release archive does not contain LICENSE"
+    }
+    if (-not (Test-Path -LiteralPath $BundledReadme -PathType Leaf)) {
+        throw "Release archive does not contain README.md"
     }
     $ExpectedLicenseHash = (Get-FileHash -Algorithm SHA256 "LICENSE").Hash
     $BundledLicenseHash = (Get-FileHash -Algorithm SHA256 $BundledLicense).Hash
     if ($ExpectedLicenseHash -ne $BundledLicenseHash) {
         throw "Release archive LICENSE differs from the repository LICENSE"
+    }
+    $ExpectedReadmeHash = (Get-FileHash -Algorithm SHA256 $ArchiveReadme).Hash
+    $BundledReadmeHash = (Get-FileHash -Algorithm SHA256 $BundledReadme).Hash
+    if ($ExpectedReadmeHash -ne $BundledReadmeHash) {
+        throw "Release archive README differs from the version-neutral source"
     }
 }
 finally {

--- a/scripts/verify-release-archive-readme.sh
+++ b/scripts/verify-release-archive-readme.sh
@@ -56,6 +56,10 @@ if ! validate_regular_file_at_parent "$archive_readme" "$expected_archive_parent
   echo "release archive README must be a regular in-repository file without linked ancestors: $archive_readme" >&2
   exit 1
 fi
+if [[ "$(git check-attr eol -- "$archive_readme")" != "$archive_readme: eol: lf" ]]; then
+  echo "release archive README must be checked out with LF on every platform" >&2
+  exit 1
+fi
 
 if contains_release_version < "$archive_readme"; then
   echo "release archive README must not hard-code a release version" >&2

--- a/scripts/verify-release-archive-readme.sh
+++ b/scripts/verify-release-archive-readme.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+archive_readme="docs/release-archive/README.md"
+release_version_pattern='(^|[^0-9])[vV]?[0-9]+\.[0-9]+\.[0-9]+([^0-9]|$)'
+
+validate_regular_file_at_parent() {
+  local candidate="$1"
+  local expected_parent="$2"
+  local actual_parent
+
+  [[ -f "$candidate" && ! -L "$candidate" ]] || return 1
+  actual_parent="$(cd "$(dirname "$candidate")" && pwd -P)" || return 1
+  [[ "$actual_parent" == "$expected_parent" ]]
+}
+
+contains_release_version() {
+  grep -Eq "$release_version_pattern"
+}
+
+if ! printf '%s\n' 'Current release: v1.8.33' | contains_release_version; then
+  echo "release archive README version guard failed its positive control" >&2
+  exit 1
+fi
+if printf '%s\n' 'Apache-2.0; run skillroster --version' | contains_release_version; then
+  echo "release archive README version guard rejected its negative control" >&2
+  exit 1
+fi
+
+path_test_root="$(mktemp -d "${TMPDIR:-/tmp}/skillroster-release-readme.XXXXXX")"
+path_test_root="$(cd "$path_test_root" && pwd -P)"
+trap 'rm -rf -- "$path_test_root"' EXIT
+mkdir "$path_test_root/real"
+printf '%s\n' 'version-neutral' > "$path_test_root/real/README.md"
+validate_regular_file_at_parent \
+  "$path_test_root/real/README.md" \
+  "$path_test_root/real"
+ln -s "$path_test_root/real/README.md" "$path_test_root/linked-readme.md"
+if validate_regular_file_at_parent "$path_test_root/linked-readme.md" "$path_test_root"; then
+  echo "release archive README path guard accepted a symlink" >&2
+  exit 1
+fi
+ln -s "$path_test_root/real" "$path_test_root/linked-parent"
+if validate_regular_file_at_parent \
+  "$path_test_root/linked-parent/README.md" \
+  "$path_test_root/linked-parent"; then
+  echo "release archive README path guard accepted a linked parent" >&2
+  exit 1
+fi
+rm -rf -- "$path_test_root"
+trap - EXIT
+
+repo_root="$(pwd -P)"
+expected_archive_parent="$repo_root/docs/release-archive"
+if ! validate_regular_file_at_parent "$archive_readme" "$expected_archive_parent"; then
+  echo "release archive README must be a regular in-repository file without linked ancestors: $archive_readme" >&2
+  exit 1
+fi
+
+if contains_release_version < "$archive_readme"; then
+  echo "release archive README must not hard-code a release version" >&2
+  exit 1
+fi
+
+for package_script in \
+  scripts/release/package-unix.sh \
+  scripts/release/package-windows.ps1; do
+  if ! grep -Fq "$archive_readme" "$package_script"; then
+    echo "release packager does not select the version-neutral README: $package_script" >&2
+    exit 1
+  fi
+done
+if ! grep -Fq 'https://github.com/tt-a1i/skillroster/releases' "$archive_readme"; then
+  echo "release archive README does not link to public release evidence" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 解决什么问题

Release candidate tags are immutable, so copying the repository README into an archive can make the archive immediately stale after publication. v1.8.33 exposed this: the binary and checksums were correct, while the packaged README still named v1.8.32.

## 价值

Every platform archive now carries one version-neutral guide whose bytes are bound to public source. Users identify the binary with `--version` and follow the Release page for current evidence, without conflicting claims inside an immutable archive.

## 方法

- package `docs/release-archive/README.md` as the root README on Unix and Windows
- reject hard-coded SemVer and linked/reparse-point source paths
- verify the extracted archive README exactly matches checked-in source
- classify changes to the archive README as full CI, and parse the Windows packager on Windows CI
- document the immutable archive contract

## 验证

- red test first: verifier failed while the archive README source was absent
- `bash scripts/ci-full-check.sh`
  - Rust unit: 321
  - acceptance: 8
  - CLI: 97
  - Node: 152
- native macOS arm64 package smoke and exact extracted-byte comparison
- independent review: Spec Clean and Standards Clean after fixing Unix symlink and Windows junction boundaries

Closes #314
