### PR TITLE
fix: recognize coordinated task exclusions

### DIFF
--- a/docs/acceptance/coordinated-task-exclusion-dogfood-v1.md
+++ b/docs/acceptance/coordinated-task-exclusion-dogfood-v1.md
@@ -1,0 +1,68 @@
+# Coordinated task-exclusion dogfood v1
+
+## Problem and value
+
+Public SkillRoster v1.8.39 correctly excluded a prohibited capability when an
+independent clause began directly with `do not`, `不要`, or `也不要`. Real Agent
+wording often introduces the same clause with a coordinator. Against one fresh
+read-only Snapshot of 263 Skills and 1,037 placements, this task returned an
+empty `task_exclusions` list and left `simplify-code` in the first five matches:
+
+```text
+Review this code for correctness and security, but do not simplify or refactor it
+```
+
+Replacing only `, but do not` with `; do not` produced the expected exclusion
+and removed the simplify candidate. The parallel Chinese comparison showed the
+same split between `但是不要` and a direct `不要` clause. This is a routing-safety
+bug: the person explicitly prohibited a capability, but the deterministic Find
+contract presented it as positive evidence.
+
+## Diagnosis
+
+The feedback loop used the anonymous public macOS arm64 v1.8.39 archive, the
+real local Skill Inventory, and a fresh temporary state directory. Scan and all
+Find calls reported `files_changed=false`; no Agent or Skill files were
+modified.
+
+Ranked hypotheses were tested one variable at a time:
+
+1. The clause parser required an exclusion marker at byte zero and did not
+   recognize a leading coordinator. Confirmed: removing only the coordinator
+   made the failure disappear.
+2. The real `simplify-code` name differed from the fixture's
+   `simplify-codebase`. Rejected: both were excluded after the punctuation-only
+   differential.
+3. Observed usage evidence overwhelmed the exclusion penalty. Rejected: the
+   failing result contained no exclusion effect at all.
+4. The published binary had drifted from the source behavior. Rejected: the
+   public tag and current parser shared the same boundary.
+
+## Fix and regression boundary
+
+[Issue #344](https://github.com/tt-a1i/skillroster/issues/344) bounds the fix.
+The parser now recognizes only six explicit coordinator prefixes immediately
+before an existing exclusion marker: `but`, `and`, `yet`, `但是`, `不过`, and
+`但`. It keeps the person's original coordinated clause in JSON evidence, then
+removes the coordinator and marker only for capability-token comparison.
+
+The public CLI regression exercises English and Chinese coordinated clauses
+through Scan and Find, proves that `code-review` stays Top-1 in the controlled
+fixture, proves that `simplify-codebase` is absent, and keeps
+`files_changed=false`. Unit coverage separately retains the negative-state
+control `diagnose why tests do not pass`, so this bounded grammar does not turn
+embedded prose into an exclusion.
+
+The original 263-Skill replay now returns the coordinated clauses in
+`task_exclusions` and removes the observed simplify candidates in both
+languages. This remains lexical routing evidence, not general pronoun
+resolution or semantic-negation understanding.
+
+## Retrospective
+
+The v1.8.39 fixture proved a direct negative clause but its release note used a
+more natural coordinated sentence that the fixture did not execute. The
+preventive change is to bind every public routing example to the exact public
+CLI regression string, including punctuation and coordinators. Future rounds
+should continue replaying realistic Agent phrasing against the full Inventory,
+not infer broad behavior from a nearby synthetic sentence.

--- a/docs/acceptance/release-v1.8.39-candidate.md
+++ b/docs/acceptance/release-v1.8.39-candidate.md
@@ -5,7 +5,7 @@
 SkillRoster 1.8.39 keeps explicit task exclusions from accidentally removing
 the capability the user actually requested.
 
-- A task such as “review this code, but do not simplify or refactor it” keeps
+- A task such as “review this code; do not simplify or refactor it” keeps
   `code-review` at Top-1 while excluding modification-oriented Skills such as
   `simplify-codebase`.
 - English `code` and Chinese `代码` are treated as shared task-object context
@@ -26,6 +26,12 @@ the English and Chinese replays reported `files_changed=false`.
 This patch changes lexical Find exclusion handling only. SQLite remains at
 schema 12, the JSON envelope remains at schema 1, and bundled Bootstrap content
 remains at version 1.8.29. It does not mutate Agent or Skill files.
+
+The published v1.8.39 parser required the negative clause itself to begin with
+an exclusion marker. Natural coordinator prefixes such as English `but` and
+Chinese `但是` were not recognized; [issue #344](https://github.com/tt-a1i/skillroster/issues/344)
+records the post-release dogfood reproducer and bounded source fix. The release
+artifacts remain immutable.
 
 ## Source and review chain
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -338,8 +338,12 @@ ordinary and folded YAML description scalars.
 An independent punctuation-delimited task clause that begins with `不要`, the
 parallel continuation `也不要`, or the complete ASCII marker `do not` remains
 verbatim in `task` but does not contribute positive candidate or ranking
-evidence. Prefixes such as `do nothing` are not markers. `task_exclusions`
-returns the recognized clauses so the Agent can audit that deterministic split.
+evidence. The bounded coordinators `but`, `and`, `yet`, `但是`, `不过`, and `但`
+may immediately precede one of those markers; the original coordinated clause
+remains verbatim in `task_exclusions`. Prefixes such as `do nothing` are not
+markers, and a coordinator without an immediate marker remains positive task
+text. `task_exclusions` returns the recognized clauses so the Agent can audit
+that deterministic split.
 Terms already present in the positive task remain shared object evidence; only
 the constraint-specific remainder may exclude a Skill whose positive name,
 trigger, or description declares the prohibited capability. Agent-authored

--- a/src/query.rs
+++ b/src/query.rs
@@ -18,6 +18,7 @@ pub const UNKNOWN_ARCHIVE_FINDING_TITLE: &str = "Archive candidacy is unknown";
 const SEMANTIC_SHARED_TERM_PREVIEW_LIMIT: usize = 20;
 const SEMANTIC_SHARED_TERM_CHARACTER_LIMIT: usize = 64;
 const TASK_EXCLUSION_MARKERS: &[&str] = &["do not", "不要", "也不要"];
+const TASK_EXCLUSION_COORDINATORS: &[&str] = &["but", "and", "yet", "但是", "不过", "但"];
 const TASK_EXCLUSION_CONTEXT_TOKENS: &[&str] = &["code", "代码"];
 const TASK_EXCLUSION_EFFECT_PREVIEW_LIMIT: usize = 10;
 
@@ -2584,7 +2585,8 @@ fn task_routing_sections(task: &str) -> (String, Vec<String>) {
 }
 
 fn task_exclusion_body(section: &str) -> &str {
-    task_exclusion_marker(section).map_or(section, |marker| section[marker.len()..].trim())
+    let clause = task_exclusion_clause(section);
+    task_exclusion_marker_at_start(clause).map_or(clause, |marker| clause[marker.len()..].trim())
 }
 
 fn task_exclusion_capability_tokens(
@@ -2624,6 +2626,38 @@ fn task_exclusion_context_token_is_object(body: &str, context_token: &str) -> bo
 }
 
 fn task_exclusion_marker(section: &str) -> Option<&'static str> {
+    task_exclusion_marker_at_start(task_exclusion_clause(section))
+}
+
+fn task_exclusion_clause(section: &str) -> &str {
+    let section = section.trim();
+    TASK_EXCLUSION_COORDINATORS
+        .iter()
+        .find_map(|coordinator| {
+            let remainder = strip_task_exclusion_coordinator(section, coordinator)?;
+            task_exclusion_marker_at_start(remainder).map(|_| remainder)
+        })
+        .unwrap_or(section)
+}
+
+fn strip_task_exclusion_coordinator<'a>(section: &'a str, coordinator: &str) -> Option<&'a str> {
+    if coordinator.is_ascii() {
+        let prefix = section.get(..coordinator.len())?;
+        if !prefix.eq_ignore_ascii_case(coordinator) {
+            return None;
+        }
+        let remainder = &section[coordinator.len()..];
+        remainder
+            .chars()
+            .next()
+            .is_some_and(|next| !next.is_alphanumeric())
+            .then(|| remainder.trim_start())
+    } else {
+        section.strip_prefix(coordinator).map(str::trim_start)
+    }
+}
+
+fn task_exclusion_marker_at_start(section: &str) -> Option<&'static str> {
     TASK_EXCLUSION_MARKERS.iter().copied().find(|marker| {
         if marker.is_ascii() {
             section
@@ -3730,6 +3764,42 @@ mod tests {
             excluded,
             vec!["不要修改代码", "do not run tests", "也不要创建 issue"]
         );
+    }
+
+    #[test]
+    fn task_routing_sections_recognize_bounded_coordinators() {
+        for (task, expected_positive, expected_exclusion, expected_body) in [
+            (
+                "Review this PR, but do not simplify it",
+                "Review this PR",
+                "but do not simplify it",
+                "simplify it",
+            ),
+            (
+                "Review this PR, and do not refactor it",
+                "Review this PR",
+                "and do not refactor it",
+                "refactor it",
+            ),
+            (
+                "审查这个 PR，但是不要简化代码",
+                "审查这个 PR",
+                "但是不要简化代码",
+                "简化代码",
+            ),
+            (
+                "审查这个 PR，但不要重构代码",
+                "审查这个 PR",
+                "但不要重构代码",
+                "重构代码",
+            ),
+        ] {
+            let (positive, excluded) = task_routing_sections(task);
+
+            assert_eq!(positive, expected_positive);
+            assert_eq!(excluded, vec![expected_exclusion]);
+            assert_eq!(task_exclusion_body(expected_exclusion), expected_body);
+        }
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1887,6 +1887,36 @@ fn public_find_keeps_shared_task_objects_out_of_capability_exclusions() {
         .concat(),
         None,
     ));
+    let constrained_with_coordinator = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "Review this Rust release PR for correctness, but do not simplify or refactor the code",
+                "--hint",
+                "code review",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    let constrained_cjk_with_coordinator = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                "审查这个 Rust 发布 PR 的正确性，但是不要简化或重构代码",
+                "--hint",
+                "code review",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
 
     assert_eq!(baseline["result"]["matches"][0]["name"], "code-review");
     assert_eq!(constrained["result"]["matches"][0]["name"], "code-review");
@@ -1929,6 +1959,26 @@ fn public_find_keeps_shared_task_objects_out_of_capability_exclusions() {
         .collect::<Vec<_>>();
     assert!(affected_cjk_names.contains(&"simplify-codebase"));
     assert!(!affected_cjk_names.contains(&"code-review"));
+    for (result, expected_exclusion) in [
+        (
+            constrained_with_coordinator,
+            "but do not simplify or refactor the code",
+        ),
+        (constrained_cjk_with_coordinator, "但是不要简化或重构代码"),
+    ] {
+        assert_eq!(result["result"]["matches"][0]["name"], "code-review");
+        assert_eq!(
+            result["result"]["task_exclusions"],
+            json!([expected_exclusion])
+        );
+        assert!(
+            result["result"]["matches"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|matched| matched["name"] != "simplify-codebase")
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## 解决什么问题

真实 Agent 任务常写成 `review ..., but do not simplify ...` 或 `审查……，但是不要简化……`。v1.8.39 只识别直接以否定标记开头的独立子句，导致用户明确禁止的能力仍进入候选。

## 价值

让 Find 在常见中英文自然表达下继续兑现“显式约束优先”：保留用户原文作为可审计证据，同时不再推荐被明确禁止的 Skill。

## 方法

- 仅识别紧邻既有否定标记的有界 coordinator：`but`、`and`、`yet`、`但是`、`不过`、`但`。
- 保留原始协调子句在 `task_exclusions`，只在能力 token 比较时剥离 coordinator 与 marker。
- 添加中英文 public Scan → Find 回归与 parser 单测。
- 修正 v1.8.39 候选说明中强于已发布行为的示例，并记录不可变发布边界。

## 验证

- Test-before-fix：英文 coordinated clause 得到空 `task_exclusions`，回归测试按预期失败。
- Post-fix：真实 263-Skill / 1,037-placement Snapshot 的中英文重放均排除 simplify 候选，`files_changed=false`。
- `bash scripts/ci-full-check.sh`：326 Rust unit、8 acceptance、114 CLI、152 Node，全绿。
- `git diff --check`：通过。

Closes #344