### PR TITLE
fix: make Bootstrap Setup impact exact

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -301,6 +301,19 @@ bounded decision fields is not equivalent: it remains immutable and auditable,
 while Setup creates one decision-complete replacement. Both can temporarily
 appear as pending; the Agent presents only the newly returned Plan ID.
 
+The affected scope applies the normal Skill identity rules to the projected
+package after Apply: declared source plus version/revision takes precedence;
+otherwise identity comes from content, excluding `.gitignore`. The content
+projection includes preserved unmanaged files and the normalized bytes of
+managed files that Setup will write. Content-derived identities remain distinct
+when identity-relevant preserved content differs. Package-level before and
+after fingerprints bind that projection to Apply, so drift in preserved files
+fails closed instead of producing a different post-Apply identity. Package
+binding reuses the same depth and byte bounds and excludes `.git`, `target`,
+`node_modules`, and `.DS_Store`, matching Scan's package boundary. Placement
+counts retain every logical Agent target even when filesystem operations share
+one physical root.
+
 Detection is Snapshot-bound and explicit. `existing_skill_root` means the
 Agent's fixed Skill root already exists. `included_session_root` means the
 current completed Snapshot included that Agent's fixed session root while its

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -8,6 +8,9 @@ use cap_std::fs::{Dir, OpenOptions, Permissions};
 use sha2::{Digest, Sha256};
 
 use crate::durable_fs::DirectorySync;
+use crate::package_fingerprint::{
+    MAX_SKILL_PACKAGE_DEPTH, PackageHashBuilder, ignored_package_entry_name,
+};
 
 #[cfg(test)]
 thread_local! {
@@ -694,6 +697,87 @@ impl<'a> AnchoredFs<'a> {
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok("missing".into()),
             Err(error) => Err(error),
         }
+    }
+
+    pub(crate) fn package_fingerprint(&self, path: &Path) -> io::Result<String> {
+        let (anchor, relative) = self.resolve(path)?;
+        let metadata = match anchor.dir.symlink_metadata(&relative) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok("missing".into());
+            }
+            Err(error) => return Err(error),
+        };
+        if !metadata.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Skill package path is not a directory",
+            ));
+        }
+        let mut hashes = PackageHashBuilder::new();
+        Self::hash_package_relative(anchor, &relative, Path::new(""), 0, &mut hashes)?;
+        Ok(format!("package:sha256:{}", hashes.finish().digest))
+    }
+
+    fn hash_package_relative(
+        anchor: &Anchor,
+        directory: &Path,
+        package_relative: &Path,
+        depth: usize,
+        hashes: &mut PackageHashBuilder,
+    ) -> io::Result<()> {
+        if depth > MAX_SKILL_PACKAGE_DEPTH {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Skill package fingerprint exceeds depth {MAX_SKILL_PACKAGE_DEPTH}"),
+            ));
+        }
+        let mut entries = anchor
+            .dir
+            .read_dir(directory)?
+            .map(|entry| entry.map(|entry| entry.file_name()))
+            .collect::<io::Result<Vec<_>>>()?;
+        entries.sort();
+        for name in entries {
+            if ignored_package_entry_name(&name) {
+                continue;
+            }
+            let child = directory.join(&name);
+            let relative_child = package_relative.join(&name);
+            let relative_text = relative_child.to_str().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "non-Unicode path cannot participate in stable identity",
+                )
+            })?;
+            let metadata = anchor.dir.symlink_metadata(&child)?;
+            if metadata.is_dir() {
+                Self::hash_package_relative(anchor, &child, &relative_child, depth + 1, hashes)?;
+            } else if metadata.is_symlink() {
+                let target = anchor.dir.read_link_contents(&child)?;
+                let target = target.to_str().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "non-Unicode path cannot participate in stable identity",
+                    )
+                })?;
+                hashes.add_symlink(relative_text, target);
+            } else if metadata.is_file() {
+                let mut bytes = Vec::new();
+                anchor
+                    .dir
+                    .open(&child)?
+                    .take(hashes.remaining_bytes().saturating_add(1))
+                    .read_to_end(&mut bytes)?;
+                hashes.add_regular_file(relative_text, &bytes)?;
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Skill package contains an unsupported file type",
+                ));
+            }
+        }
+        Ok(())
     }
 
     fn fingerprint_relative(anchor: &Anchor, relative: &Path) -> io::Result<String> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -6140,6 +6140,7 @@ fn plan_detail_command(store: &StateStore, id: &str) -> Result<Value> {
     );
     object.insert("source_updates".into(), json!(prepared.source_updates));
     object.insert("library_changes".into(), json!(prepared.library_changes));
+    object.insert("path_projections".into(), json!(prepared.path_projections));
     object.insert(
         "roster_before".into(),
         record.input["roster_before"].clone(),
@@ -6205,7 +6206,7 @@ fn affected_summary(
         .iter()
         .map(|change| change.agent.clone())
         .collect::<std::collections::BTreeSet<_>>();
-    let skills = prepared
+    let mut skills = prepared
         .roster_changes
         .iter()
         .map(|change| change.skill_id.clone())
@@ -6222,6 +6223,11 @@ fn affected_summary(
                 .map(|change| change.skill_id.clone()),
         )
         .collect::<std::collections::BTreeSet<_>>();
+    skills.extend(
+        bootstrap_scope
+            .into_iter()
+            .flat_map(|scope| scope.affected_skill_ids.iter().cloned()),
+    );
     let roster_pairs = prepared
         .roster_changes
         .iter()
@@ -6272,13 +6278,16 @@ fn affected_summary(
     );
     let skill_count = skills.len();
     let skill_ids = skills.iter().take(10).cloned().collect::<Vec<_>>();
+    let bootstrap_placement_count = bootstrap_scope
+        .map(|scope| scope.affected_placement_count)
+        .unwrap_or_default();
     json!({
         "agent_count": agents.len(),
         "agents": agents,
         "skill_count": skill_count,
         "skill_ids": skill_ids,
         "skill_ids_truncated": skill_count > 10,
-        "placement_count": placements.len()
+        "placement_count": placements.len().saturating_add(bootstrap_placement_count)
     })
 }
 
@@ -6524,6 +6533,8 @@ struct BootstrapPlanScope {
     anchor_roots: Vec<PathBuf>,
     missing_skill_roots: Vec<PathBuf>,
     affected_agents: Vec<String>,
+    affected_skill_ids: Vec<String>,
+    affected_placement_count: usize,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
@@ -7914,6 +7925,9 @@ fn prepare_plan(
         "library_changes",
         "before_state",
     ];
+    if !prepared.path_projections.is_empty() {
+        detail_contains.push("path_projections");
+    }
     if selection_evidence_full.is_some() {
         detail_contains.push("complete_core_selections");
     }
@@ -8531,6 +8545,7 @@ fn setup_command_with_manifests<'a>(
     let mut physical_targets = BTreeSet::new();
     let mut planned_directories = BTreeSet::new();
     let mut planned_files = BTreeSet::new();
+    let mut planned_package_overrides = BTreeMap::<PathBuf, BTreeMap<PathBuf, String>>::new();
     let mut planned_agents = BTreeSet::new();
     let mut bootstrap_anchor_roots = BTreeSet::new();
     let mut bootstrap_missing_skill_roots = BTreeSet::new();
@@ -8710,6 +8725,10 @@ fn setup_command_with_manifests<'a>(
                     if !planned_files.insert(physical_target) {
                         continue;
                     }
+                    planned_package_overrides
+                        .entry(physical_directory.clone())
+                        .or_default()
+                        .insert(PathBuf::from(relative_path), content.clone());
                     let kind = match status {
                         BootstrapFileStatus::Missing => "write_file",
                         BootstrapFileStatus::Modified
@@ -8793,15 +8812,50 @@ fn setup_command_with_manifests<'a>(
         });
         return Ok(result);
     }
