### PR TITLE
fix: require direct evidence for Skill loads

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -414,12 +414,15 @@ verified Top-1 content result. It requires one unambiguous routable identity, a
 current non-Archived roster state, an eligible placement, complete package and
 entrypoint digests from the latest Snapshot, a regular file contained by an
 approved root, valid UTF-8, and at most 128 KiB of raw `SKILL.md` bytes. The
-load also abstains when a CJK task has no Agent-authored hint and Top-1 has
-neither strong direct metadata evidence nor correlated CJK metadata and body
-evidence. Ordinary Find still returns the bounded lexical candidates and its
-actionable hint warning; the blocked load returns no partial instructions.
-An explicit single-token Skill name remains direct evidence, so this boundary
-does not prevent deliberate mixed-language selection. The
+load also abstains when a CJK task has no Agent-authored hint and Top-1 has no
+direct selection evidence. Direct selection requires an exact declared name or
+trigger, complete Skill-name token coverage, or an exact description phrase
+with at least two matching tokens. Broad description-token or CJK bigram
+overlap may preserve an ordinary lexical candidate but cannot authorize
+complete instruction loading. Ordinary Find still returns the bounded lexical
+candidates and its actionable hint warning; the blocked load returns no partial
+instructions. An explicit complete Skill name remains direct evidence, so this
+boundary does not prevent deliberate mixed-language selection. The
 loaded placement is selected only after identity ranking: an eligible
 `default_exposed` placement outranks inventory-only exact copies, with path as
 the deterministic tie-breaker; when no exposed placement exists, the same

