### PR TITLE
release: record v1.8.42 publication

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "97784d4c1faf4253e802e273b8404603aa108263"
-  version "1.8.41"
+      revision: "b365824bb49ec55cb77501368d913e77f958ee8c"
+  version "1.8.42"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.41", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.42", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.41 implements the complete local governance loop. Every
+Public release v1.8.42 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.41 release and platform evidence](docs/acceptance/release-v1.8.41-candidate.md)
+- [v1.8.42 release and platform evidence](docs/acceptance/release-v1.8.42-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.41 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.42 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.41 发布与平台证据](docs/acceptance/release-v1.8.41-candidate.md)
+- [v1.8.42 发布与平台证据](docs/acceptance/release-v1.8.42-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.42-candidate.md
+++ b/docs/acceptance/release-v1.8.42-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.42 candidate
+# SkillRoster v1.8.42 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.42 prevents broad native-CJK lexical overlap from authorizing
 the complete instructions of an unrelated Skill.
@@ -35,9 +35,9 @@ This patch changes bounded lexical Find loading only. SQLite remains at schema
 12, the JSON envelope remains at schema 1, and bundled Bootstrap content remains
 at version 1.8.29. It does not mutate Agent or Skill files.
 
-## Preparation evidence
+## Source and review chain
 
-Candidate preparation starts from exact `origin/main` revision
+Release preparation started from exact `origin/main` revision
 `dbf673b636a557de4b08e70d1d6e28d03ab3d841`.
 
 [#355](https://github.com/tt-a1i/skillroster/pull/355) separated rank-preservation
@@ -62,25 +62,75 @@ acceptance tests, 117 CLI tests, and 152 Node harness tests, plus strict Clippy,
 formatting, installation-surface validation, archive README validation, the
 change-scope self-test, and `git diff --check`.
 
-The source candidate and Cargo package are versioned as 1.8.42. Public install
-examples, the checked-in Formula, website current-release label, and README
-release evidence deliberately remain at v1.8.41 until the v1.8.42 tag,
-artifacts, checksums, and Homebrew package actually exist.
+[#356](https://github.com/tt-a1i/skillroster/pull/356) prepared version 1.8.42
+at exact head `0fa88bcac559d100bdcfadb167439c5233649fff` and merged as exact
+release source revision `b365824bb49ec55cb77501368d913e77f958ee8c`.
+The PR [CI run 33314498797](https://github.com/tt-a1i/skillroster/actions/runs/33314498797)
+and exact-main [CI run 33314804782](https://github.com/tt-a1i/skillroster/actions/runs/33314804782)
+passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
+and the aggregate CI gate at their exact revisions.
 
-## Candidate gates
+## Published release
 
-The candidate is not accepted until one exact final source revision passes:
+Annotated tag `v1.8.42` has tag object
+`5d422a8aebd0d34ef2f7ab08c89db66628b59696` and resolves to exact source
+revision `b365824bb49ec55cb77501368d913e77f958ee8c`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33315010094)
+passed the strict repository gate, all four supported-platform jobs, each
+governance smoke, and WSL2 at that exact revision.
 
-- `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.42)
+contains four archives and four adjacent checksum files:
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `d1f40d6add081edbb7403dbe04ede75abff7d7fca8fcb84235cde6b9662926c8` |
+| `x86_64-apple-darwin` | `37cf9efafa19268832687c3b122576a280831a1451f464d4ede481ab1bd29b16` |
+| `x86_64-pc-windows-msvc` | `c767a52d413c0975dae444f353064863490d58b6be42be0526e7fc9eecf7f117` |
+| `x86_64-unknown-linux-gnu` | `ae308cbc0747aa38e7cc6e2b8ac3e34039b3bfb8634cce4aafdbff1c6dcd264b` |
+
+All adjacent checksums passed, and every archive README and LICENSE matched
+the checked-in Git blobs byte-for-byte. The public asset inventory contained
+exactly those eight files with matching service-side archive digests. An
+anonymous macOS arm64 download passed its adjacent checksum, matched the tag
+workflow artifact byte-for-byte, reported `skillroster 1.8.42`, and passed the
+full release governance smoke in isolated temporary directories. The released
+binary also replayed the two-Skill regression: the broad unhinted CJK load
+returned the typed blocker with no result, while a faithful diagnostic hint
+loaded `diagnose` completely.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #16](https://github.com/tt-a1i/homebrew-skillroster/pull/16)
+at exact head `4e3c68ab0f99aa53a0d54e6647706290e60490e0`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33316203246)
+built and tested macOS arm64 and Linux x86_64 bottles at that PR head. The
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33316532993)
+was dispatched from tap `main` at
+`b19d9841db8a08dc420516079ffc3e7258e66476` after test-bot passed. It closed
+the PR without a regular merge commit, created equivalent Formula commit
+`d6c2fbfb6010ffe2d0c3ee8562c8ee24ce6b8868`, published both bottles, and
+advanced tap `main` through bottle commit
+`6019feffa842324cdf0687b95b7ed9b16c5977ed`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `e7400b165a7d63ee2f8c63ed71709acf32bf85696f316a9a3f85b9b19cc8044e` |
+| `x86_64_linux` | `78c1e00bf22453dca157a3eb2b0f9a3718d378e8cd8f2132ad0643e060fee3b8` |
+
+Both public bottles were downloaded without repository credentials and
+matched their Formula checksums. The arm64 bottle reported version 1.8.42 and
+passed the release governance smoke. Verification extracted the bottles in
+isolated temporary directories and did not mutate the user's installed
+Homebrew package.
+
+## Boundaries
+
+- The stricter load boundary applies to unhinted CJK lexical routing; it is not
+  a general semantic translation or intent-resolution engine.
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent or Skill files,
+  or change the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.41**. Its Formula, annotated tag, four
+The current public release is **v1.8.42**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.41
+SKILLROSTER_VERSION=1.8.42
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.41 skillroster
+  --tag v1.8.42 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.41 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.42 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.42**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.41 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.42 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.41 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.42 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.41 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.41 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.42 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.42 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 结果

记录已实际发布的 SkillRoster v1.8.42，并把所有公开安装面切换到该版本。

## 已验证发布事实

- annotated tag `v1.8.42` 精确解析到 release source `b365824bb49ec55cb77501368d913e77f958ee8c`
- tag workflow `33315010094` 的严格 gate、四平台构建、治理 smoke 与 WSL2 全绿
- GitHub Release 公开包含 4 个 archives + 4 个 adjacent checksums，服务端 digest 与 workflow 产物一致
- 无凭证 macOS arm64 下载通过 checksum、版本、治理 smoke 与针对性加载回归
- Homebrew PR #16 的 macOS arm64/Linux x86_64 test-bot 全绿
- `brew pr-pull` run `33316532993` 发布两只 bottles，tap main 到 `6019feffa842324cdf0687b95b7ed9b16c5977ed`
- 两只公开 bottles 无凭证下载并匹配 Formula checksum；arm64 bottle 版本与治理 smoke 通过

## 本 PR

- 更新 checked-in Formula revision/version
- 更新中英文 README、安装页和网站当前版本
- 将候选说明收敛为完整发布回执
- 不修改 Cargo/tag source、schema、Bootstrap 或发布资产

## 验证

`bash scripts/ci-full-check.sh`：327 unit、8 acceptance、117 CLI、152 Node；严格 Clippy、格式、安装面、archive README、change-scope 和 diff checks 全绿。