### PR TITLE
release: record v1.8.41 publication

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "7df4c68e5e37444a7a701c735e19f2bb3e4b39ec"
-  version "1.8.40"
+      revision: "97784d4c1faf4253e802e273b8404603aa108263"
+  version "1.8.41"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.40", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.41", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.40 implements the complete local governance loop. Every
+Public release v1.8.41 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.40 release and platform evidence](docs/acceptance/release-v1.8.40-candidate.md)
+- [v1.8.41 release and platform evidence](docs/acceptance/release-v1.8.41-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.40 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.41 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.40 发布与平台证据](docs/acceptance/release-v1.8.40-candidate.md)
+- [v1.8.41 发布与平台证据](docs/acceptance/release-v1.8.41-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.41-candidate.md
+++ b/docs/acceptance/release-v1.8.41-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.41 candidate
+# SkillRoster v1.8.41 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.41 prevents an unhinted CJK task from loading complete Skill
 instructions from a weak incidental English Top-1 match.
@@ -35,14 +35,11 @@ This patch changes bounded lexical Find loading only. SQLite remains at schema
 12, the JSON envelope remains at schema 1, and bundled Bootstrap content remains
 at version 1.8.29. It does not mutate Agent or Skill files.
 
-## Preparation evidence
-
-Candidate preparation starts from exact `origin/main` revision
-`d8a871a2c9bf2cec46cd07867df27f9a0f767cdf`.
+## Source and review chain
 
 [#351](https://github.com/tt-a1i/skillroster/pull/351) added the typed load
 abstention at exact head `8748fc891ab9734286f09a98c9fbe82f56e6abfe`
-and merged as the candidate base. The linked
+and merged as `d8a871a2c9bf2cec46cd07867df27f9a0f767cdf`. The linked
 [issue #350](https://github.com/tt-a1i/skillroster/issues/350) records the
 public reproducer, ranked hypotheses, minimal fixture, and bounded acceptance
 criteria. The exact-head PR
@@ -55,6 +52,14 @@ The exact-main
 also passed the same four-platform matrix and aggregate gate at candidate base
 revision `d8a871a2c9bf2cec46cd07867df27f9a0f767cdf`.
 
+[#352](https://github.com/tt-a1i/skillroster/pull/352) prepared version 1.8.41
+at exact head `7eedb6b84b922bbcb2dfab38171e0bcc32469bfd` and merged as exact
+release source revision `97784d4c1faf4253e802e273b8404603aa108263`.
+The PR [CI run 33308246502](https://github.com/tt-a1i/skillroster/actions/runs/33308246502)
+and exact-main [CI run 33308436653](https://github.com/tt-a1i/skillroster/actions/runs/33308436653)
+passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
+and the aggregate CI gate at their exact revisions.
+
 The test-before-fix regression failed because the weak unhinted `--load`
 command succeeded and returned unrelated complete instructions. At the final
 fix head, the full local gate passed 327 Rust unit tests, 8 acceptance tests,
@@ -62,25 +67,65 @@ fix head, the full local gate passed 327 Rust unit tests, 8 acceptance tests,
 installation-surface validation, archive README validation, the change-scope
 self-test, and `git diff --check`.
 
-The source candidate and Cargo package are versioned as 1.8.41. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.40 until the v1.8.41 tag,
-artifacts, checksums, and Homebrew package actually exist.
+## Published release
 
-## Candidate gates
+Annotated tag `v1.8.41` has tag object
+`67d8c096de06b2fc0a35ac478b8452a5f6ce163e` and resolves to exact source
+revision `97784d4c1faf4253e802e273b8404603aa108263`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33308649493)
+passed the strict repository gate, all four supported-platform jobs, the
+governance smoke, and WSL2 at that exact revision.
 
-The candidate is not accepted until one exact final source revision passes:
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.41)
+contains four archives and four adjacent checksum files:
 
-- `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `9c2ee528b46a475fb14e8061f361d51e3b02858f1b26e6b734271faabdee78d0` |
+| `x86_64-apple-darwin` | `7869cdf60d0b6734aff7fcd914d551e315d259145be6673c82bf3a6fca1a97af` |
+| `x86_64-pc-windows-msvc` | `dad19fbb2524b5a62ceb22f47aace784a1c45e36dbe14ad1d0c538cfd21ac78f` |
+| `x86_64-unknown-linux-gnu` | `26fdacfdbaad9a963dbb82eda94e7dadc454eb549a87b2ea3217ca9faf3595d6` |
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+All four adjacent checksums passed, and every archive README and LICENSE
+matched the checked-in Git blobs byte-for-byte. The public asset inventory
+contained exactly those eight files with matching service-side archive
+digests. An anonymous macOS arm64 download passed its adjacent checksum,
+matched the tag-workflow artifact byte-for-byte, reported `skillroster
+1.8.41`, and passed the full release governance smoke in isolated temporary
+directories.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #15](https://github.com/tt-a1i/homebrew-skillroster/pull/15)
+at exact head `fd87af1ec67da0979ae75f8b517cb4eb19d5038e`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33309738470)
+built and tested macOS arm64 and Linux x86_64 bottles at that PR head. The
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33310021051)
+was dispatched from tap `main` at
+`4e4be54f5b105ac2e1f6b1f5e3b1371ec84661b9` after test-bot passed. It closed
+the PR without a regular merge commit, created equivalent Formula commit
+`b774ae3812cc0f387c2caa4c5c9286532455fdef`, published both bottles, and
+advanced tap `main` through bottle commit
+`b19d9841db8a08dc420516079ffc3e7258e66476`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `cf0235c43f5a8c7701bbcc2f1cfe75da8b74702767445ef5a79eefb9b67a206c` |
+| `x86_64_linux` | `493d57bb958928c6af4ff89dac40fd951fbde9c807c65d675b9fe28eedd2db73` |
+
+Both public bottles were downloaded without repository credentials and
+matched their Formula checksums. The arm64 bottle reported version 1.8.41 and
+passed the release governance smoke. Verification extracted the bottles in
+isolated temporary directories and did not mutate the user's installed
+Homebrew package.
+
+## Boundaries
+
+- Weak unhinted cross-language loading remains a bounded lexical policy, not
+  a general semantic translation or intent-resolution engine.
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent or Skill files,
+  or change the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.40**. Its Formula, annotated tag, four
+The current public release is **v1.8.41**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.40
+SKILLROSTER_VERSION=1.8.41
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.40 skillroster
+  --tag v1.8.41 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.40 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.41 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.41**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.40 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.41 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.40 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.41 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.40 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.40 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.41 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.41 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Records facts that already exist for the v1.8.41 publication.

- advances the checked-in Formula, bilingual README status, installation examples, and website install surface to v1.8.41
- converts the candidate note into an exact source/review/tag/artifact/Homebrew receipt
- records all four archive digests, both bottle digests, and the WSL2 boundary

Local full gate at this exact head: 327 Rust unit, 8 acceptance, 116 CLI, and 152 Node tests, plus strict Clippy, formatting, installation-surface validation, archive README validation, change-scope self-test, and `git diff --check`.