### PR TITLE
Fix the Chinese Agent Find example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ skillroster scan --summary --json
 skillroster report --findings --limit 20 --json
 
 # 检索并完整加载一份经过指纹校验的 Skill
-skillroster find --load --limit 1 --json -- "审查这个 Pull Request"
+skillroster find --hint "review a Pull Request on GitHub" --load --limit 1 --json -- "审查这个 Pull Request"
 
 # 预览为已检测 Agent 安装引导 Skill 的方案
 skillroster setup --json

--- a/scripts/verify-readme-value.sh
+++ b/scripts/verify-readme-value.sh
@@ -51,3 +51,4 @@ require_literal "$readme_zh" "| SkillRoster Apply 后 | **$roster_exposure** | *
 require_literal "$readme_zh" "Undo 按字节恢复 Agent tree"
 require_literal "$readme_zh" "不是对 token、人工成本、生产性能、模型质量"
 require_literal "$readme_zh" "Core / On-demand 划分普遍优越性的证明"
+require_literal "$readme_zh" 'skillroster find --hint "review a Pull Request on GitHub" --load --limit 1 --json -- "审查这个 Pull Request"'


### PR DESCRIPTION
## 解决什么问题

The canonical Chinese README command asked SkillRoster to load a Skill for `审查这个 Pull Request` without the English lexical hint required when the relevant Skill metadata is English. Public v1.8.40 reproducibly ranked `request-refactor-plan` first, so the official first-use loop could load the wrong capability.

Closes #348.

## 价值是什么

Agents copying the documented command now exercise the product's supported bilingual retrieval contract and load `github-code-review` on the real public inventory, while preserving the original Chinese task and keeping Find read-only.

## 方法是什么

- Add the concise Agent-authored hint `review a Pull Request on GitHub` to the Chinese `find --load` example.
- Bind that exact command in the README value-evidence guard so it cannot silently regress to unhinted cross-language retrieval.
- Do not change lexical ranking: differential dogfood showed detailed review intents already route correctly, and the CLI already emits the correct CJK/English hint warning.

## Evidence

- Public v1.8.40 exact command: Top-1 and loaded identity `github-code-review`; `files_changed=false`.
- `bash scripts/verify-readme-value.sh`: pass after a demonstrated red failure on the old README.
- `bash scripts/ci-full-check.sh`: pass (326 unit, 8 acceptance, 114 CLI, 152 Node harness; fmt and strict Clippy included).
- `git diff --check`: pass.
