### PR TITLE
fix: require direct evidence before hinted Skill load

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -416,11 +416,16 @@ verified Top-1 content result. It requires one unambiguous routable identity, a
 current non-Archived roster state, an eligible placement, complete package and
 entrypoint digests from the latest Snapshot, a regular file contained by an
 approved root, valid UTF-8, and at most 128 KiB of raw `SKILL.md` bytes. The
+load also requires direct selection evidence whenever the Agent supplied a
+retrieval hint; weak fused Top-1 overlap remains visible through ordinary Find
+but cannot return complete instructions until the Agent refines the hint. The
 load also abstains when a CJK task has no Agent-authored hint and Top-1 has no
 direct selection evidence. Direct selection requires an exact declared name or
-trigger, complete Skill-name token coverage, or an exact description phrase
-with at least two matching tokens. Broad description-token or CJK bigram
-overlap may preserve an ordinary lexical candidate but cannot authorize
+trigger, complete Skill-name token coverage, an exact description phrase with
+at least two matching tokens, or complete normalized token coverage for one
+task or hint phrase with at least two tokens. Broad
+description-token or CJK bigram overlap may preserve an ordinary lexical
+candidate but cannot authorize
 complete instruction loading. Ordinary Find still returns the bounded lexical
 candidates and its actionable hint warning; the blocked load returns no partial
 instructions. An explicit complete Skill name remains direct evidence, so this

--- a/skill/skillroster/references/routing.md
+++ b/skill/skillroster/references/routing.md
@@ -36,9 +36,12 @@ Roster, or authorize a later Plan.
 For `no_routable_match`, retry once with a refined capability hint. For
 `cjk_hint_required_for_weak_match`, keep `TASK` unchanged, author the one
 faithful English capability hint required by the root Route gate, and retry
-once. For drift, legacy Snapshot, unreadable, oversized, escaping, or
-untrusted-source reasons, follow `error.details.next_action`; never bypass the
-check or recover partial instructions. A successful load returns complete
+once. For `hint_direct_selection_evidence_required`, keep `TASK` unchanged and
+refine the existing hint once with the target surface, object, operation, and
+state; do not add a guessed Skill name. For drift, legacy Snapshot, unreadable,
+oversized, escaping, or untrusted-source reasons, follow
+`error.details.next_action`; never bypass the check or recover partial
+instructions. A successful load returns complete
 instructions but does not activate, install, authorize, endorse, or establish
 task success.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5145,13 +5145,21 @@ fn find_command(
         }
         .into());
     }
