### PR TITLE
release: prepare v1.8.39 candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "skillroster"
-version = "1.8.38"
+version = "1.8.39"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skillroster"
-version = "1.8.38"
+version = "1.8.39"
 edition = "2024"
 rust-version = "1.85"
 description = "Local skill governance for AI agents"

--- a/docs/acceptance/release-v1.8.39-candidate.md
+++ b/docs/acceptance/release-v1.8.39-candidate.md
@@ -1,0 +1,71 @@
+# SkillRoster v1.8.39 candidate
+
+## Release notes draft
+
+SkillRoster 1.8.39 keeps explicit task exclusions from accidentally removing
+the capability the user actually requested.
+
+- A task such as “review this code, but do not simplify or refactor it” keeps
+  `code-review` at Top-1 while excluding modification-oriented Skills such as
+  `simplify-codebase`.
+- English `code` and Chinese `代码` are treated as shared task-object context
+  only when the same negative clause contains another searchable constraint
+  and they are not its leading token. Sole or leading capability exclusions
+  remain effective.
+- Exclusions are derived independently per clause, so `do not code; do not
+  publish` still excludes both capabilities rather than weakening either one.
+- JSON exclusion evidence remains bounded and auditable, and Agent hints still
+  cannot override an actual prohibited capability.
+
+The real-inventory A/B replay reused one read-only Snapshot of 263 Skills and
+1,037 placements. Before the fix, adding “do not simplify or refactor the code”
+removed `code-review` and promoted `impact-gated-pr`. After the fix,
+`code-review` remained Top-1, `simplify-codebase` remained excluded, and both
+the English and Chinese replays reported `files_changed=false`.
+
+This patch changes lexical Find exclusion handling only. SQLite remains at
+schema 12, the JSON envelope remains at schema 1, and bundled Bootstrap content
+remains at version 1.8.29. It does not mutate Agent or Skill files.
+
+## Preparation evidence
+
+Candidate preparation starts from exact `origin/main` revision
+`0cb27d9982a526fef8f83cc61fd15d4e6670f674`.
+
+[#341](https://github.com/tt-a1i/skillroster/pull/341) fixed shared task-object
+exclusions at exact head `817fc48eabac53ba58d8716985baf61d39b29985`
+and merged as the candidate base. The linked
+[issue #340](https://github.com/tt-a1i/skillroster/issues/340) records the
+real bilingual reproducer, root cause, and bounded acceptance criteria.
+Sequential Spec/Evidence and Standards/Compatibility reviews were Clean.
+
+The exact-main
+[CI run 33300043677](https://github.com/tt-a1i/skillroster/actions/runs/33300043677)
+passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
+and the aggregate CI gate at the candidate base. The final local gate for #341
+passed 325 Rust unit tests, 8 acceptance tests, 114 CLI tests, and 152 Node
+harness tests, plus strict Clippy, formatting, installation-surface validation,
+archive README validation, the change-scope self-test, and `git diff --check`.
+
+The source candidate and Cargo package are versioned as 1.8.39. Public install
+examples, the checked-in Formula, website current-release label, and README
+release evidence deliberately remain at v1.8.38 until the v1.8.39 tag,
+artifacts, checksums, and Homebrew package actually exist.
+
+## Candidate gates
+
+The candidate is not accepted until one exact final source revision passes:
+
+- `cargo fmt --all --check`;
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
+- `cargo test --locked --all-targets --all-features`;
+- the public CLI acceptance suite and Node harnesses;
+- `git diff --check`, installation-surface validation, archive README
+  validation, and the CI change-scope self-test;
+- four platform build and governance jobs plus the WSL2 governance smoke;
+- downloaded checksum verification and an external four-archive comparison
+  against the checked-in README Git blob.
+
+Candidate preparation does not create or push a tag, publish a GitHub Release,
+update Homebrew, or mutate an existing public release asset. Those operations
+remain separately evidenced after candidate acceptance.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -94,7 +94,7 @@ skillroster setup --json
 ```
 
 Published CLI v1.8.38 bundles Bootstrap content version 1.8.29.
-The source tree is **v1.8.38**.
+The source tree is **v1.8.39**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap
 instructions.

--- a/website/index.html
+++ b/website/index.html
@@ -1496,7 +1496,7 @@ footer { overflow: hidden; }
       </div>
     </div>
     <div class="footer-rule">
-      <span>SOURCE TREE v1.8.38 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
+      <span>SOURCE TREE v1.8.39 — RUST 2024 · ONE BINARY · ONE DATABASE · ONE BOOTSTRAP SKILL</span>
       <span>NO DAEMON · NO CLOUD · NO TELEMETRY</span>
     </div>
   </div>


### PR DESCRIPTION
## 解决什么问题

把已合入并验证的 #341 固化为 v1.8.39 候选：显式禁止项中的共享任务对象不再误伤用户真正请求的审查能力。

## 价值是什么

- “审查代码，但不要简化或重构”继续选择 code-review。
- simplify-codebase 等修改类 Skill 仍被排除，Agent hint 不能绕过禁止项。
- 英文和中文路径都有公开 CLI 回归，排除效果继续可审计。

## 发布边界

- Cargo/source tree: 1.8.39
- SQLite schema: 12
- JSON envelope: 1
- Bootstrap content: 1.8.29
- 公开安装面、Formula、README 和 website current release 保持 v1.8.38，直到真实 tag、artifact 与 Homebrew 存在。

## 验证

- 完整本地门禁在 exact head 35547897fad2b9a64d35ed80fbe74894602302c7 通过
- 325 Rust unit + 8 acceptance + 114 CLI
- 152 Node tests
- optimized release build + release governance smoke: pass
- Spec/Evidence review: 1 个 P2 文案问题已修复，复审 PASS
- Standards/Compatibility review: PASS
- diff、installation surface、archive README、change-scope self-test: pass

真实发布证据将在 tag workflow、GitHub Release 与 Homebrew 完成后回填。