### PR TITLE
fix: respect task routing exclusions

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -333,7 +333,27 @@ a larger result. A hint can therefore surface English
 metadata without letting its raw token count set one global cutoff that
 discards a strong native-task result. Each task or hint also remains a separate phrase for
 exact name, description, and declared-trigger evidence. The scanner reads
-ordinary and folded YAML description scalars. Ranking uses
+ordinary and folded YAML description scalars.
+
+An independent punctuation-delimited task clause that begins with `不要`, the
+parallel continuation `也不要`, or the complete ASCII marker `do not` remains
+verbatim in `task` but does not contribute positive candidate or ranking
+evidence. Prefixes such as `do nothing` are not markers. `task_exclusions`
+returns the recognized clauses so the Agent can audit that deterministic split.
+Terms already present in the positive task remain shared object evidence; only
+the constraint-specific remainder may exclude a Skill whose positive name,
+trigger, or description declares the prohibited capability. Agent-authored
+hints remain separate positive evidence and cannot cancel a task exclusion.
+`task_exclusion_effects` reports the exact affected candidate count plus a
+deterministic preview of at most 10 affected Skill identities, ordered by name
+and opaque Skill ID. Each preview item contains only the name, opaque ID, and
+the positive name, trigger, and description token counts that caused exclusion;
+`items_truncated` states whether more affected candidates were omitted. It does
+not expose Skill paths or content. An embedded negative state such as `diagnose
+why tests do not pass` is not an independent constraint clause and remains
+intact.
+
+Ranking uses
 top-level `triggers` and the semicolon-separated string
 `metadata.skillroster-routing-triggers` as the same declared retrieval
 evidence. The latter must be explicitly quoted and remains valid under the

--- a/src/app.rs
+++ b/src/app.rs
@@ -4995,8 +4995,9 @@ fn find_command(
         }
     }
     require_content_identity(&scan)?;
