### PR TITLE
fix: report affected Agents in setup Plans

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6103,7 +6103,12 @@ fn operation_groups(operations: &[Operation]) -> Value {
     json!(groups)
 }
 
-fn affected_summary(prepared: &PreparedPlan, scan: &ScanResult, impact: &Value) -> Value {
+fn affected_summary(
+    prepared: &PreparedPlan,
+    scan: &ScanResult,
+    impact: &Value,
+    bootstrap_scope: Option<&BootstrapPlanScope>,
+) -> Value {
     let mut agents = prepared
         .roster_changes
         .iter()
@@ -6168,6 +6173,11 @@ fn affected_summary(prepared: &PreparedPlan, scan: &ScanResult, impact: &Value) 
             .flatten()
             .filter_map(Value::as_str)
             .map(str::to_owned),
+    );
+    agents.extend(
+        bootstrap_scope
+            .into_iter()
+            .flat_map(|scope| scope.affected_agents.iter().cloned()),
     );
     let skill_count = skills.len();
     let skill_ids = skills.iter().take(10).cloned().collect::<Vec<_>>();
@@ -6422,6 +6432,7 @@ enum PlanOrigin {
 struct BootstrapPlanScope {
     anchor_roots: Vec<PathBuf>,
     missing_skill_roots: Vec<PathBuf>,
+    affected_agents: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
@@ -7797,7 +7808,7 @@ fn prepare_plan(
     let risk = plan_risk(&prepared);
     let operations_by_kind = operation_groups(&prepared.operations);
     let impact = bounded_plan_impact(impact);
-    let affected = affected_summary(&prepared, &scan, &impact);
+    let affected = affected_summary(&prepared, &scan, &impact, bootstrap_scope);
     let diff_summary = plan_diff_summary(
         effective_origin,
         &source_update_diffs,
@@ -8429,6 +8440,7 @@ fn setup_command_with_manifests<'a>(
     let mut physical_targets = BTreeSet::new();
     let mut planned_directories = BTreeSet::new();
     let mut planned_files = BTreeSet::new();
+    let mut planned_agents = BTreeSet::new();
     let mut bootstrap_anchor_roots = BTreeSet::new();
     let mut bootstrap_missing_skill_roots = BTreeSet::new();
     let physical_home = std::fs::canonicalize(home)
@@ -8552,6 +8564,7 @@ fn setup_command_with_manifests<'a>(
                 || (package_status == "modified"
                     && matches!(modified_choice, Some(ModifiedBootstrapChoice::AdoptCurrent)));
             if should_install {
+                planned_agents.insert(agent.id().to_owned());
                 if root_missing {
                     let mut missing_directories = Vec::new();
                     let mut cursor = Some(root.as_path());
@@ -8692,6 +8705,7 @@ fn setup_command_with_manifests<'a>(
     let bootstrap_scope = BootstrapPlanScope {
         anchor_roots: bootstrap_anchor_roots.into_iter().collect(),
         missing_skill_roots: bootstrap_missing_skill_roots.into_iter().collect(),
+        affected_agents: planned_agents.into_iter().collect(),
     };
     let plan = prepare_plan(
         store,
@@ -8703,7 +8717,8 @@ fn setup_command_with_manifests<'a>(
                 None => Value::Null,
                 Some(ModifiedBootstrapChoice::RetainLocal) => json!("retain-local"),
                 Some(ModifiedBootstrapChoice::AdoptCurrent) => json!("adopt-current"),
-            }
+            },
+            "affected_agents": bootstrap_scope.affected_agents.clone()
         })),
         &[],
         Some(&bootstrap_scope),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4259,6 +4259,8 @@ fn setup_treats_a_package_with_no_managed_files_as_missing_and_preserves_extra_f
     assert_eq!(setup["result"]["modified_count"], 0);
     assert_eq!(setup["result"]["targets"][0]["status"], "missing");
     assert_eq!(setup["result"]["operation_count"], 5);
+    assert_eq!(setup["result"]["affected"]["agent_count"], 1);
+    assert_eq!(setup["result"]["affected"]["agents"], json!(["codex"]));
     let applied = json_output(&run(
         &[
             &common[..],
@@ -4382,6 +4384,20 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
     assert_eq!(setup["result"]["missing_count"], 8);
     assert_eq!(setup["result"]["physical_target_count"], 6);
     assert_eq!(setup["result"]["operation_count"], 36);
+    assert_eq!(setup["result"]["affected"]["agent_count"], 8);
+    assert_eq!(
+        setup["result"]["affected"]["agents"],
+        json!([
+            "claude-code",
+            "codex",
+            "cursor",
+            "gemini-cli",
+            "github-copilot",
+            "hermes",
+            "opencode",
+            "pi"
+        ])
+    );
 
     let plan_id = setup["result"]["plan_id"].as_str().unwrap();
     let detail = json_output(&run(
@@ -4689,6 +4705,55 @@ fn setup_does_not_reuse_an_incomplete_legacy_plan_summary() {
     let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
     assert_eq!(status["result"]["pending_plan_count"], 2);
     assert!(status["result"]["last_receipt"].is_null());
+}
+
+#[test]
+fn setup_does_not_reuse_a_legacy_zero_affected_agent_summary() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    fs::create_dir_all(&root).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let first = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    let first_plan_id = first["result"]["plan_id"].as_str().unwrap();
+
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let immutable: String = database
+        .query_row(
+            "SELECT immutable_json FROM plans WHERE id = ?1",
+            [first_plan_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut legacy: Value = serde_json::from_str(&immutable).unwrap();
+    legacy["input"]["summary"]["affected"]["agent_count"] = json!(0);
+    legacy["input"]["summary"]["affected"]["agents"] = json!([]);
+    legacy["input"]["reuse_identity"]
+        .as_object_mut()
+        .unwrap()
+        .remove("affected_agents");
+    database
+        .execute(
+            "UPDATE plans SET immutable_json = ?1 WHERE id = ?2",
+            rusqlite::params![legacy.to_string(), first_plan_id],
+        )
+        .unwrap();
+    drop(database);
+
+    let retry = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(retry["result"]["state"], "preview_ready");
+    assert_ne!(retry["result"]["plan_id"], first["result"]["plan_id"]);
+    assert_eq!(retry["result"]["affected"]["agent_count"], 1);
+    assert_eq!(retry["result"]["affected"]["agents"], json!(["codex"]));
+    assert!(!root.join("skillroster").exists());
 }
 
 #[test]


### PR DESCRIPTION
## 解决什么问题

`setup --json` 会列出真实 Bootstrap 写操作，却把受影响 Agent 报告为 0，导致 Agent 在确认 Plan 时低估修改范围。

## 价值

Setup 与不可变 Plan 现在会准确报告实际将被安装或替换的逻辑 Agent；多个 Agent 共享物理目录时仍保留完整逻辑影响范围。旧版错误的零影响 Plan 保持不可变，但不会被继续复用。

## 方法

- 在 Bootstrap Plan scope 中记录实际进入安装/替换分支的 Agent。
- 将该集合并入通用 `affected` 汇总与 Plan reuse identity。
- 添加单 Agent、共享根 8 Agent、旧 Plan 兼容回归测试。

## 验证

- 红灯回归先复现：预期 1，实际 0。
- 修复后真实 v1.8.34 dogfood replay：6 个 detected/missing Agent、25 个操作、4 个物理目标，`affected.agent_count` 从 0 修正为 6，且未修改 Home 文件。
- `bash scripts/ci-full-check.sh`：321 Rust unit + 8 acceptance + 98 CLI + 152 Node，通过。
- `git diff --check`：通过。
- 独立 Spec review：Clean。
- 独立 Standards review：Clean。

Resolves #320
