### PR TITLE
release: record v1.8.40 publication

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "efa98c05ec042d17dd9a7f1310daee6fc43da8e8"
-  version "1.8.39"
+      revision: "7df4c68e5e37444a7a701c735e19f2bb3e4b39ec"
+  version "1.8.40"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.39", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.40", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.39 implements the complete local governance loop. Every
+Public release v1.8.40 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.39 release and platform evidence](docs/acceptance/release-v1.8.39-candidate.md)
+- [v1.8.40 release and platform evidence](docs/acceptance/release-v1.8.40-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.39 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.40 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.39 发布与平台证据](docs/acceptance/release-v1.8.39-candidate.md)
+- [v1.8.40 发布与平台证据](docs/acceptance/release-v1.8.40-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.40-candidate.md
+++ b/docs/acceptance/release-v1.8.40-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.40 candidate
+# SkillRoster v1.8.40 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.40 recognizes explicit capability exclusions when ordinary
 English or Chinese coordinators introduce the negative clause.
@@ -27,14 +27,11 @@ This patch changes bounded lexical Find routing only. SQLite remains at schema
 12, the JSON envelope remains at schema 1, and bundled Bootstrap content remains
 at version 1.8.29. It does not mutate Agent or Skill files.
 
-## Preparation evidence
-
-Candidate preparation starts from exact `origin/main` revision
-`3a03538920aa642f450fe8adc74a758f4a52ad3c`.
+## Source and review chain
 
 [#345](https://github.com/tt-a1i/skillroster/pull/345) fixed coordinated task
 exclusions at exact head `b8287753df7fccbbafd5f408b7decba5cdecef8b`
-and merged as the candidate base. The linked
+and merged as `3a03538920aa642f450fe8adc74a758f4a52ad3c`. The linked
 [issue #344](https://github.com/tt-a1i/skillroster/issues/344) records the real
 bilingual reproducer, one-variable differential, and bounded acceptance
 criteria. The exact-head PR
@@ -47,31 +44,78 @@ The exact-main
 also passed the same four-platform matrix and aggregate gate at candidate base
 revision `3a03538920aa642f450fe8adc74a758f4a52ad3c`.
 
+[#346](https://github.com/tt-a1i/skillroster/pull/346) prepared version 1.8.40
+at exact head `402aeba629f7a3d60d21b1baac4563b2815c119c` and merged as exact
+release source revision `7df4c68e5e37444a7a701c735e19f2bb3e4b39ec`.
+The PR [CI run 33303888383](https://github.com/tt-a1i/skillroster/actions/runs/33303888383)
+and exact-main [CI run 33304146689](https://github.com/tt-a1i/skillroster/actions/runs/33304146689)
+passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
+and the aggregate CI gate at their exact revisions.
+
 The test-before-fix public CLI regression failed with an empty English
 `task_exclusions` array. At the final fix head, the full local gate passed 326
 Rust unit tests, 8 acceptance tests, 114 CLI tests, and 152 Node harness tests,
 plus strict Clippy, formatting, installation-surface validation, archive README
 validation, the change-scope self-test, and `git diff --check`.
 
-The source candidate and Cargo package are versioned as 1.8.40. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.39 until the v1.8.40 tag,
-artifacts, checksums, and Homebrew package actually exist.
+## Published release
 
-## Candidate gates
+Annotated tag `v1.8.40` has tag object
+`e9a619a08b0807931d45ea42460c3202056dd09f` and resolves to exact source
+revision `7df4c68e5e37444a7a701c735e19f2bb3e4b39ec`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33304469207)
+passed the strict repository gate, all four supported-platform jobs, the
+governance smoke, and WSL2 at that exact revision.
 
-The candidate is not accepted until one exact final source revision passes:
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.40)
+contains four archives and four adjacent checksum files:
 
-- `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `bfbf0c259d41f7d8817f6f6171c3643b745d76980cdbb5a980928632c5089bfb` |
+| `x86_64-apple-darwin` | `bed295976203cc2ab01dd527300940dbccb44e1dc6d7015df7d1e9f8b011d457` |
+| `x86_64-pc-windows-msvc` | `4abf4968910170068107ff1e3d93ec34de245e6e839d21fc0002f0dee1bef92f` |
+| `x86_64-unknown-linux-gnu` | `39726cdfdc40d497811a8798f7b12f8f3cec6a1fee51d1bd5c58c644878530a3` |
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+All four adjacent checksums passed, and every archive README and LICENSE
+matched the checked-in Git blobs byte-for-byte. The public asset inventory
+contained exactly those eight files with matching service-side archive
+digests. An anonymous macOS arm64 download passed its adjacent checksum,
+matched the tag-workflow artifact byte-for-byte, reported `skillroster
+1.8.40`, and passed the full release governance smoke in isolated temporary
+directories.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #14](https://github.com/tt-a1i/homebrew-skillroster/pull/14)
+at exact head `f0130f1a6e31bc5567ec9417747ee5abd69c48ae`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33305221735)
+built and tested macOS arm64 and Linux x86_64 bottles at that PR head. The
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33305513508)
+was dispatched from tap `main` at
+`4df9a5e26aeced5a598364463dd4a2a5bb1a5843` after test-bot passed. It closed
+the PR without a regular merge commit, created equivalent Formula commit
+`232cee41d4f2a17121e398260ba4e59b9e7f76a1`, published both bottles, and
+advanced tap `main` through bottle commit
+`4e4be54f5b105ac2e1f6b1f5e3b1371ec84661b9`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `d7134699850bbf129c7e98c54e2960ed1a660b3bc15a6fa3075745bc0e4a63dd` |
+| `x86_64_linux` | `8e291267270b39d4c21464f5723acd0eed5a9016cc44352f408f141be261ede1` |
+
+The public arm64 bottle was downloaded without repository credentials,
+matched the Formula checksum, reported version 1.8.40, and passed the release
+governance smoke. Verification extracted the bottle in an isolated temporary
+directory and did not mutate the user's installed Homebrew package.
+
+## Boundaries
+
+- Coordinated task exclusion remains a bounded lexical rule, not a general
+  semantic-negation or pronoun-resolution engine.
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent or Skill files,
+  or change the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.39**. Its Formula, annotated tag, four
+The current public release is **v1.8.40**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.39
+SKILLROSTER_VERSION=1.8.40
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.39 skillroster
+  --tag v1.8.40 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.39 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.40 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.40**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.39 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.40 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.39 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.40 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.39 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.39 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.40 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.40 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Records the published v1.8.40 release and updates public installation surfaces.

- binds the checked-in Formula to exact release source `7df4c68e5e37444a7a701c735e19f2bb3e4b39ec`
- updates English/Chinese README, installation docs, and website current-release labels
- converts the candidate note into a source, CI, artifact, Homebrew, and anonymous-download receipt
- full local gate passes: 326 Rust unit + 8 acceptance + 114 CLI + 152 Node; strict Clippy, formatting, installation/release checks, and diff checks