### PR TITLE
fix: revoke source-root Snapshot authority

### DIFF
--- a/docs/agent-experience-spec.md
+++ b/docs/agent-experience-spec.md
@@ -358,7 +358,10 @@ action without adding the confirmed path as `--source-root`. Alternatively, it
 can skip durable confirmation and use temporary `--source-root` flags for one
 Scan. These paths are never combined. Neither decision endorses content or
 authorizes a Plan; unconfirmed, revoked, or identity-drifted sources remain
-excluded. Drift detection
+excluded. A revoke or persistent identity drift invalidates any latest
+Snapshot that relied on that durable permission: Home and `status` return
+`rescan_required`, and current-Snapshot commands expose a typed Scan
+continuation without returning external Skill content. Drift detection
 uses bounded identity and entrypoint-binding checks around discovery and
 content consumption; it detects accidental or persistent changes, not a
 malicious same-user ABA race completed entirely between checkpoints.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -269,6 +269,11 @@ entirely between checkpoints; descriptor/handle-bound traversal is tracked as
 separate security hardening. The persisted object epoch is conservative:
 platform metadata changes that could indicate object reuse may require an
 explicit revoke and reconfirm rather than silently retaining read access.
+Revoking a permission used by the latest Snapshot, or observing persistent
+identity drift after that Scan, immediately makes the Snapshot
+`rescan_required`. Current-Snapshot commands fail closed with the affected
+permission IDs and a typed Scan continuation; an old `find --load` may not use
+the Snapshot as continuing read authority.
 
 The escaping-link Finding keeps legacy resolution fields for schema
 compatibility and adds the canonical `decision_code` plus two explicitly

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,11 +38,13 @@ mod error;
 use error::{
     ContentIdentityRescanRequired, FindSnapshotChanged, LibraryRootConflict,
     MAX_AGENT_LOADED_SKILL_BYTES, PlanEvidenceScopeMismatch, PlanSnapshotDrift, SkillLoadBlocked,
-    SnapshotRescanRequired, StoredFindingCoverageInvalid, incomplete_fingerprint_blocker,
+    SnapshotRescanRequired, SourceRootSnapshotRescanRequired, StoredFindingCoverageInvalid,
+    incomplete_fingerprint_blocker,
 };
 pub use error::{error_json, error_json_with_context};
 
 const STATUS_PENDING_PLAN_LIMIT: usize = 20;
