### PR TITLE
release: record v1.8.43 publication

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "b365824bb49ec55cb77501368d913e77f958ee8c"
-  version "1.8.42"
+      revision: "76a6885669f96ba37c919641f4b207e99b2b27fe"
+  version "1.8.43"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.42", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.43", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.42 implements the complete local governance loop. Every
+Public release v1.8.43 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.42 release and platform evidence](docs/acceptance/release-v1.8.42-candidate.md)
+- [v1.8.43 release and platform evidence](docs/acceptance/release-v1.8.43-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.42 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.43 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.42 发布与平台证据](docs/acceptance/release-v1.8.42-candidate.md)
+- [v1.8.43 发布与平台证据](docs/acceptance/release-v1.8.43-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.43-candidate.md
+++ b/docs/acceptance/release-v1.8.43-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.43 candidate
+# SkillRoster v1.8.43 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.43 makes Agent-authored retrieval hints both more reliable and
 safer at the complete-instruction boundary.
@@ -44,9 +44,9 @@ verified-load authorization. SQLite remains at schema 12, the JSON envelope
 remains at schema 1, and bundled Bootstrap content remains at version 1.8.29.
 It does not mutate Agent or Skill files.
 
-## Preparation evidence
+## Source and review chain
 
-Candidate preparation starts from exact `origin/main` revision
+Release preparation started from exact `origin/main` revision
 `5996148473a09d39b9956e7832f091894fdff55d`.
 
 [#359](https://github.com/tt-a1i/skillroster/pull/359) aligned complete
@@ -84,25 +84,83 @@ fix head, the full local gate passed 327 Rust unit tests, 8 acceptance tests,
 installation-surface validation, archive README validation, the change-scope
 self-test, and `git diff --check`.
 
-The source candidate and Cargo package are versioned as 1.8.43. Public install
-examples, the website current-release labels, README release evidence, and the
-Homebrew Formula deliberately remain at v1.8.42 until the v1.8.43 tag,
-artifacts, checksums, and Homebrew package actually exist.
+[#362](https://github.com/tt-a1i/skillroster/pull/362) prepared version 1.8.43
+at exact head `59be020d07dfc0ec8c730864783154887746ddcc` and merged as exact
+release source revision `76a6885669f96ba37c919641f4b207e99b2b27fe`.
+The PR
+[CI run 33321599897](https://github.com/tt-a1i/skillroster/actions/runs/33321599897)
+and exact-main
+[CI run 33321885194](https://github.com/tt-a1i/skillroster/actions/runs/33321885194)
+passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
+and the aggregate CI gate at their exact revisions. Two independent exact-head
+reviews passed with no blocking findings. The complete local gate passed twice
+on the candidate bytes: 327 Rust unit tests, 8 acceptance tests, 119 CLI tests,
+and 152 Node harness tests, plus strict Clippy, formatting, installation-surface
+validation, archive README validation, the change-scope self-test, and
+`git diff --check`.
 
-## Candidate gates
+## Published release
 
-The candidate is not accepted until one exact final source revision passes:
+Annotated tag `v1.8.43` has tag object
+`7eb064beaba68061ad8cf3258ecbc5f737df54fe` and resolves to exact source
+revision `76a6885669f96ba37c919641f4b207e99b2b27fe`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33322098095)
+passed the strict repository gate, all four supported-platform jobs, each
+governance smoke, and WSL2 at that exact revision.
 
-- `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README Git blob.
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.43)
+contains four archives and four adjacent checksum files:
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `0def10401e283cce13332eec4af16d135b5963c8352da54d07f44768358edbca` |
+| `x86_64-apple-darwin` | `ffc54fecb49a9e540879f7a2fb9ca278d7d5bb387c60b6f6bfe741873664b5df` |
+| `x86_64-pc-windows-msvc` | `941f0b9f697fa4bbc135b8b536528844fd566c74ccbfa66078a976ebff96bb04` |
+| `x86_64-unknown-linux-gnu` | `a661bc5952305f884f1f22a0cd78daa9c20b2b9e53bcd36252e0b2f8e9171cae` |
+
+All adjacent checksums passed. Every archive contained only its versioned
+directory, binary, README, and LICENSE; each README and LICENSE matched the
+checked-in Git blob byte-for-byte. The public asset inventory contained exactly
+those eight files. An anonymous macOS arm64 download matched its adjacent
+checksum and the tag-workflow artifact byte-for-byte, reported
+`skillroster 1.8.43`, and passed the release governance smoke in isolated
+temporary directories.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #17](https://github.com/tt-a1i/homebrew-skillroster/pull/17)
+at exact head `335cd7956b7575bbf377f7f0c3d6ddeda4a74fbc`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33323499540)
+built, installed, and tested macOS arm64 and Linux x86_64 bottles at that PR
+head. The
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33323773777)
+was dispatched from tap `main` at
+`6019feffa842324cdf0687b95b7ed9b16c5977ed` after test-bot passed. It closed
+the PR without a regular merge commit, created equivalent Formula commit
+`c4f679d1a9bd950d12b341c02d64950a60527605`, published both bottles, and
+advanced tap `main` through bottle commit
+`f141e46f3f492fae25fdc1d69f2b5d6527448df5`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `40527cc32a3604f4795ff3a9241cf0ff0e1d44187b4ea5ce879127e8f5686dad` |
+| `x86_64_linux` | `bb4576bf7ead8842750994ed9d8d8107ea3ddebb8da63604eb2db70f294f2eca` |
+
+The public Formula checksums match the release-asset digests. An anonymous
+arm64 bottle download matched its Formula checksum, reported version 1.8.43,
+and completed an isolated `scan --summary --json` smoke with `ok=true` and
+`files_changed=false`. Verification extracted the bottle in a temporary
+directory and did not mutate the user's installed Homebrew package.
+
+## Boundaries
+
+- Direct-selection evidence is a lexical authorization boundary, not a general
+  semantic translation or intent-resolution engine.
+- Same-name Skill variants remain ambiguous until the Agent supplies an exact
+  verified variant; the ranking fix does not silently choose between them.
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent or Skill files,
+  or change the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.42**. Its Formula, annotated tag, four
+The current public release is **v1.8.43**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.42
+SKILLROSTER_VERSION=1.8.43
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.42 skillroster
+  --tag v1.8.43 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.42 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.43 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.43**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.42 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.43 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.42 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.43 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.42 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.42 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.43 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.43 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 结果

记录已实际发布的 SkillRoster v1.8.43，并把所有公开安装面切换到该版本。

## 已验证发布事实

- annotated tag `v1.8.43` 精确解析到 release source `76a6885669f96ba37c919641f4b207e99b2b27fe`
- tag workflow `33322098095` 的严格 gate、四平台构建、治理 smoke 与 WSL2 全绿
- GitHub Release 公开包含 4 个 archives + 4 个 adjacent checksums；匿名 macOS arm64 下载通过 checksum、版本和治理 smoke
- Homebrew PR #17 的 macOS arm64/Linux x86_64 test-bot 全绿
- `brew pr-pull` run `33323773777` 发布两只 bottles，tap main 到 `f141e46f3f492fae25fdc1d69f2b5d6527448df5`
- 公开 arm64 bottle 无凭证下载并匹配 Formula checksum，版本与只读 Scan smoke 通过

## 本 PR

- 更新 checked-in Formula revision/version
- 更新中英文 README、安装页和网站当前版本
- 将候选说明收敛为完整发布回执
- 不修改 Cargo/tag source、schema、Bootstrap 或发布资产

## 验证

`bash scripts/ci-full-check.sh`：327 unit、8 acceptance、119 CLI、152 Node；严格 Clippy、格式、安装面、archive README、change-scope 和 diff checks 全绿。两轮独立 exact-head review 均 PASS。