### PR TITLE
fix: prefer exposed placements when loading skills

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -403,6 +403,11 @@ verified Top-1 content result. It requires one unambiguous routable identity, a
 current non-Archived roster state, an eligible placement, complete package and
 entrypoint digests from the latest Snapshot, a regular file contained by an
 approved root, valid UTF-8, and at most 128 KiB of raw `SKILL.md` bytes. The
+loaded placement is selected only after identity ranking: an eligible
+`default_exposed` placement outranks inventory-only exact copies, with path as
+the deterministic tie-breaker; when no exposed placement exists, the same
+deterministic eligible fallback keeps source-only Skills loadable. Hidden and
+nested exact copies remain inventory facts. The
 success result separates selection, complete content, governance, and
 verification facts. Digest or path drift, legacy Snapshot data, ambiguity,
 Archived state, untrusted source, unreadable content, escape, or oversize fails

--- a/src/app.rs
+++ b/src/app.rs
@@ -5853,7 +5853,11 @@ fn verified_top_skill_load(
         .iter()
         .filter(|placement| placement.skill_id == matched.skill_id)
         .collect::<Vec<_>>();
-    placements.sort_by(|left, right| left.entrypoint.cmp(&right.entrypoint));
+    // Identity ranking is already complete; prefer the Agent's active surface
+    // over inventory-only exact copies before applying the existing safety gates.
+    placements.sort_by(|left, right| {
+        (!left.default_exposed, &left.entrypoint).cmp(&(!right.default_exposed, &right.entrypoint))
+    });
     if placements.is_empty() {
         return Err(blocked("placement_missing_from_snapshot", None, None, None).into());
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2759,6 +2759,18 @@ fn gitignore_only_copies_share_routing_identity_but_keep_integrity_drift_checks(
             .as_str()
             .unwrap(),
     );
+    let found_again = json_output(&run(
+        &[
+            &common[..],
+            &["find", "exact route fixture", "--load", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(
+        found_again["result"]["loaded_skill"]["content"]["path"],
+        found["result"]["loaded_skill"]["content"]["path"]
+    );
     fs::write(
         loaded_entrypoint.parent().unwrap().join(".gitignore"),
         "changed after scan\n",
@@ -11187,6 +11199,99 @@ fn find_preserves_leading_hyphen_tasks_and_replayable_variant_actions() {
                 argv[argv.len() - 2..] == [json!("--"), json!(option_shaped_task)]
             })
     );
+}
+
+#[test]
+fn find_load_prefers_an_agent_exposed_placement_over_hidden_inventory_copy() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let hidden = home.join(".codex/skills/.bak-sync/code-review");
+    let exposed = home.join(".codex/skills/code-review");
+    let content = "---\nname: code-review\ndescription: Review a repository change against its specification.\n---\n\nReview the exact diff and report reproducible findings.\n";
+    for directory in [&hidden, &exposed] {
+        fs::create_dir_all(directory).unwrap();
+        fs::write(directory.join("SKILL.md"), content).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "review a repository change against its specification",
+                "--load",
+                "--limit",
+                "1",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["matches"][0]["name"], "code-review");
+    assert_eq!(
+        found["result"]["matches"][0]["paths"],
+        json!([hidden.join("SKILL.md"), exposed.join("SKILL.md")])
+    );
+    assert_eq!(
+        found["result"]["loaded_skill"]["content"]["path"],
+        exposed.join("SKILL.md").to_str().unwrap()
+    );
+    assert_eq!(found["result"]["files_changed"], false);
+}
+
+#[test]
+fn find_load_keeps_a_source_only_skill_loadable_without_an_exposed_placement() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let source = temp.path().join("source-only");
+    let skill = source.join("private-review");
+    fs::create_dir_all(&skill).unwrap();
+    let content = "---\nname: private-review\ndescription: Review a private source package.\n---\n\nRead-only source instructions.\n";
+    fs::write(skill.join("SKILL.md"), content).unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--source-root",
+        source.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "review a private source package",
+                "--load",
+                "--limit",
+                "1",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["matches"][0]["name"], "private-review");
+    let expected_path = fs::canonicalize(skill.join("SKILL.md")).unwrap();
+    assert_eq!(
+        found["result"]["loaded_skill"]["content"]["path"],
+        expected_path.to_str().unwrap()
+    );
+    assert_eq!(found["result"]["files_changed"], false);
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11206,7 +11206,7 @@ fn find_load_prefers_an_agent_exposed_placement_over_hidden_inventory_copy() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
     let state = temp.path().join("state");
-    let skill_root = home.join(".codex").join("skills");
+    let skill_root = home.join(".codex/skills");
     let hidden = skill_root.join(".bak-sync").join("code-review");
     let exposed = skill_root.join("code-review");
     let content = "---\nname: code-review\ndescription: Review a repository change against its specification.\n---\n\nReview the exact diff and report reproducible findings.\n";

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11206,8 +11206,9 @@ fn find_load_prefers_an_agent_exposed_placement_over_hidden_inventory_copy() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
     let state = temp.path().join("state");
-    let hidden = home.join(".codex/skills/.bak-sync/code-review");
-    let exposed = home.join(".codex/skills/code-review");
+    let skill_root = home.join(".codex").join("skills");
+    let hidden = skill_root.join(".bak-sync").join("code-review");
+    let exposed = skill_root.join("code-review");
     let content = "---\nname: code-review\ndescription: Review a repository change against its specification.\n---\n\nReview the exact diff and report reproducible findings.\n";
     for directory in [&hidden, &exposed] {
         fs::create_dir_all(directory).unwrap();


### PR DESCRIPTION
## 解决什么问题

`find --load` 已经正确选中 Skill identity，但同一 identity 有多个 exact-copy placements 时，仅按路径字典序选择读取文件，导致 `.bak-*` 备份可能压过真正暴露给 Agent 的 placement。真实 dogfood 中 `code-review` 就从备份路径加载，返回的 placement governance 也与 aggregate match 不一致。

## 价值是什么

- Agent 实际执行时加载当前暴露面，而不是偶然排在前面的备份。
- 备份仍保留为 inventory/duplicate evidence，不破坏 #143。
- source-only / On-demand Skill 仍可通过确定性 fallback 加载。
- 原有 root、trust、digest、fingerprint、UTF-8、size 与 drift 检查完全保留。

## 方法

- identity ranking 完成后，eligible placement 选择以 `default_exposed` 为首要优先级，path 为稳定 tie-break。
- 没有 exposed placement 时保持原来的路径确定性回退。
- 公开 CLI 回归覆盖 hidden+exposed、source-only、multiple exposed determinism 与 drift fail-closed。

## 验证

- `bash scripts/ci-full-check.sh`
- 325 Rust unit + 8 acceptance + 112 CLI
- 152 Node tests
- Spec review: Clean
- Standards/compatibility review: Clean
- 真实 263-Skill replay：`code-review` 从 `.claude/skills/code-review/SKILL.md` 加载，`backup_loaded=false`、`owned_by_agent=true`、`files_changed=false`

Closes #336