+const SOURCE_ROOT_INVALIDATION_PREVIEW_LIMIT: usize = 10;
 const MUTATION_CHANGED_PATH_PREVIEW_LIMIT: usize = 10;
 const SETUP_PLAN_SUMMARY_FIELDS: &[&str] = &[
     "snapshot_id",
@@ -736,6 +738,8 @@ struct ReadinessDecision {
     snapshot_state: SnapshotState,
     latest_snapshot: Option<ScanRun>,
     invalidating_receipt_id: Option<ReceiptId>,
+    invalidating_source_root_permission_ids: Vec<String>,
+    frozen_source_roots: Option<Vec<crate::source_policy::FrozenSourceRoot>>,
     pending_plan_count: usize,
     pending_plans: Vec<PlanRecord>,
     recovery_required: bool,
@@ -753,9 +757,22 @@ fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessD
     let invalidating_receipt_id = invalidation
         .as_ref()
         .map(|invalidation| invalidation.receipt_id.clone());
+    let (invalidating_source_root_permission_ids, frozen_source_roots) =
+        if let Some(scan_id) = latest_scan_id {
+            let scan = store.scan_payload::<ScanResult>(scan_id)?;
+            if let Some(scan) = scan.as_ref() {
+                snapshot_source_root_invalidations(store, scan)?
+            } else {
+                (Vec::new(), None)
+            }
+        } else {
+            (Vec::new(), None)
+        };
     let snapshot_state = if latest_scan_id.is_none() {
         SnapshotState::Missing
-    } else if invalidating_receipt_id.is_some() {
+    } else if invalidating_receipt_id.is_some()
+        || !invalidating_source_root_permission_ids.is_empty()
+    {
         SnapshotState::RescanRequired
     } else {
         SnapshotState::Current
@@ -795,6 +812,11 @@ fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessD
             actions.push(receipt_undo_action(invalidation.receipt_id.as_str()));
         }
         (ReadinessState::RescanRequired, actions)
+    } else if !invalidating_source_root_permission_ids.is_empty() {
+        (
+            ReadinessState::RescanRequired,
+            vec![source_root_snapshot_rescan_action()],
+        )
     } else if let Some(plan) = pending_plans.first() {
         (
             ReadinessState::PlanReady,
@@ -820,6 +842,8 @@ fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessD
         snapshot_state,
         latest_snapshot,
         invalidating_receipt_id,
+        invalidating_source_root_permission_ids,
+        frozen_source_roots,
         pending_plan_count,
         pending_plans,
         recovery_required,
@@ -829,11 +853,19 @@ fn readiness_decision(store: &StateStore, state_dir: &Path) -> Result<ReadinessD
 }
 
 fn home_result(readiness: &ReadinessDecision) -> Value {
+    let source_root_permission_ids = readiness
+        .invalidating_source_root_permission_ids
+        .iter()
+        .take(SOURCE_ROOT_INVALIDATION_PREVIEW_LIMIT)
+        .collect::<Vec<_>>();
     json!({
         "state": readiness.state.as_str(),
         "snapshot_state": readiness.snapshot_state.as_str(),
         "latest_snapshot_id": readiness.latest_snapshot.as_ref().map(|scan| scan.id.to_string()),
         "snapshot_invalidated_by_receipt_id": &readiness.invalidating_receipt_id,
+        "snapshot_invalidated_by_source_root_permission_ids": source_root_permission_ids,
+        "snapshot_invalidated_by_source_root_permission_count": readiness.invalidating_source_root_permission_ids.len(),
+        "snapshot_invalidated_by_source_root_permission_ids_truncated": readiness.invalidating_source_root_permission_ids.len() > SOURCE_ROOT_INVALIDATION_PREVIEW_LIMIT,
         "pending_plan_count": readiness.pending_plan_count,
         "recovery_state": if readiness.recovery_required { "required" } else { "clear" },
         "files_changed": false
@@ -846,6 +878,11 @@ fn status_result(
     state_dir: &Path,
     readiness: &ReadinessDecision,
 ) -> Result<Value> {
+    let source_root_permission_ids = readiness
+        .invalidating_source_root_permission_ids
+        .iter()
+        .take(SOURCE_ROOT_INVALIDATION_PREVIEW_LIMIT)
+        .collect::<Vec<_>>();
     let pending_plans = readiness
         .pending_plans
         .iter()
@@ -867,6 +904,11 @@ fn status_result(
         })
     });
     let lifecycle = store.lifecycle_counts()?;
+    let source_root_permissions = if let Some(frozen) = readiness.frozen_source_roots.as_deref() {
+        crate::source_policy::policy_value_from_frozen(store, frozen, 100, 0)?
+    } else {
+        crate::source_policy::policy_value(store, true, 100, 0)?
+    };
     Ok(json!({
         "state": readiness.state.as_str(),
         "database_path": database_path,
@@ -875,6 +917,9 @@ fn status_result(
         "latest_snapshot_at": readiness.latest_snapshot.as_ref().and_then(|scan| scan.completed_at),
         "snapshot_state": readiness.snapshot_state.as_str(),
         "snapshot_invalidated_by_receipt_id": &readiness.invalidating_receipt_id,
+        "snapshot_invalidated_by_source_root_permission_ids": source_root_permission_ids,
+        "snapshot_invalidated_by_source_root_permission_count": readiness.invalidating_source_root_permission_ids.len(),
+        "snapshot_invalidated_by_source_root_permission_ids_truncated": readiness.invalidating_source_root_permission_ids.len() > SOURCE_ROOT_INVALIDATION_PREVIEW_LIMIT,
         "pending_plan_count": readiness.pending_plan_count,
         "pending_plans_returned": pending_plans.len(),
         "pending_plans_truncated": readiness.pending_plan_count > pending_plans.len(),
@@ -889,7 +934,7 @@ fn status_result(
             "source_confirmation_details": source_confirmation_detail_summary(state_dir)?,
             "current": lifecycle,
         },
-        "source_root_permissions": crate::source_policy::policy_value(store, true, 100, 0)?,
+        "source_root_permissions": source_root_permissions,
         "files_changed": false
     }))
 }
@@ -5209,6 +5254,11 @@ fn find_command(
     if let Some(loaded_skill) = loaded_skill {
         result["loaded_skill"] = loaded_skill;
     }
+    // Find derives current paths and may load content after its initial
+    // Snapshot check. Re-freeze durable permissions before returning so a
+    // persistent revoke or filesystem-identity drift observed during the read
+    // discards those derived facts instead of returning them as authorized.
+    require_loaded_snapshot_current(store, &scan_id, &scan)?;
     Ok((result, actions))
 }
 
@@ -8426,7 +8476,7 @@ fn setup_command_with_manifests<'a>(
             "next": "skillroster scan --summary --json"
         }));
     };