+    let mut affected_skill_ids = BTreeSet::new();
+    let mut path_projections = Vec::with_capacity(planned_package_overrides.len());
+    for (directory, overrides) in &planned_package_overrides {
+        let expected_before_fingerprint = change::package_fingerprint(directory)?;
+        affected_skill_ids.insert(scan::projected_skill_id(directory, overrides).with_context(
+            || {
+                format!(
+                    "cannot determine projected Bootstrap Skill identity for {}",
+                    directory.display()
+                )
+            },
+        )?);
+        let expected_after_fingerprint =
+            change::projected_package_fingerprint(directory, overrides)?;
+        if change::package_fingerprint(directory)? != expected_before_fingerprint {
+            bail!(
+                "Bootstrap Skill package {} changed while Setup was projecting it; rerun Scan and Setup",
+                directory.display()
+            );
+        }
+        path_projections.push(json!({
+            "path": directory,
+            "expected_before_fingerprint": expected_before_fingerprint,
+            "expected_after_fingerprint": expected_after_fingerprint
+        }));
+    }
+    let affected_skill_ids = affected_skill_ids.into_iter().collect();
+    let affected_agents = planned_agents.into_iter().collect::<Vec<_>>();
     let bootstrap_scope = BootstrapPlanScope {
         anchor_roots: bootstrap_anchor_roots.into_iter().collect(),
         missing_skill_roots: bootstrap_missing_skill_roots.into_iter().collect(),
-        affected_agents: planned_agents.into_iter().collect(),
+        affected_placement_count: affected_agents.len(),
+        affected_agents,
+        affected_skill_ids,
     };
     let plan = prepare_plan(
         store,
         state_dir,
-        json!({"schema_version": 1, "scan_id": snapshot_id, "operations": operations}),
+        json!({
+            "schema_version": 1,
+            "scan_id": snapshot_id,
+            "operations": operations,
+            "path_projections": path_projections
+        }),
         PlanOrigin::BootstrapSetup,
         Some(json!({
             "modified_choice": match modified_choice {
@@ -8809,7 +8863,9 @@ fn setup_command_with_manifests<'a>(
                 Some(ModifiedBootstrapChoice::RetainLocal) => json!("retain-local"),
                 Some(ModifiedBootstrapChoice::AdoptCurrent) => json!("adopt-current"),
             },
-            "affected_agents": bootstrap_scope.affected_agents.clone()
+            "affected_agents": bootstrap_scope.affected_agents.clone(),
+            "affected_skill_ids": bootstrap_scope.affected_skill_ids.clone(),
+            "affected_placement_count": bootstrap_scope.affected_placement_count
         })),
         &[],
         Some(&bootstrap_scope),
@@ -11482,6 +11538,7 @@ mod recovery_tests {
             }],
             source_updates: vec![],
             library_changes: vec![],
+            path_projections: vec![],
             approved_roots: vec![PathBuf::from("/fixture")],
             state_dir: PathBuf::from("/fixture/state"),
         };
@@ -11544,6 +11601,7 @@ mod recovery_tests {
             }],
             source_updates: vec![],
             library_changes: vec![],
+            path_projections: vec![],
             approved_roots: vec![PathBuf::from("/fixture")],
             state_dir: PathBuf::from("/fixture/state"),
         };
@@ -11610,6 +11668,7 @@ mod recovery_tests {
                 canonical_path: placement_path.clone(),
                 library_path: None,
             }],
+            path_projections: vec![],
             approved_roots: vec![PathBuf::from("/fixture")],
             state_dir: PathBuf::from("/fixture/state"),
         };
@@ -11671,6 +11730,7 @@ mod recovery_tests {
                 target: entrypoint,
             }],
             library_changes: vec![],
+            path_projections: vec![],
             approved_roots: vec![PathBuf::from("/fixture")],
             state_dir: PathBuf::from("/fixture/state"),
         };
@@ -11724,6 +11784,7 @@ mod recovery_tests {
                 canonical_path: PathBuf::from("/fixture/root/shared/a2"),
                 library_path: None,
             }],
+            path_projections: vec![],
             approved_roots: vec![PathBuf::from("/fixture")],
             state_dir: PathBuf::from("/fixture/state"),
         };
@@ -12192,6 +12253,7 @@ mod recovery_tests {
             roster_changes: vec![],
             source_updates: vec![],
             library_changes: vec![],
+            path_projections: vec![],
             approved_roots: vec![temp.path().to_path_buf()],
             state_dir: state_dir.clone(),
         };
@@ -12275,6 +12337,7 @@ mod recovery_tests {
             roster_changes: vec![],
             source_updates: vec![],
             library_changes: vec![],
+            path_projections: vec![],
             approved_roots: vec![temp.path().to_path_buf()],
             state_dir: state_dir.clone(),
         };
@@ -12364,6 +12427,7 @@ mod recovery_tests {
             roster_changes: vec![],
             source_updates: vec![],
             library_changes: vec![],
+            path_projections: vec![],
             approved_roots: vec![],
             state_dir: PathBuf::new(),
         };

--- a/src/change.rs
+++ b/src/change.rs
@@ -3,7 +3,7 @@
 //! The module deliberately has no "force" path. A plan is prepared against exact
 //! fingerprints, and every apply/undo obtains the same process write lock.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, File};
@@ -16,6 +16,10 @@ use sha2::{Digest, Sha256};
 
 use crate::anchored_fs::AnchoredFs;
 use crate::durable_fs::{DirectorySync, SystemDirectorySync};
+use crate::package_fingerprint::{
+    MAX_SKILL_PACKAGE_DEPTH, PackageHashBuilder, ignored_package_entry_name,
+    normalized_relative_package_path,
+};
 
 #[cfg(test)]
 thread_local! {
@@ -150,6 +154,16 @@ pub struct PlanInput {
     pub source_updates: Vec<SourceUpdateAction>,
     #[serde(default)]
     pub library_changes: Vec<LibraryChangeAction>,
+    #[serde(default)]
+    pub path_projections: Vec<PathProjection>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PathProjection {
+    pub path: PathBuf,
+    pub expected_before_fingerprint: String,
+    pub expected_after_fingerprint: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -299,6 +313,8 @@ pub struct PreparedPlan {
     pub roster_changes: Vec<RosterChange>,
     pub source_updates: Vec<SourceUpdateAction>,
     pub library_changes: Vec<LibraryChangeAction>,
+    #[serde(default)]
+    pub path_projections: Vec<PathProjection>,
     pub approved_roots: Vec<PathBuf>,
     pub state_dir: PathBuf,
 }
@@ -477,6 +493,14 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
             "Agent-authored Plans must reference Evidence from the latest Snapshot",
         ));
     }
