### PR TITLE
release: record v1.8.38 publication

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "cbfebe6e3dbaa29aecca109bc8858779812f02a6"
-  version "1.8.37"
+      revision: "74243e5f1a9e283ef08be9a69c2dce9de0274833"
+  version "1.8.38"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.37", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.38", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.37 implements the complete local governance loop. Every
+Public release v1.8.38 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.37 release and platform evidence](docs/acceptance/release-v1.8.37-candidate.md)
+- [v1.8.38 release and platform evidence](docs/acceptance/release-v1.8.38-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.37 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.38 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.37 发布与平台证据](docs/acceptance/release-v1.8.37-candidate.md)
+- [v1.8.38 发布与平台证据](docs/acceptance/release-v1.8.38-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.38-candidate.md
+++ b/docs/acceptance/release-v1.8.38-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.38 candidate
+# SkillRoster v1.8.38 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.38 makes Agent routing obey explicit task exclusions and makes
 verified loading prefer the Skill placement that is actually exposed to an
@@ -33,10 +33,7 @@ remains at schema 12, the JSON envelope remains at schema 1, and bundled
 Bootstrap content remains at version 1.8.29. It does not mutate Agent or Skill
 files.
 
-## Preparation evidence
-
-Candidate preparation starts from exact `origin/main` revision
-`03dc398cd7ca8050eac64ad28987b5bf25e8e9fa`.
+## Source and review chain
 
 [#335](https://github.com/tt-a1i/skillroster/pull/335) fixed explicit task
 exclusions and merged as `30ce00dde95567d28b4e567078120fb446770fbf`.
@@ -44,42 +41,84 @@ The linked [issue #334](https://github.com/tt-a1i/skillroster/issues/334)
 records its reproducer and acceptance boundary.
 
 [#337](https://github.com/tt-a1i/skillroster/pull/337) fixed exposed-placement
-loading and merged as the candidate base. The linked
-[issue #336](https://github.com/tt-a1i/skillroster/issues/336) records the
-real `.bak-*` load failure, root cause, and bounded acceptance criteria.
-Sequential Spec and Standards reviews were Clean for both changes. The final
-Windows-specific test representation correction was also reviewed in that
-order before merge.
+loading at exact head `e1dd36c95e4eb4de341df74368d9abdfcc23b1a4` and merged as
+`03dc398cd7ca8050eac64ad28987b5bf25e8e9fa`. The linked
+[issue #336](https://github.com/tt-a1i/skillroster/issues/336) records the real
+`.bak-*` load failure, root cause, and bounded acceptance criteria.
 
-The exact-main
-[CI run 33295591534](https://github.com/tt-a1i/skillroster/actions/runs/33295591534)
+[#338](https://github.com/tt-a1i/skillroster/pull/338) prepared version 1.8.38
+at exact head `0d32e67fd456f7d2d4c061f8fd1b06d7adf2db3f` and merged as exact
+release source revision `74243e5f1a9e283ef08be9a69c2dce9de0274833`.
+The PR [CI run 33296194445](https://github.com/tt-a1i/skillroster/actions/runs/33296194445)
+and exact-main [CI run 33296351682](https://github.com/tt-a1i/skillroster/actions/runs/33296351682)
 passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
-and the aggregate CI gate at the candidate base. One first-attempt Linux test
-hit an unrelated transient `ETXTBSY`; the failed job was rerun at the same SHA
-and passed without a source change. The final local gate for #337 passed 325
-Rust unit tests, 8 acceptance tests, 112 CLI tests, and 152 Node harness tests,
-plus strict Clippy, formatting, installation-surface validation, archive
-README validation, the change-scope self-test, and `git diff --check`.
+and the aggregate CI gate.
 
-The source candidate and Cargo package are versioned as 1.8.38. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.37 until the v1.8.38 tag,
-artifacts, checksums, and Homebrew package actually exist.
+The final local gate passed 325 Rust unit tests, 8 acceptance tests, 112 CLI
+tests, and 152 Node harness tests, plus strict Clippy, formatting,
+installation-surface validation, archive README validation, the change-scope
+self-test, and `git diff --check`. Sequential Spec/Evidence and
+Standards/Compatibility reviews were Clean.
 
-## Candidate gates
+## Published release
 
-The candidate is not accepted until one exact final source revision passes:
+Annotated tag `v1.8.38` has tag object
+`a4058a50a8492004b66e278c35d879d90a0cfa82` and resolves to exact source
+revision `74243e5f1a9e283ef08be9a69c2dce9de0274833`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33296693186)
+passed the strict repository gate, all four supported-platform jobs, the
+governance smoke, and WSL2 at that exact revision. The first strict-gate
+attempt encountered a transient Linux `ETXTBSY` while replacing a running test
+executable; the failed job was rerun at the same SHA and passed without a
+source or tag change.
 
-- `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.38)
+contains four archives and four adjacent checksum files:
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `daea023385e9699db530d86ea7bf68a796a214bfec2a81c8fb9851c31b875536` |
+| `x86_64-apple-darwin` | `e9b0c327121f9f75a8d06f856e0bc163208716c551a0b2991aea3e3f6e50fa17` |
+| `x86_64-pc-windows-msvc` | `7aff6ef15085b1022db50430ab0a7d472ff633dc9aedefb2165ce2c7cc9ca0f6` |
+| `x86_64-unknown-linux-gnu` | `3b66e4f24ee0899388316f72d9d7ccd4a3d96b349e771033ee59e9b3bb291689` |
+
+All four adjacent checksums passed, and each archive README matched the
+checked-in Git blob byte-for-byte. The public asset inventory contained
+exactly those eight files with matching service-side archive digests. An
+anonymous macOS arm64 download passed its adjacent checksum, matched the
+tag-workflow artifact byte-for-byte, reported `skillroster 1.8.38`, and passed
+the full Scan, Setup, Apply, Undo, and Status governance smoke in isolated
+temporary directories.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #12](https://github.com/tt-a1i/homebrew-skillroster/pull/12)
+at exact head `28118b14738ad2a93cfa9820fe69276cb5df6d6e`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33297952661)
+built and tested macOS arm64 and Linux x86_64 bottles at that PR head. The
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33298180364)
+was dispatched from tap `main` at
+`b07a7382107bbffa0f949cf6f7ce321d5277e0fc` after test-bot passed. It closed
+the PR without a regular merge commit, created equivalent Formula commit
+`539b2bc8cb89afbf7ce742e4c8bf5b4eac5be6f3`, published both bottles, and
+advanced tap `main` through bottle
+commit `5b8a44d0e474938993ffc6cca9082c223ebdc504`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `e43437b327bca03c8de84b29919606abada84ba572b5982b02d33ac40ef0037b` |
+| `x86_64_linux` | `64c22cdb7a4f96675b65347895a6030eb15ad5eccb69e38c6bc096a8d9c3f8d0` |
+
+The public arm64 bottle was downloaded without repository credentials, matched
+the Formula checksum, reported version 1.8.38, and passed the governance
+smoke. Verification extracted the bottle in an isolated temporary directory
+and did not mutate the user's installed Homebrew package.
+
+## Boundaries
+
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent or Skill files,
+  or change the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.37**. Its Formula, annotated tag, four
+The current public release is **v1.8.38**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.37
+SKILLROSTER_VERSION=1.8.38
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.37 skillroster
+  --tag v1.8.38 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.37 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.38 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.38**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.37 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.38 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.37 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.38 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.37 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.37 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.38 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.38 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Outcome

Records the already-published v1.8.38 release across the checked-in Formula, bilingual README status, installation guide, website, and release receipt.

## Evidence

- Exact release source: `74243e5f1a9e283ef08be9a69c2dce9de0274833`
- Annotated tag and 8 public assets verified
- Four supported-platform jobs plus WSL2 passed
- Homebrew macOS arm64 and Linux x86_64 bottles published and anonymously verified
- Local full gate: 325 unit + 8 acceptance + 112 CLI + 152 Node
- Sequential Spec/Evidence and Standards/Compatibility reviews: Clean

## Boundaries

Documentation and release-record changes only. No runtime, schema, Bootstrap, Agent file, Skill file, or user state mutation.