### PR TITLE
fix: respect complete multi-token Skill hints

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -325,6 +325,8 @@ omit the field. Rank position remains discriminating within these
 small candidate pools: a high-ranked Agent hint match outranks weak lexical
 overlap that merely appears in both channels, while the strongest original-task
 match remains within the default top three when it has protectable evidence.
+A complete Skill-name token match is direct hint evidence for both single- and
+multi-token names; a partial multi-token name match is not.
 Smaller limits intentionally return only the corresponding stable prefix.
 Hinted retrieval uses a fixed internal pool of up to 100 capabilities, matching
 the public maximum limit. For the same Snapshot, task, and hints, changing

--- a/src/query.rs
+++ b/src/query.rs
@@ -2717,11 +2717,7 @@ pub(crate) fn has_strong_verified_load_evidence(matched: &FindMatch) -> bool {
         .match_reasons
         .iter()
         .any(|reason| matches!(reason.as_str(), "exact_name" | "declared_trigger"));
-    let has_complete_name_tokens = {
-        let name_token_count = tokens(&matched.name).len();
-        name_token_count > 0
-            && match_reason_count(matched, "name_tokens:") == Some(name_token_count)
-    };
+    let has_complete_name_tokens = has_complete_name_token_evidence(matched);
     let has_specific_description_phrase = matched
         .match_reasons
         .iter()
@@ -2731,11 +2727,14 @@ pub(crate) fn has_strong_verified_load_evidence(matched: &FindMatch) -> bool {
 }
 
 fn has_direct_hint_evidence(matched: &FindMatch) -> bool {
-    let has_complete_single_token_name = tokens(&matched.name).len() == 1
-        && match_reason_count(matched, "name_tokens:").is_some_and(|count| count == 1);
     has_direct_metadata_reason(matched)
-        || has_complete_single_token_name
+        || has_complete_name_token_evidence(matched)
         || match_reason_count(matched, "trigger_tokens:").is_some_and(|count| count >= 2)
+}
+
+fn has_complete_name_token_evidence(matched: &FindMatch) -> bool {
+    let name_token_count = tokens(&matched.name).len();
+    name_token_count > 0 && match_reason_count(matched, "name_tokens:") == Some(name_token_count)
 }
 
 fn has_direct_metadata_reason(matched: &FindMatch) -> bool {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1805,6 +1805,73 @@ fn public_find_does_not_treat_part_of_a_multi_token_name_as_direct_hint_evidence
 }
 
 #[test]
+fn public_find_prefers_a_complete_multi_token_name_hint_over_broad_native_overlap() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "simplify-codebase",
+            "---\nname: simplify-codebase\ndescription: Remove accidental codebase complexity through evidence-backed simplification.\n---\n",
+        ),
+        (
+            "workflow-manager",
+            "---\nname: workflow-manager\ndescription: 管理代码库复杂。\n---\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let task = "分析当前代码库有哪些不必要的复杂度，提出最小化方案";
+    let unhinted = json_output(&run(
+        &[&common[..], &["find", task, "--limit", "3"]].concat(),
+        None,
+    ));
+    assert_eq!(unhinted["result"]["matches"][0]["name"], "workflow-manager");
+
+    let hinted = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                task,
+                "--hint",
+                "simplify codebase accidental complexity",
+                "--load",
+                "--limit",
+                "3",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(hinted["result"]["matches"][0]["name"], "simplify-codebase");
+    assert_eq!(hinted["result"]["matches"][0]["augmented_channel_rank"], 1);
+    assert!(
+        hinted["result"]["matches"][0]["match_reasons"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reason| reason == "name_tokens:2")
+    );
+    assert_eq!(
+        hinted["result"]["loaded_skill"]["selection"]["name"],
+        "simplify-codebase"
+    );
+}
+
+#[test]
 fn public_find_respects_a_chinese_do_not_use_clause() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");


### PR DESCRIPTION
## 解决什么问题

中文或混合语言任务按 Bootstrap 契约提供英文 `--hint` 后，完整命中多词 Skill 名的目标仍可能被宽泛 native 词面候选通过 `protected_original_task_match` 抢占 Top-1。真实现场中，`simplify-codebase` 的 `name_tokens:2` 排在 `pingcode-assistant-pro` 后面，导致一调用加载走向错误候选或错误歧义。

## 价值

Agent 可以保留用户原始任务，同时用忠实的跨语言能力提示稳定找到真正目标。完整多词 Skill 名与完整单词 Skill 名现在遵守同一条直接证据规则；局部多词命中仍然不能获得这项保护。

## 方法

- 将已有“完整 Skill 名 token 覆盖”提取成一个共享事实函数。
- 让 hinted ranking 和 verified load 使用同一判断，避免两个安全边界漂移。
- 新增真实 CLI seam 回归，覆盖宽泛中文 Top-1、完整 `simplify-codebase` hint、Top-1、channel rank、`name_tokens:2` 和 verified load。
- 在产品规范中明确完整单/多 token 名称与局部多 token 名称的边界。

## 真实 Dogfood

公开 v1.8.42、全新状态、真实 263 Skills / 1,037 placements：

- 修复前 3/3：`pingcode-assistant-pro` Top-1，`simplify-codebase` Top-2。
- 修复后 3/3：`simplify-codebase` Top-1，`pingcode-assistant-pro` Top-2。
- 同名 variant 仍 fail closed；显式选择当前 variant 后完整 6.9KB Skill 加载成功，身份、入口摘要和包指纹均匹配。
- 所有调用 `files_changed=false`。

## 验证

- `bash scripts/ci-full-check.sh`
  - Rust unit: 327/327
  - acceptance: 8/8
  - CLI: 118/118
  - Node harness: 152/152
  - strict Clippy、format、安装/归档/变更范围检查：通过
- exact-head Standards review: PASS
- exact-head Spec review: PASS
- `git diff --check`: PASS

Closes #358