+    if !matches!(ctx.operation_policy, OperationPolicy::BootstrapSetup { .. })
+        && !input.path_projections.is_empty()
+    {
+        return Err(ChangeError::new(
+            "invalid_path_projection",
+            "path projections are reserved for trusted Bootstrap Setup Plans",
+        ));
+    }
 
     let state_dir = canonical_directory(&ctx.state_dir, "state_dir")?;
     let roots = normalize_roots(&ctx.approved_roots, &state_dir)?;
@@ -522,6 +546,7 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
         ));
     }
 
+    let raw_path_projections = input.path_projections;
     let mut targets = HashSet::new();
     let mut operations = Vec::with_capacity(input.operations.len());
     let mut projected_missing = HashSet::new();
@@ -583,15 +608,57 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
         ));
     }
 
-    let digest_payload = serde_json::to_vec(&(
-        input.scan_id.as_str(),
+    let allowed_projection_paths = operations
+        .iter()
+        .filter_map(|operation| bootstrap_skill_directory(operation.target()))
+        .map(Path::to_path_buf)
+        .collect::<HashSet<_>>();
+    let mut projection_paths = HashSet::new();
+    let mut path_projections = Vec::with_capacity(raw_path_projections.len());
+    for projection in raw_path_projections {
+        let path = normalize_target(&projection.path, &roots)?;
+        if !allowed_projection_paths.contains(&path) {
+            return Err(ChangeError::new(
+                "invalid_path_projection",
+                format!(
+                    "Bootstrap projection {} is not a planned fixed package",
+                    path.display()
+                ),
+            ));
+        }
+        if !projection_paths.insert(path.clone()) {
+            return Err(ChangeError::new(
+                "ambiguous_path_projection",
+                format!("multiple projections bind {}", path.display()),
+            ));
+        }
+        let actual = package_fingerprint(&path)?;
+        if actual != projection.expected_before_fingerprint {
+            return Err(ChangeError::new(
+                "plan_drifted",
+                format!(
+                    "{} expected {}, found {actual}",
+                    path.display(),
+                    projection.expected_before_fingerprint
+                ),
+            ));
+        }
+        path_projections.push(PathProjection {
+            path,
+            expected_before_fingerprint: projection.expected_before_fingerprint,
+            expected_after_fingerprint: projection.expected_after_fingerprint,
+        });
+    }
+
+    let digest_payload = plan_digest_payload(
+        &input.scan_id,
         &input.evidence_ids,
         &operations,
         &input.roster_changes,
         &input.source_updates,
         &input.library_changes,
-    ))
-    .map_err(|error| ChangeError::new("plan_encoding_failed", error.to_string()))?;
+        &path_projections,
+    )?;
     let digest = format!("sha256:{}", hex::encode(Sha256::digest(digest_payload)));
     Ok(PreparedPlan {
         id: format!("plan_{}", ulid::Ulid::new()),
@@ -602,6 +669,7 @@ pub fn prepare(input: &str, ctx: &PrepareContext) -> Result<PreparedPlan> {
         roster_changes: input.roster_changes,
         source_updates: input.source_updates,
         library_changes: input.library_changes,
+        path_projections,
         approved_roots: roots,
         state_dir,
     })
@@ -634,6 +702,7 @@ fn apply_locked_with_anchored(
 ) -> Result<ApplyOutcome> {
     validate_prepared_plan(plan)?;
     run_before_sequence_validation_hook();
+    validate_path_projections_anchored(&plan.path_projections, &anchored, false)?;
     validate_operation_sequence_anchored(&plan.operations, &anchored)?;
     reject_unresolved_recovery_except(&anchored, &plan.state_dir, "")?;
     anchored
@@ -780,6 +849,26 @@ fn apply_locked_with_anchored(
         }
     }
 
+    if let Err(error) = validate_path_projections_anchored(&plan.path_projections, &anchored, true)
+    {
+        receipt.error = Some(error.to_string());
+        let rollback = compensate_all(&receipt, &anchored);
+        receipt.status = if rollback.is_ok() {
+            ReceiptStatus::FailedRolledBack
+        } else {
+            ReceiptStatus::RecoveryRequired
+        };
+        finalize_rollback_results(&mut receipt, rollback.is_ok(), &anchored);
+        if let Err(rollback_error) = rollback {
+            receipt.error = Some(format!("{error}; compensation failed: {rollback_error}"));
+        }
+        persist_journal_with(&receipt, &anchored)?;
+        return Ok(ApplyOutcome {
+            receipt,
+            verification_passed: false,
+        });
+    }
+
     receipt.status = ReceiptStatus::Applied;
     if let Err(error) = persist_journal_with(&receipt, &anchored) {
         receipt.status = ReceiptStatus::RecoveryRequired;
@@ -796,6 +885,43 @@ fn apply_locked_with_anchored(
         receipt,
         verification_passed: true,
     })
+}
+
+fn validate_path_projections_anchored(
+    projections: &[PathProjection],
+    anchored: &AnchoredFs<'_>,
+    after_apply: bool,
+) -> Result<()> {
+    for projection in projections {
+        let expected = if after_apply {
+            &projection.expected_after_fingerprint
+        } else {
+            &projection.expected_before_fingerprint
+        };
+        let actual = anchored
+            .package_fingerprint(&projection.path)
+            .map_err(|error| {
+                ChangeError::io(
+                    "inspect package through approved root handle",
+                    &projection.path,
+                    error,
+                )
+            })?;
+        if actual != *expected {
+            return Err(ChangeError::new(
+                if after_apply {
+                    "plan_postcondition_failed"
+                } else {
+                    "plan_drifted"
+                },
+                format!(
+                    "{} expected {expected}, found {actual}",
+                    projection.path.display()
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 pub fn undo(receipt: &ChangeReceipt) -> Result<ApplyOutcome> {
@@ -1229,10 +1355,13 @@ fn validate_bootstrap_operation_target(
 }
 
 fn bootstrap_skill_root(target: &Path) -> Option<&Path> {
+    bootstrap_skill_directory(target).and_then(Path::parent)
+}
+
+fn bootstrap_skill_directory(target: &Path) -> Option<&Path> {
     target
         .ancestors()
         .find(|ancestor| ancestor.file_name() == Some(OsStr::new("skillroster")))
-        .and_then(Path::parent)
 }
 
 fn validate_current_state(operation: &Operation, roots: &[PathBuf]) -> Result<()> {
@@ -1983,16 +2112,48 @@ fn remove_expected_anchored_file_if_present(
         .map_err(|error| ChangeError::io(action, path, error))
 }
 
+fn plan_digest_payload(
+    scan_id: &str,
+    evidence_ids: &[String],
+    operations: &[Operation],
+    roster_changes: &[RosterChange],
+    source_updates: &[SourceUpdateAction],
+    library_changes: &[LibraryChangeAction],
+    path_projections: &[PathProjection],
+) -> Result<Vec<u8>> {
+    if path_projections.is_empty() {
+        serde_json::to_vec(&(
+            scan_id,
+            evidence_ids,
+            operations,
+            roster_changes,
+            source_updates,
+            library_changes,
+        ))
+    } else {
+        serde_json::to_vec(&(
+            scan_id,
+            evidence_ids,
+            operations,
+            roster_changes,
+            source_updates,
+            library_changes,
+            path_projections,
+        ))
+    }
+    .map_err(|error| ChangeError::new("plan_encoding_failed", error.to_string()))
+}
+
 fn validate_prepared_plan(plan: &PreparedPlan) -> Result<()> {
-    let payload = serde_json::to_vec(&(
-        plan.scan_id.as_str(),
+    let payload = plan_digest_payload(
+        &plan.scan_id,
         &plan.evidence_ids,
         &plan.operations,
         &plan.roster_changes,
         &plan.source_updates,
         &plan.library_changes,
-    ))
-    .map_err(|e| ChangeError::new("plan_encoding_failed", e.to_string()))?;
+        &plan.path_projections,
+    )?;
     let actual = format!("sha256:{}", hex::encode(Sha256::digest(payload)));
     if actual != plan.digest {
         return Err(ChangeError::new(
@@ -2058,6 +2219,167 @@ pub fn fingerprint(path: &Path) -> Result<String> {
         "unsupported_file_type",
         format!("{} is not a file, directory, or symlink", path.display()),
     ))
+}
+
+pub fn package_fingerprint(directory: &Path) -> Result<String> {
+    projected_package_fingerprint(directory, &BTreeMap::new())
+}
+
+pub fn projected_package_fingerprint(
+    directory: &Path,
+    regular_file_overrides: &BTreeMap<PathBuf, String>,
+) -> Result<String> {
+    let regular_file_overrides = regular_file_overrides
+        .iter()
+        .map(|(relative_path, content)| {
+            normalized_relative_package_path(relative_path)
+                .map(|relative_path| (relative_path, content.clone()))
+                .map_err(|_| {
+                    ChangeError::new(
+                        "invalid_path_projection",
+                        "projected file path must be a normalized relative path",
+                    )
+                })
+        })
+        .collect::<Result<BTreeMap<_, _>>>()?;
+    let metadata = match fs::symlink_metadata(directory) {
+        Ok(metadata) => Some(metadata),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(ChangeError::io(
+                "inspect projected package",
+                directory,
+                error,
+            ));
+        }
+    };
+    if metadata.as_ref().is_some_and(|metadata| !metadata.is_dir()) {
+        return Err(ChangeError::new(
+            "unsupported_file_type",
+            format!("{} is not a directory", directory.display()),
+        ));
+    }
+    if metadata.is_none() && regular_file_overrides.is_empty() {
+        return Ok("missing".into());
+    }
+
+    let mut hashes = PackageHashBuilder::new();
+    project_package_files(
+        directory,
+        Path::new(""),
+        0,
+        &regular_file_overrides,
+        &mut hashes,
+    )?;
+    Ok(format!("package:sha256:{}", hashes.finish().digest))
+}
+
+fn project_package_files(
+    path: &Path,
+    relative_path: &Path,
+    depth: usize,
+    regular_file_overrides: &BTreeMap<PathBuf, String>,
+    hashes: &mut PackageHashBuilder,
+) -> Result<()> {
+    if depth > MAX_SKILL_PACKAGE_DEPTH {
+        return Err(ChangeError::new(
+            "package_fingerprint_bounded",
+            format!("Skill package fingerprint exceeds depth {MAX_SKILL_PACKAGE_DEPTH}"),
+        ));
+    }
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => Some(metadata),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(ChangeError::io("inspect projected path", path, error)),
+    };
+    let mut names = std::collections::BTreeSet::new();
+    if metadata.is_some() {
+        names.extend(
+            fs::read_dir(path)
+                .map_err(|error| ChangeError::io("read projected directory", path, error))?
+                .map(|entry| {
+                    entry
+                        .map(|entry| entry.file_name())
+                        .map_err(|error| ChangeError::io("read projected directory", path, error))
+                })
+                .collect::<Result<Vec<_>>>()?,
+        );
+    }
+    for override_path in regular_file_overrides.keys() {
+        let Ok(remainder) = override_path.strip_prefix(relative_path) else {
+            continue;
+        };
+        if let Some(Component::Normal(name)) = remainder.components().next() {
+            names.insert(name.to_os_string());
+        }
+    }
+    for name in names {
+        if ignored_package_entry_name(&name) {
+            continue;
+        }
+        let child = path.join(&name);
+        let relative_child = relative_path.join(&name);
+        let relative_text = relative_child.to_str().ok_or_else(|| {
+            ChangeError::new(
+                "non_unicode_identity_path",
+                "non-Unicode path cannot participate in stable identity",
+            )
+        })?;
+        if let Some(content) = regular_file_overrides.get(&relative_child) {
+            hashes
+                .add_regular_file(relative_text, content.as_bytes())
+                .map_err(|error| ChangeError::io("hash projected package", &child, error))?;
+            continue;
+        }
+        let metadata = match fs::symlink_metadata(&child) {
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(ChangeError::io("inspect projected path", &child, error)),
+        };
+        if metadata.as_ref().is_some_and(|metadata| metadata.is_dir())
+            || (metadata.is_none()
+                && regular_file_overrides
+                    .keys()
+                    .any(|override_path| override_path.starts_with(&relative_child)))
+        {
+            project_package_files(
+                &child,
+                &relative_child,
+                depth + 1,
+                regular_file_overrides,
+                hashes,
+            )?;
+        } else if metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.file_type().is_symlink())
+        {
+            let target = fs::read_link(&child)
+                .map_err(|error| ChangeError::io("read projected symlink", &child, error))?;
+            let target = target.to_str().ok_or_else(|| {
+                ChangeError::new(
+                    "non_unicode_identity_path",
+                    "non-Unicode path cannot participate in stable identity",
+                )
+            })?;
+            hashes.add_symlink(relative_text, target);
+        } else if metadata.as_ref().is_some_and(|metadata| metadata.is_file()) {
+            let mut bytes = Vec::new();
+            File::open(&child)
+                .map_err(|error| ChangeError::io("open projected package file", &child, error))?
+                .take(hashes.remaining_bytes().saturating_add(1))
+                .read_to_end(&mut bytes)
+                .map_err(|error| ChangeError::io("read projected package file", &child, error))?;
+            hashes
+                .add_regular_file(relative_text, &bytes)
+                .map_err(|error| ChangeError::io("hash projected package", &child, error))?;
+        } else if metadata.is_some() {
+            return Err(ChangeError::new(
+                "unsupported_file_type",
+                format!("{} is not a file, directory, or symlink", child.display()),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn normalize_roots(roots: &[PathBuf], state_dir: &Path) -> Result<Vec<PathBuf>> {
@@ -2693,6 +3015,104 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(unsupported.code, "unsupported_plan_schema");
+    }
+
+    #[test]
+    fn projected_package_fingerprint_matches_the_materialized_tree() {
+        let (_temp, root, _state) = fixture();
+        let package = root.join("skillroster");
+        fs::create_dir(&package).unwrap();
+        fs::write(package.join("notes.local.md"), "preserved\n").unwrap();
+        let overrides = BTreeMap::from([
+            (PathBuf::from("SKILL.md"), "managed entrypoint\n".into()),
+            (
+                PathBuf::from("references/routing.md"),
+                "managed reference\n".into(),
+            ),
+        ]);
+
+        let projected = projected_package_fingerprint(&package, &overrides).unwrap();
+        fs::create_dir(package.join("references")).unwrap();
+        for (relative_path, content) in overrides {
+            fs::write(package.join(relative_path), content).unwrap();
+        }
+
+        assert_eq!(projected, package_fingerprint(&package).unwrap());
+    }
+
+    #[test]
+    fn package_projection_rejects_content_beyond_the_scan_byte_bound() {
+        let (_temp, root, _state) = fixture();
+        let package = root.join("skillroster");
+        fs::create_dir(&package).unwrap();
+        File::create(package.join("oversized.bin"))
+            .unwrap()
+            .set_len(crate::package_fingerprint::MAX_SKILL_PACKAGE_BYTES + 1)
+            .unwrap();
+
+        let error = package_fingerprint(&package).unwrap_err();
+
+        assert!(error.to_string().contains("byte fingerprint safety limit"));
+    }
+
+    #[test]
+    fn bootstrap_apply_rolls_back_when_package_projection_drifts_during_apply() {
+        let (_temp, root, state) = fixture();
+        let package = root.join("skillroster");
+        fs::create_dir(&package).unwrap();
+        let extra = package.join("notes.local.md");
+        fs::write(&extra, "before\n").unwrap();
+        let target = package.join("SKILL.md");
+        let overrides = BTreeMap::from([(PathBuf::from("SKILL.md"), "managed\n".into())]);
+        let input = serde_json::json!({
+            "schema_version": 1,
+            "scan_id": "scan_1",
+            "operations": [{
+                "kind": "write_file",
+                "target": target,
+                "content": "managed\n",
+                "expected_fingerprint": "missing"
+            }],
+            "path_projections": [{
+                "path": package,
+                "expected_before_fingerprint": package_fingerprint(&package).unwrap(),
+                "expected_after_fingerprint": projected_package_fingerprint(&package, &overrides).unwrap()
+            }]
+        })
+        .to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state,
+                operation_policy: OperationPolicy::BootstrapSetup {
+                    missing_skill_roots: vec![],
+                },
+            },
+        )
+        .unwrap();
+        BEFORE_EXECUTE_HOOK.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                fs::write(extra, "after\n").unwrap();
+            }));
+        });
+
+        let outcome = apply(&plan).unwrap();
+
+        assert!(!outcome.verification_passed);
+        assert_eq!(outcome.receipt.status, ReceiptStatus::FailedRolledBack);
+        assert!(
+            outcome
+                .receipt
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("plan_postcondition_failed"))
+        );
+        assert!(!target.exists());
+        assert_eq!(
+            fs::read_to_string(package.join("notes.local.md")).unwrap(),
+            "after\n"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cli;
 mod durable_fs;
 pub mod harness;
 pub mod model;
+mod package_fingerprint;
 pub mod present;
 pub mod query;
 pub mod roster_plan;

--- a/src/package_fingerprint.rs
+++ b/src/package_fingerprint.rs
@@ -1,0 +1,128 @@
+use std::ffi::OsStr;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+pub(crate) const MAX_SKILL_FILE_BYTES: u64 = 2 * 1024 * 1024;
+pub(crate) const MAX_SKILL_PACKAGE_BYTES: u64 = 16 * 1024 * 1024;
+pub(crate) const MAX_SKILL_PACKAGE_DEPTH: usize = 8;
+
+pub(crate) fn ignored_package_entry_name(name: &OsStr) -> bool {
+    matches!(
+        name.to_str(),
+        Some(".git" | "target" | "node_modules" | ".DS_Store")
+    )
+}
+
+pub(crate) fn normalized_relative_package_path(path: &Path) -> io::Result<PathBuf> {
+    if path.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "package path must be relative",
+        ));
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(name) => normalized.push(name),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "package path must contain only normal relative components",
+                ));
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "package path must not be empty",
+        ));
+    }
+    Ok(normalized)
+}
+
+pub(crate) struct PackageHashes {
+    pub(crate) digest: String,
+    pub(crate) content_identity_digest: String,
+    pub(crate) skill_markdown: Option<String>,
+}
+
+pub(crate) struct PackageHashBuilder {
+    digest: Sha256,
+    content_identity: Sha256,
+    total_bytes: u64,
+    skill_markdown: Option<String>,
+}
+
+impl PackageHashBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            digest: Sha256::new(),
+            content_identity: Sha256::new(),
+            total_bytes: 0,
+            skill_markdown: None,
+        }
+    }
+
+    pub(crate) fn remaining_bytes(&self) -> u64 {
+        MAX_SKILL_PACKAGE_BYTES.saturating_sub(self.total_bytes)
+    }
+
+    pub(crate) fn add_regular_file(&mut self, relative_path: &str, bytes: &[u8]) -> io::Result<()> {
+        self.total_bytes = self.total_bytes.saturating_add(bytes.len() as u64);
+        if self.total_bytes > MAX_SKILL_PACKAGE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("package exceeds {MAX_SKILL_PACKAGE_BYTES} byte fingerprint safety limit"),
+            ));
+        }
+        update_regular_file_identity(&mut self.digest, relative_path, bytes);
+        if relative_path != ".gitignore" {
+            update_regular_file_identity(&mut self.content_identity, relative_path, bytes);
+        }
+        if relative_path == "SKILL.md" {
+            if bytes.len() as u64 > MAX_SKILL_FILE_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Skill entrypoint exceeds {MAX_SKILL_FILE_BYTES} byte safety limit"),
+                ));
+            }
+            self.skill_markdown = Some(String::from_utf8(bytes.to_vec()).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "Skill entrypoint is not UTF-8")
+            })?);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn add_symlink(&mut self, relative_path: &str, target: &str) {
+        update_symlink_identity(&mut self.digest, relative_path, target);
+        if relative_path != ".gitignore" {
+            update_symlink_identity(&mut self.content_identity, relative_path, target);
+        }
+    }
+
+    pub(crate) fn finish(self) -> PackageHashes {
+        PackageHashes {
+            digest: format!("{:x}", self.digest.finalize()),
+            content_identity_digest: format!("{:x}", self.content_identity.finalize()),
+            skill_markdown: self.skill_markdown,
+        }
+    }
+}
+
+fn update_regular_file_identity(digest: &mut Sha256, relative_path: &str, bytes: &[u8]) {
+    digest.update(relative_path.as_bytes());
+    digest.update([0]);
+    digest.update(bytes);
+    digest.update([0xff]);
+}
+
+fn update_symlink_identity(digest: &mut Sha256, relative_path: &str, target: &str) {
+    digest.update(relative_path.as_bytes());
+    digest.update([0]);
+    digest.update(b"symlink\0");
+    digest.update(target.as_bytes());
+    digest.update([0xff]);
+}

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -2,6 +2,12 @@ use crate::harness::{
     AgentKind, SessionSignal, SkillDiscoverySemantics, known_agent_roots,
     session_record_observations,
 };
