### PR TITLE
fix: preserve task objects in routing exclusions

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -344,6 +344,13 @@ Terms already present in the positive task remain shared object evidence; only
 the constraint-specific remainder may exclude a Skill whose positive name,
 trigger, or description declares the prohibited capability. Agent-authored
 hints remain separate positive evidence and cannot cancel a task exclusion.
+Within one bounded exclusion clause, `code` and `代码` remain shared task-object
+context when the same clause contains another searchable constraint token and
+the object follows earlier constraint material;
+they cannot by themselves exclude review or analysis Skills. When either is
+the clause's only capability token or leads the clause, it remains an effective
+exclusion. This filter is applied independently to each exclusion clause so
+one constraint cannot weaken another.
 `task_exclusion_effects` reports the exact affected candidate count plus a
 deterministic preview of at most 10 affected Skill identities, ordered by name
 and opaque Skill ID. Each preview item contains only the name, opaque ID, and

--- a/src/query.rs
+++ b/src/query.rs
@@ -18,6 +18,7 @@ pub const UNKNOWN_ARCHIVE_FINDING_TITLE: &str = "Archive candidacy is unknown";
 const SEMANTIC_SHARED_TERM_PREVIEW_LIMIT: usize = 20;
 const SEMANTIC_SHARED_TERM_CHARACTER_LIMIT: usize = 64;
 const TASK_EXCLUSION_MARKERS: &[&str] = &["do not", "不要", "也不要"];