-    let retrieval_query = crate::query::RetrievalQuery::from_parts(
-        std::iter::once(task).chain(retrieval_hints.iter().map(String::as_str)),
+    let retrieval_query = crate::query::RetrievalQuery::from_task_and_hints(
+        task,
+        retrieval_hints.iter().map(String::as_str),
     );
     let candidate_search_text = crate::query::candidate_search_text(retrieval_query.text());
     let mut candidate_ids = store
@@ -5027,13 +5028,15 @@ fn find_command(
     } else {
         usize::from(crate::cli::MAX_FIND_RESULTS)
     };
-    let augmented_matches = crate::query::find_matching(
+    let augmented_result = crate::query::find_matching_with_evidence(
         &scan,
         &retrieval_query,
         pool_limit,
         Some(&candidate_ids),
         Some(&routable_ids),
     );
+    let task_exclusion_effects = augmented_result.task_exclusion_effects;
+    let augmented_matches = augmented_result.matches;
     let ranking_strategy = if retrieval_hints.is_empty() {
         "single_lexical_channel"
     } else {
@@ -5042,7 +5045,8 @@ fn find_command(
     let mut matches = if retrieval_hints.is_empty() {
         augmented_matches
     } else {
-        let task_query = crate::query::RetrievalQuery::from_parts([task]);
+        let task_query =
+            crate::query::RetrievalQuery::from_task_and_hints(task, std::iter::empty::<&str>());
         let task_matches = crate::query::find_matching(
             &scan,
             &task_query,
@@ -5244,6 +5248,8 @@ fn find_command(
     let mut result = json!({
         "snapshot_id": scan_id,
         "task": task,
+        "task_exclusions": retrieval_query.excluded_task_phrases(),
+        "task_exclusion_effects": task_exclusion_effects,
         "retrieval_hints": retrieval_hints,
         "ranking_strategy": ranking_strategy,
         "matches": matches,

--- a/src/query.rs
+++ b/src/query.rs
@@ -17,6 +17,8 @@ pub const UNKNOWN_ARCHIVE_FINDING_TITLE: &str = "Archive candidacy is unknown";
 
 const SEMANTIC_SHARED_TERM_PREVIEW_LIMIT: usize = 20;
 const SEMANTIC_SHARED_TERM_CHARACTER_LIMIT: usize = 64;
+const TASK_EXCLUSION_MARKERS: &[&str] = &["do not", "不要", "也不要"];
+const TASK_EXCLUSION_EFFECT_PREVIEW_LIMIT: usize = 10;
 
 fn normalize_skill_name(name: &str) -> String {
     name.trim().to_lowercase()
@@ -361,6 +363,27 @@ pub struct FindMatch {
     pub variant_finding: Option<VariantFindingReference>,
 }
 
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct TaskExclusionEffects {
+    pub affected_candidate_count: usize,
+    pub items: Vec<TaskExclusionEffect>,
+    pub items_truncated: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct TaskExclusionEffect {
+    pub skill_id: String,
+    pub name: String,
+    pub name_token_count: usize,
+    pub trigger_token_count: usize,
+    pub description_token_count: usize,
+}
+
+pub(crate) struct FindMatchingResult {
+    pub matches: Vec<FindMatch>,
+    pub task_exclusion_effects: TaskExclusionEffects,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VariantFindingReference {
     pub state: VariantFindingState,
@@ -436,10 +459,13 @@ fn placement_authority_facts(
 #[derive(Clone, Debug)]
 pub(crate) struct RetrievalQuery {
     text: String,
+    positive_task_text: String,
     phrases: Vec<String>,
+    excluded_task_phrases: Vec<String>,
 }
 
 impl RetrievalQuery {
+    #[cfg(test)]
     pub(crate) fn from_parts<'a>(parts: impl IntoIterator<Item = &'a str>) -> Self {
         let phrases = parts
             .into_iter()
@@ -447,14 +473,39 @@ impl RetrievalQuery {
             .filter(|part| !part.is_empty())
             .map(str::to_owned)
             .collect::<Vec<_>>();
+        let text = phrases.join(" ");
+        Self {
+            positive_task_text: text.clone(),
+            text,
+            phrases,
+            excluded_task_phrases: Vec::new(),
+        }
+    }
+
+    pub(crate) fn from_task_and_hints<'a>(
+        task: &str,
+        hints: impl IntoIterator<Item = &'a str>,
+    ) -> Self {
+        let (positive_task, excluded_task_phrases) = task_routing_sections(task);
+        let positive_task_text = positive_task.clone();
+        let phrases = std::iter::once(positive_task)
+            .chain(hints.into_iter().map(str::trim).map(str::to_owned))
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>();
         Self {
             text: phrases.join(" "),
+            positive_task_text,
             phrases,
+            excluded_task_phrases,
         }
     }
 
     pub(crate) fn text(&self) -> &str {
         &self.text
+    }
+
+    pub(crate) fn excluded_task_phrases(&self) -> &[String] {
+        &self.excluded_task_phrases
     }
 }
 
@@ -1847,7 +1898,7 @@ fn category_name(category: FindingCategory) -> &'static str {
 }
 
 pub fn find(scan: &ScanResult, task: &str, limit: usize) -> Vec<FindMatch> {
-    let query = RetrievalQuery::from_parts([task]);
+    let query = RetrievalQuery::from_task_and_hints(task, std::iter::empty::<&str>());
     find_matching(scan, &query, limit, None, None)
 }
 
@@ -1858,11 +1909,37 @@ pub(crate) fn find_matching(
     candidate_ids: Option<&BTreeSet<String>>,
     variant_eligible_ids: Option<&BTreeSet<String>>,
 ) -> Vec<FindMatch> {
+    find_matching_with_evidence(scan, query, limit, candidate_ids, variant_eligible_ids).matches
+}
+
+pub(crate) fn find_matching_with_evidence(
+    scan: &ScanResult,
+    query: &RetrievalQuery,
+    limit: usize,
+    candidate_ids: Option<&BTreeSet<String>>,
+    variant_eligible_ids: Option<&BTreeSet<String>>,
+) -> FindMatchingResult {
     let query_text = query.text().trim().to_lowercase();
     if query_text.is_empty() || limit == 0 {
-        return Vec::new();
+        return FindMatchingResult {
+            matches: Vec::new(),
+            task_exclusion_effects: TaskExclusionEffects::default(),
+        };
     }
     let query_tokens = tokens(&query_text);
+    let positive_task_tokens = tokens(&query.positive_task_text);
+    let excluded_task_tokens = tokens(
+        &query
+            .excluded_task_phrases
+            .iter()
+            .map(|phrase| task_exclusion_body(phrase))
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
+    let excluded_only_task_tokens = excluded_task_tokens
+        .difference(&positive_task_tokens)
+        .cloned()
+        .collect::<BTreeSet<_>>();
     let query_phrases = query
         .phrases
         .iter()
@@ -1885,6 +1962,7 @@ pub(crate) fn find_matching(
         variants.sort();
         variants.dedup();
     }
+    let mut task_exclusion_effects = Vec::new();
     let mut matches = scan
         .skills
         .iter()
@@ -1909,6 +1987,27 @@ pub(crate) fn find_matching(
             let name_overlap = query_tokens.intersection(&name_tokens).count();
             let trigger_overlap = query_tokens.intersection(&trigger_tokens).count();
             let description_overlap = query_tokens.intersection(&description_tokens).count();
+            let task_excluded_name_overlap =
+                excluded_only_task_tokens.intersection(&name_tokens).count();
+            let task_excluded_trigger_overlap = excluded_only_task_tokens
+                .intersection(&trigger_tokens)
+                .count();
+            let task_excluded_description_overlap = excluded_only_task_tokens
+                .intersection(&description_tokens)
+                .count();
+            if task_excluded_name_overlap > 0
+                || task_excluded_trigger_overlap > 0
+                || task_excluded_description_overlap > 0
+            {
+                task_exclusion_effects.push(TaskExclusionEffect {
+                    skill_id: skill.id.clone(),
+                    name: skill.name.clone(),
+                    name_token_count: task_excluded_name_overlap,
+                    trigger_token_count: task_excluded_trigger_overlap,
+                    description_token_count: task_excluded_description_overlap,
+                });
+                return None;
+            }
             let excluded_description_overlap = query_tokens
                 .intersection(&excluded_description_tokens)
                 .count();
@@ -2138,7 +2237,22 @@ pub(crate) fn find_matching(
     for (index, matched) in capabilities.iter_mut().enumerate() {
         matched.rank = index + 1;
     }
-    capabilities
+    task_exclusion_effects.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.skill_id.cmp(&right.skill_id))
+    });
+    let affected_candidate_count = task_exclusion_effects.len();
+    let items_truncated = affected_candidate_count > TASK_EXCLUSION_EFFECT_PREVIEW_LIMIT;
+    task_exclusion_effects.truncate(TASK_EXCLUSION_EFFECT_PREVIEW_LIMIT);
+    FindMatchingResult {
+        matches: capabilities,
+        task_exclusion_effects: TaskExclusionEffects {
+            affected_candidate_count,
+            items: task_exclusion_effects,
+            items_truncated,
+        },
+    }
 }
 
 pub(crate) fn fuse_retrieval_channels(
@@ -2455,6 +2569,47 @@ fn description_routing_sections(description: &str) -> (String, String) {
         }
     }
     (positive.join(" "), excluded.join(" "))
+}
+
+fn task_routing_sections(task: &str) -> (String, Vec<String>) {
+    let mut positive = Vec::new();
+    let mut excluded = Vec::new();
+    for section in task.split(['.', '!', '?', ';', ',', '\n', '。', '！', '？', '；', '，']) {
+        let section = section.trim();
+        if section.is_empty() {
+            continue;
+        }
+        if task_exclusion_marker(section).is_some() {
+            excluded.push(section.to_owned());
+        } else {
+            positive.push(section);
+        }
+    }
+    if excluded.is_empty() {
+        (task.trim().to_owned(), excluded)
+    } else {
+        (positive.join(" "), excluded)
+    }
+}
+
+fn task_exclusion_body(section: &str) -> &str {
+    task_exclusion_marker(section).map_or(section, |marker| section[marker.len()..].trim())
+}
+
+fn task_exclusion_marker(section: &str) -> Option<&'static str> {
+    TASK_EXCLUSION_MARKERS.iter().copied().find(|marker| {
+        if marker.is_ascii() {
+            section
+                .get(..marker.len())
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case(marker))
+                && section[marker.len()..]
+                    .chars()
+                    .next()
+                    .is_none_or(|next| !next.is_alphanumeric())
+        } else {
+            section.starts_with(marker)
+        }
+    })
 }
 
 fn trim_low_confidence_tail(matches: &mut Vec<FindMatch>, query_token_count: usize) {
@@ -3535,6 +3690,155 @@ mod tests {
 
         assert_eq!(desired, "use for standalone spreadsheet files");
         assert_eq!(excluded, "not for a live excel session");
+    }
+
+    #[test]
+    fn task_routing_sections_separate_independent_cjk_and_english_constraints() {
+        let (positive, excluded) = task_routing_sections(
+            "检查工作树问题，不要修改代码; do not run tests，也不要创建 issue",
+        );
+
+        assert_eq!(positive, "检查工作树问题");
+        assert_eq!(
+            excluded,
+            vec!["不要修改代码", "do not run tests", "也不要创建 issue"]
+        );
+    }
+
+    #[test]
+    fn task_routing_sections_require_a_complete_do_not_marker() {
+        for task in [
+            "do nothing unusual; inspect worktree problems",
+            "diagnose why tests do not pass",
+        ] {
+            let (positive, excluded) = task_routing_sections(task);
+
+            assert_eq!(positive, task);
+            assert!(excluded.is_empty());
+        }
+    }
+
+    #[test]
+    fn task_exclusions_filter_conflicting_hints_and_bound_effect_evidence() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("skillroster-task-exclusions-{nonce}"));
+        let inspect = root.join("inspect-worktree");
+        fs::create_dir_all(&inspect).unwrap();
+        fs::write(
+            inspect.join("SKILL.md"),
+            "---\nname: inspect-worktree\ndescription: Inspect worktree problems.\n---\n",
+        )
+        .unwrap();
+        for index in 0..12 {
+            let editor = root.join(format!("editor-{index:02}"));
+            fs::create_dir_all(&editor).unwrap();
+            fs::write(
+                editor.join("SKILL.md"),
+                format!("---\nname: editor-{index:02}\ndescription: Modify.\n---\n"),
+            )
+            .unwrap();
+        }
+        let mut options = ScanOptions::for_home(root.join("home"));
+        options
+            .explicit_skill_roots
+            .push(crate::scan::ExplicitSkillRoot {
+                agent: AgentKind::Codex,
+                path: root.clone(),
+            });
+        options.include_session_evidence = false;
+        let scan = scan(&options).unwrap();
+        let query = RetrievalQuery::from_task_and_hints(
+            "Inspect worktree problems; do not modify",
+            ["editor-00"],
+        );
+
+        let result = find_matching_with_evidence(&scan, &query, 3, None, None);
+
+        assert_eq!(result.matches[0].name, "inspect-worktree");
+        assert_eq!(result.task_exclusion_effects.affected_candidate_count, 12);
+        assert_eq!(result.task_exclusion_effects.items.len(), 10);
+        assert!(result.task_exclusion_effects.items_truncated);
+        assert_eq!(result.task_exclusion_effects.items[0].name, "editor-00");
+        assert_eq!(result.task_exclusion_effects.items[9].name, "editor-09");
+        assert!(
+            result
+                .task_exclusion_effects
+                .items
+                .iter()
+                .all(|effect| effect.description_token_count == 1)
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn task_exclusion_controls_preserve_exact_cjk_and_english_scores() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("skillroster-task-controls-{nonce}"));
+        for (directory, contents) in [
+            (
+                "inspect-worktree",
+                "---\nname: inspect-worktree\ndescription: 检查工作树问题。\n---\n",
+            ),
+            (
+                "modify-code",
+                "---\nname: modify-code\ndescription: 修改当前工作树中的代码并运行测试。\n---\n",
+            ),
+            (
+                "inspect-en",
+                "---\nname: inspect-en\ndescription: Inspect worktree problems.\n---\n",
+            ),
+            (
+                "modify-en",
+                "---\nname: modify-en\ndescription: Modify current worktree code and run tests.\n---\n",
+            ),
+        ] {
+            let skill = root.join(directory);
+            fs::create_dir_all(&skill).unwrap();
+            fs::write(skill.join("SKILL.md"), contents).unwrap();
+        }
+        let mut options = ScanOptions::for_home(root.join("home"));
+        options
+            .explicit_skill_roots
+            .push(crate::scan::ExplicitSkillRoot {
+                agent: AgentKind::Codex,
+                path: root.clone(),
+            });
+        options.include_session_evidence = false;
+        let scan = scan(&options).unwrap();
+
+        for (baseline_task, constrained_task, expected_name, expected_score) in [
+            (
+                "检查工作树问题",
+                "检查工作树问题，不要修改当前工作树中的代码并运行测试",
+                "inspect-worktree",
+                115.0,
+            ),
+            (
+                "Inspect worktree problems",
+                "Inspect worktree problems; do not modify current worktree code or run tests",
+                "inspect-en",
+                94.0,
+            ),
+        ] {
+            let baseline_query =
+                RetrievalQuery::from_task_and_hints(baseline_task, std::iter::empty::<&str>());
+            let constrained_query =
+                RetrievalQuery::from_task_and_hints(constrained_task, std::iter::empty::<&str>());
+            let baseline = find_matching(&scan, &baseline_query, 2, None, None);
+            let constrained = find_matching(&scan, &constrained_query, 2, None, None);
+
+            assert_eq!(baseline[0].name, expected_name);
+            assert_eq!(baseline[0].score, expected_score);
+            assert_eq!(constrained[0].name, baseline[0].name);
+            assert_eq!(constrained[0].score, baseline[0].score);
+        }
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1625,6 +1625,305 @@ fn public_find_respects_a_chinese_do_not_use_clause() {
 }
 
 #[test]
+fn public_find_does_not_route_to_an_explicitly_excluded_task_capability() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "inspect-worktree",
+            "---\nname: inspect-worktree\ndescription: 检查工作树问题。\n---\nInspect worktree problems without changing files.\n",
+        ),
+        (
+            "modify-code",
+            "---\nname: modify-code\ndescription: 修改当前工作树中的代码并运行测试。\n---\nModify code and run tests.\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let baseline = json_output(&run(
+        &[&common[..], &["find", "检查工作树问题", "--limit", "2"]].concat(),
+        None,
+    ));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "检查工作树问题，不要修改当前工作树中的代码并运行测试",
+                "--limit",
+                "2",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(baseline["result"]["matches"][0]["name"], "inspect-worktree");
+    assert_eq!(baseline["result"]["matches"][0]["score"], 115.0);
+    assert_eq!(found["result"]["matches"][0]["name"], "inspect-worktree");
+    assert_eq!(
+        found["result"]["matches"][0]["score"],
+        baseline["result"]["matches"][0]["score"]
+    );
+    assert_eq!(
+        found["result"]["task_exclusions"],
+        json!(["不要修改当前工作树中的代码并运行测试"])
+    );
+    assert_eq!(found["result"]["files_changed"], false);
+}
+
+#[test]
+fn public_find_recognizes_parallel_cjk_task_exclusions() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "inspect-worktree",
+            "---\nname: inspect-worktree\ndescription: 检查工作树问题。\n---\nInspect worktree problems without changing files.\n",
+        ),
+        (
+            "modify-code",
+            "---\nname: modify-code\ndescription: 修改当前工作树中的代码并运行测试。\n---\nModify code and run tests.\n",
+        ),
+        (
+            "github-issues",
+            "---\nname: github-issues\ndescription: 创建和管理 GitHub issue。\n---\nCreate and manage GitHub issues.\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "检查工作树问题，不要修改当前工作树中的代码并运行测试，也不要创建 issue",
+                "--limit",
+                "2",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["matches"][0]["name"], "inspect-worktree");
+    assert_eq!(
+        found["result"]["task_exclusions"],
+        json!(["不要修改当前工作树中的代码并运行测试", "也不要创建 issue"])
+    );
+    assert_eq!(
+        found["result"]["task_exclusion_effects"]["affected_candidate_count"],
+        2
+    );
+}
+
+#[test]
+fn public_find_does_not_route_to_an_english_do_not_constraint() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "inspect-en",
+            "---\nname: inspect-en\ndescription: Inspect worktree problems.\n---\nInspect the worktree without changing files.\n",
+        ),
+        (
+            "modify-en",
+            "---\nname: modify-en\ndescription: Modify current worktree code and run tests.\n---\nChange the worktree and run tests.\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let baseline = json_output(&run(
+        &[
+            &common[..],
+            &["find", "Inspect worktree problems", "--limit", "2"],
+        ]
+        .concat(),
+        None,
+    ));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "Inspect worktree problems; do not modify current worktree code or run tests",
+                "--limit",
+                "2",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(baseline["result"]["matches"][0]["name"], "inspect-en");
+    assert_eq!(baseline["result"]["matches"][0]["score"], 94.0);
+    assert_eq!(found["result"]["matches"][0]["name"], "inspect-en");
+    assert_eq!(
+        found["result"]["matches"][0]["score"],
+        baseline["result"]["matches"][0]["score"]
+    );
+    assert_eq!(
+        found["result"]["task_exclusions"],
+        json!(["do not modify current worktree code or run tests"])
+    );
+}
+
+#[test]
+fn public_find_task_exclusion_constrains_a_conflicting_agent_hint() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "inspect-en",
+            "---\nname: inspect-en\ndescription: Inspect worktree problems.\n---\nInspect the worktree without changing files.\n",
+        ),
+        (
+            "editor",
+            "---\nname: editor\ndescription: Modify.\n---\nEdit files.\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "Inspect worktree problems; do not modify",
+                "--hint",
+                "editor",
+                "--limit",
+                "2",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["matches"][0]["name"], "inspect-en");
+    assert_eq!(
+        found["result"]["task"],
+        "Inspect worktree problems; do not modify"
+    );
+    assert_eq!(found["result"]["retrieval_hints"], json!(["editor"]));
+    let effects = &found["result"]["task_exclusion_effects"];
+    assert_eq!(effects["affected_candidate_count"], 1);
+    assert_eq!(effects["items_truncated"], false);
+    assert_eq!(effects["items"].as_array().unwrap().len(), 1);
+    assert_eq!(effects["items"][0]["name"], "editor");
+    assert_eq!(effects["items"][0]["name_token_count"], 0);
+    assert_eq!(effects["items"][0]["trigger_token_count"], 0);
+    assert_eq!(effects["items"][0]["description_token_count"], 1);
+    assert!(
+        effects["items"][0]["skill_id"]
+            .as_str()
+            .is_some_and(|skill_id| !skill_id.is_empty())
+    );
+}
+
+#[test]
+fn public_find_keeps_a_negative_state_inside_the_positive_task() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "diagnose",
+            "---\nname: diagnose\ndescription: Diagnose why tests fail and identify the root cause.\n---\n",
+        ),
+        (
+            "pass-tests",
+            "---\nname: pass-tests\ndescription: Run tests and make tests pass.\n---\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &["find", "diagnose why tests do not pass", "--limit", "2"],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["task_exclusions"], json!([]));
+    assert!(
+        found["result"]["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|matched| matched["name"] == "diagnose")
+    );
+}
+
+#[test]
 fn public_find_keeps_a_positive_cjk_clause_after_an_exclusion() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## 解决什么问题

Agent 的任务常把目标和禁止项写在一起，例如“检查工作树问题，不要修改代码”。此前 `find` 把整段 TASK 都当作正向证据，强 hint 甚至会把明确禁止的修改类 Skill 推到 Top-1。

## 价值是什么

- 明确禁止的能力不再进入正向候选和排序，Agent 路由更符合用户真实意图。
- 正向任务分数保持不变：中文 control 115→115，英文 control 94→94。
- JSON 返回可审计、无路径/内容泄露的有界排除效果，Agent 能知道哪些候选因哪些声明字段被过滤。

## 方法

- 只识别独立标点子句开头的 `不要`、`也不要` 和完整 `do not` 标记。
- 从正向 TASK token 中扣除共享对象词，再用剩余禁止能力约束 name、trigger、description。
- hint 仍是正向证据，但不能取消 TASK exclusion。
- 新增 `task_exclusions` 与最多 10 项的 `task_exclusion_effects`。

## 验证

- `bash scripts/ci-full-check.sh`
- 325 Rust unit + 8 acceptance + 110 CLI
- 152 Node tests
- Spec review: Clean
- Standards/compatibility review: Clean
- 真实 263-Skill inventory 回放：目标 Skill 保持 Top-1，两个禁止子句均识别，`files_changed=false`

Closes #334