### PR TITLE
fix: respect precise cross-language routing hints

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -345,8 +345,9 @@ only to the already-scanned, locally routable Skill set so natural CJK
 paraphrases can reach CJK metadata even when SQLite FTS has no whole-token
 candidate; Archived Skills remain excluded. Match reasons expose CJK
 description and full-text bigram counts. Ranking also treats explicit use and
-do-not-use description clauses as positive and exclusion evidence, and removes
-the low-confidence tail relative to the strongest result. Same-name Skill
+English/CJK do-not-use description clauses, including `not for` and `不应触发`,
+as positive and exclusion evidence, and removes the low-confidence tail
+relative to the strongest result. Same-name Skill
 identities occupy one ranked capability result and are
 reported as explicit variants rather than silently treated as equivalent.
 For an ambiguous result, `variant_finding` binds the complete routable identity

--- a/src/query.rs
+++ b/src/query.rs
@@ -2430,11 +2430,12 @@ fn description_routing_sections(description: &str) -> (String, String) {
         "must not use",
         "should not use",
         "not for",
+        "不应触发",
     ];
     let description = description.to_lowercase();
     let mut positive = Vec::new();
     let mut excluded = Vec::new();
-    for section in description.split(['.', '!', '?', ';', '\n']) {
+    for section in description.split(['.', '!', '?', ';', '\n', '。', '！', '？', '；']) {
         let section = section.trim();
         if section.is_empty() {
             continue;
@@ -2494,10 +2495,11 @@ fn has_protectable_task_evidence(matched: &FindMatch) -> bool {
 }
 
 fn has_direct_hint_evidence(matched: &FindMatch) -> bool {
+    let has_complete_single_token_name = tokens(&matched.name).len() == 1
+        && match_reason_count(matched, "name_tokens:").is_some_and(|count| count == 1);
     has_direct_metadata_reason(matched)
-        || ["name_tokens:", "trigger_tokens:"]
-            .iter()
-            .any(|prefix| match_reason_count(matched, prefix).is_some_and(|count| count >= 2))
+        || has_complete_single_token_name
+        || match_reason_count(matched, "trigger_tokens:").is_some_and(|count| count >= 2)
 }
 
 fn has_direct_metadata_reason(matched: &FindMatch) -> bool {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1469,6 +1469,202 @@ fn public_find_hints_do_not_erase_a_native_task_match() {
 }
 
 #[test]
+fn public_find_prefers_a_direct_single_token_name_hint_over_broad_native_overlap() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "pdf",
+            "---\nname: pdf\ndescription: Read PDF files and inspect rendered layout on every page.\n---\n",
+        ),
+        (
+            "yunxiao-smartcr",
+            "---\nname: yunxiao-smartcr\ndescription: >\n  本地代码审查师（Code Reviewer），通过 AST 静态检查和 LLM 审查产出报告。\n  触发场景：审查代码变更、检查一下、看有没有问题、PR 检查。\n  不应触发：排障、性能优化建议、纯代码解释、单测生成。\n---\n读取变更并检查每一页报告的排版。\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "读取这个 PDF 并检查每一页的排版有没有问题",
+                "--hint",
+                "read PDF inspect rendered layout on every page",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["matches"][0]["name"], "pdf");
+    assert_eq!(found["result"]["matches"][0]["augmented_channel_rank"], 1);
+}
+
+#[test]
+fn public_find_does_not_treat_part_of_a_multi_token_name_as_direct_hint_evidence() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "native-task",
+            "---\nname: native-task\ndescription: 原始任务专用能力\n---\n",
+        ),
+        (
+            "github-code-review",
+            "---\nname: github-code-review\ndescription: Review documents, contracts, reports, plans, policies, requirements, evidence, and risks.\n---\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "原始任务专用能力",
+                "--hint",
+                "review documents contracts reports plans policies requirements evidence risks",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["matches"][0]["name"], "native-task");
+    assert_eq!(
+        found["result"]["matches"][0]["ranking_adjustments"],
+        json!(["protected_original_task_match"])
+    );
+}
+
+#[test]
+fn public_find_respects_a_chinese_do_not_use_clause() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "diagnose",
+            "---\nname: diagnose\ndescription: Diagnose intermittent failures, reproduce them, and identify root causes.\n---\n",
+        ),
+        (
+            "yunxiao-smartcr",
+            "---\nname: yunxiao-smartcr\ndescription: >\n  本地代码审查师。触发场景：审查代码变更、检查一下、看有没有问题。\n  不应触发：偶现失败、复现并定位、排障、为什么会崩、报错是什么意思。\n---\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "这个偶现失败到底是什么原因，帮我复现并定位",
+                "--hint",
+                "diagnose intermittent failure reproduce and identify root cause",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    let names = found["result"]["matches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|matched| matched["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(names[0], "diagnose");
+    assert!(!names.contains(&"yunxiao-smartcr"));
+}
+
+#[test]
+fn public_find_keeps_a_positive_cjk_clause_after_an_exclusion() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill = home.join(".codex/skills/mixed-routing");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: mixed-routing\ndescription: 适用于代码审查。不应触发：排障。也适用于事故复盘。\n---\n",
+    )
+    .unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "事故复盘",
+                "--hint",
+                "incident retrospective",
+                "--limit",
+                "1",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["matches"][0]["name"], "mixed-routing");
+}
+
+#[test]
 fn public_find_hinted_ranking_is_prefix_stable_across_limits() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## 解决什么问题

中文或混合语言任务按 Bootstrap 契约提供英文 `--hint` 后，弱的中文词面候选仍可能通过 `protected_original_task_match` 抢占 Top-1；中文 Skill 描述里的 `不应触发` 也会被误当成正向匹配文本。

## 价值

Agent 可以保留用户原始中文任务，同时用一个忠实英文能力提示找到真正匹配的本地 Skill。`diagnose`、`pdf` 这类单词 Skill 名的精确提示不再被宽泛代码审查 Skill 覆盖，中文排除条款也真正生效。

## 方法

- 仅当 Skill 名自身恰好一个 token 且该 token 被命中时，视为直接名称提示证据；多 token 名称的局部命中不享受该保护。
- 将 `不应触发` 纳入描述排除边界，并支持 `。！？；` 中文子句分隔。
- 新增四个公开 CLI 回归，覆盖 PDF、真实诊断文案、多 token 反例和正向→排除→正向中文子句。

## 验证

- 真实 263-Skill 快照：PR 审查、诊断、简化、PDF、数据质量五条中文任务全部恢复预期 Top-1，`files_changed=false`
- `bash scripts/ci-full-check.sh`
  - Rust unit: 321/321
  - acceptance: 8/8
  - CLI: 105/105
  - Node harness: 152/152
- Spec 顺序复审：通过
- Standards 顺序复审：通过
- `git diff --check`

Closes #330