### PR TITLE
release: record v1.8.44 publication

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "76a6885669f96ba37c919641f4b207e99b2b27fe"
-  version "1.8.43"
+      revision: "c79b08346552814b6b4438a4f87964f9ab9a06a0"
+  version "1.8.44"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.43", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.44", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -214,7 +214,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.43 implements the complete local governance loop. Every
+Public release v1.8.44 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -222,7 +222,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.43 release and platform evidence](docs/acceptance/release-v1.8.43-candidate.md)
+- [v1.8.44 release and platform evidence](docs/acceptance/release-v1.8.44-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -201,14 +201,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.43 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.44 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.43 发布与平台证据](docs/acceptance/release-v1.8.43-candidate.md)
+- [v1.8.44 发布与平台证据](docs/acceptance/release-v1.8.44-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.44-candidate.md
+++ b/docs/acceptance/release-v1.8.44-candidate.md
@@ -94,8 +94,10 @@ contains four archives and four adjacent checksum files:
 | `x86_64-pc-windows-msvc` | `b2b8cb46f8c386ffab4160d0fc798bdd14707b1cab8f30dc336fb437406ca412` |
 | `x86_64-unknown-linux-gnu` | `608d5cb4884d2f02d52a42635c099c99c1dd4fa539a47e9498e5651970f4a407` |
 
-All adjacent checksums passed. Every archive contained only its versioned
-directory, binary, README, and LICENSE; each README and LICENSE matched the
+All adjacent checksums passed. Every archive kept its binary, README, and
+LICENSE under one versioned top-level directory or path prefix; the tar archives
+also contained an explicit directory entry, while the Windows ZIP contained
+only the three prefixed payload entries. Each README and LICENSE matched the
 checked-in Git blob byte-for-byte. The public asset inventory contained exactly
 those eight files. An anonymous macOS arm64 download matched its adjacent
 checksum and the tag-workflow artifact byte-for-byte, reported

--- a/docs/acceptance/release-v1.8.44-candidate.md
+++ b/docs/acceptance/release-v1.8.44-candidate.md
@@ -1,6 +1,6 @@
-# SkillRoster v1.8.44 candidate
+# SkillRoster v1.8.44 release receipt
 
-## Release notes draft
+## Outcome
 
 SkillRoster 1.8.44 makes Bootstrap Setup previews truthful and binds Apply to
 the exact package identity that the preview promised.
@@ -37,9 +37,9 @@ validation. SQLite remains at schema 12, the JSON envelope remains at schema 1,
 and bundled Bootstrap content remains at version 1.8.29. It does not mutate
 Agent or Skill files during Scan or Setup.
 
-## Preparation evidence
+## Source and review chain
 
-Candidate preparation starts from exact `origin/main` revision
+Release preparation started from exact `origin/main` revision
 `233fc7c51f75e21a8738ac1f7b429407ebb52c90`.
 
 [#365](https://github.com/tt-a1i/skillroster/pull/365) implements the fix at
@@ -60,25 +60,84 @@ acceptance tests, 122 CLI tests, and 152 Node harness tests, plus strict Clippy,
 formatting, installation-surface validation, archive README validation, the
 change-scope self-test, and `git diff --check`.
 
-The source candidate and Cargo package are versioned as 1.8.44. Public install
-examples, website current-release labels, README release evidence, and the
-Homebrew Formula deliberately remain at v1.8.43 until the v1.8.44 tag,
-artifacts, checksums, and Homebrew package actually exist.
+[#366](https://github.com/tt-a1i/skillroster/pull/366) prepared version 1.8.44
+at exact head `113cc1c2d201a0b4ddadc350042e8c71647f6241` and merged as exact
+release source revision `c79b08346552814b6b4438a4f87964f9ab9a06a0`.
+The PR
+[CI run 33329426160](https://github.com/tt-a1i/skillroster/actions/runs/33329426160)
+and exact-main
+[CI run 33455660320](https://github.com/tt-a1i/skillroster/actions/runs/33455660320)
+passed change scope, Linux x86_64, Windows x86_64, macOS arm64, macOS x86_64,
+and the aggregate CI gate at their exact revisions. Two independent exact-head
+reviews passed after one release-note scope finding was corrected. The complete
+local candidate gate passed 331 Rust unit tests, 8 acceptance tests, 122 CLI
+tests, and 152 Node harness tests, plus strict Clippy, formatting,
+installation-surface validation, archive README validation, the change-scope
+self-test, and `git diff --check`.
 
-## Candidate gates
+## Published release
 
-The candidate is not accepted until one exact final source revision passes:
+Annotated tag `v1.8.44` has tag object
+`9f712cee1d06a9016eaae87ca2dd242853431031` and resolves to exact source
+revision `c79b08346552814b6b4438a4f87964f9ab9a06a0`. The tag
+[release workflow](https://github.com/tt-a1i/skillroster/actions/runs/33455956695)
+passed the strict repository gate, all four supported-platform jobs, each
+governance smoke, and WSL2 at that exact revision.
 
-- `cargo fmt --all --check`;
-- `cargo clippy --locked --all-targets --all-features -- -D warnings`;
-- `cargo test --locked --all-targets --all-features`;
-- the public CLI acceptance suite and Node harnesses;
-- `git diff --check`, installation-surface validation, archive README
-  validation, and the CI change-scope self-test;
-- four platform build and governance jobs plus the WSL2 governance smoke;
-- downloaded checksum verification and an external four-archive comparison
-  against the checked-in README and LICENSE Git blobs.
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.44)
+contains four archives and four adjacent checksum files:
 
-Candidate preparation does not create or push a tag, publish a GitHub Release,
-update Homebrew, or mutate an existing public release asset. Those operations
-remain separately evidenced after candidate acceptance.
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `1546b4711c5a2a64c1771f236a3f74786aff7caa8df79c45cb499becfe63203f` |
+| `x86_64-apple-darwin` | `ece76757edaec6aea3c2b7aa078b558299320b70cd6c9c144c0644896dba23b7` |
+| `x86_64-pc-windows-msvc` | `b2b8cb46f8c386ffab4160d0fc798bdd14707b1cab8f30dc336fb437406ca412` |
+| `x86_64-unknown-linux-gnu` | `608d5cb4884d2f02d52a42635c099c99c1dd4fa539a47e9498e5651970f4a407` |
+
+All adjacent checksums passed. Every archive contained only its versioned
+directory, binary, README, and LICENSE; each README and LICENSE matched the
+checked-in Git blob byte-for-byte. The public asset inventory contained exactly
+those eight files. An anonymous macOS arm64 download matched its adjacent
+checksum and the tag-workflow artifact byte-for-byte, reported
+`skillroster 1.8.44`, and passed the release governance smoke in isolated
+temporary directories.
+
+## Homebrew
+
+The public [Homebrew tap](https://github.com/tt-a1i/homebrew-skillroster)
+updated through [PR #18](https://github.com/tt-a1i/homebrew-skillroster/pull/18)
+at exact head `9c5c80e44815605b137b0f5c479e46e090101420`. The
+[brew test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33456916677)
+built, installed, and tested macOS arm64 and Linux x86_64 bottles at that PR
+head. The
+[brew pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33457382749)
+was dispatched from tap `main` at
+`f141e46f3f492fae25fdc1d69f2b5d6527448df5` after test-bot passed. It closed
+the PR without a regular merge commit, created equivalent Formula commit
+`503ba7012333e7975a4b0bb860a2367b151ce9fe`, published both bottles, and
+advanced tap `main` through bottle commit
+`7b7d445a7f43f30ab16602c997c3f1cc1f9ae864`.
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `9c6611bf0ed693efc7da1fbc14b1857aa1eafbbad09ab4d210b86fcd9918ec2c` |
+| `x86_64_linux` | `344fdbdc317926759cfd29863a3659a586ce0de4a387ec34c2a38d482dc1f6d4` |
+
+The public Formula source checksum matches an independent v1.8.44 tag archive
+download. An anonymous arm64 bottle download matched its Formula checksum,
+reported version 1.8.44, and completed an isolated `scan --summary --json`
+smoke with `ok=true` and `files_changed=false`. Verification extracted the
+bottle in a temporary directory and did not mutate the user's installed
+Homebrew package.
+
+## Boundaries
+
+- Package postconditions cover new mutating Bootstrap Setup Plans, not every
+  historical or non-Bootstrap Plan.
+- Identity-relevant retained files inside the bounded package set participate
+  in drift checks; documented package exclusions remain outside that boundary.
+- WSL2 is verified with the Linux archive. WSL1 remains fail-closed for Apply
+  and Undo because it lacks the required atomic no-replace rename primitive.
+- The release does not claim native Linux arm64 or Windows arm64 artifacts.
+- Publishing this release did not migrate state, modify Agent or Skill files,
+  or change the Bootstrap content version.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.43**. Its Formula, annotated tag, four
+The current public release is **v1.8.44**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.43
+SKILLROSTER_VERSION=1.8.44
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.43 skillroster
+  --tag v1.8.44 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -93,7 +93,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.43 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.44 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.44**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.43 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.44 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.43 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.44 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.43 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.43 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.44 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.44 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Outcome

Record the already-published v1.8.44 release and make public install surfaces point to evidence that now exists.

## Evidence recorded

- annotated tag `v1.8.44` -> exact source `c79b08346552814b6b4438a4f87964f9ab9a06a0`
- release workflow 33455956695: strict gate, four targets, governance smoke, WSL2
- public GitHub Release: four archives + four adjacent checksums
- anonymous arm64 archive: checksum, workflow-byte equality, version, governance smoke
- Homebrew PR #18 test-bot on macOS arm64 and Linux x86_64
- brew pr-pull 33457382749, two public bottles, tap main `7b7d445`
- anonymous arm64 bottle: Formula checksum, version, isolated scan smoke

## Repository updates

- README, installation guide, and website current-release labels -> v1.8.44
- checked-in source Formula -> exact v1.8.44 source revision
- candidate record -> completed release receipt with evidence boundaries

## Local verification

- `bash scripts/ci-full-check.sh`
- 331 Rust unit + 8 acceptance + 122 CLI + 152 Node
- installation/archive/change-scope/format/strict-Clippy gates
- `git diff --check`

This PR does not recreate or mutate published release assets.