+const TASK_EXCLUSION_CONTEXT_TOKENS: &[&str] = &["code", "代码"];
 const TASK_EXCLUSION_EFFECT_PREVIEW_LIMIT: usize = 10;
 
 fn normalize_skill_name(name: &str) -> String {
@@ -1928,18 +1929,8 @@ pub(crate) fn find_matching_with_evidence(
     }
     let query_tokens = tokens(&query_text);
     let positive_task_tokens = tokens(&query.positive_task_text);
-    let excluded_task_tokens = tokens(
-        &query
-            .excluded_task_phrases
-            .iter()
-            .map(|phrase| task_exclusion_body(phrase))
-            .collect::<Vec<_>>()
-            .join(" "),
-    );
-    let excluded_only_task_tokens = excluded_task_tokens
-        .difference(&positive_task_tokens)
-        .cloned()
-        .collect::<BTreeSet<_>>();
+    let excluded_only_task_tokens =
+        task_exclusion_capability_tokens(&query.excluded_task_phrases, &positive_task_tokens);
     let query_phrases = query
         .phrases
         .iter()
@@ -2594,6 +2585,42 @@ fn task_routing_sections(task: &str) -> (String, Vec<String>) {
 
 fn task_exclusion_body(section: &str) -> &str {
     task_exclusion_marker(section).map_or(section, |marker| section[marker.len()..].trim())
+}
+
+fn task_exclusion_capability_tokens(
+    phrases: &[String],
+    positive_task_tokens: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    phrases
+        .iter()
+        .flat_map(|phrase| {
+            let body = task_exclusion_body(phrase);
+            let mut clause_tokens = tokens(body)
+                .difference(positive_task_tokens)
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            if clause_tokens.len() > 1 {
+                for context_token in TASK_EXCLUSION_CONTEXT_TOKENS {
+                    if task_exclusion_context_token_is_object(body, context_token) {
+                        clause_tokens.remove(*context_token);
+                    }
+                }
+            }
+            clause_tokens
+        })
+        .collect()
+}
+
+fn task_exclusion_context_token_is_object(body: &str, context_token: &str) -> bool {
+    if context_token.is_ascii() {
+        body.split(|character: char| !character.is_alphanumeric())
+            .filter(|part| !part.is_empty())
+            .position(|part| part.eq_ignore_ascii_case(context_token))
+            .is_some_and(|position| position > 0)
+    } else {
+        body.find(context_token)
+            .is_some_and(|position| !body[..position].trim().is_empty())
+    }
 }
 
 fn task_exclusion_marker(section: &str) -> Option<&'static str> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1810,6 +1810,212 @@ fn public_find_does_not_route_to_an_english_do_not_constraint() {
 }
 
 #[test]
+fn public_find_keeps_shared_task_objects_out_of_capability_exclusions() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "code-review",
+            "---\nname: code-review\ndescription: Review code for correctness and defects. 审查代码正确性和缺陷。\n---\n",
+        ),
+        (
+            "simplify-codebase",
+            "---\nname: simplify-codebase\ndescription: Simplify and refactor code for maintainability. 简化和重构代码。\n---\n",
+        ),
+        (
+            "impact-gated-pr",
+            "---\nname: impact-gated-pr\ndescription: Run pull request workflows and compatibility review.\n---\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let baseline = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "Review this Rust release PR for correctness",
+                "--hint",
+                "code review",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let constrained = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "Review this Rust release PR for correctness; do not simplify or refactor the code",
+                "--hint",
+                "code review",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let constrained_cjk = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "审查这个 Rust 发布 PR 的正确性，不要简化或重构代码",
+                "--hint",
+                "code review",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(baseline["result"]["matches"][0]["name"], "code-review");
+    assert_eq!(constrained["result"]["matches"][0]["name"], "code-review");
+    let names = constrained["result"]["matches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|matched| matched["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(!names.contains(&"simplify-codebase"));
+    assert_eq!(
+        constrained["result"]["task_exclusions"],
+        json!(["do not simplify or refactor the code"])
+    );
+    let affected_names = constrained["result"]["task_exclusion_effects"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|effect| effect["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(affected_names.contains(&"simplify-codebase"));
+    assert!(!affected_names.contains(&"code-review"));
+    assert_eq!(constrained["result"]["files_changed"], false);
+    assert_eq!(
+        constrained_cjk["result"]["matches"][0]["name"],
+        "code-review"
+    );
+    assert!(
+        constrained_cjk["result"]["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|matched| matched["name"] != "simplify-codebase")
+    );
+    let affected_cjk_names = constrained_cjk["result"]["task_exclusion_effects"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|effect| effect["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(affected_cjk_names.contains(&"simplify-codebase"));
+    assert!(!affected_cjk_names.contains(&"code-review"));
+}
+
+#[test]
+fn public_find_keeps_single_token_exclusions_independent_across_clauses() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "inspect-worktree",
+            "---\nname: inspect-worktree\ndescription: Inspect worktree problems.\n---\n",
+        ),
+        (
+            "code-action",
+            "---\nname: code-action\ndescription: Code.\n---\n",
+        ),
+        (
+            "publish-action",
+            "---\nname: publish-action\ndescription: Publish.\n---\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let found = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "Inspect worktree problems; do not code; do not publish",
+                "--hint",
+                "code publish",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let coordinated = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "Inspect worktree problems; do not code or publish",
+                "--hint",
+                "code publish",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+
+    assert_eq!(found["result"]["matches"][0]["name"], "inspect-worktree");
+    let affected_names = found["result"]["task_exclusion_effects"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|effect| effect["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(affected_names, vec!["code-action", "publish-action"]);
+    let coordinated_affected_names = coordinated["result"]["task_exclusion_effects"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|effect| effect["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        coordinated_affected_names,
+        vec!["code-action", "publish-action"]
+    );
+}
+
+#[test]
 fn public_find_task_exclusion_constrains_a_conflicting_agent_hint() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## Problem

An explicit exclusion such as `do not simplify or refactor the code` treated the shared object `code` as a prohibited capability. On the same real Snapshot, adding that clause removed `code-review` before ranking and changed Top-1 to `impact-gated-pr`.

## Solution

- derive exclusion capability tokens independently for each bounded clause
- keep trailing `code` / `代码` as shared object context when a stronger searchable constraint is present
- preserve leading or sole `code` / `代码` as effective constraints
- keep Agent hints unable to restore genuinely excluded simplify/refactor capabilities
- document the deterministic boundary

## Evidence

- real 263-Skill / 1,037-placement replay: English and Chinese review tasks return `code-review` Top-1; `simplify-codebase` remains in exclusion effects; `files_changed=false`
- regression tests cover English, Chinese, independent clauses, and coordinated single-token exclusions
- full local gate: 325 unit + 8 acceptance + 114 CLI + 152 Node
- strict Clippy, formatting, installation surface, archive README, change-scope self-test, and diff check passed
- two-axis Standards and Spec review: no blocking findings

Closes #340