### PR TITLE
docs: record v1.8.37 release

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "9a5fce3e57ef59fad7b2ccd4f5ff1242e0105846"
-  version "1.8.36"
+      revision: "cbfebe6e3dbaa29aecca109bc8858779812f02a6"
+  version "1.8.37"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.36", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.37", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.36 implements the complete local governance loop. Every
+Public release v1.8.37 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.36 release and platform evidence](docs/acceptance/release-v1.8.36-candidate.md)
+- [v1.8.37 release and platform evidence](docs/acceptance/release-v1.8.37-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.36 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.37 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.36 发布与平台证据](docs/acceptance/release-v1.8.36-candidate.md)
+- [v1.8.37 发布与平台证据](docs/acceptance/release-v1.8.37-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.37-candidate.md
+++ b/docs/acceptance/release-v1.8.37-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.37 candidate
+# SkillRoster v1.8.37 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.37 makes cross-language Skill routing follow a precise Agent
 hint without discarding the user's original task.
@@ -19,55 +19,107 @@ hint without discarding the user's original task.
 
 The real-inventory replay covered Chinese tasks for PR review, diagnosis,
 codebase simplification, PDF layout inspection, and data-quality analysis. All
-five returned the intended Top-1 Skill, and exact `find --load` checks for
-`diagnose` and `pdf` returned verified complete content without changing files.
+five returned the intended Top-1 Skill. Exact `find --load` checks for
+`diagnose` and `pdf` returned verified complete content without changing
+files.
 
 This patch changes deterministic Find ranking and description polarity only.
 SQLite remains at schema 12, the JSON envelope remains at schema 1, and bundled
 Bootstrap content remains at version 1.8.29. It does not mutate Agent or Skill
 files.
 
-## Preparation evidence
-
-Candidate preparation starts from exact `origin/main` revision
-`c6c4f5235d428fc664e5c47245b08ba5b8540002`.
+## Source and review chain
 
 [#331](https://github.com/tt-a1i/skillroster/pull/331) fixed precise
 cross-language routing at exact head
-`3dfdb74f13e15e2bba945a5684017e4deebd857f` and merged as the candidate base.
-The linked [issue #330](https://github.com/tt-a1i/skillroster/issues/330)
-records the reproducible failure, ranked hypotheses, root cause, and bounded
-acceptance criteria. Sequential Spec and Standards reviews passed after the
-implementation was corrected to keep partial multi-token name hits from being
-treated as direct name evidence.
+`3dfdb74f13e15e2bba945a5684017e4deebd857f` and merged as
+`c6c4f5235d428fc664e5c47245b08ba5b8540002`. The linked
+[issue #330](https://github.com/tt-a1i/skillroster/issues/330) records the
+reproducible failure, ranked hypotheses, root cause, and bounded acceptance
+criteria. Sequential Spec and Standards reviews passed after the implementation
+was corrected to keep partial multi-token name hits from being treated as
+direct name evidence.
 
-The exact-main
-[CI run 33287816660](https://github.com/tt-a1i/skillroster/actions/runs/33287816660)
+[#332](https://github.com/tt-a1i/skillroster/pull/332) prepared version 1.8.37
+at exact head `d1acecf6f550183c701df1161add6b3e410056c7` and merged as exact
+release source revision `cbfebe6e3dbaa29aecca109bc8858779812f02a6`.
+The PR [CI run 33289094357](https://github.com/tt-a1i/skillroster/actions/runs/33289094357)
+and exact-main [CI run 33289252565](https://github.com/tt-a1i/skillroster/actions/runs/33289252565)
 passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
-and the aggregate CI gate at the candidate base. The final local gate for #331
-passed 321 Rust unit tests, 8 acceptance tests, 105 CLI tests, and 152 Node
-harness tests, plus strict Clippy, formatting, installation-surface validation,
-archive README validation, the change-scope self-test, and `git diff --check`.
+and the aggregate CI gate.
 
-The source candidate and Cargo package are versioned as 1.8.37. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.36 until the v1.8.37 tag,
-artifacts, checksums, and Homebrew package actually exist.
+The final local release-preparation gate passed 321 Rust unit tests, 8
+acceptance tests, 105 CLI tests, and 152 Node harness tests, plus strict
+Clippy, formatting, installation-surface validation, archive README validation,
+the change-scope self-test, and `git diff --check`. Sequential Release
+Spec/Evidence and Standards/Compatibility reviews were Clean.
 
-## Candidate gates
+## Candidate acceptance
 
-The candidate is not accepted until one exact final source revision passes:
+The exact-main candidate
+[run 33289450524](https://github.com/tt-a1i/skillroster/actions/runs/33289450524)
+passed the strict repository gate, four platform build and governance jobs,
+and the WSL2 governance smoke at exact revision
+`cbfebe6e3dbaa29aecca109bc8858779812f02a6`.
 
-- `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+All four downloaded candidate checksums passed. Each archive README matched
+the checked-in Git blob byte-for-byte. The macOS arm64 candidate reported
+`skillroster 1.8.37` and passed the release-governance smoke.
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+## Published release
+
+Annotated tag `v1.8.37` has tag object
+`aea2732e30378599b2f441cf4e560b5714f0be46` and resolves to exact source
+revision `cbfebe6e3dbaa29aecca109bc8858779812f02a6`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33290122154)
+repeated the strict gate, all four supported-platform jobs, and WSL2
+successfully.
+
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.37)
+contains four archives and four adjacent checksum files:
+
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `36b49fe4e5572c91603a3969377ff431f3f9466a03fd4938156ada4632f6abea` |
+| `x86_64-apple-darwin` | `7498ebd8a7db734e5c5af1a7caa767158e81ca12575e0ace41ef5d9a4e33df28` |
+| `x86_64-pc-windows-msvc` | `06d9dc8a286bf13811aa0c52232b3a2950184f418eeb6c59b38cee029dda8c7f` |
+| `x86_64-unknown-linux-gnu` | `ff794f9b9fb1858c37302514185f70322b835afe4f73ff62792e5cea63da76a9` |
+
+The public release asset inventory was read back and contained exactly those
+eight uploaded files with matching service-side archive digests. An anonymous
+macOS arm64 download passed its adjacent checksum, matched the tag-workflow
+artifact byte-for-byte, reported `skillroster 1.8.37`, and passed the
+release-governance smoke.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #11](https://github.com/tt-a1i/homebrew-skillroster/pull/11)
+at exact head `701c14da9b9b292c87efb4b59738c032035f1632`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33291109014)
+built and tested macOS arm64 and Linux x86_64 bottles at that PR head. The
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33291374890)
+was dispatched from tap `main` at
+`2e56d1d1122ddf2e5eb26a8222e4513b0656912e` after test-bot passed. It
+closed the PR without a regular merge commit, created equivalent Formula
+commit `42d9779d93e4c75825a3b88c80def2850aad4d74`, published both bottles,
+and advanced tap `main` through bottle commit
+`b07a7382107bbffa0f949cf6f7ce321d5277e0fc`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `db495039f5140b67221ec2ee8d6b96f156812820b6563ce5e6b64b6036277ed7` |
+| `x86_64_linux` | `b568b793c1a73856e52b804de2f675e2cc72498a348390b018b0d123787a9a32` |
+
+The public arm64 bottle was downloaded without repository credentials, matched
+the Formula checksum, reported version 1.8.37, and passed the
+release-governance smoke. Verification extracted the bottle in an isolated
+temporary directory and did not mutate the user's installed Homebrew package.
+
+## Boundaries
+
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent files, or change
+  the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.36**. Its Formula, annotated tag, four
+The current public release is **v1.8.37**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.36
+SKILLROSTER_VERSION=1.8.37
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.36 skillroster
+  --tag v1.8.37 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.36 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.37 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.37**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.36 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.37 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.36 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.37 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.36 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.36 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.37 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.37 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- promote public release references in bilingual README, installation guide, website, and checked-in Formula to v1.8.37
- convert the candidate note into an exact release receipt covering source, CI, candidate, tag, GitHub Release, checksums, Homebrew bottles, and boundaries
- preserve Bootstrap content 1.8.29 and schema compatibility facts

## Validation
- `bash scripts/ci-full-check.sh` (321 unit, 8 acceptance, 105 CLI, 152 Node)
- installation-surface, archive-README, and change-scope checks
- `git diff --check`
- sequential Release Fact and Standards reviews: Clean

## Published evidence
- GitHub Release: https://github.com/tt-a1i/skillroster/releases/tag/v1.8.37
- tag workflow: https://github.com/tt-a1i/skillroster/actions/runs/33290122154
- Homebrew test-bot: https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33291109014
- Homebrew pr-pull: https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33291374890