### PR TITLE
docs: record v1.8.34 release

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "a9b649efbc0ca0b5c7a853e795ee6257c21629c8"
-  version "1.8.33"
+      revision: "188335ffe3eef570d403c344c954b366faaad0b5"
+  version "1.8.34"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.33", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.34", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.33 implements the complete local governance loop. Every
+Public release v1.8.34 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.33 release and platform evidence](docs/acceptance/release-v1.8.33-candidate.md)
+- [v1.8.34 release and platform evidence](docs/acceptance/release-v1.8.34-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.33 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.34 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.33 发布与平台证据](docs/acceptance/release-v1.8.33-candidate.md)
+- [v1.8.34 发布与平台证据](docs/acceptance/release-v1.8.34-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.34-candidate.md
+++ b/docs/acceptance/release-v1.8.34-candidate.md
@@ -1,70 +1,107 @@
-# SkillRoster v1.8.34 candidate
+# SkillRoster v1.8.34 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.34 makes the documentation inside every immutable platform
 archive trustworthy for the lifetime of that archive.
 
-- Linux, Windows, macOS arm64, and macOS x86_64 archives now package one
-  version-neutral guide instead of copying the repository README from the
-  candidate tag.
+- Linux, Windows, macOS arm64, and macOS x86_64 archives package one
+  version-neutral guide instead of copying the repository README.
 - The guide tells users to verify the adjacent checksum, identify the exact
   binary with `skillroster --version`, and use the public Releases page for
   current version evidence.
 - Packaging rejects a linked source path on Unix and a reparse-point source or
   ancestor on Windows before reading or copying the guide.
 - CI rejects hard-coded release versions and requires LF checkout bytes on
-  every platform. Each packager then verifies the extracted README against the
+  every platform. Each packager verifies the extracted README against the
   checked-in source.
 
-This patch changes release packaging and its validation only. SQLite remains
-at schema 12, the JSON envelope remains at schema 1, and bundled Bootstrap
-content remains at version 1.8.29. There is no database migration or change to
-the local-only, explicit-confirmation, Receipt-backed mutation model.
+This patch changes release packaging and validation only. SQLite remains at
+schema 12, the JSON envelope remains at schema 1, and bundled Bootstrap content
+remains at version 1.8.29. There is no database migration or change to the
+local-only, explicit-confirmation, Receipt-backed mutation model.
 
-## Preparation evidence
+## Source and review chain
 
-Candidate preparation starts from exact `origin/main` revision
-`9ab82a7c82bb2fdd371c88a471301f2afa730a54`, after
-[#317](https://github.com/tt-a1i/skillroster/pull/317) closed
-[#314](https://github.com/tt-a1i/skillroster/issues/314). That pull request
-passed change-scope, Linux, Windows, macOS arm64, macOS x86_64, and aggregate CI
-gates. Independent Spec and Standards reviews were Clean after Unix symlink and
-Windows junction findings were fixed.
+[#317](https://github.com/tt-a1i/skillroster/pull/317) implemented the archive
+contract and closed [#314](https://github.com/tt-a1i/skillroster/issues/314).
+Independent Spec and Standards reviews were Clean after Unix symlink and
+Windows ancestor-junction findings were fixed. External archive readback also
+caught a Windows LF-to-CRLF conversion that the first green packaging run had
+missed; `.gitattributes` now pins the guide to LF, and packaging verifies the
+effective Git attribute.
 
-Before the version bump, PR #317 validation
-[run 33274488000](https://github.com/tt-a1i/skillroster/actions/runs/33274488000)
-passed the exact-SHA repository gate at `9cdde70edab4e88cee8c36a2469de5da7cfa78f4`
-with release version 1.8.33, all four build/governance jobs, and the WSL2 Linux
-archive smoke. All four downloaded checksums verified, and every extracted
-README matched the checked-in Git blob byte for byte. This proves the packaging
-contract merged by #317; it is not evidence that the 1.8.34 candidate has run.
+[#318](https://github.com/tt-a1i/skillroster/pull/318) prepared version 1.8.34
+and merged as exact source revision
+`188335ffe3eef570d403c344c954b366faaad0b5`. Its exact-main candidate
+[run 33275243875](https://github.com/tt-a1i/skillroster/actions/runs/33275243875)
+passed the strict repository gate, Linux, Windows, both macOS architectures,
+and WSL2. Four downloaded candidate checksums passed, and all four archive
+READMEs matched the checked-in Git blob byte for byte.
 
-That cross-platform readback caught and fixed one defect which the first green
-packaging-validation run did not: Windows checkout had converted the guide from
-LF to CRLF, so the archive matched its local checkout but not the Git blob. The
-final contract fixes the file to `eol=lf` and verifies the effective Git
-attribute before packaging.
-
-The source candidate and Cargo package are versioned as 1.8.34. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.33 until the v1.8.34 tag,
-artifacts, checksums, and Homebrew package actually exist.
-
-## Candidate gates
-
-The candidate is not accepted until one exact final source revision passes:
+The candidate gate included:
 
 - `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+- strict Clippy across all targets and features;
+- 321 Rust unit tests, 8 acceptance tests, 97 CLI tests, and 152 Node harness
+  tests;
+- installation-surface, archive-README, change-scope, and `git diff --check`
+  validation;
+- four platform build/governance jobs and the WSL2 governance smoke.
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+## Published release
+
+Annotated tag `v1.8.34` has tag object
+`3496c4f7ef1af1eed530cb77729671e9ecc65c72` and resolves to exact source
+revision `188335ffe3eef570d403c344c954b366faaad0b5`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33275766709)
+repeated the strict gate and all supported-platform jobs successfully.
+
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.34)
+contains four archives and four adjacent checksum files:
+
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `ced3b792cfa57cd12bfe47a17404ea09bf0bef01d757fd49c512da6f1b3eae0f` |
+| `x86_64-apple-darwin` | `106b43962963a140e1b030e2c1441381466d775a8878ef8187de60374dc6ad1a` |
+| `x86_64-pc-windows-msvc` | `05d3f3ccc67bb58a547689e98529d0e78cf5f442ab73b52336768b0717454430` |
+| `x86_64-unknown-linux-gnu` | `33bc9062ca525abc1a71bd59755d202e0cf3091e8e45388b823c027b61b0f0fe` |
+
+The public release asset inventory was read back and contained exactly those
+eight files. An anonymous macOS arm64 download passed its adjacent checksum,
+reported `skillroster 1.8.34`, passed the release-governance smoke, and
+contained the exact checked-in archive README bytes.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #8](https://github.com/tt-a1i/homebrew-skillroster/pull/8)
+at exact head `db693ef878fff14733f1de51049bb3449d08e3ad`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33276415624)
+built and tested both macOS arm64 and Linux x86_64 bottles. The exact-head
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33276709861)
+published the bottles and advanced tap `main` to
+`0c15049251853e5c1a274bbbbcfefbb4eebb4450`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `55602a66c8ae05f9f3b36163831bb047821e62a140054a7857ce7925a0181ad8` |
+| `x86_64_linux` | `d47197b9dee091757821c01053490ed5a224985ba035e5a053425926a6a495ed` |
+
+The public arm64 bottle was downloaded without repository credentials, matched
+the Formula checksum, reported version 1.8.34, and passed the release-governance
+smoke. The local Homebrew installation was then upgraded from 1.8.28 to 1.8.34
+and passed the same checks using `/opt/homebrew/opt/skillroster/bin/skillroster`.
+
+The user's existing `~/.local/bin/skillroster` remains version 1.8.28 and
+precedes Homebrew on `PATH`. It was deliberately preserved: invoking
+`skillroster` by name in that shell still resolves to the user-owned older
+binary, while the verified Homebrew binary is available by its absolute path.
+
+## Boundaries
+
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent files, or change
+  the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.33**. Its Formula, annotated tag, four
+The current public release is **v1.8.34**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.33
+SKILLROSTER_VERSION=1.8.34
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.33 skillroster
+  --tag v1.8.34 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.33 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.34 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.34**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.33 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.34 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.33 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.34 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.33 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.33 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.34 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.34 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Records the already-published v1.8.34 release across the bilingual README, installation guide, website, and checked-in Formula.

The receipt binds the annotated tag, exact source SHA, candidate and tag workflow runs, four archive checksums, public release readback, Homebrew test-bot/pr-pull, bottle checksums, and the preserved local PATH shadow boundary.

Validation:
- bash scripts/ci-full-check.sh
- bash scripts/verify-installation-surface.sh
- bash scripts/verify-release-archive-readme.sh
- bash scripts/ci-change-scope.sh --self-test
- git diff --check
- independent Spec and Standards review: Clean