### PR TITLE
docs: verify executable selection after upgrades

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -85,6 +85,9 @@ brew install tt-a1i/skillroster/skillroster
 skillroster --version
 ```
 
+Already installed? See [upgrade and executable-path checks](docs/installation.md#upgrade-and-verify-the-executable-your-agent-uses):
+an older copy earlier on PATH can still be selected after a Homebrew upgrade.
+
 Then ask your agent:
 
 > Use SkillRoster to inspect my local Skills, explain the biggest problems, and

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ brew install tt-a1i/skillroster/skillroster
 skillroster --version
 ```
 
+已经安装过？请先看[升级与执行路径检查](docs/installation.md#upgrade-and-verify-the-executable-your-agent-uses)：
+升级 Homebrew 后，PATH 中排在前面的旧副本仍可能被 Agent 调用。
+
 然后直接告诉你的 Agent：
 
 > 使用 SkillRoster 检查我电脑上的 Skills，解释最需要处理的问题，并给出一套更安全的

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,6 +83,49 @@ installation does not require GitHub authentication. This is an upstream tap,
 not a Homebrew/core Formula. Never paste a GitHub token into a Formula or a
 command line.
 
+## Upgrade and verify the executable your Agent uses
+
+Pick one installation method to own future CLI upgrades. For Homebrew:
+
+```sh
+brew update
+brew upgrade tt-a1i/skillroster/skillroster
+```
+
+An upgraded package does not prove that `skillroster` selects it. A previous
+Release binary in `~/.local/bin`, a Cargo install in `~/.cargo/bin`, or a shell
+alias/function can take precedence. In the shell that launches your Agent,
+check the selected command, all resolutions, and the Homebrew copy separately:
+
+```sh
+command -v skillroster
+type -a skillroster
+skillroster --version
+"$(brew --prefix)/bin/skillroster" --version
+```
+
+`type -a` is supported by Bash and Zsh. In PowerShell, use
+`Get-Command skillroster -All` to inspect command precedence instead. Compare
+the CLI version with the release you intended to install, not with Bootstrap
+content version: those versions can intentionally differ.
+
+If the selected command is still old, inspect its ownership before changing
+anything. Do not delete every result from `type -a` or overwrite an alias,
+wrapper, package-manager link, or shell configuration automatically. For a
+confirmed standalone binary that you choose to retire, move that exact file
+to a recoverable backup outside command lookup. If existing callers need its
+old absolute path, a symlink at that path can point to the verified stable
+`$(brew --prefix)/bin/skillroster` entrypoint, rather than a versioned Cellar
+path. Keep the backup until the replacement is verified. Never point that
+entrypoint back to the retired path or create a link to a missing target.
+
+Open a fresh shell (or run `hash -r` in Bash / `rehash` in Zsh), then repeat the
+path and version checks. Restart the Agent that was launched with the old
+environment and ask it to run the checks too. A successful terminal check does
+not establish which binary an already-running Agent or saved absolute-path
+command uses. This verification does not authorize changes to Agent Skill
+files; Bootstrap upgrades still require the reviewed Setup Plan below.
+
 ## Install or upgrade the Agent bootstrap Skill
 
 After installing a new CLI version, refresh the local Snapshot and inspect all


### PR DESCRIPTION
## 解决什么问题

A Homebrew upgrade can succeed while an older standalone binary remains first on PATH. The reproduced setup selected CLI 1.8.28 despite an installed Homebrew 1.8.35 and published 1.8.44.

## 价值是什么

Users and Agents can verify the actual executable after an upgrade and safely consolidate installation ownership without deleting arbitrary files or modifying Agent Skills.

## 方法是什么

Document Homebrew upgrade, selected/all command resolutions, explicit Homebrew version checks, recoverable retirement of a verified standalone binary, stable-link ownership, fresh-shell and Agent-environment rechecks. Both README quick starts link to this guidance.

Documentation only; no version bump, runtime behavior, updater, telemetry, or Bootstrap changes.

## Verification

- Exact head: 31e80ee5f2b6fefc4b64d4e66a31870505a76eb5
- Local full check: 331 Rust unit, 8 acceptance, 122 CLI, 152 Node; formatting, strict Clippy, README/installation/archive checks all passed.
- Independent Standards: Clean at exact head.
- Independent Spec: Clean at exact head.
- Real maintainer remediation: Homebrew updated to 1.8.44; previous standalone copy preserved with matching before/after SHA-256; old path now resolves through stable Homebrew entrypoint. Fresh shell and explicit Homebrew versions both 1.8.44.
- Homebrew formula test and isolated packaged Setup/Apply/Undo smoke passed.
- This is not independent-user pilot evidence; #261 and #262 remain separate.

Closes #368