### PR TITLE
release: record v1.8.39 publication

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "74243e5f1a9e283ef08be9a69c2dce9de0274833"
-  version "1.8.38"
+      revision: "efa98c05ec042d17dd9a7f1310daee6fc43da8e8"
+  version "1.8.39"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.38", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.39", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.38 implements the complete local governance loop. Every
+Public release v1.8.39 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.38 release and platform evidence](docs/acceptance/release-v1.8.38-candidate.md)
+- [v1.8.39 release and platform evidence](docs/acceptance/release-v1.8.39-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.38 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.39 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.38 发布与平台证据](docs/acceptance/release-v1.8.38-candidate.md)
+- [v1.8.39 发布与平台证据](docs/acceptance/release-v1.8.39-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.39-candidate.md
+++ b/docs/acceptance/release-v1.8.39-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.39 candidate
+# SkillRoster v1.8.39 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.39 keeps explicit task exclusions from accidentally removing
 the capability the user actually requested.
@@ -27,45 +27,89 @@ This patch changes lexical Find exclusion handling only. SQLite remains at
 schema 12, the JSON envelope remains at schema 1, and bundled Bootstrap content
 remains at version 1.8.29. It does not mutate Agent or Skill files.
 
-## Preparation evidence
-
-Candidate preparation starts from exact `origin/main` revision
-`0cb27d9982a526fef8f83cc61fd15d4e6670f674`.
+## Source and review chain
 
 [#341](https://github.com/tt-a1i/skillroster/pull/341) fixed shared task-object
 exclusions at exact head `817fc48eabac53ba58d8716985baf61d39b29985`
-and merged as the candidate base. The linked
+and merged as `0cb27d9982a526fef8f83cc61fd15d4e6670f674`. The linked
 [issue #340](https://github.com/tt-a1i/skillroster/issues/340) records the
 real bilingual reproducer, root cause, and bounded acceptance criteria.
 Sequential Spec/Evidence and Standards/Compatibility reviews were Clean.
 
-The exact-main
-[CI run 33300043677](https://github.com/tt-a1i/skillroster/actions/runs/33300043677)
+[#342](https://github.com/tt-a1i/skillroster/pull/342) prepared version 1.8.39
+at exact head `35547897fad2b9a64d35ed80fbe74894602302c7` and merged as exact
+release source revision `efa98c05ec042d17dd9a7f1310daee6fc43da8e8`.
+Spec/Evidence review found one documentation sentence that was narrower than
+the implemented clause rule; the wording was corrected, all gates were rerun,
+and both Spec/Evidence and Standards/Compatibility re-reviews passed at the
+final head.
+
+The PR [CI run 33300490903](https://github.com/tt-a1i/skillroster/actions/runs/33300490903)
+and exact-main [CI run 33300681762](https://github.com/tt-a1i/skillroster/actions/runs/33300681762)
 passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
-and the aggregate CI gate at the candidate base. The final local gate for #341
-passed 325 Rust unit tests, 8 acceptance tests, 114 CLI tests, and 152 Node
-harness tests, plus strict Clippy, formatting, installation-surface validation,
-archive README validation, the change-scope self-test, and `git diff --check`.
+and the aggregate CI gate. The final local gate passed 325 Rust unit tests, 8
+acceptance tests, 114 CLI tests, and 152 Node harness tests, plus strict
+Clippy, formatting, installation-surface validation, archive README
+validation, the change-scope self-test, and `git diff --check`.
 
-The source candidate and Cargo package are versioned as 1.8.39. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.38 until the v1.8.39 tag,
-artifacts, checksums, and Homebrew package actually exist.
+## Published release
 
-## Candidate gates
+Annotated tag `v1.8.39` has tag object
+`8604dc31f4bdc03295af69614d504963dc339ba0` and resolves to exact source
+revision `efa98c05ec042d17dd9a7f1310daee6fc43da8e8`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33300975709)
+passed the strict repository gate, all four supported-platform jobs, the
+governance smoke, and WSL2 at that exact revision.
 
-The candidate is not accepted until one exact final source revision passes:
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.39)
+contains four archives and four adjacent checksum files:
 
-- `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `d68c707fc07725a2008b3e50b3ed09b68bbab7c8b35f135ef868ba7a52343ff2` |
+| `x86_64-apple-darwin` | `3a66ec33aed7cada5f514f630674afc3d8b9821e2426e7ff59c3a73fb535ba56` |
+| `x86_64-pc-windows-msvc` | `f7259519a653922c3fd9f3dd8061c99570a2310d80623c54a0a494ffeeab56f5` |
+| `x86_64-unknown-linux-gnu` | `0728c17e9122b7797474a176205ec42ccf0db30c876ee6f1279020519cbe7126` |
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+All four adjacent checksums passed, and each archive README and LICENSE
+matched the checked-in Git blobs byte-for-byte. The public asset inventory
+contained exactly those eight files with matching service-side archive
+digests. An anonymous macOS arm64 download passed its adjacent checksum,
+matched the tag-workflow artifact byte-for-byte, reported `skillroster
+1.8.39`, and passed the full Scan, Setup, Apply, Undo, and Status governance
+smoke in isolated temporary directories.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #13](https://github.com/tt-a1i/homebrew-skillroster/pull/13)
+at exact head `71068e596f506246567a01c81841aca28e85fb4d`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33301932343)
+built and tested macOS arm64 and Linux x86_64 bottles at that PR head. The
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33302210671)
+was dispatched from tap `main` at
+`5b8a44d0e474938993ffc6cca9082c223ebdc504` after test-bot passed. It closed
+the PR without a regular merge commit, created equivalent Formula commit
+`4f95853502739ff5b5efd8892febf6dd05b7a7c1`, published both bottles, and
+advanced tap `main` through bottle commit
+`4df9a5e26aeced5a598364463dd4a2a5bb1a5843`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `1512732b61d49050fe1c8b29b95b9cfae36c4c8a2a04ec709bfd20f8e9ec167a` |
+| `x86_64_linux` | `3f3e2bd606a7464c5f7cc271df58e96c331077c267fdfec840ff62ddc88b0a2d` |
+
+The public arm64 bottle was downloaded without repository credentials,
+matched the Formula checksum, reported version 1.8.39, and passed the
+governance smoke. Verification extracted the bottle in an isolated temporary
+directory and did not mutate the user's installed Homebrew package.
+
+## Boundaries
+
+- The lexical `code` / `代码` rule is deliberately bounded; it is not a
+  general semantic-negation engine.
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent or Skill files,
+  or change the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.38**. Its Formula, annotated tag, four
+The current public release is **v1.8.39**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.38
+SKILLROSTER_VERSION=1.8.39
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.38 skillroster
+  --tag v1.8.39 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.38 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.39 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.39**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.38 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.39 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.38 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.39 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.38 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.38 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.39 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.39 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Records the already-published v1.8.39 release and updates public installation surfaces.

- binds the checked-in Formula to exact release source efa98c05ec042d17dd9a7f1310daee6fc43da8e8
- updates English/Chinese README, installation docs, and website current-release labels
- converts the candidate note into a source, CI, artifact, Homebrew, and anonymous-download receipt
- full local gate passes: 325 Rust unit + 8 acceptance + 114 CLI + 152 Node; strict Clippy, formatting, installation/release checks, and diff checks