### PR TITLE
docs: record v1.8.36 release

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "8764f2d71a25697c77af5652616083b0f77ec6fc"
-  version "1.8.35"
+      revision: "9a5fce3e57ef59fad7b2ccd4f5ff1242e0105846"
+  version "1.8.36"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.35", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.36", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.35 implements the complete local governance loop. Every
+Public release v1.8.36 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.35 release and platform evidence](docs/acceptance/release-v1.8.35-candidate.md)
+- [v1.8.36 release and platform evidence](docs/acceptance/release-v1.8.36-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.35 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.36 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.35 发布与平台证据](docs/acceptance/release-v1.8.35-candidate.md)
+- [v1.8.36 发布与平台证据](docs/acceptance/release-v1.8.36-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.36-candidate.md
+++ b/docs/acceptance/release-v1.8.36-candidate.md
@@ -1,12 +1,12 @@
-# SkillRoster v1.8.36 candidate
+# SkillRoster v1.8.36 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.36 closes two Agent continuation and local-read authority gaps.
 
-- Commands that require a first Snapshot now fail with the stable
+- Commands that require a first Snapshot fail with the stable
   `snapshot_required` error plus one context-bound, read-only
-  `scan --summary --json` continuation. The Agent no longer has to reconstruct
+  `scan --summary --json` continuation. The Agent does not have to reconstruct
   Home, state, explicit roots, source roots, or the running executable.
 - Revoking a durable source-root permission immediately invalidates a current
   Snapshot that used it. Persistent root identity drift has the same effect.
@@ -21,15 +21,12 @@ SkillRoster 1.8.36 closes two Agent continuation and local-read authority gaps.
   inference from retained durable-read Placements; unused permissions and
   temporary one-Scan `--source-root` overrides do not cause false invalidation.
 
-This patch changes Agent continuation metadata, Snapshot read-authority facts,
-and readiness validation. SQLite remains at schema 12, the JSON envelope remains
-at schema 1, and bundled Bootstrap content remains at version 1.8.29. No Agent
-or Skill files are changed by these checks.
+This release changes Agent continuation metadata, Snapshot read-authority
+facts, and readiness validation. SQLite remains at schema 12, the JSON envelope
+remains at schema 1, and bundled Bootstrap content remains at version 1.8.29.
+No Agent or Skill files are changed by these checks.
 
-## Preparation evidence
-
-Candidate preparation starts from exact `origin/main` revision
-`082fbcead88eb8166c50312c6635f18075af5df4`.
+## Source and review chain
 
 [#325](https://github.com/tt-a1i/skillroster/pull/325) fixed the fresh-state
 continuation at exact head `aae16d40188b49413226d29c231a37c186635b87`
@@ -37,40 +34,94 @@ and merged as `6420b38dd7df1c59ee09f39af69c8e25e4d00809`.
 
 [#327](https://github.com/tt-a1i/skillroster/pull/327) fixed source-root
 Snapshot authority at exact head
-`631ca74b0cbbe526659e17ef034d49ebb82eeadc` and merged as the candidate base.
-The original dogfood fixture reproduced a successful old-Snapshot
-`find --load` after revoke; the corrected binary returned
-`source_root_snapshot_rescan_required`, reported `rescan_required`, and did not
-return the external Skill content. Independent Spec/Safety and
-Standards/Compatibility reviews were Clean after their findings were fixed.
+`631ca74b0cbbe526659e17ef034d49ebb82eeadc` and merged as
+`082fbcead88eb8166c50312c6635f18075af5df4`. The original dogfood fixture
+reproduced a successful old-Snapshot `find --load` after revoke; the corrected
+binary returned `source_root_snapshot_rescan_required`, reported
+`rescan_required`, and did not return the external Skill content. Independent
+Spec/Safety and Standards/Compatibility reviews were Clean after their
+findings were fixed.
 
-The exact-main post-merge
-[CI run 33282916200](https://github.com/tt-a1i/skillroster/actions/runs/33282916200)
+[#328](https://github.com/tt-a1i/skillroster/pull/328) prepared version 1.8.36
+at exact head `e64f39d245b7295fd068428b58feffee0d1ba87c` and merged as exact
+release source revision `9a5fce3e57ef59fad7b2ccd4f5ff1242e0105846`.
+The PR [CI run 33283348164](https://github.com/tt-a1i/skillroster/actions/runs/33283348164)
+and exact-main [CI run 33283579580](https://github.com/tt-a1i/skillroster/actions/runs/33283579580)
 passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
-and the aggregate CI gate. The final pre-commit local gate for #327 passed 321
-Rust unit tests, 8 acceptance tests, 101 CLI tests, and 152 Node harness tests,
-plus strict Clippy, formatting, installation-surface validation, archive README
-validation, and `git diff --check`.
+and the aggregate CI gate.
 
-The source candidate and Cargo package are versioned as 1.8.36. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.35 until the v1.8.36 tag,
-artifacts, checksums, and Homebrew package actually exist.
+The final local release-preparation gate passed 321 Rust unit tests, 8
+acceptance tests, 101 CLI tests, and 152 Node harness tests, plus strict
+Clippy, formatting, installation-surface validation, archive README validation,
+the change-scope self-test, and `git diff --check`. Two sequential independent
+release reviews were Clean after one overbroad documentation claim was
+corrected.
 
-## Candidate gates
+## Candidate acceptance
 
-The candidate is not accepted until one exact final source revision passes:
+The exact-main candidate
+[run 33283749052](https://github.com/tt-a1i/skillroster/actions/runs/33283749052)
+passed the strict repository gate, four platform build and governance jobs,
+and the WSL2 governance smoke at exact revision
+`9a5fce3e57ef59fad7b2ccd4f5ff1242e0105846`.
 
-- `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+All four downloaded candidate checksums passed. Each archive README matched
+the checked-in Git blob byte-for-byte. The macOS arm64 candidate reported
+`skillroster 1.8.36` and passed the release-governance smoke.
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+## Published release
+
+Annotated tag `v1.8.36` has tag object
+`14774c6d4984711bc26355b9de01924464659006` and resolves to exact source
+revision `9a5fce3e57ef59fad7b2ccd4f5ff1242e0105846`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33284198267)
+repeated the strict gate, all four supported-platform jobs, and WSL2
+successfully.
+
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.36)
+contains four archives and four adjacent checksum files:
+
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `dc6ef92ba78ef5e96a72d759b4e16ffc553e4a2310a55e229462743a2d5dee63` |
+| `x86_64-apple-darwin` | `8a7e2a4d2fce6cce3387cef4db355a394e36541d6cbc7851857a109000201796` |
+| `x86_64-pc-windows-msvc` | `847e66873c9dd4881a6a059e0cedcf598ba5e5b1b52fff7eb4036f2494f3f360` |
+| `x86_64-unknown-linux-gnu` | `7b32a243365fee5d805f94bce07be801d7d2f7f82cb8968af4cc4e0067bc4c03` |
+
+The public release asset inventory was read back and contained exactly those
+eight uploaded files with matching service-side digests. An anonymous macOS
+arm64 download passed its adjacent checksum, reported `skillroster 1.8.36`,
+passed the release-governance smoke, and contained the exact checked-in archive
+README bytes.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #10](https://github.com/tt-a1i/homebrew-skillroster/pull/10)
+at exact head `ee9044a33f0ad9ad23c57626c954b5ba4c47352a`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33284775441)
+built and tested macOS arm64 and Linux x86_64 bottles at that PR head. The
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33285019217)
+was dispatched from tap `main` at
+`cb5babe56475a818b3d2ecb52528b5b1caa62457` after test-bot passed. It
+closed the PR without a regular merge commit, created equivalent Formula
+commit `dbac10bcfe122f7c0aa7cb3f4a315c7fcf3c6e23`, published both bottles, and
+advanced tap `main` to `2e56d1d1122ddf2e5eb26a8222e4513b0656912e`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `f17ae58187e2e52ccc6da89b7acb8f469fd56ef7dd57b739de8d2545d62fb0fc` |
+| `x86_64_linux` | `72bc9854246f06b1e688a8670aa287bd3411dc5048842cdb2a433f924c4296e5` |
+
+The public arm64 bottle was downloaded without repository credentials, matched
+the Formula checksum, reported version 1.8.36, and passed the
+release-governance smoke. Verification extracted the bottle in an isolated
+temporary directory and did not mutate the user's installed Homebrew package.
+
+## Boundaries
+
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent files, or change
+  the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.35**. Its Formula, annotated tag, four
+The current public release is **v1.8.36**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.35
+SKILLROSTER_VERSION=1.8.36
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.35 skillroster
+  --tag v1.8.36 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.35 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.36 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.36**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.35 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.36 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.35 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.36 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.35 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.35 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.36 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.36 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- promote public release references in the bilingual README, installation guide, website, and checked-in Formula to the published v1.8.36
- convert the candidate note into an exact release receipt covering source, CI, candidate, tag, GitHub Release, checksums, Homebrew bottles, and boundaries
- preserve Bootstrap content version 1.8.29 and schema compatibility facts

## Validation
- `bash scripts/ci-full-check.sh` (321 unit, 8 acceptance, 101 CLI, 152 Node)
- `bash scripts/ci-change-scope.sh --self-test`
- installation-surface and archive-README verification
- `git diff --check`
- sequential Release Fact and Standards reviews: Clean after correcting the Homebrew pr-pull commit-chain wording

## Published evidence
- GitHub Release: https://github.com/tt-a1i/skillroster/releases/tag/v1.8.36
- tag workflow: https://github.com/tt-a1i/skillroster/actions/runs/33284198267
- Homebrew test-bot: https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33284775441
- Homebrew pr-pull: https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33285019217