--- a/src/query.rs
+++ b/src/query.rs
@@ -2711,7 +2711,23 @@ fn has_protectable_task_evidence(matched: &FindMatch) -> bool {
 }
 
 pub(crate) fn has_strong_verified_load_evidence(matched: &FindMatch) -> bool {
-    has_protectable_task_evidence(matched) || has_direct_hint_evidence(matched)
+    // Rank fusion may preserve broad lexical evidence. Returning complete Skill
+    // instructions requires direct selection evidence instead.
+    let has_exact_metadata_phrase = matched
+        .match_reasons
+        .iter()
+        .any(|reason| matches!(reason.as_str(), "exact_name" | "declared_trigger"));
+    let has_complete_name_tokens = {
+        let name_token_count = tokens(&matched.name).len();
+        name_token_count > 0
+            && match_reason_count(matched, "name_tokens:") == Some(name_token_count)
+    };
+    let has_specific_description_phrase = matched
+        .match_reasons
+        .iter()
+        .any(|reason| reason == "description_phrase")
+        && match_reason_count(matched, "description_tokens:").is_some_and(|count| count >= 2);
+    has_exact_metadata_phrase || has_complete_name_tokens || has_specific_description_phrase
 }
 
 fn has_direct_hint_evidence(matched: &FindMatch) -> bool {
@@ -3675,7 +3691,7 @@ mod tests {
     }
 
     #[test]
-    fn verified_load_strength_distinguishes_weak_overlap_from_direct_or_cjk_evidence() {
+    fn verified_load_strength_requires_direct_selection_evidence() {
         assert!(!has_strong_verified_load_evidence(&matched(
             "request-refactor-plan",
             1,
@@ -3691,10 +3707,24 @@ mod tests {
             1,
             &["name_tokens:2", "all_text_tokens:2"],
         )));
-        assert!(has_strong_verified_load_evidence(&matched(
+        assert!(!has_strong_verified_load_evidence(&matched(
             "humanizer-zh",
             1,
             &["cjk_description_bigrams:1", "cjk_all_text_bigrams:3"],
+        )));
+        assert!(!has_strong_verified_load_evidence(&matched(
+            "request-refactor-plan",
+            1,
+            &["name_phrase", "name_tokens:1"],
+        )));
+        assert!(has_strong_verified_load_evidence(&matched(
+            "native-review",
+            1,
+            &[
+                "description_phrase",
+                "description_tokens:4",
+                "cjk_description_bigrams:4",
+            ],
         )));
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1487,6 +1487,98 @@ fn find_load_abstains_from_a_weak_unhinted_cross_language_match() {
 }
 
 #[test]
+fn find_load_abstains_from_broad_native_cjk_overlap_without_direct_evidence() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "diagnose",
+            "---\nname: diagnose\ndescription: Reproduce product bugs, rank falsifiable root-cause hypotheses, fix them, and add regression tests.\n---\nUse a deterministic feedback loop before changing code.\n",
+        ),
+        (
+            "site-publisher",
+            "---\nname: site-publisher\ndescription: 创建有价值的网站应用，发现需求问题，分析并修复网页发布结果，持续改进发布体验。\n---\n创建、部署和更新网站。\n",
+        ),
+    ] {
+        let skill = skill_root.join(directory);
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let task = "发现有价值的问题，分析根因，修复并复盘";
+    let unhinted = json_output(&run(
+        &[&common[..], &["find", task, "--limit", "5"]].concat(),
+        None,
+    ));
+    assert_eq!(unhinted["result"]["matches"][0]["name"], "site-publisher");
+    let reasons = unhinted["result"]["matches"][0]["match_reasons"]
+        .as_array()
+        .unwrap();
+    assert!(
+        reasons
+            .iter()
+            .any(|reason| reason.as_str().unwrap().starts_with("description_tokens:"))
+    );
+    assert!(reasons.iter().all(|reason| !matches!(
+        reason.as_str().unwrap(),
+        "exact_name" | "name_phrase" | "declared_trigger" | "description_phrase"
+    )));
+    assert!(
+        unhinted["result"]["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|warning| warning.as_str().unwrap().contains("--hint"))
+    );
+
+    let blocked = run(
+        &[&common[..], &["find", task, "--load", "--limit", "5"]].concat(),
+        None,
+    );
+    assert!(!blocked.status.success());
+    let blocked: Value = serde_json::from_slice(&blocked.stdout).unwrap();
+    assert_eq!(blocked["error"]["code"], "verified_skill_load_blocked");
+    assert_eq!(
+        blocked["error"]["details"]["reason"],
+        "cjk_hint_required_for_weak_match"
+    );
+    assert_eq!(blocked["error"]["details"]["files_changed"], false);
+    assert!(blocked["result"].is_null());
+
+    let hinted = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                task,
+                "--hint",
+                "reproduce product bugs, diagnose root causes, fix them, and add regression tests",
+                "--load",
+                "--limit",
+                "5",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(hinted["result"]["matches"][0]["name"], "diagnose");
+    assert_eq!(
+        hinted["result"]["loaded_skill"]["selection"]["name"],
+        "diagnose"
+    );
+}
+
+#[test]
 fn find_load_keeps_strong_native_cjk_and_explicit_name_routes() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## 解决什么问题

无提示的中文任务会因为宽泛的描述词和 CJK bigram 重叠，把词法 Top-1 当成强激活证据，并通过 `find --load` 返回完整但无关的 Skill 指令。

## 价值是什么

完整 Skill 指令只在用户或 Agent 给出直接选择证据时加载。普通 Find 的候选召回与排序保持不变；弱匹配会以 typed blocker fail closed，不再把无关指令注入 Agent 上下文。

## 方法

- 把“可保护的词法排名证据”与“可授权完整加载的直接证据”分开
- 完整加载仅接受精确 name/trigger、完整 Skill 名 token 覆盖，或具有至少两个匹配 token 的精确 description phrase
- 添加两 Skill 的确定性中文回归，覆盖普通排名、弱匹配阻断和英文 hint 正确加载
- 更新产品规范中的证据边界

## 验证

- 回归先在 v1.8.41 行为上失败：弱 CJK 匹配错误成功加载
- 修复后最小夹具与真实 263-Skill roster 均返回 `verified_skill_load_blocked`，且 `result=null`、`files_changed=false`
- 忠实英文 hint 仍完整加载 `diagnose`
- 普通 Find 的 rank/name/score/match_reasons/skill_id 投影与 v1.8.41 一致
- `bash scripts/ci-full-check.sh`：327 unit、8 acceptance、117 CLI、152 Node；格式、严格 Clippy、diff/change-scope 均通过

Closes #354