+#[cfg(test)]
+use crate::package_fingerprint::MAX_SKILL_PACKAGE_BYTES;
+use crate::package_fingerprint::{
+    MAX_SKILL_FILE_BYTES, MAX_SKILL_PACKAGE_DEPTH, PackageHashBuilder, PackageHashes,
+    ignored_package_entry_name, normalized_relative_package_path,
+};
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
 use chrono::{DateTime, Datelike, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
@@ -14,8 +20,6 @@ use std::path::{Component, Path, PathBuf};
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-const MAX_SKILL_FILE_BYTES: u64 = 2 * 1024 * 1024;
-const MAX_SKILL_PACKAGE_BYTES: u64 = 16 * 1024 * 1024;
 pub const CONTENT_IDENTITY_ALGORITHM: &str = "sha256-content-unicode-v2";
 const MAX_REMOTE_PLUGIN_INSTALL_BYTES: u64 = 16 * 1024;
 const MAX_SESSION_DISCOVERY_FILES_PER_ROOT: usize = 10_000;
@@ -1988,10 +1992,8 @@ fn materialize_candidates_with_hook(
             ));
             executable_files.clear();
         };
-        let identity_basis = match (&metadata.source, &metadata.version, &metadata.revision) {
-            (Some(source), Some(version), _) => format!("source:{source}@{version}"),
-            (Some(source), _, Some(revision)) => format!("source:{source}@{revision}"),
-            _ if safe_to_read && !content.is_empty() => {
+        let identity_basis = declared_skill_identity_basis(&metadata).unwrap_or_else(|| {
+            if safe_to_read && !content.is_empty() {
                 content_identity_digest.as_ref().map_or_else(
                     || {
                         let entrypoint = candidate
@@ -2002,15 +2004,14 @@ fn materialize_candidates_with_hook(
                     },
                     |identity| format!("content:{identity}"),
                 )
-            }
-            _ => {
+            } else {
                 let entrypoint = candidate
                     .entrypoint
                     .to_str()
                     .expect("discovery excludes non-Unicode entrypoints");
                 format!("unreadable-link:{entrypoint}")
             }
-        };
+        });
         let skill_id = format!("skill_{}", stable_digest(identity_basis.as_bytes()));
         let name = metadata
             .name
@@ -2317,6 +2318,16 @@ fn stable_digest(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
+fn declared_skill_identity_basis(metadata: &SkillMetadata) -> Option<String> {
+    Some(
+        match (&metadata.source, &metadata.version, &metadata.revision) {
+            (Some(source), Some(version), _) => format!("source:{source}@{version}"),
+            (Some(source), _, Some(revision)) => format!("source:{source}@{revision}"),
+            _ => return None,
+        },
+    )
+}
+
 #[derive(Debug)]
 struct PackageFingerprint {
     digest: String,
@@ -2437,7 +2448,8 @@ fn package_file_checkpoints(
 
 fn package_checkpoint(directory: &Path) -> io::Result<Option<Vec<PackageFileCheckpoint>>> {
     let mut files = Vec::new();
-    let complete = collect_skill_files(directory, directory, 0, 8, &mut files)?;
+    let complete =
+        collect_skill_files(directory, directory, 0, MAX_SKILL_PACKAGE_DEPTH, &mut files)?;
     if !complete {
         return Ok(None);
     }
@@ -2479,61 +2491,17 @@ fn executable_files_from_checkpoints(checkpoints: &[PackageFileCheckpoint]) -> V
 
 fn digest_skill_directory(directory: &Path) -> io::Result<PackageFingerprint> {
     let mut files = Vec::new();
-    let complete = collect_skill_files(directory, directory, 0, 8, &mut files)?;
+    let complete =
+        collect_skill_files(directory, directory, 0, MAX_SKILL_PACKAGE_DEPTH, &mut files)?;
     files.sort_by(|left, right| left.0.cmp(&right.0));
     let checkpoints = package_file_checkpoints(&files)?;
     let executable_relative_files = executable_files_from_checkpoints(&checkpoints);
-
-    let mut digest = Sha256::new();
-    let mut content_identity_digest = Sha256::new();
-    let mut total_bytes = 0_u64;
-    for (relative_path, path, file_type) in files {
-        let is_source_control_metadata = relative_path == Path::new(".gitignore");
-        let relative_path_bytes = relative_path
-            .to_str()
-            .expect("package checkpoints reject non-Unicode paths");
-        digest.update(relative_path_bytes.as_bytes());
-        digest.update([0]);
-        if !is_source_control_metadata {
-            content_identity_digest.update(relative_path_bytes.as_bytes());
-            content_identity_digest.update([0]);
-        }
-        if file_type.is_symlink() {
-            let target = fs::read_link(path)?;
-            let target = target
-                .to_str()
-                .ok_or_else(|| non_unicode_identity_error(1))?;
-            digest.update(b"symlink\0");
-            digest.update(target.as_bytes());
-            if !is_source_control_metadata {
-                content_identity_digest.update(b"symlink\0");
-                content_identity_digest.update(target.as_bytes());
-            }
-        } else {
-            let metadata = fs::metadata(&path)?;
-            total_bytes = total_bytes.saturating_add(metadata.len());
-            if total_bytes > MAX_SKILL_PACKAGE_BYTES {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "package exceeds {MAX_SKILL_PACKAGE_BYTES} byte fingerprint safety limit"
-                    ),
-                ));
-            }
-            let bytes = fs::read(path)?;
-            digest.update(&bytes);
-            if !is_source_control_metadata {
-                content_identity_digest.update(&bytes);
-            }
-        }
-        digest.update([0xff]);
-        if !is_source_control_metadata {
-            content_identity_digest.update([0xff]);
-        }
-    }
+    let hashes = hash_package_files(files.into_iter().map(|(relative_path, path, file_type)| {
+        (relative_path, ProjectedPackageFile::Disk(path, file_type))
+    }))?;
     Ok(PackageFingerprint {
-        digest: format!("{:x}", digest.finalize()),
-        content_identity_digest: format!("{:x}", content_identity_digest.finalize()),
+        digest: hashes.digest,
+        content_identity_digest: hashes.content_identity_digest,
         completeness: if complete {
             FingerprintCompleteness::Complete
         } else {
@@ -2543,6 +2511,94 @@ fn digest_skill_directory(directory: &Path) -> io::Result<PackageFingerprint> {
         checkpoint: complete.then_some(checkpoints),
         executable_relative_files,
     })
+}
+
+pub(crate) fn projected_skill_id(
+    directory: &Path,
+    regular_file_overrides: &BTreeMap<PathBuf, String>,
+) -> io::Result<String> {
+    let mut observed_files = Vec::new();
+    let complete = if directory.exists() {
+        collect_skill_files(
+            directory,
+            directory,
+            0,
+            MAX_SKILL_PACKAGE_DEPTH,
+            &mut observed_files,
+        )?
+    } else {
+        true
+    };
+    if !complete {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "projected Skill package fingerprint is bounded at depth 8",
+        ));
+    }
+
+    let mut files = observed_files
+        .into_iter()
+        .map(|(relative_path, path, file_type)| {
+            (relative_path, ProjectedPackageFile::Disk(path, file_type))
+        })
+        .collect::<BTreeMap<_, _>>();
+    for (relative_path, content) in regular_file_overrides {
+        let relative_path = normalized_relative_package_path(relative_path).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "projected Skill override path must be a relative package path",
+            )
+        })?;
+        files.insert(relative_path, ProjectedPackageFile::Regular(content));
+    }
+    let hashes = hash_package_files(files)?;
+    let skill_markdown = hashes.skill_markdown.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "projected Skill package has no SKILL.md entrypoint",
+        )
+    })?;
+    let metadata = parse_skill_markdown(&skill_markdown);
+    let identity_basis = declared_skill_identity_basis(&metadata)
+        .unwrap_or_else(|| format!("content:{}", hashes.content_identity_digest));
+    Ok(format!(
+        "skill_{}",
+        stable_digest(identity_basis.as_bytes())
+    ))
+}
+
+enum ProjectedPackageFile<'a> {
+    Disk(PathBuf, fs::FileType),
+    Regular(&'a str),
+}
+
+fn hash_package_files<'a>(
+    files: impl IntoIterator<Item = (PathBuf, ProjectedPackageFile<'a>)>,
+) -> io::Result<PackageHashes> {
+    let mut hashes = PackageHashBuilder::new();
+    for (relative_path, file) in files {
+        let relative_path_text = unicode_identity_path(&relative_path)?;
+        if let ProjectedPackageFile::Disk(path, file_type) = &file {
+            if file_type.is_symlink() {
+                let target = fs::read_link(path)?;
+                let target = unicode_identity_path(&target)?;
+                hashes.add_symlink(relative_path_text, target);
+                continue;
+            }
+        }
+        let bytes = match file {
+            ProjectedPackageFile::Disk(path, _) => {
+                let mut bytes = Vec::new();
+                File::open(path)?
+                    .take(hashes.remaining_bytes().saturating_add(1))
+                    .read_to_end(&mut bytes)?;
+                bytes
+            }
+            ProjectedPackageFile::Regular(content) => content.as_bytes().to_vec(),
+        };
+        hashes.add_regular_file(relative_path_text, &bytes)?;
+    }
+    Ok(hashes.finish())
 }
 
 fn collect_skill_files(
@@ -2560,10 +2616,7 @@ fn collect_skill_files(
     entries.sort_by_key(|entry| entry.file_name());
     for entry in entries {
         let name = entry.file_name();
-        if matches!(
-            name.to_str(),
-            Some(".git" | "target" | "node_modules" | ".DS_Store")
-        ) {
+        if ignored_package_entry_name(&name) {
             continue;
         }
         let path = entry.path();
@@ -3510,11 +3563,8 @@ pub(crate) fn inspect_skill_identity(entrypoint: &Path) -> io::Result<(String, S
         ));
     }
     let digest = fingerprint.digest;
-    let identity_basis = match (&metadata.source, &metadata.version, &metadata.revision) {
-        (Some(source), Some(version), _) => format!("source:{source}@{version}"),
-        (Some(source), _, Some(revision)) => format!("source:{source}@{revision}"),
-        _ => format!("content:{}", fingerprint.content_identity_digest),
-    };
+    let identity_basis = declared_skill_identity_basis(&metadata)
+        .unwrap_or_else(|| format!("content:{}", fingerprint.content_identity_digest));
     Ok((
         format!("skill_{}", stable_digest(identity_basis.as_bytes())),
         digest,
@@ -4819,6 +4869,38 @@ enabled = true
         assert_ne!(first_id, changed_id);
         let changed = scan(&options).unwrap();
         assert_eq!(changed.skills.len(), 2);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn projected_package_identity_matches_post_overlay_scan_with_crlf_and_extras() {
+        let root = temp_directory("projected-package-identity");
+        let skill = root.join("skillroster");
+        fs::create_dir_all(skill.join("references")).unwrap();
+        fs::write(skill.join("references/routing.md"), "Routing.\r\n").unwrap();
+        fs::write(skill.join("notes.local.md"), "Preserved local note.\n").unwrap();
+        let overrides = BTreeMap::from([
+            (
+                PathBuf::from("SKILL.md"),
+                "---\nname: skillroster\ndescription: Fixture\n---\nInstructions.\n".into(),
+            ),
+            (
+                PathBuf::from("references/governance.md"),
+                "Governance.\n".into(),
+            ),
+            (
+                PathBuf::from("references/mutation.md"),
+                "Mutation.\n".into(),
+            ),
+        ]);
+
+        let predicted = projected_skill_id(&skill, &overrides).unwrap();
+        for (relative_path, content) in &overrides {
+            fs::write(skill.join(relative_path), content).unwrap();
+        }
+        let (observed, _) = inspect_skill_identity(&skill.join("SKILL.md")).unwrap();
+
+        assert_eq!(predicted, observed);
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5423,6 +5423,12 @@ fn setup_treats_a_package_with_no_managed_files_as_missing_and_preserves_extra_f
     assert_eq!(setup["result"]["operation_count"], 5);
     assert_eq!(setup["result"]["affected"]["agent_count"], 1);
     assert_eq!(setup["result"]["affected"]["agents"], json!(["codex"]));
+    assert_eq!(setup["result"]["affected"]["skill_count"], 1);
+    let projected_skill_id = setup["result"]["affected"]["skill_ids"][0]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    assert_eq!(setup["result"]["affected"]["placement_count"], 1);
     let applied = json_output(&run(
         &[
             &common[..],
@@ -5434,6 +5440,17 @@ fn setup_treats_a_package_with_no_managed_files_as_missing_and_preserves_extra_f
     assert_eq!(fs::read_to_string(&extra).unwrap(), "keep me\n");
     assert!(package.join("SKILL.md").is_file());
     assert!(package.join("references/mutation.md").is_file());
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let observed_skill_id: String = database
+        .query_row(
+            "SELECT id FROM skills WHERE name = 'skillroster' ORDER BY rowid DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(projected_skill_id, observed_skill_id);
+    drop(database);
 
     let undone = json_output(&run(
         &[
@@ -5447,6 +5464,184 @@ fn setup_treats_a_package_with_no_managed_files_as_missing_and_preserves_extra_f
     assert_eq!(fs::read_to_string(&extra).unwrap(), "keep me\n");
     assert!(!package.join("SKILL.md").exists());
     assert!(!package.join("references").exists());
+}
+
+#[test]
+fn setup_apply_fails_closed_when_a_preserved_file_changes_after_planning() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let package = home.join(".codex/skills/skillroster");
+    fs::create_dir_all(&package).unwrap();
+    let extra = package.join("notes.local.md");
+    fs::write(&extra, "before\n").unwrap();
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    let plan_id = setup["result"]["plan_id"].as_str().unwrap();
+    let detail = json_output(&run(
+        &[&common[..], &["plan", "--show", plan_id]].concat(),
+        None,
+    ));
+    assert_eq!(
+        detail["result"]["path_projections"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+
+    fs::write(&extra, "after\n").unwrap();
+    let blocked = run(&[&common[..], &["apply", plan_id]].concat(), None);
+
+    assert!(!blocked.status.success());
+    let blocked: Value = serde_json::from_slice(&blocked.stdout).unwrap();
+    assert_eq!(blocked["error"]["code"], "plan_drifted");
+    assert_eq!(fs::read_to_string(&extra).unwrap(), "after\n");
+    assert!(!package.join("SKILL.md").exists());
+    assert!(!package.join("references").exists());
+    let status = json_output(&run(&[&common[..], &["status"]].concat(), None));
+    assert_eq!(status["result"]["pending_plan_count"], 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_projection_ignores_bounded_package_exclusions() {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::FileTypeExt;
+
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let package = home.join(".codex/skills/skillroster");
+    let dependencies = package.join("node_modules");
+    fs::create_dir_all(&dependencies).unwrap();
+    let fifo = dependencies.join("ignored.fifo");
+    let fifo_path = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+    assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+
+    assert_eq!(setup["result"]["state"], "preview_ready");
+    assert_eq!(setup["result"]["affected"]["skill_count"], 1);
+    assert_eq!(setup["result"]["files_changed"], false);
+    let applied = json_output(&run(
+        &[
+            &common[..],
+            &["apply", setup["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert!(package.join("SKILL.md").is_file());
+    assert!(fs::symlink_metadata(&fifo).unwrap().file_type().is_fifo());
+    let undone = json_output(&run(
+        &[
+            &common[..],
+            &["undo", applied["result"]["receipt_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(undone["result"]["verification"], "passed");
+    assert!(fs::symlink_metadata(&fifo).unwrap().file_type().is_fifo());
+}
+
+#[test]
+fn setup_reports_each_distinct_projected_identity_when_preserved_extras_differ() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let roots = [
+        home.join(".codex/skills"),
+        home.join(".config/opencode/skills"),
+    ];
+    for (index, root) in roots.iter().enumerate() {
+        let package = root.join("skillroster");
+        fs::create_dir_all(&package).unwrap();
+        fs::write(
+            package.join("notes.local.md"),
+            format!("preserved variant {index}\n"),
+        )
+        .unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+
+    let setup = json_output(&run(&[&common[..], &["setup"]].concat(), None));
+    assert_eq!(setup["result"]["state"], "preview_ready");
+    assert_eq!(setup["result"]["affected"]["agent_count"], 2);
+    assert_eq!(setup["result"]["affected"]["placement_count"], 2);
+    assert_eq!(setup["result"]["affected"]["skill_count"], 2);
+    let projected_skill_ids = setup["result"]["affected"]["skill_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|value| value.as_str().unwrap().to_owned())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(projected_skill_ids.len(), 2);
+
+    let applied = json_output(&run(
+        &[
+            &common[..],
+            &["apply", setup["result"]["plan_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    json_output(&run(&[&common[..], &["scan", "--summary"]].concat(), None));
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let mut statement = database
+        .prepare("SELECT id FROM skills WHERE name = 'skillroster' ORDER BY id")
+        .unwrap();
+    let observed_skill_ids = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(projected_skill_ids, observed_skill_ids);
+    drop(statement);
+    drop(database);
+
+    let undone = json_output(&run(
+        &[
+            &common[..],
+            &["undo", applied["result"]["receipt_id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(undone["result"]["verification"], "passed");
+    for (index, root) in roots.iter().enumerate() {
+        let package = root.join("skillroster");
+        assert_eq!(
+            fs::read_to_string(package.join("notes.local.md")).unwrap(),
+            format!("preserved variant {index}\n")
+        );
+        assert!(!package.join("SKILL.md").exists());
+        assert!(!package.join("references").exists());
+    }
 }
 
 #[cfg(unix)]
@@ -5560,6 +5755,16 @@ fn setup_deduplicates_shared_agent_roots_and_undo_restores_each_physical_root() 
             "pi"
         ])
     );
+    assert_eq!(setup["result"]["affected"]["skill_count"], 1);
+    assert_eq!(
+        setup["result"]["affected"]["skill_ids"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(setup["result"]["affected"]["skill_ids_truncated"], false);
+    assert_eq!(setup["result"]["affected"]["placement_count"], 8);
 
     let plan_id = setup["result"]["plan_id"].as_str().unwrap();
     let detail = json_output(&run(
@@ -5870,7 +6075,7 @@ fn setup_does_not_reuse_an_incomplete_legacy_plan_summary() {
 }
 
 #[test]
-fn setup_does_not_reuse_a_legacy_zero_affected_agent_summary() {
+fn setup_does_not_reuse_a_legacy_incomplete_affected_summary() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");
     let state = temp.path().join("state");
@@ -5898,10 +6103,21 @@ fn setup_does_not_reuse_a_legacy_zero_affected_agent_summary() {
     let mut legacy: Value = serde_json::from_str(&immutable).unwrap();
     legacy["input"]["summary"]["affected"]["agent_count"] = json!(0);
     legacy["input"]["summary"]["affected"]["agents"] = json!([]);
+    legacy["input"]["summary"]["affected"]["skill_count"] = json!(0);
+    legacy["input"]["summary"]["affected"]["skill_ids"] = json!([]);
+    legacy["input"]["summary"]["affected"]["placement_count"] = json!(0);
     legacy["input"]["reuse_identity"]
         .as_object_mut()
         .unwrap()
         .remove("affected_agents");
+    legacy["input"]["reuse_identity"]
+        .as_object_mut()
+        .unwrap()
+        .remove("affected_skill_ids");
+    legacy["input"]["reuse_identity"]
+        .as_object_mut()
+        .unwrap()
+        .remove("affected_placement_count");
     database
         .execute(
             "UPDATE plans SET immutable_json = ?1 WHERE id = ?2",
@@ -5915,6 +6131,15 @@ fn setup_does_not_reuse_a_legacy_zero_affected_agent_summary() {
     assert_ne!(retry["result"]["plan_id"], first["result"]["plan_id"]);
     assert_eq!(retry["result"]["affected"]["agent_count"], 1);
     assert_eq!(retry["result"]["affected"]["agents"], json!(["codex"]));
+    assert_eq!(retry["result"]["affected"]["skill_count"], 1);
+    assert_eq!(
+        retry["result"]["affected"]["skill_ids"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(retry["result"]["affected"]["placement_count"], 1);
     assert!(!root.join("skillroster").exists());
 }
 


### PR DESCRIPTION
## Problem

Real v1.8.43 Agent dogfood prepared a Bootstrap Setup Plan for six logical Agent targets and 25 filesystem operations, but `setup --json` and `plan --show` both reported zero affected Skills and zero affected placements.

The first fix exposed a second correctness boundary: preserved unmanaged package files can change the projected post-Apply Skill identity, so their effective package state must be bound to Apply rather than only displayed in the preview.

## Value

Agents now receive an accurate, immutable confirmation summary before Bootstrap writes:

- logical Agents, Skills, and placements reflect the actual proposed result;
- physical roots remain deduplicated for filesystem operations;
- preserved identity-relevant files participate in projected identity;
- drift after Setup fails closed, and drift during Apply is compensated;
- ignored repository/build/dependency entries do not create false blockers.

## Method

- project the post-Apply Bootstrap Skill identity for every physical package;
- report distinct projected Skill IDs and logical placement count in both Setup and Plan detail;
- bind bounded package-level before/after fingerprints into the immutable Plan digest;
- validate those fingerprints through retained root handles before and after Apply;
- share one package hashing policy across Scan, Setup projection, and Apply: depth 8, 16 MiB, and the same `.git` / `target` / `node_modules` / `.DS_Store` exclusions;
- preserve legacy Plan digest compatibility when no path projections exist.

## Evidence

- `bash scripts/ci-full-check.sh`
  - Rust unit: 331 passed
  - acceptance: 8 passed
  - CLI: 122 passed
  - Node: 152 passed
  - strict Clippy and formatting passed
- targeted regressions cover:
  - preserved-file drift after Setup;
  - during-Apply drift with compensation rollback;
  - CRLF-normalized managed writes;
  - distinct preserved extras across physical roots;
  - ignored `node_modules` FIFO through Setup → Apply → Undo;
  - package byte bound;
  - legacy incomplete Plan non-reuse.
- current local read-only replay:
  - Scan: 263 Skills / 1,037 placements / no files changed
  - Setup: 6 Agents / 1 Skill / 6 placements / 4 physical package bindings / 25 operations / confirmation required / no files changed
- independent final Standards review: Clean at `3ccbe722efff9f2a494c78c786a892ac75288e3a`
- independent final Spec review: Clean at the same exact head

Closes #364
