### PR TITLE
docs: record v1.8.35 release

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "188335ffe3eef570d403c344c954b366faaad0b5"
-  version "1.8.34"
+      revision: "8764f2d71a25697c77af5652616083b0f77ec6fc"
+  version "1.8.35"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.34", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.35", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.34 implements the complete local governance loop. Every
+Public release v1.8.35 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.34 release and platform evidence](docs/acceptance/release-v1.8.34-candidate.md)
+- [v1.8.35 release and platform evidence](docs/acceptance/release-v1.8.35-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.34 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.35 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.34 发布与平台证据](docs/acceptance/release-v1.8.34-candidate.md)
+- [v1.8.35 发布与平台证据](docs/acceptance/release-v1.8.35-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.35-candidate.md
+++ b/docs/acceptance/release-v1.8.35-candidate.md
@@ -1,61 +1,106 @@
-# SkillRoster v1.8.35 candidate
+# SkillRoster v1.8.35 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.35 makes Bootstrap Setup Plans report their real Agent impact.
 
-- `setup --json` and `plan --show` now include every logical Agent whose
-  Bootstrap target will actually be installed or replaced.
+- `setup --json` and `plan --show` include every logical Agent whose Bootstrap
+  target will actually be installed or replaced.
 - Agents that share one physical root remain distinct in the bounded impact
   summary, so deduplication cannot hide affected callers.
 - Already-current, unsupported, and retained-local targets are not counted as
   affected.
 - Complete Plans created by older versions with an incorrect zero-Agent
-  summary remain immutable, but Setup will not reuse them.
+  summary remain immutable, but Setup does not reuse them.
 
 This patch changes Setup Plan reporting and reuse identity only. SQLite remains
 at schema 12, the JSON envelope remains at schema 1, and bundled Bootstrap
 content remains at version 1.8.29. Setup is still preview-only until explicit
 Apply confirmation, and Apply/Undo remain Receipt-backed.
 
-## Preparation evidence
+## Source and review chain
 
-Candidate preparation starts from exact `origin/main` revision
-`3f2aadfc539c86d898bb8f6e7be21f4487e09648`, where
-[#321](https://github.com/tt-a1i/skillroster/pull/321) closed
-[#320](https://github.com/tt-a1i/skillroster/issues/320).
+[#321](https://github.com/tt-a1i/skillroster/pull/321) fixed
+[#320](https://github.com/tt-a1i/skillroster/issues/320) at exact head
+`3e259fdbec93c34160898a725f6ef8efae3d239b`. The public v1.8.34 binary first
+reproduced the defect with six detected and missing Agents, 25 planned
+filesystem operations, four physical targets, and an incorrect zero-Agent
+summary. The corrected source created a new Plan, reported all six logical
+Agents, and did not modify the Home fixture. Independent Spec and Standards
+reviews were Clean.
 
-The defect was reproduced first with the public v1.8.34 binary: six detected
-and missing Agents, 25 planned filesystem operations, and four physical targets
-were incorrectly summarized as zero affected Agents. The corrected source
-created a new Plan instead of reusing the old summary and reported all six
-logical Agents without modifying the Home fixture.
+[#322](https://github.com/tt-a1i/skillroster/pull/322) prepared version 1.8.35
+and merged as exact source revision
+`8764f2d71a25697c77af5652616083b0f77ec6fc`. Its exact-main candidate
+[run 33278766650](https://github.com/tt-a1i/skillroster/actions/runs/33278766650)
+passed the strict repository gate, Linux, Windows, both macOS architectures,
+and WSL2. All four downloaded candidate checksums passed, every archive README
+matched the checked-in Git blob, and the macOS arm64 binary reported 1.8.35 and
+passed the release-governance smoke.
 
-PR #321 passed change-scope, Linux x86_64, Windows x86_64, macOS arm64, macOS
-x86_64, and aggregate CI gates at exact head
-`3e259fdbec93c34160898a725f6ef8efae3d239b`. Its local full gate passed 321
-Rust unit tests, 8 acceptance tests, 98 CLI tests, and 152 Node harness tests.
-Independent Spec and Standards reviews were Clean.
-
-The source candidate and Cargo package are versioned as 1.8.35. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.34 until the v1.8.35 tag,
-artifacts, checksums, and Homebrew package actually exist.
-
-## Candidate gates
-
-The candidate is not accepted until one exact final source revision passes:
+The candidate gate included:
 
 - `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+- strict Clippy across all targets and features;
+- 321 Rust unit tests, 8 acceptance tests, 98 CLI tests, and 152 Node harness
+  tests;
+- installation-surface, archive-README, change-scope, and `git diff --check`
+  validation;
+- four platform build/governance jobs and the WSL2 governance smoke.
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+## Published release
+
+Annotated tag `v1.8.35` has tag object
+`834b936466cd027c89575310bdb5677147b08668` and resolves to exact source
+revision `8764f2d71a25697c77af5652616083b0f77ec6fc`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33279179458)
+repeated the strict gate and all supported-platform jobs successfully.
+
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.35)
+contains four archives and four adjacent checksum files:
+
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `ea08604862b35ee4dc323cff95c4e478bc8c007c79d3b93f5b47ffc2bc949e2c` |
+| `x86_64-apple-darwin` | `12bd2f32049794196e406ff61e8c3cf641c66a12d9554b5175d32f75dd87cf63` |
+| `x86_64-pc-windows-msvc` | `905efd7cc8131e828ce605202c716ff3fb4008b3de9203da1c27ee8d8f66a527` |
+| `x86_64-unknown-linux-gnu` | `3dbfa430c0ed475398d19b4ebdd9ee1cf349775aa91cec785fd4936441883a1c` |
+
+The public release asset inventory was read back and contained exactly those
+eight files. An anonymous macOS arm64 download passed its adjacent checksum,
+reported `skillroster 1.8.35`, passed the release-governance smoke, and
+contained the exact checked-in archive README bytes.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #9](https://github.com/tt-a1i/homebrew-skillroster/pull/9)
+at exact head `055807ec3c7311dadf7e61331862eedb0e85ff06`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33279788451)
+built and tested both macOS arm64 and Linux x86_64 bottles. The exact-head
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33280033423)
+published the bottles and advanced tap `main` to
+`cb5babe56475a818b3d2ecb52528b5b1caa62457`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `58924df4b2135196bdab0a1abb86ba73d927ad7ced87a11014918bb50d81dbfe` |
+| `x86_64_linux` | `039bfffeb6694068e6d27d4464202e642217004569a26f767cf87c349e5b909f` |
+
+The public arm64 bottle was downloaded without repository credentials, matched
+the Formula checksum, reported version 1.8.35, and passed the release-governance
+smoke. The local Homebrew installation was upgraded from 1.8.34 to 1.8.35 and
+passed the same checks using `/opt/homebrew/opt/skillroster/bin/skillroster`.
+
+The user's existing `~/.local/bin/skillroster` remains version 1.8.28 and
+precedes Homebrew on `PATH`. It was deliberately preserved: invoking
+`skillroster` by name in that shell still resolves to the user-owned older
+binary, while the verified Homebrew binary is available by its absolute path.
+
+## Boundaries
+
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent files, or change
+  the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.34**. Its Formula, annotated tag, four
+The current public release is **v1.8.35**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.34
+SKILLROSTER_VERSION=1.8.35
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.34 skillroster
+  --tag v1.8.35 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.34 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.35 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.35**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.34 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.35 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.34 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.35 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.34 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.34 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.35 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.35 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 结果

记录已完成的 SkillRoster v1.8.35 发布，并把所有公开入口从 v1.8.34 同步到 v1.8.35。

## 同步内容

- 中英文 README、安装文档与网站 current-release。
- 仓库内 Homebrew Formula 的 exact revision、version 与版本测试。
- v1.8.35 完整发布收据：修复/候选/tag/Release/Homebrew/本机安装证据。

## 已验证发布证据

- annotated tag `v1.8.35` → exact source `8764f2d71a25697c77af5652616083b0f77ec6fc`。
- exact-main candidate run 33278766650 与 tag run 33279179458：严格仓库门禁、四平台、WSL2 全绿。
- GitHub Release：8 个资产；4 个 archive checksum 与匿名 macOS arm64 readback 通过。
- Homebrew PR #9 exact head `055807e`：macOS/Linux test-bot 全绿；exact-head pr-pull 33280033423 发布两项 bottles。
- 本机 Homebrew 1.8.34 → 1.8.35，绝对路径二进制通过治理烟测；用户自有 PATH 前置 1.8.28 保留。
- 本提交 `bash scripts/ci-full-check.sh`：321 unit + 8 acceptance + 98 CLI + 152 Node，通过。
- 独立 Spec review：Clean。
- 独立 Standards review：Clean。
