### PR TITLE
release: prepare v1.8.35 candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.34"
+version = "1.8.35"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.34"
+version = "1.8.35"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/docs/acceptance/release-v1.8.35-candidate.md
+++ b/docs/acceptance/release-v1.8.35-candidate.md
@@ -1,0 +1,61 @@
+# SkillRoster v1.8.35 candidate
+
+## Release notes draft
+
+SkillRoster 1.8.35 makes Bootstrap Setup Plans report their real Agent impact.
+
+- `setup --json` and `plan --show` now include every logical Agent whose
+  Bootstrap target will actually be installed or replaced.
+- Agents that share one physical root remain distinct in the bounded impact
+  summary, so deduplication cannot hide affected callers.
+- Already-current, unsupported, and retained-local targets are not counted as
+  affected.
+- Complete Plans created by older versions with an incorrect zero-Agent
+  summary remain immutable, but Setup will not reuse them.
+
+This patch changes Setup Plan reporting and reuse identity only. SQLite remains
+at schema 12, the JSON envelope remains at schema 1, and bundled Bootstrap
+content remains at version 1.8.29. Setup is still preview-only until explicit
+Apply confirmation, and Apply/Undo remain Receipt-backed.
+
+## Preparation evidence
+
+Candidate preparation starts from exact `origin/main` revision
+`3f2aadfc539c86d898bb8f6e7be21f4487e09648`, where
+[#321](https://github.com/tt-a1i/skillroster/pull/321) closed
+[#320](https://github.com/tt-a1i/skillroster/issues/320).
+
+The defect was reproduced first with the public v1.8.34 binary: six detected
+and missing Agents, 25 planned filesystem operations, and four physical targets
+were incorrectly summarized as zero affected Agents. The corrected source
+created a new Plan instead of reusing the old summary and reported all six
+logical Agents without modifying the Home fixture.
+
+PR #321 passed change-scope, Linux x86_64, Windows x86_64, macOS arm64, macOS
+x86_64, and aggregate CI gates at exact head
+`3e259fdbec93c34160898a725f6ef8efae3d239b`. Its local full gate passed 321
+Rust unit tests, 8 acceptance tests, 98 CLI tests, and 152 Node harness tests.
+Independent Spec and Standards reviews were Clean.
+
+The source candidate and Cargo package are versioned as 1.8.35. Public install
+examples, the checked-in Formula, website current-release label, and README
+release evidence deliberately remain at v1.8.34 until the v1.8.35 tag,
+artifacts, checksums, and Homebrew package actually exist.
+
+## Candidate gates
+
+The candidate is not accepted until one exact final source revision passes:
+
+- `cargo fmt --all --check`;
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
+- `cargo test --locked --all-targets --all-features`;
+- the public CLI acceptance suite and Node harnesses;
+- `git diff --check`, installation-surface validation, archive README
+  validation, and the CI change-scope self-test;
+- four platform build and governance jobs plus the WSL2 governance smoke;
+- downloaded checksum verification and an external four-archive comparison
+  against the checked-in README Git blob.
+
+Candidate preparation does not create or push a tag, publish a GitHub Release,
+update Homebrew, or mutate an existing public release asset. Those operations
+remain separately evidenced after candidate acceptance.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -94,7 +94,7 @@ skillroster setup --json
 ```
 
 Published CLI v1.8.34 bundles Bootstrap content version 1.8.29.
-The source tree is **v1.8.34**.
+The source tree is **v1.8.35**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap
 instructions.

--- a/website/index.html
+++ b/website/index.html
@@ -1496,7 +1496,7 @@ footer { overflow: hidden; }
       </div>
     </div>
     <div class="footer-rule">
-      <span>SOURCE TREE v1.8.34 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
+      <span>SOURCE TREE v1.8.35 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
       <span>NO DAEMON · NO CLOUD · NO TELEMETRY</span>
     </div>
   </div>


### PR DESCRIPTION
## 解决什么问题

准备发布修复 #320 的 SkillRoster 1.8.35 候选，使 Setup Plan 对实际会安装或替换的逻辑 Agent 给出准确影响范围。

## 发布边界

- Cargo 包与 source-tree 标识更新为 1.8.35。
- 新增候选收据，绑定 #321 的 exact head、merge SHA、测试与复审证据。
- README、公开安装命令、Formula 与网站 current-release 仍保持已公开的 1.8.34；候选阶段不提前宣称 1.8.35 已发布。
- SQLite schema 12、JSON schema 1、Bootstrap content 1.8.29 均不变。

## 验证

- `bash scripts/ci-full-check.sh`：321 Rust unit + 8 acceptance + 98 CLI + 152 Node，通过。
- 安装面、archive README、change-scope self-test、严格 Clippy、格式和 `git diff --check`：通过。
- 独立 Spec review：Clean。
- 独立 Standards review：Clean。

后续 exact-main candidate workflow、tag、GitHub Release 和 Homebrew 更新仍分别验证。