-    require_snapshot_current(store, &snapshot_id)?;
+    require_loaded_snapshot_current(store, &snapshot_id, &snapshot)?;
     let current_package = current_bootstrap_package();
     let mut detected = Vec::new();
     let mut targets = Vec::new();
@@ -9509,12 +9559,15 @@ fn latest_scan(store: &StateStore) -> Result<(ScanId, ScanResult)> {
     let scan = store
         .latest_scan_payload()?
         .ok_or_else(|| anyhow!("no completed Snapshot; run skillroster scan first"))?;
-    require_snapshot_current(store, &scan.0)?;
+    require_loaded_snapshot_current(store, &scan.0, &scan.1)?;
     Ok(scan)
 }
 
 fn require_snapshot_current(store: &StateStore, scan_id: &ScanId) -> Result<()> {
-    if let Some(invalidation) = store.snapshot_invalidating_receipt(scan_id)? {
+    let scan = store.scan_payload::<ScanResult>(scan_id)?;
+    if let Some(scan) = scan.as_ref() {
+        require_loaded_snapshot_current(store, scan_id, scan)?;
+    } else if let Some(invalidation) = store.snapshot_invalidating_receipt(scan_id)? {
         return Err(SnapshotRescanRequired {
             snapshot_id: scan_id.clone(),
             receipt_id: invalidation.receipt_id,
@@ -9522,6 +9575,91 @@ fn require_snapshot_current(store: &StateStore, scan_id: &ScanId) -> Result<()> 
         .into());
     }
     Ok(())
+}
+
+fn require_loaded_snapshot_current(
+    store: &StateStore,
+    scan_id: &ScanId,
+    scan: &ScanResult,
+) -> Result<()> {
+    if let Some(invalidation) = store.snapshot_invalidating_receipt(scan_id)? {
+        return Err(SnapshotRescanRequired {
+            snapshot_id: scan_id.clone(),
+            receipt_id: invalidation.receipt_id,
+        }
+        .into());
+    }
+    let (permission_ids, _) = snapshot_source_root_invalidations(store, scan)?;
+    if !permission_ids.is_empty() {
+        return Err(SourceRootSnapshotRescanRequired {
+            snapshot_id: scan_id.clone(),
+            permission_ids,
+        }
+        .into());
+    }
+    Ok(())
+}
+
+fn snapshot_source_root_invalidations(
+    store: &StateStore,
+    scan: &ScanResult,
+) -> Result<(
+    Vec<String>,
+    Option<Vec<crate::source_policy::FrozenSourceRoot>>,
+)> {
+    let inferred_permission_ids;
+    let used_permission_ids =
+        if let Some(permission_ids) = scan.durable_read_used_permission_ids.as_ref() {
+            permission_ids
+        } else {
+            inferred_permission_ids = legacy_used_source_root_permission_ids(scan);
+            &inferred_permission_ids
+        };
+    let snapshot_permissions = scan
+        .source_root_policy
+        .iter()
+        .filter(|fact| fact.state == crate::source_policy::SourceRootState::Active)
+        .filter(|fact| used_permission_ids.contains(&fact.permission_id))
+        .collect::<Vec<_>>();
+    if snapshot_permissions.is_empty() {
+        return Ok((Vec::new(), None));
+    }
+    let current = crate::source_policy::freeze_active_roots(store)?;
+    let mut invalidated = snapshot_permissions
+        .into_iter()
+        .filter(|fact| {
+            !current.iter().any(|root| {
+                root.permission.id.as_str() == fact.permission_id
+                    && root.permission.path == fact.granted_path
+                    && root.permission.granted_at == fact.granted_at
+                    && root.state == crate::source_policy::SourceRootState::Active
+                    && root.resolved_path == fact.resolved_path
+            })
+        })
+        .map(|fact| fact.permission_id.clone())
+        .collect::<Vec<_>>();
+    invalidated.sort();
+    invalidated.dedup();
+    Ok((invalidated, Some(current)))
+}
+
+fn legacy_used_source_root_permission_ids(scan: &ScanResult) -> BTreeSet<String> {
+    scan.source_root_policy
+        .iter()
+        .filter(|fact| fact.state == crate::source_policy::SourceRootState::Active)
+        .filter(|fact| {
+            let root = fact.resolved_path.as_deref().unwrap_or(&fact.granted_path);
+            scan.placements.iter().any(|placement| {
+                placement.mutation_scope == Some(scan::MutationScope::DurableReadOnly)
+                    && placement
+                        .physical_directory
+                        .as_deref()
+                        .or(placement.link_target.as_deref())
+                        .is_some_and(|directory| directory.starts_with(root))
+            })
+        })
+        .map(|fact| fact.permission_id.clone())
+        .collect()
 }
 
 fn require_content_identity(scan: &ScanResult) -> Result<()> {
@@ -9894,6 +10032,16 @@ fn snapshot_rescan_action() -> SuggestedAction {
         false,
         false,
         "verified_mutation_requires_rescan",
+    )
+}
+
+fn source_root_snapshot_rescan_action() -> SuggestedAction {
+    action(
+        "scan",
+        &["scan", "--summary", "--json"],
+        false,
+        false,
+        "source_root_permission_changed_requires_rescan",
     )
 }
 

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -2,7 +2,10 @@ use std::path::PathBuf;
 
 use serde_json::{Value, json};
 
-use super::{action, physical_identity_rescan_action, snapshot_rescan_action};
+use super::{
+    action, physical_identity_rescan_action, snapshot_rescan_action,
+    source_root_snapshot_rescan_action,
+};
 use crate::action_context::ActionContext;
 use crate::model::{ApiError, FindingId, JsonEnvelope, PlanId, ReceiptId, ScanId};
 use crate::scan;
@@ -94,6 +97,25 @@ impl std::fmt::Display for SnapshotRescanRequired {
 }
 
 impl std::error::Error for SnapshotRescanRequired {}
+
+#[derive(Debug)]
+pub(super) struct SourceRootSnapshotRescanRequired {
+    pub(super) snapshot_id: ScanId,
+    pub(super) permission_ids: Vec<String>,
+}
+
+impl std::fmt::Display for SourceRootSnapshotRescanRequired {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Snapshot {} relied on {} source-root permission(s) that are no longer active; run skillroster scan --summary --json before using current inventory facts",
+            self.snapshot_id,
+            self.permission_ids.len()
+        )
+    }
+}
+
+impl std::error::Error for SourceRootSnapshotRescanRequired {}
 
 #[derive(Debug)]
 pub(super) struct PlanEvidenceScopeMismatch {
@@ -204,6 +226,41 @@ pub fn error_json_with_context(
             },
         );
         envelope.suggested_actions = vec![snapshot_rescan_action()];
