### PR TITLE
fix: continue from a missing Snapshot

### DIFF
--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -356,7 +356,7 @@ pub fn error_json_with_context(
             .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into());
     }
     let classified = classify_error(error);
-    serde_json::to_string(&JsonEnvelope::<Value>::failure(
+    let mut envelope = JsonEnvelope::<Value>::failure(
         command,
         ApiError {
             code: classified.code.into(),
@@ -366,8 +366,18 @@ pub fn error_json_with_context(
             relevant_ids: extract_relevant_ids(&error.to_string()),
             paths: extract_paths(&error.to_string()),
         },
-    ))
-    .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into())
+    );
+    if classified.code == "snapshot_required" {
+        envelope.suggested_actions = vec![action(
+            "scan",
+            &["scan", "--summary", "--json"],
+            false,
+            false,
+            "snapshot_required",
+        )];
+        action_context.apply(&mut envelope.suggested_actions);
+    }
+    serde_json::to_string(&envelope).unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into())
 }
 
 struct ClassifiedError {
@@ -937,7 +947,7 @@ fn classify_generic_error(error: &(dyn std::error::Error + 'static)) -> (&'stati
         };
     }
     if message.contains("no completed snapshot") {
-        ("snapshot_required", false)
+        ("snapshot_required", true)
     } else if message.contains("recovery is required") {
         ("recovery_required", false)
     } else if message.contains("does not exist") {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5369,12 +5369,14 @@ fn agent_plan_refuses_arbitrary_skill_root_write_file() {
 #[test]
 fn json_failure_is_one_parseable_document() {
     let temp = TempDir::new().unwrap();
+    let home = temp.path();
+    let state = temp.path().join("state");
     let output = run(
         &[
             "--home",
-            temp.path().to_str().unwrap(),
+            home.to_str().unwrap(),
             "--state-dir",
-            temp.path().join("state").to_str().unwrap(),
+            state.to_str().unwrap(),
             "--json",
             "report",
         ],
@@ -5385,7 +5387,15 @@ fn json_failure_is_one_parseable_document() {
     assert_eq!(value["ok"], false);
     assert_eq!(value["command"], "report");
     assert_eq!(value["error"]["code"], "snapshot_required");
-    assert_eq!(value["error"]["retryable"], false);
+    assert_eq!(value["error"]["retryable"], true);
+    assert_eq!(
+        value["suggested_actions"][0]["argv"],
+        context_action_argv(home, &state, &["scan", "--summary", "--json"])
+    );
+    assert_eq!(
+        value["suggested_actions"][0]["reason_code"],
+        "snapshot_required"
+    );
     assert!(output.stderr.is_empty());
 
     let invalid = run(&["--json", "not-a-command"], None);


### PR DESCRIPTION
## 解决什么问题

Fresh state 上，`report --json` 和 `find --load ... --json` 返回 `snapshot_required`，但错误被标成不可重试且没有机器可执行续接。Agent 只能解析英文文案并重建 CLI 上下文，首用路径因此中断。

## 价值

缺失 Snapshot 是可通过只读 Scan 恢复的状态。现在 Agent 能沿同一个 executable、Home、state、root 和 source-root 边界继续，而不需要猜命令，也不会自动执行或扩大权限。

## 方法

- 保持稳定错误码 `snapshot_required`；
- 将其标记为 `retryable=true`；
- 返回唯一 `scan --summary --json` suggested action；
- 通过现有 `ActionContext` 绑定原调用上下文；
- 在进程级 CLI seam 增加回归断言。

## 验证

- `bash scripts/ci-full-check.sh`
  - Rust: 321 unit + 8 acceptance + 98 CLI
  - Node: 152
  - strict Clippy / fmt: pass
- 原始 public v1.8.35 repro：失败且无 action
- 修复后二进制 replay：失败仍 fail closed，返回可执行只读 Scan，执行后生成 20-Skill Snapshot
- 双轴独立复审：no findings
- `git diff --check`

Fixes #324