-    if load && cjk_hint_required {
-        if let Some(ranked) = matches
+    if load {
+        let weak_top_match = matches
             .first()
-            .filter(|ranked| !crate::query::has_strong_verified_load_evidence(ranked))
-        {
+            .filter(|ranked| ranked.variant_count == 1 || variant_skill_id.is_some())
+            .filter(|ranked| !crate::query::has_strong_verified_load_evidence(ranked));
+        let weak_match_reason = if cjk_hint_required {
+            Some("cjk_hint_required_for_weak_match")
+        } else if !retrieval_hints.is_empty() {
+            Some("hint_direct_selection_evidence_required")
+        } else {
+            None
+        };
+        if let (Some(ranked), Some(reason)) = (weak_top_match, weak_match_reason) {
             return Err(SkillLoadBlocked {
-                reason: "cjk_hint_required_for_weak_match",
+                reason,
                 skill_id: ranked.skill_id.clone(),
                 skill_name: ranked.name.clone(),
                 path: None,

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -594,6 +594,10 @@ fn classify_error(error: &(dyn std::error::Error + 'static)) -> ClassifiedError 
                 "retry_with_agent_authored_english_hint",
                 "agent_correction_required",
             ),
+            "hint_direct_selection_evidence_required" => (
+                "refine_agent_authored_hint_with_direct_capability_evidence",
+                "agent_correction_required",
+            ),
             "untrusted_external_source" => (
                 "confirm_exact_source_root_then_scan",
                 "user_decision_required",

--- a/src/query.rs
+++ b/src/query.rs
@@ -1938,6 +1938,11 @@ pub(crate) fn find_matching_with_evidence(
         .map(|part| part.trim().to_lowercase())
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>();
+    let query_phrase_tokens = query_phrases
+        .iter()
+        .map(|phrase| tokens(phrase))
+        .filter(|phrase_tokens| phrase_tokens.len() >= 2)
+        .collect::<Vec<_>>();
     let placement_groups = placements_by_skill(scan);
     let mut variants_by_name = BTreeMap::<String, Vec<String>>::new();
     for skill in scan
@@ -2042,6 +2047,12 @@ pub(crate) fn find_matching_with_evidence(
             {
                 score += 25.0;
                 reasons.push("description_phrase".into());
+            }
+            if query_phrase_tokens
+                .iter()
+                .any(|phrase_tokens| phrase_tokens.is_subset(&description_tokens))
+            {
+                reasons.push("description_token_phrase".into());
             }
             if name_overlap > 0 {
                 reasons.push(format!("name_tokens:{name_overlap}"));
@@ -2721,8 +2732,7 @@ pub(crate) fn has_strong_verified_load_evidence(matched: &FindMatch) -> bool {
     let has_specific_description_phrase = matched
         .match_reasons
         .iter()
-        .any(|reason| reason == "description_phrase")
-        && match_reason_count(matched, "description_tokens:").is_some_and(|count| count >= 2);
+        .any(|reason| reason == "description_token_phrase");
     has_exact_metadata_phrase || has_complete_name_tokens || has_specific_description_phrase
 }
 
@@ -3707,6 +3717,11 @@ mod tests {
             &["name_tokens:2", "all_text_tokens:2"],
         )));
         assert!(!has_strong_verified_load_evidence(&matched(
+            "github-code-review",
+            1,
+            &["name_tokens:2", "description_tokens:4"],
+        )));
+        assert!(!has_strong_verified_load_evidence(&matched(
             "humanizer-zh",
             1,
             &["cjk_description_bigrams:1", "cjk_all_text_bigrams:3"],
@@ -3716,7 +3731,7 @@ mod tests {
             1,
             &["name_phrase", "name_tokens:1"],
         )));
-        assert!(has_strong_verified_load_evidence(&matched(
+        assert!(!has_strong_verified_load_evidence(&matched(
             "native-review",
             1,
             &[
@@ -3724,6 +3739,11 @@ mod tests {
                 "description_tokens:4",
                 "cjk_description_bigrams:4",
             ],
+        )));
+        assert!(has_strong_verified_load_evidence(&matched(
+            "github-code-review",
+            1,
+            &["description_token_phrase", "description_tokens:4"],
         )));
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1480,6 +1480,13 @@ fn find_load_abstains_from_a_weak_unhinted_cross_language_match() {
         None,
     ));
     assert_eq!(hinted["result"]["matches"][0]["name"], "github-code-review");
+    assert!(
+        hinted["result"]["matches"][0]["match_reasons"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reason| reason == "description_token_phrase")
+    );
     assert_eq!(
         hinted["result"]["loaded_skill"]["selection"]["name"],
         "github-code-review"
@@ -1868,6 +1875,96 @@ fn public_find_prefers_a_complete_multi_token_name_hint_over_broad_native_overla
     assert_eq!(
         hinted["result"]["loaded_skill"]["selection"]["name"],
         "simplify-codebase"
+    );
+}
+
+#[test]
+fn public_find_load_rejects_a_weak_hinted_top_match_before_returning_instructions() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill_root = home.join(".codex/skills");
+    for (directory, contents) in [
+        (
+            "product-business-analysis",
+            "---\nname: product-business-analysis\ndescription: Analyze product or business data to support a decision or recommendation.\n---\n",
+        ),
+        (
+            "to-spec",
+            "---\nname: to-spec\ndescription: Turn the current conversation into a spec and publish it to the project issue tracker.\n---\n",
+        ),
+    ] {
+        let path = skill_root.join(directory);
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("SKILL.md"), contents).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let task = "把这组产品决定整理成可执行规格";
+    let weak_hint = "convert product decisions into an executable specification";
+    let ordinary = json_output(&run(
+        &[
+            &common[..],
+            &["find", task, "--hint", weak_hint, "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(
+        ordinary["result"]["matches"][0]["name"],
+        "product-business-analysis"
+    );
+
+    let blocked = run(
+        &[
+            &common[..],
+            &["find", task, "--hint", weak_hint, "--load", "--limit", "1"],
+        ]
+        .concat(),
+        None,
+    );
+    assert!(!blocked.status.success());
+    let blocked: Value = serde_json::from_slice(&blocked.stdout).unwrap();
+    assert_eq!(blocked["error"]["code"], "verified_skill_load_blocked");
+    assert_eq!(
+        blocked["error"]["details"]["reason"],
+        "hint_direct_selection_evidence_required"
+    );
+    assert_eq!(
+        blocked["error"]["details"]["next_action"],
+        "refine_agent_authored_hint_with_direct_capability_evidence"
+    );
+    assert_eq!(blocked["error"]["details"]["files_changed"], false);
+    assert!(blocked["result"].is_null());
+    assert!(blocked["suggested_actions"].as_array().unwrap().is_empty());
+
+    let refined = json_output(&run(
+        &[
+            &common[..],
+            &[
+                "find",
+                task,
+                "--hint",
+                "turn the current conversation into a spec and publish it to the project issue tracker",
+                "--load",
+                "--limit",
+                "1",
+            ],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(refined["result"]["matches"][0]["name"], "to-spec");
+    assert_eq!(
+        refined["result"]["loaded_skill"]["selection"]["name"],
+        "to-spec"
     );
 }
 


### PR DESCRIPTION
## 结果

阻止带提示的弱 Top-1 候选直接返回完整且错误的 Skill 指令。

## 解决什么问题

真实 Home dogfood 中，任务“把这组产品决定整理成可执行规格”加弱提示 `convert product decisions into an executable specification` 时，`find --load` 会成功加载 `product-business-analysis`，而不是目标 `to-spec`。身份与内容验证只证明加载的是所选候选，不能证明候选语义选择正确。

## 价值

完整 Skill 指令进入 Agent 上下文前，现在也必须有直接选择证据。普通 `find` 仍保留弱候选供 Agent 判断，但 `--load` 会 fail closed，不再把排序相关性误当成加载授权。

## 方法

- 将直接选择证据门禁扩展到带提示的 `find --load`
- 接受完整 Skill 名称、精确声明触发器，或单条任务/提示短语被正向 description 完整覆盖
- 拒绝部分名称 token 和零散描述 token 的拼接证据
- 返回 typed blocker，要求 Agent 改写提示；不返回部分指令
- 保持普通 Find 排名、同名变体歧义优先级、SQLite schema 和 JSON envelope 不变

## 验证

- 真实 263-Skill / 1,037-placement Snapshot 重放：弱错误候选被拒绝；精确提示锁定 `to-spec`，随后按既有同名变体规则 fail closed
- Rust 327 unit、8 acceptance、119 CLI 全部通过
- Node harness 152/152
- 严格 Clippy、格式、安装面、archive README、change-scope、`git diff --check` 通过
- 两轴独立 exact-head 复审通过，0 个阻断 finding

Closes #360