+        action_context.apply(&mut envelope.suggested_actions);
+        return serde_json::to_string(&envelope)
+            .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into());
+    }
+    if let Some(required) = error.downcast_ref::<SourceRootSnapshotRescanRequired>() {
+        const PREVIEW_LIMIT: usize = 10;
+        let permission_ids = required
+            .permission_ids
+            .iter()
+            .take(PREVIEW_LIMIT)
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut relevant_ids = vec![required.snapshot_id.to_string()];
+        relevant_ids.extend(permission_ids.iter().cloned());
+        let mut envelope = JsonEnvelope::<Value>::failure(
+            command,
+            ApiError {
+                code: "source_root_snapshot_rescan_required".into(),
+                message: error.to_string(),
+                retryable: true,
+                relevant_ids,
+                paths: Vec::new(),
+                details: Some(json!({
+                    "reason": "source_root_permission_no_longer_active",
+                    "snapshot_id": required.snapshot_id,
+                    "permission_ids": permission_ids,
+                    "permission_count": required.permission_ids.len(),
+                    "permission_ids_truncated": required.permission_ids.len() > PREVIEW_LIMIT,
+                    "files_changed": false,
+                    "state_files_changed": false,
+                    "next_action": "scan"
+                })),
+            },
+        );
+        envelope.suggested_actions = vec![source_root_snapshot_rescan_action()];
         action_context.apply(&mut envelope.suggested_actions);
         return serde_json::to_string(&envelope)
             .unwrap_or_else(|_| r#"{"schema_version":1,"ok":false}"#.into());

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -494,6 +494,12 @@ pub struct ScanResult {
     /// drift, even if a later path check appears active again.
     #[serde(default)]
     pub durable_read_drifted_permission_ids: BTreeSet<String>,
+    /// Durable permissions that actually authorized at least one completely
+    /// observed Skill placement in this Snapshot. `None` identifies payloads
+    /// written before this dependency fact existed; readers infer those
+    /// conservatively from the retained placement authority.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durable_read_used_permission_ids: Option<BTreeSet<String>>,
 }
 
 impl ScanResult {
@@ -972,6 +978,7 @@ pub fn scan(options: &ScanOptions) -> io::Result<ScanResult> {
     let mut result = ScanResult {
         content_identity_algorithm: Some(CONTENT_IDENTITY_ALGORITHM.into()),
         identity_path_coverage: IdentityPathCoverage::Complete,
+        durable_read_used_permission_ids: Some(BTreeSet::new()),
         ..ScanResult::default()
     };
     let known = known_agent_roots(&options.home);
@@ -2068,6 +2075,14 @@ fn materialize_candidates_with_hook(
         } else {
             MutationScope::Mutable
         };
+        if safe_to_read && mutation_scope == MutationScope::DurableReadOnly {
+            if let Some(root) = durable_anchor {
+                result
+                    .durable_read_used_permission_ids
+                    .get_or_insert_default()
+                    .insert(root.permission_id.clone());
+            }
+        }
         result.placements.push(SkillPlacement {
             id: format!("placement_{}", stable_digest(placement_basis.as_bytes())),
             skill_id,

--- a/src/source_policy.rs
+++ b/src/source_policy.rs
@@ -673,28 +673,39 @@ pub fn policy_value(
     limit: usize,
     offset: usize,
 ) -> StorageResult<Value> {
-    policy_value_with_page(store, with_current_state, Some((limit, offset)))
-}
-
-/// Complete local export view. This is written to the user-selected lifecycle
-/// export file rather than returned inline in the Agent JSON envelope.
-pub fn policy_export_value(store: &StateStore) -> StorageResult<Value> {
-    policy_value_with_page(store, false, None)
-}
-
-fn policy_value_with_page(
-    store: &StateStore,
-    with_current_state: bool,
-    page: Option<(usize, usize)>,
-) -> StorageResult<Value> {
-    let permissions = inspect_permissions(store)?;
     let frozen = if with_current_state {
         Some(freeze_active_roots(store)?)
     } else {
         None
     };
+    policy_value_with_page(store, frozen.as_deref(), Some((limit, offset)))
+}
+
+/// Build the same bounded policy view from roots already frozen by readiness
+/// validation. Status uses this to avoid a second filesystem walk while it
+/// holds the shared state lock.
+pub fn policy_value_from_frozen(
+    store: &StateStore,
+    frozen: &[FrozenSourceRoot],
+    limit: usize,
+    offset: usize,
+) -> StorageResult<Value> {
+    policy_value_with_page(store, Some(frozen), Some((limit, offset)))
+}
+
+/// Complete local export view. This is written to the user-selected lifecycle
+/// export file rather than returned inline in the Agent JSON envelope.
+pub fn policy_export_value(store: &StateStore) -> StorageResult<Value> {
+    policy_value_with_page(store, None, None)
+}
+
+fn policy_value_with_page(
+    store: &StateStore,
+    frozen: Option<&[FrozenSourceRoot]>,
+    page: Option<(usize, usize)>,
+) -> StorageResult<Value> {
+    let permissions = inspect_permissions(store)?;
     let frozen_by_id = frozen
-        .as_ref()
         .map(|frozen| {
             frozen
                 .iter()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11054,6 +11054,29 @@ fn escaping_link_resolution_separates_durable_and_temporary_read_paths() {
         0
     );
     let temporary_snapshot = temporary_scan["result"]["snapshot_id"].as_str().unwrap();
+    let temporary_status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(temporary_status["result"]["snapshot_state"], "current");
+    assert_eq!(temporary_status["result"]["state"], "report_required");
+    let temporary_load = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "external-0 fixture",
+                "--require-snapshot",
+                temporary_snapshot,
+                "--load",
+                "--limit",
+                "1",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(
+        temporary_load["result"]["loaded_skill"]["selection"]["name"],
+        "external-0"
+    );
     let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
     let load_payload = |snapshot| {
         database
@@ -11597,6 +11620,400 @@ fn escaping_link_finding_requests_exact_read_permission_instead_of_a_plan() {
             .unwrap()
             .iter()
             .any(|finding| finding["title"] == "Skill links escape an approved root")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn revoked_durable_source_root_invalidates_snapshot_reads_immediately() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    let source = temp.path().join("trusted-source");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(&source).unwrap();
+    fs::write(
+        source.join("SKILL.md"),
+        "---\nname: revocable-external\ndescription: revocation boundary fixture\n---\nprivate revocation boundary content\n",
+    )
+    .unwrap();
+    let source = fs::canonicalize(source).unwrap();
+    std::os::unix::fs::symlink(&source, root.join("revocable-external")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let report = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Skill links escape an approved root")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let detail = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "--source-root",
+                source.to_str().unwrap(),
+                "report",
+                "--finding",
+                finding_id,
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let confirm = detail["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|action| action["action"] == "confirm_source_root_read_permission")
+        .unwrap();
+    let confirmed = json_output(&run_suggested_action(confirm));
+    let permission_id = confirmed["result"]["permission"]["permission_id"]
+        .as_str()
+        .unwrap();
+
+    let rescanned = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let snapshot_id = rescanned["result"]["snapshot_id"].as_str().unwrap();
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let payload: String = database
+        .query_row(
+            "SELECT payload_json FROM scan_payloads WHERE scan_id = ?1",
+            [snapshot_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut legacy_payload: Value = serde_json::from_str(&payload).unwrap();
+    assert!(
+        legacy_payload
+            .as_object_mut()
+            .unwrap()
+            .remove("durable_read_used_permission_ids")
+            .is_some()
+    );
+    database
+        .execute(
+            "UPDATE scan_payloads SET payload_json = ?1 WHERE scan_id = ?2",
+            [legacy_payload.to_string(), snapshot_id.to_owned()],
+        )
+        .unwrap();
+    drop(database);
+    let load_args = [
+        "find",
+        "revocation boundary",
+        "--require-snapshot",
+        snapshot_id,
+        "--load",
+        "--limit",
+        "1",
+    ];
+    let loaded = json_output(&run(&[&common[..], &load_args].concat(), None));
+    assert_eq!(
+        loaded["result"]["loaded_skill"]["selection"]["name"],
+        "revocable-external"
+    );
+
+    json_output(&run(
+        &[&common[..], &["source-root", "revoke", permission_id]].concat(),
+        None,
+    ));
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["state"], "rescan_required");
+    assert_eq!(status["result"]["snapshot_state"], "rescan_required");
+    assert_eq!(
+        status["result"]["snapshot_invalidated_by_source_root_permission_ids"],
+        json!([permission_id])
+    );
+    assert!(
+        status["suggested_actions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|action| action["action"] == "scan"
+                && action["reason_code"] == "source_root_permission_changed_requires_rescan")
+    );
+
+    let stale_load = run(&[&common[..], &load_args].concat(), None);
+    assert!(!stale_load.status.success());
+    let stale_stdout = stale_load.stdout;
+    let stale_load: Value = serde_json::from_slice(&stale_stdout).unwrap();
+    assert_eq!(
+        stale_load["error"]["code"],
+        "source_root_snapshot_rescan_required"
+    );
+    assert_eq!(
+        stale_load["error"]["details"]["reason"],
+        "source_root_permission_no_longer_active"
+    );
+    assert_eq!(
+        stale_load["error"]["details"]["permission_ids"],
+        json!([permission_id])
+    );
+    assert_eq!(stale_load["error"]["retryable"], true);
+    assert_eq!(stale_load["error"]["details"]["permission_count"], 1);
+    assert_eq!(
+        stale_load["error"]["details"]["permission_ids_truncated"],
+        false
+    );
+    assert_eq!(stale_load["error"]["details"]["files_changed"], false);
+    assert_eq!(stale_load["error"]["details"]["state_files_changed"], false);
+    assert_eq!(stale_load["error"]["details"]["snapshot_id"], snapshot_id);
+    let scan_action = &stale_load["suggested_actions"][0];
+    assert_eq!(scan_action["action"], "scan");
+    assert_eq!(scan_action["mutates"], false);
+    assert_eq!(scan_action["requires_confirmation"], false);
+    let scan_argv = scan_action["argv"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|arg| arg.as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(scan_argv[0], env!("CARGO_BIN_EXE_skillroster"));
+    assert!(
+        scan_argv
+            .windows(2)
+            .any(|pair| pair == ["--home", home.to_str().unwrap()])
+    );
+    assert!(
+        scan_argv
+            .windows(2)
+            .any(|pair| pair == ["--state-dir", state.to_str().unwrap()])
+    );
+    assert!(
+        scan_argv
+            .windows(2)
+            .any(|pair| pair == ["scan", "--summary"])
+    );
+    assert!(
+        !String::from_utf8_lossy(&stale_stdout).contains("private revocation boundary content")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn durable_source_root_identity_drift_invalidates_snapshot_reads_immediately() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    let source = temp.path().join("trusted-source");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(&source).unwrap();
+    let skill_content = "---\nname: driftable-external\ndescription: identity drift boundary fixture\n---\nidentity drift private content\n";
+    fs::write(source.join("SKILL.md"), skill_content).unwrap();
+    let source = fs::canonicalize(source).unwrap();
+    std::os::unix::fs::symlink(&source, root.join("driftable-external")).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let report = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Skill links escape an approved root")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let detail = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "--source-root",
+                source.to_str().unwrap(),
+                "report",
+                "--finding",
+                finding_id,
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let confirm = detail["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|action| action["action"] == "confirm_source_root_read_permission")
+        .unwrap();
+    let confirmed = json_output(&run_suggested_action(confirm));
+    let permission_id = confirmed["result"]["permission"]["permission_id"]
+        .as_str()
+        .unwrap();
+    let rescanned = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let snapshot_id = rescanned["result"]["snapshot_id"].as_str().unwrap();
+
+    let original = temp.path().join("original-source");
+    fs::rename(&source, &original).unwrap();
+    fs::create_dir(&source).unwrap();
+    fs::write(source.join("SKILL.md"), skill_content).unwrap();
+
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["state"], "rescan_required");
+    assert_eq!(status["result"]["snapshot_state"], "rescan_required");
+    assert_eq!(
+        status["result"]["snapshot_invalidated_by_source_root_permission_ids"],
+        json!([permission_id])
+    );
+    let stale_load = run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "identity drift boundary",
+                "--require-snapshot",
+                snapshot_id,
+                "--load",
+                "--limit",
+                "1",
+            ],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!stale_load.status.success());
+    assert!(
+        !String::from_utf8_lossy(&stale_load.stdout).contains("identity drift private content")
+    );
+    let stale_load: Value = serde_json::from_slice(&stale_load.stdout).unwrap();
+    assert_eq!(
+        stale_load["error"]["code"],
+        "source_root_snapshot_rescan_required"
+    );
+    assert_eq!(
+        stale_load["error"]["details"]["permission_ids"],
+        json!([permission_id])
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn revoking_an_unused_source_root_does_not_invalidate_the_snapshot() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let root = home.join(".codex/skills");
+    let source = temp.path().join("trusted-source");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(source.join("nested")).unwrap();
+    fs::write(
+        source.join("nested/SKILL.md"),
+        "---\nname: unused-external\ndescription: unused permission fixture\n---\n",
+    )
+    .unwrap();
+    let source = fs::canonicalize(source).unwrap();
+    let linked = root.join("unused-external");
+    std::os::unix::fs::symlink(&source, &linked).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let report = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    let finding_id = report["result"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["title"] == "Skill links escape an approved root")
+        .unwrap()["id"]
+        .as_str()
+        .unwrap();
+    let detail = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "--source-root",
+                source.to_str().unwrap(),
+                "report",
+                "--finding",
+                finding_id,
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let confirm = detail["suggested_actions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|action| action["action"] == "confirm_source_root_read_permission")
+        .unwrap();
+    let confirmed = json_output(&run_suggested_action(confirm));
+    let permission_id = confirmed["result"]["permission"]["permission_id"]
+        .as_str()
+        .unwrap();
+
+    fs::remove_file(linked).unwrap();
+    fs::remove_file(source.join("nested/SKILL.md")).unwrap();
+    let rescanned = json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    assert_eq!(rescanned["result"]["skill_count"], 0);
+    assert_eq!(
+        rescanned["result"]["source_root_policy"]["permissions"][0]["state"],
+        "active"
+    );
+    let snapshot_id = rescanned["result"]["snapshot_id"].as_str().unwrap();
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let payload: String = database
+        .query_row(
+            "SELECT payload_json FROM scan_payloads WHERE scan_id = ?1",
+            [snapshot_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut legacy_payload: Value = serde_json::from_str(&payload).unwrap();
+    assert!(
+        legacy_payload
+            .as_object_mut()
+            .unwrap()
+            .remove("durable_read_used_permission_ids")
+            .is_some()
+    );
+    database
+        .execute(
+            "UPDATE scan_payloads SET payload_json = ?1 WHERE scan_id = ?2",
+            [legacy_payload.to_string(), snapshot_id.to_owned()],
+        )
+        .unwrap();
+    drop(database);
+    json_output(&run(
+        &[&common[..], &["source-root", "revoke", permission_id]].concat(),
+        None,
+    ));
+
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["snapshot_state"], "current");
+    assert_eq!(status["result"]["state"], "report_required");
+    assert_eq!(
+        status["result"]["snapshot_invalidated_by_source_root_permission_ids"],
+        json!([])
     );
 }
 


### PR DESCRIPTION
## 解决什么问题

撤销 durable source-root 权限后，旧 Snapshot 仍被视为 current，`find --require-snapshot <old> --load` 可以继续读取原外部 `SKILL.md`，直到用户手动重新 Scan。持久身份漂移也有同样的窗口。

## 价值

让“撤销”立即生效：Snapshot 不再是一张无限期读票据。Agent 会得到可恢复的 typed Scan continuation，而不是在权限已撤销或根目录已替换后继续消费外部内容。

## 方法

- Snapshot 记录实际授权过读取的 durable permission IDs。
- readiness 与所有 current-Snapshot 入口复核当前 permission 生命周期和根身份。
- Find 在返回已加载内容前再做一次 bounded live check。
- Home/status 输出有界的 invalidating permission IDs 与精确计数。
- 新旧 Snapshot 都兼容；旧 payload 从 retained durable-read placements 保守推断。
- temporary one-Scan `--source-root` 不受 durable permission 生命周期误伤。

## 验证

- `bash scripts/ci-full-check.sh`
  - Rust unit 321/321
  - acceptance 8/8
  - CLI 101/101
  - Node 152/152
  - strict Clippy / fmt 通过
- 原始 dogfood fixture 重放：status=rescan_required；旧 Snapshot find --load 退出 1 且不返回外部内容。
- 两路独立复审最终均 No findings。

Closes #326