### PR TITLE
fix: bound overlap resources and harden recovery metadata

### DIFF
--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -112,10 +112,41 @@ those vocabularies for pair comparison. On the unchanged real Snapshot the
 unoptimized first report fell to 2.22 seconds and the optimized 1.7.1 build
 produced the complete report in 0.84 seconds. Normalized complete reports from
 the official 1.7.0 binary and the 1.7.1 build were byte-identical after removing
-random Run, Report, and Finding IDs. A 193-Skill core regression that previously
-took 75.32 seconds now completes in under one second and enforces a five-second
-upper bound in the unoptimized test profile. These measurements describe the
-recorded reference run, not a universal machine-performance guarantee.
+random Run, Report, and Finding IDs. The recorded 193-Skill core regression fell
+from 75.32 seconds to under one second. Its current deterministic assertions
+check one vocabulary per Skill, the exact pair count, and at most 25 retained
+candidates; there is no five-second wall-clock assertion. These historical
+measurements describe the recorded reference run, not a universal
+machine-performance guarantee.
+
+### Synthetic overlap scale baseline (release-hardening round)
+
+Run `bash scripts/benchmark-overlap.sh` to compile the optimized library test
+and measure each size in a separate process with `/usr/bin/time`. Compilation
+is excluded. `analysis_ms` covers overlap analysis; peak RSS covers the entire
+test process, including its synthetic Snapshot. The fixture uses distinct
+identities, dense shared routing vocabulary, and 20 repeats of the same body.
+It deliberately makes every pair a candidate; it is not a full Scan, database,
+CLI, or representative real-user latency benchmark.
+
+Single local measurements on macOS 26.5.2 arm64, Rust 1.98.0, comparing main
+`2beab5d` plus measurement instrumentation against bounded selection and
+score-only comparison:
+
+| Skills | Pairs | Before analysis | After analysis | Before peak RSS | After peak RSS |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 193 | 18,528 | 13 ms | 5 ms | 10,452,992 B | 9,814,016 B |
+| 1,000 | 499,500 | 307 ms | 73 ms | 28,344,320 B | 14,712,832 B |
+| 5,000 | 12,497,500 | 7,752 ms | 1,558 ms | 339,918,848 B | 38,338,560 B |
+
+Changing only candidate retention reduced the 5,000-Skill peak RSS to
+38,174,720 B but took 8,055 ms. Removing unused pairwise explanation allocation
+then reduced analysis time. Selection retains at most 25 entries throughout;
+vocabulary storage still grows with the inventory, and pair enumeration is
+still quadratic. No latency or total-memory limit is promised. CI uses
+deterministic resource-count assertions and an independent full-sort oracle
+covering empty/small inputs, ties, reordered IDs, same-name variants, and equal
+digests. The timing experiment is opt-in and is not a flaky pass/fail gate.
 
 ## Agent session-evidence dogfood
 

--- a/docs/hardening-evidence.md
+++ b/docs/hardening-evidence.md
@@ -1,0 +1,95 @@
+# Release hardening evidence and boundaries
+
+This round addresses [#370](https://github.com/tt-a1i/skillroster/issues/370),
+[#371](https://github.com/tt-a1i/skillroster/issues/371), and
+[#372](https://github.com/tt-a1i/skillroster/issues/372), from main `2beab5d`.
+Historical published assets remain separately tracked in
+[#55](https://github.com/tt-a1i/skillroster/issues/55). Independent user-pilot
+work is outside this round.
+
+## Performance
+
+[The acceptance record](acceptance.md#synthetic-overlap-scale-baseline-release-hardening-round)
+contains the reproducible synthetic workload, machine, before/after timing and
+process peak RSS. The deterministic gate proves at most 25 retained semantic
+candidates, exact pair counts, and identical output against the original
+full-sort algorithm. Pair enumeration remains quadratic. There is no universal
+five-second report guarantee.
+
+## Recovery tests
+
+The ordinary Rust suite includes `storage_errno_failures_keep_a_durable_recovery_boundary`.
+It injects ENOSPC/EIO on Unix, and ERROR_DISK_FULL/ERROR_IO_DEVICE on Windows,
+at the initial journal-directory barrier and at the created target's directory
+barrier, in both one-shot and persistent forms. It checks whether target bytes
+exist, that journal evidence remains readable, and that a later Apply refuses
+to proceed past unresolved recovery. This is an injected directory-sync errno
+test, not a physically full filesystem or an emulated failing block device.
+
+`killed_apply_blocks_new_writes_after_process_restart` runs the real Apply
+implementation in a separate test process. The parent waits for a concrete
+checkpoint after initial journal publication or target-file publication,
+terminates that child (SIGKILL on Unix), waits for its death, and starts a fresh
+process against the same disposable state. The restarted process must observe
+the Applying journal and reject a new write. Journal bytes and the expected
+target bytes are compared across restart. Hooks and subprocess environment
+keys exist only in the test build, not the shipped CLI.
+
+These tests run through the normal full CI/release Rust suites. A green result
+establishes only the exercised software boundaries. It does **not** simulate
+loss of filesystem/device caches, controller write reordering, power failure,
+or a disk that acknowledges durability without providing it. Do not call this
+physical power-loss certification. Existing directory synchronization,
+compensation, SQLite finalization, and lifecycle-reconciliation tests remain
+separate gates; process death does not replace them.
+
+## Copy and replacement metadata
+
+Copy-based mutations inspect metadata using retained source/destination file
+handles. A copy may now refuse a filesystem layout that previously lost
+metadata silently. There is no override that discards unsupported metadata.
+
+| Platform | Supported copy metadata | Refused or deliberately outside the guarantee |
+| --- | --- | --- |
+| Linux | Current-user owner, group, permission bits; directory modes finalized after children | Observable xattrs, including POSIX ACLs; failed metadata inspection |
+| macOS | Current-user owner, group, permission bits; identical OS-created provenance bytes | Other xattrs, extended ACLs, nonzero file flags, changed provenance |
+| Windows | Ordinary/readonly attributes and exactly matching owner/group/DACL, including inheritance control | Different destination ACL defaults, named streams, EAs, other file attributes |
+
+Windows recovery backups deliberately retain owner-only access. Original
+owner/group/DACL evidence is stored as an additive private Receipt field, not
+applied to the backup. Before bytes are copied into a restoration staging file,
+its security descriptor must match that evidence. SkillRoster never changes a
+destination DACL to force a match. Legacy Windows **replacement** Receipts with
+no original security evidence cannot establish that comparison and are refused;
+their files and recovery evidence remain for explicit manual recovery. This
+does not invalidate non-replacement Undo operations or Unix Receipts.
+
+Replacement Undo also compares the current observable metadata with recovery
+evidence. A changed mode, owner/group, visible xattr/ACL or Windows DACL is a
+recovery boundary, not permission to overwrite the user's change.
+
+This does not claim to preserve timestamps, sparse allocation, hard-link
+topology, privileged/invisible metadata, filesystem-specific policy, or Windows
+SACL audit settings. An application requiring those properties needs a native
+metadata-aware backup/migration workflow. Read-only Scan/Report/Find remain
+available for such files; observation is not mutation authorization.
+
+Reference contracts: [Linux handle-based xattr enumeration](https://man7.org/linux/man-pages/man2/listxattr.2.html)
+may omit attributes inaccessible to the caller; this is why absence cannot
+prove privileged metadata is absent. Darwin distinguishes missing ACL
+properties from empty ACL objects in its
+[ACL handle implementation](https://github.com/apple-oss-distributions/Libc/blob/main/posix1e/acl_file.c)
+and [filesec property implementation](https://github.com/apple-oss-distributions/Libc/blob/main/gen/filesec.c).
+Windows [file security](https://learn.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights)
+is attached to the file itself; a private parent directory is not a substitute
+for protecting a recovery file's DACL.
+
+## Focused simplification
+
+The former private `AnchoredFs::copy_file` wrapper had no remaining production
+callers after backup/restore metadata became explicit. Its two tests now use
+the production `copy_tree` entrypoint, which dispatches regular files to the
+same retained-handle implementation. No containment, identity, durability or
+rollback guard was removed. The source diff/commit can be reverted independently
+of any released artifacts; reverting source does not repair metadata already
+lost by an older binary or restore deleted release assets.

--- a/docs/hardening-evidence.md
+++ b/docs/hardening-evidence.md
@@ -102,7 +102,11 @@ cannot inspect xattrs; Windows read-only directory handles cannot apply metadata
 or flush it. Copy now opens explicitly readable source directories and
 metadata-write/flush-capable destination directories, retaining no-follow and
 directory-type checks. `recursive_directory_copy_and_undo_round_trip` runs on
-every platform, in addition to the Unix readonly-directory test.
+every platform, in addition to the Unix readonly-directory test. On Windows,
+long-lived copy handles also retain no-delete-sharing protection for source
+and destination directories; they are deliberately separate from short-lived
+parent-sync handles. The test attempts to rename both directory trees and
+their nested directories during child-file copying and requires refusal.
 
 On Windows, replacement also closes its retained original-file handles after
 validated removal and before publishing the staged file. Otherwise the delete

--- a/docs/hardening-evidence.md
+++ b/docs/hardening-evidence.md
@@ -106,7 +106,13 @@ every platform, in addition to the Unix readonly-directory test. On Windows,
 long-lived copy handles also retain no-delete-sharing protection for source
 and destination directories; they are deliberately separate from short-lived
 parent-sync handles. The test attempts to rename both directory trees and
-their nested directories during child-file copying and requires refusal.
+requires refusal before child enumeration, then attempts both trees and their
+nested directories during child-file copying. The earlier checkpoint caught
+an actual source-directory rename at test-only head `4031b25` in
+[Windows CI](https://github.com/tt-a1i/skillroster/actions/runs/33754471577/job/100645481705).
+The later child-file checkpoint alone passed before the explicit protection;
+that pass is not evidence that the earlier window was safe. This reproduces
+the missing rename protection, not a complete outside-root exploit.
 
 On Windows, replacement also closes its retained original-file handles after
 validated removal and before publishing the staged file. Otherwise the delete

--- a/docs/hardening-evidence.md
+++ b/docs/hardening-evidence.md
@@ -93,3 +93,20 @@ same retained-handle implementation. No containment, identity, durability or
 rollback guard was removed. The source diff/commit can be reverted independently
 of any released artifacts; reverting source does not repair metadata already
 lost by an older binary or restore deleted release assets.
+
+## Cross-platform regression checks
+
+Independent review and the first platform CI run caught two handle-lifecycle
+regressions before merge. Linux directory capabilities may use `O_PATH`, which
+cannot inspect xattrs; Windows read-only directory handles cannot apply metadata
+or flush it. Copy now opens explicitly readable source directories and
+metadata-write/flush-capable destination directories, retaining no-follow and
+directory-type checks. `recursive_directory_copy_and_undo_round_trip` runs on
+every platform, in addition to the Unix readonly-directory test.
+
+On Windows, replacement also closes its retained original-file handles after
+validated removal and before publishing the staged file. Otherwise the delete
+disposition stays pending and the no-replace rename correctly refuses an
+apparently occupied destination. The existing readonly Replace/Undo, complete
+Bootstrap upgrade/Undo, and full operation-ledger tests exercise that lifecycle.
+See Microsoft's [delete-disposition contract](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_file_disposition_information_ex).

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -190,8 +190,24 @@ handle and restores its platform permissions before publication. Unix
 permission bits and Windows file attributes, including readonly, must therefore
 survive both Apply and Undo, including an originally non-writable file. Windows
 removal uses a handle-bound disposition that ignores readonly without first
-weakening the original path's attributes. SkillRoster does not claim portable
-preservation of owner, ACLs, or extended attributes.
+weakening the original path's attributes. Copy-based mutations additionally
+validate observable metadata through retained handles: Unix owner/group and
+permission bits must survive; unsupported extended attributes and ACLs refuse
+the copy. macOS system provenance is accepted only when its exact value survives
+unchanged, while extended ACLs and other file flags are unsupported. Recursive
+copies finalize directory permissions after copying children. Windows ordinary
+file attributes, owner, group, and DACL must match at the destination; a copy
+across different inherited ACLs is refused instead of broadening access.
+Windows named streams, extended attributes, and non-ordinary file attributes
+are unsupported. Private replacement backups keep their private DACL; the
+original Windows owner/group/DACL evidence is saved in the private Receipt and
+checked against the restoration destination. Legacy Windows replacement
+Receipts without that evidence fail closed rather than guessing lost metadata.
+Replacement Undo refuses observable metadata drift from its recovery evidence.
+This is not a portable archive/backup contract for timestamps, hard-link
+topology, privileged audit policy (such as Windows SACLs), or metadata the OS
+does not expose to this process. See [hardening evidence](hardening-evidence.md)
+for precise failure-test and metadata boundaries.
 
 Apply, compensation, and Undo open approved roots and the private state root as
 directory capabilities before mutation. Filesystem paths are resolved relative

--- a/scripts/benchmark-overlap.sh
+++ b/scripts/benchmark-overlap.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Explicit synthetic measurement, not a timing gate or whole-CLI benchmark.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+case "$(uname -s)" in
+  Darwin) timing=(-l) ;;
+  Linux) timing=(-v) ;;
+  *) echo 'Peak-RSS measurement requires macOS or Linux /usr/bin/time.' >&2; exit 1 ;;
+esac
+executable="$(cargo test --locked --release --lib --no-run --message-format=json | node -e '
+let input = "";
+process.stdin.on("data", chunk => input += chunk);
+process.stdin.on("end", () => {
+  const artifacts = input.trim().split("\n").map(line => JSON.parse(line))
+    .filter(row => row.reason === "compiler-artifact" && row.target.name === "skillroster"
+      && row.target.kind.includes("lib") && row.profile.test && row.executable);
+  if (artifacts.length !== 1) process.exit(1);
+  process.stdout.write(artifacts[0].executable);
+});
+')"
+rustc --version
+uname -sm
+for count in 193 1000 5000; do
+  SKILLROSTER_BENCH_SKILLS="$count" /usr/bin/time "${timing[@]}" "$executable" \
+    --exact query::tests::semantic_overlap_scale_measurement --ignored --nocapture
+done

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -4,7 +4,9 @@ use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
 use cap_std::ambient_authority;
-use cap_std::fs::{Dir, OpenOptions, Permissions};
+#[cfg(unix)]
+use cap_std::fs::Permissions;
+use cap_std::fs::{Dir, OpenOptions};
 use sha2::{Digest, Sha256};
 
 use crate::copy_metadata::{CopyDestination, CopyMetadata};
@@ -1318,7 +1320,7 @@ impl<'a> AnchoredFs<'a> {
         }
         #[cfg(not(unix))]
         target_anchor.dir.create_dir(target)?;
-        let opened = open_directory_for_sync(&target_anchor.dir, target)?;
+        let opened = open_copy_destination_directory(&target_anchor.dir, target)?;
         copy_metadata.validate_destination(&opened)?;
         self.require_opened_directory_at(target_anchor, target, &opened)?;
         run_after_created_entry_first_check_hook();
@@ -1723,14 +1725,49 @@ fn open_readable_directory(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
     #[cfg(windows)]
     {
         use cap_std::fs::OpenOptionsExt as _;
-        use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
-        options.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        };
+        // Child copies still resolve names relative to the approved root.
+        // Deny renames/deletion for this directory throughout recursion.
+        options
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
     }
     let file = dir.open_with(relative, &options)?.into_std();
     if !file.metadata()?.is_dir() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "opened metadata source is not a directory",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(not(windows))]
+fn open_copy_destination_directory(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
+    open_readable_directory(dir, relative)
+}
+
+#[cfg(windows)]
+fn open_copy_destination_directory(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
+    use cap_std::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        ._cap_fs_ext_follow(cap_primitives::fs::FollowSymlinks::No)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+    let file = dir.open_with(relative, &options)?.into_std();
+    if !file.metadata()?.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "opened copy destination is not a directory",
         ));
     }
     Ok(file)
@@ -1745,7 +1782,6 @@ fn open_directory_for_sync(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
 
     let mut options = OpenOptions::new();
     options
-        .read(true)
         .write(true)
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS);

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -1017,6 +1017,11 @@ impl<'a> AnchoredFs<'a> {
         metadata.verify(&original_handle)?;
         self.require_opened_file_at(target_anchor, &target_relative, &original)?;
         self.remove_regular_file(target_anchor, &target_relative)?;
+        // Windows delete disposition remains pending until our retained source
+        // handles close. Keep them through validation/removal, but release them
+        // before syncing the removal and publishing the replacement name.
+        drop(original_handle);
+        drop(original);
         self.sync_parent(target_anchor, &target_relative)?;
         self.rename(temp, target)?;
         self.require_opened_file_at(target_anchor, &target_relative, &staged)?;
@@ -1302,7 +1307,7 @@ impl<'a> AnchoredFs<'a> {
                 "source is not a supported file type",
             ));
         }
-        let source_directory = source_anchor.dir.open_dir(source)?.into_std_file();
+        let source_directory = open_readable_directory(&source_anchor.dir, source)?;
         let copy_metadata = CopyMetadata::read(&source_directory)?;
         #[cfg(unix)]
         {
@@ -1313,7 +1318,7 @@ impl<'a> AnchoredFs<'a> {
         }
         #[cfg(not(unix))]
         target_anchor.dir.create_dir(target)?;
-        let opened = target_anchor.dir.open_dir(target)?.into_std_file();
+        let opened = open_directory_for_sync(&target_anchor.dir, target)?;
         copy_metadata.validate_destination(&opened)?;
         self.require_opened_directory_at(target_anchor, target, &opened)?;
         run_after_created_entry_first_check_hook();
@@ -1702,13 +1707,33 @@ fn open_directory_handle_bound(path: &Path) -> io::Result<Dir> {
 
 #[cfg(unix)]
 fn open_directory_for_sync(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
-    use cap_std::fs::OpenOptionsExt as _;
+    open_readable_directory(dir, relative)
+}
 
+fn open_readable_directory(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
     let mut options = OpenOptions::new();
     options
         .read(true)
-        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY);
-    Ok(dir.open_with(relative, &options)?.into_std())
+        ._cap_fs_ext_follow(cap_primitives::fs::FollowSymlinks::No);
+    #[cfg(unix)]
+    {
+        use cap_std::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY);
+    }
+    #[cfg(windows)]
+    {
+        use cap_std::fs::OpenOptionsExt as _;
+        use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
+        options.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+    }
+    let file = dir.open_with(relative, &options)?.into_std();
+    if !file.metadata()?.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "opened metadata source is not a directory",
+        ));
+    }
+    Ok(file)
 }
 
 #[cfg(windows)]
@@ -1720,6 +1745,7 @@ fn open_directory_for_sync(dir: &Dir, relative: &Path) -> io::Result<fs::File> {
 
     let mut options = OpenOptions::new();
     options
+        .read(true)
         .write(true)
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS);

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -74,7 +74,7 @@ pub(crate) fn set_after_created_symlink_first_check_hook(hook: impl FnOnce() + '
     AFTER_CREATED_SYMLINK_FIRST_CHECK_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 pub(crate) fn set_after_created_entry_first_check_hook(hook: impl FnOnce() + 'static) {
     AFTER_CREATED_ENTRY_FIRST_CHECK_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
 }

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -7,6 +7,7 @@ use cap_std::ambient_authority;
 use cap_std::fs::{Dir, OpenOptions, Permissions};
 use sha2::{Digest, Sha256};
 
+use crate::copy_metadata::{CopyDestination, CopyMetadata};
 use crate::durable_fs::DirectorySync;
 use crate::package_fingerprint::{
     MAX_SKILL_PACKAGE_DEPTH, PackageHashBuilder, ignored_package_entry_name,
@@ -1008,9 +1009,13 @@ impl<'a> AnchoredFs<'a> {
                 "replacement staging path must share the target anchor",
             ));
         }
-        let permissions = target_anchor.dir.metadata(&target_relative)?.permissions();
+        let original = target_anchor.dir.open(&target_relative)?;
+        let original_handle = original.try_clone()?.into_std();
+        let metadata = CopyMetadata::read(&original_handle)?;
         let staged =
-            self.create_file_with_permissions(temp_anchor, &temp_relative, content, permissions)?;
+            self.create_file_with_metadata(temp_anchor, &temp_relative, content, &metadata)?;
+        metadata.verify(&original_handle)?;
+        self.require_opened_file_at(target_anchor, &target_relative, &original)?;
         self.remove_regular_file(target_anchor, &target_relative)?;
         self.sync_parent(target_anchor, &target_relative)?;
         self.rename(temp, target)?;
@@ -1205,7 +1210,46 @@ impl<'a> AnchoredFs<'a> {
         })
     }
 
-    pub(crate) fn copy_file(&self, source: &Path, target: &Path) -> io::Result<u64> {
+    pub(crate) fn original_windows_security(&self, source: &Path) -> io::Result<Option<String>> {
+        let (anchor, relative) = self.resolve(source)?;
+        CopyMetadata::read(&anchor.dir.open(relative)?.into_std())
+            .map(|metadata| metadata.windows_security())
+    }
+
+    pub(crate) fn copy_private_backup(&self, source: &Path, target: &Path) -> io::Result<u64> {
+        self.copy_file_to(source, target, CopyDestination::PrivateBackup)
+    }
+
+    pub(crate) fn restore_private_backup(
+        &self,
+        source: &Path,
+        target: &Path,
+        original_security: Option<&str>,
+    ) -> io::Result<u64> {
+        self.copy_file_to(source, target, CopyDestination::Restore(original_security))
+    }
+
+    pub(crate) fn verify_restoration_metadata(
+        &self,
+        backup: &Path,
+        target: &Path,
+        original_security: Option<&str>,
+    ) -> io::Result<()> {
+        let (backup_anchor, backup_relative) = self.resolve(backup)?;
+        let backup = backup_anchor.dir.open(backup_relative)?.into_std();
+        let (target_anchor, target_relative) = self.resolve(target)?;
+        let target = target_anchor.dir.open(target_relative)?.into_std();
+        CopyMetadata::read(&backup)?
+            .for_destination(&target, CopyDestination::Restore(original_security))?
+            .verify(&target)
+    }
+
+    fn copy_file_to(
+        &self,
+        source: &Path,
+        target: &Path,
+        purpose: CopyDestination<'_>,
+    ) -> io::Result<u64> {
         let (source_anchor, source_relative) = self.resolve(source)?;
         let (target_anchor, target_relative) = self.resolve(target)?;
         self.copy_file_relative(
@@ -1213,6 +1257,7 @@ impl<'a> AnchoredFs<'a> {
             &source_relative,
             target_anchor,
             &target_relative,
+            purpose,
         )
     }
 
@@ -1242,7 +1287,13 @@ impl<'a> AnchoredFs<'a> {
             ));
         }
         if metadata.is_file() {
-            self.copy_file_relative(source_anchor, source, target_anchor, target)?;
+            self.copy_file_relative(
+                source_anchor,
+                source,
+                target_anchor,
+                target,
+                CopyDestination::Preserve,
+            )?;
             return Ok(());
         }
         if !metadata.is_dir() {
@@ -1251,8 +1302,19 @@ impl<'a> AnchoredFs<'a> {
                 "source is not a supported file type",
             ));
         }
+        let source_directory = source_anchor.dir.open_dir(source)?.into_std_file();
+        let copy_metadata = CopyMetadata::read(&source_directory)?;
+        #[cfg(unix)]
+        {
+            use cap_std::fs::DirBuilderExt;
+            let mut builder = cap_std::fs::DirBuilder::new();
+            builder.mode(0o700);
+            target_anchor.dir.create_dir_with(target, &builder)?;
+        }
+        #[cfg(not(unix))]
         target_anchor.dir.create_dir(target)?;
         let opened = target_anchor.dir.open_dir(target)?.into_std_file();
+        copy_metadata.validate_destination(&opened)?;
         self.require_opened_directory_at(target_anchor, target, &opened)?;
         run_after_created_entry_first_check_hook();
         self.sync_parent_preserving_identity(target_anchor, target, || {
@@ -1271,28 +1333,33 @@ impl<'a> AnchoredFs<'a> {
                 &target.join(name),
             )?;
         }
+        copy_metadata.verify(&source_directory)?;
+        copy_metadata.apply_to(&opened)?;
+        opened.sync_all()?;
         Ok(())
     }
 
-    fn create_file_with_permissions(
+    fn create_file_with_metadata(
         &self,
         anchor: &Anchor,
         relative: &Path,
         content: &[u8],
-        permissions: Permissions,
+        metadata: &CopyMetadata,
     ) -> io::Result<cap_std::fs::File> {
         let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
+        options.read(true).write(true).create_new(true);
         #[cfg(unix)]
         {
             use cap_std::fs::{OpenOptionsExt as _, PermissionsExt as _};
 
-            options.mode(permissions.mode() & 0o7777);
+            options.mode(metadata.permissions().mode() & 0o7777);
         }
         let mut file = anchor.dir.open_with(relative, &options)?;
         run_after_staging_file_open_hook();
+        let handle = file.try_clone()?.into_std();
+        metadata.apply_to(&handle)?;
         file.write_all(content)?;
-        file.set_permissions(permissions)?;
+        metadata.apply_to(&handle)?;
         file.sync_all()?;
         self.require_opened_file_at(anchor, relative, &file)?;
         run_after_created_entry_first_check_hook();
@@ -1308,21 +1375,28 @@ impl<'a> AnchoredFs<'a> {
         source: &Path,
         target_anchor: &Anchor,
         target: &Path,
+        purpose: CopyDestination<'_>,
     ) -> io::Result<u64> {
         let mut source_file = source_anchor.dir.open(source)?;
-        let permissions = source_file.metadata()?.permissions();
+        let source_handle = source_file.try_clone()?.into_std();
+        let metadata = CopyMetadata::read(&source_handle)?;
         let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
+        options.read(true).write(true).create_new(true);
         #[cfg(unix)]
         {
             use cap_std::fs::{OpenOptionsExt as _, PermissionsExt as _};
 
-            options.mode(permissions.mode() & 0o7777);
+            options.mode(metadata.permissions().mode() & 0o7777);
         }
         let mut target_file = target_anchor.dir.open_with(target, &options)?;
         run_after_staging_file_open_hook();
+        let target_handle = target_file.try_clone()?.into_std();
+        let destination_metadata = metadata.for_destination(&target_handle, purpose)?;
+        destination_metadata.apply_to(&target_handle)?;
         let copied = io::copy(&mut source_file, &mut target_file)?;
-        target_file.set_permissions(permissions)?;
+        metadata.verify(&source_handle)?;
+        destination_metadata.apply_to(&target_handle)?;
+        self.require_opened_file_at(source_anchor, source, &source_file)?;
         target_file.sync_all()?;
         self.require_opened_file_at(target_anchor, target, &target_file)?;
         run_after_created_entry_first_check_hook();

--- a/src/anchored_fs.rs
+++ b/src/anchored_fs.rs
@@ -44,7 +44,7 @@ pub(crate) fn set_after_symlink_source_open_hook(hook: impl FnOnce() + 'static) 
     AFTER_SYMLINK_SOURCE_OPEN_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 pub(crate) fn set_after_staging_file_open_hook(hook: impl FnOnce() + 'static) {
     AFTER_STAGING_FILE_OPEN_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
 }

--- a/src/change.rs
+++ b/src/change.rs
@@ -4686,8 +4686,10 @@ mod tests {
         .unwrap();
         #[cfg(windows)]
         let rename_checks_ran = {
-            let ran = std::rc::Rc::new(std::cell::Cell::new(false));
+            let ran = std::rc::Rc::new(std::cell::Cell::new(0));
             let hook_ran = ran.clone();
+            let directory_hook_ran = ran.clone();
+            let directories = [source.clone(), target.clone()];
             let paths = [
                 source.clone(),
                 source.join("nested"),
@@ -4696,6 +4698,16 @@ mod tests {
             ];
             BEFORE_EXECUTE_HOOK.with(|slot| {
                 *slot.borrow_mut() = Some(Box::new(move || {
+                    crate::anchored_fs::set_after_created_entry_first_check_hook(move || {
+                        for path in directories {
+                            assert!(
+                                fs::rename(&path, path.with_extension("moved")).is_err(),
+                                "copy directory must be protected before children: {}",
+                                path.display()
+                            );
+                        }
+                        directory_hook_ran.set(directory_hook_ran.get() + 1);
+                    });
                     crate::anchored_fs::set_after_staging_file_open_hook(move || {
                         for path in paths {
                             assert!(
@@ -4704,7 +4716,7 @@ mod tests {
                                 path.display()
                             );
                         }
-                        hook_ran.set(true);
+                        hook_ran.set(hook_ran.get() + 1);
                     });
                 }));
             });
@@ -4713,7 +4725,7 @@ mod tests {
         let applied = apply(&plan).unwrap();
         assert!(applied.verification_passed, "{:?}", applied.receipt.error);
         #[cfg(windows)]
-        assert!(rename_checks_ran.get(), "nested file-copy checkpoint ran");
+        assert_eq!(rename_checks_ran.get(), 2, "both copy checkpoints ran");
         assert_eq!(
             fs::read_to_string(target.join("nested/file")).unwrap(),
             "retained"

--- a/src/change.rs
+++ b/src/change.rs
@@ -4665,6 +4665,40 @@ mod tests {
         fs::set_permissions(target, fs::Permissions::from_mode(0o700)).unwrap();
     }
 
+    #[test]
+    fn recursive_directory_copy_and_undo_round_trip() {
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("target");
+        fs::create_dir_all(source.join("nested")).unwrap();
+        fs::write(source.join("nested/file"), "retained").unwrap();
+        let input = serde_json::json!({"schema_version":1,"scan_id":"scan_1","operations":[{
+            "kind":"copy","source":source,"target":target,"expected_fingerprint":fingerprint(&source).unwrap()
+        }]}).to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let applied = apply(&plan).unwrap();
+        assert!(applied.verification_passed, "{:?}", applied.receipt.error);
+        assert_eq!(
+            fs::read_to_string(target.join("nested/file")).unwrap(),
+            "retained"
+        );
+        let undone = undo(&applied.receipt).unwrap();
+        assert!(undone.verification_passed, "{:?}", undone.receipt.error);
+        assert!(!target.exists());
+        assert_eq!(
+            fs::read_to_string(source.join("nested/file")).unwrap(),
+            "retained"
+        );
+    }
+
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn copy_and_replace_refuse_extended_attributes_without_losing_original() {

--- a/src/change.rs
+++ b/src/change.rs
@@ -4684,8 +4684,36 @@ mod tests {
             },
         )
         .unwrap();
+        #[cfg(windows)]
+        let rename_checks_ran = {
+            let ran = std::rc::Rc::new(std::cell::Cell::new(false));
+            let hook_ran = ran.clone();
+            let paths = [
+                source.clone(),
+                source.join("nested"),
+                target.clone(),
+                target.join("nested"),
+            ];
+            BEFORE_EXECUTE_HOOK.with(|slot| {
+                *slot.borrow_mut() = Some(Box::new(move || {
+                    crate::anchored_fs::set_after_staging_file_open_hook(move || {
+                        for path in paths {
+                            assert!(
+                                fs::rename(&path, path.with_extension("moved")).is_err(),
+                                "copy directory must remain rename-protected: {}",
+                                path.display()
+                            );
+                        }
+                        hook_ran.set(true);
+                    });
+                }));
+            });
+            ran
+        };
         let applied = apply(&plan).unwrap();
         assert!(applied.verification_passed, "{:?}", applied.receipt.error);
+        #[cfg(windows)]
+        assert!(rename_checks_ran.get(), "nested file-copy checkpoint ran");
         assert_eq!(
             fs::read_to_string(target.join("nested/file")).unwrap(),
             "retained"

--- a/src/change.rs
+++ b/src/change.rs
@@ -392,6 +392,8 @@ pub enum Compensation {
         expected_replacement: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         staged_replacement: Option<PathBuf>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        original_windows_security: Option<String>,
     },
 }
 
@@ -1715,11 +1717,14 @@ fn stage_compensation(
             expected_fingerprint,
         } => {
             verify_anchored_fingerprint(anchored, target, expected_fingerprint)?;
+            let original_windows_security = anchored
+                .original_windows_security(target)
+                .map_err(|error| ChangeError::io("inspect replacement metadata", target, error))?;
             let directory = create_recovery_dir(anchored, state_dir, receipt_id)?;
             let backup = directory.join(format!("replace-{index}.backup"));
             require_anchored_missing(anchored, &backup)?;
             anchored
-                .copy_file(target, &backup)
+                .copy_private_backup(target, &backup)
                 .map_err(|error| ChangeError::io("persist replacement backup", target, error))?;
             let backup_fingerprint = anchored
                 .fingerprint(&backup)
@@ -1739,6 +1744,7 @@ fn stage_compensation(
                 expected_original: expected_fingerprint.clone(),
                 expected_replacement: file_content_fingerprint(content.as_bytes()),
                 staged_replacement: Some(replacement_temp_path(target, receipt_id, index)?),
+                original_windows_security,
             }))
         }
         Operation::RemoveSymlink { .. } => Ok(None),
@@ -2029,6 +2035,7 @@ fn compensate(
             expected_original,
             expected_replacement,
             staged_replacement,
+            original_windows_security,
         } => {
             if let Some(staged_replacement) = staged_replacement {
                 remove_expected_anchored_file_if_present(
@@ -2039,6 +2046,17 @@ fn compensate(
                 )?;
             }
             let actual = anchored_fingerprint(anchored, target)?;
+            if actual != "missing" {
+                anchored
+                    .verify_restoration_metadata(
+                        backup,
+                        target,
+                        original_windows_security.as_deref(),
+                    )
+                    .map_err(|error| {
+                        ChangeError::io("verify replacement restoration metadata", target, error)
+                    })?;
+            }
             if actual == *expected_original {
                 remove_expected_anchored_file_if_present(
                     anchored,
@@ -2066,7 +2084,7 @@ fn compensate(
             ));
             require_anchored_missing(anchored, &restore)?;
             anchored
-                .copy_file(backup, &restore)
+                .restore_private_backup(backup, &restore, original_windows_security.as_deref())
                 .map_err(|error| ChangeError::io("stage restored file", backup, error))?;
             if actual != "missing" {
                 anchored
@@ -3723,6 +3741,203 @@ mod tests {
     }
 
     #[test]
+    fn storage_errno_failures_keep_a_durable_recovery_boundary() {
+        struct StorageError {
+            path: PathBuf,
+            errno: i32,
+            persistent: bool,
+            failed: Cell<bool>,
+        }
+        impl DirectorySync for StorageError {
+            fn sync_directory(&self, path: &Path) -> io::Result<()> {
+                if path == self.path && (self.persistent || !self.failed.get()) {
+                    self.failed.set(true);
+                    Err(io::Error::from_raw_os_error(self.errno))
+                } else {
+                    SystemDirectorySync.sync_directory(path)
+                }
+            }
+        }
+        #[cfg(unix)]
+        let errors = [libc::ENOSPC, libc::EIO];
+        #[cfg(windows)]
+        let errors = [112, 1117]; // ERROR_DISK_FULL, ERROR_IO_DEVICE
+        for errno in errors {
+            for persistent in [false, true] {
+                for at_journal in [false, true] {
+                    let (_temp, root, state) = fixture();
+                    let target = root.join("target.md");
+                    let plan = prepared_write(&root, &state, &target);
+                    let sync = StorageError {
+                        path: if at_journal {
+                            state.join("receipts")
+                        } else {
+                            root.clone()
+                        },
+                        errno,
+                        persistent,
+                        failed: Cell::new(false),
+                    };
+                    let outcome = apply_locked_with(&plan, &sync);
+                    assert!(sync.failed.get());
+                    if at_journal {
+                        assert_eq!(outcome.unwrap_err().code, "filesystem_error");
+                        assert!(!target.exists());
+                    } else {
+                        let outcome = outcome.unwrap();
+                        assert!(!outcome.verification_passed);
+                        assert_eq!(outcome.receipt.status, ReceiptStatus::RecoveryRequired);
+                        assert!(
+                            outcome
+                                .receipt
+                                .error
+                                .unwrap()
+                                .contains(&format!("os error {errno}"))
+                        );
+                        assert_eq!(
+                            fs::read_to_string(&target).unwrap(),
+                            "published before injected barrier failure"
+                        );
+                    }
+                    let receipts = journals(&state).unwrap();
+                    assert_eq!(receipts.len(), 1);
+                    assert!(matches!(
+                        receipts[0].status,
+                        ReceiptStatus::Applying | ReceiptStatus::RecoveryRequired
+                    ));
+                    let next = prepared_write(&root, &state, &root.join("next.md"));
+                    assert_eq!(apply(&next).unwrap_err().code, "recovery_required");
+                    assert!(!root.join("next.md").exists());
+                }
+            }
+        }
+    }
+
+    // Subprocess entrypoint: these environment keys are read only by this test
+    // binary, never by the shipped CLI. Each child receives one disposable root.
+    #[test]
+    fn recovery_process_child() {
+        let Some(base) = std::env::var_os("SKILLROSTER_RECOVERY_TEST_ROOT") else {
+            return;
+        };
+        let base = PathBuf::from(base);
+        let root = base.join("root");
+        let state = base.join("state");
+        let role = std::env::var("SKILLROSTER_RECOVERY_TEST_ROLE").unwrap();
+        if role == "restart" {
+            let receipts = journals(&state).unwrap();
+            assert_eq!(receipts.len(), 1);
+            assert_eq!(receipts[0].status, ReceiptStatus::Applying);
+            let next = prepared_write(&root, &state, &root.join("next.md"));
+            assert_eq!(apply(&next).unwrap_err().code, "recovery_required");
+            assert!(!root.join("next.md").exists());
+            return;
+        }
+        let marker = base.join("checkpoint");
+        let stop = move || {
+            fs::write(marker, b"ready").unwrap();
+            // Parent kills this process; no destructor or compensation runs.
+            loop {
+                std::thread::park();
+            }
+        };
+        match role.as_str() {
+            "journal" => {
+                BEFORE_MUTATION_HOOK.with(|hook| *hook.borrow_mut() = Some(Box::new(stop)))
+            }
+            "target" => {
+                struct StopAfterTargetSync {
+                    root: PathBuf,
+                    stop: std::cell::RefCell<Option<Box<dyn FnOnce()>>>,
+                }
+                impl DirectorySync for StopAfterTargetSync {
+                    fn sync_directory(&self, path: &Path) -> io::Result<()> {
+                        SystemDirectorySync.sync_directory(path)?;
+                        if path == self.root {
+                            if let Some(stop) = self.stop.borrow_mut().take() {
+                                stop();
+                            }
+                        }
+                        Ok(())
+                    }
+                }
+                let sync = StopAfterTargetSync {
+                    root: root.clone(),
+                    stop: std::cell::RefCell::new(Some(Box::new(stop))),
+                };
+                let plan = prepared_write(&root, &state, &root.join("target.md"));
+                let _lock = WriteLock::acquire(&state).unwrap();
+                apply_locked_with(&plan, &sync).unwrap();
+                panic!("target checkpoint was not reached");
+            }
+            _ => panic!("unknown subprocess role"),
+        }
+        let plan = prepared_write(&root, &state, &root.join("target.md"));
+        apply(&plan).unwrap();
+        panic!("journal checkpoint was not reached");
+    }
+
+    #[test]
+    fn killed_apply_blocks_new_writes_after_process_restart() {
+        use std::process::{Command, Stdio};
+        use std::time::{Duration, Instant};
+        for checkpoint in ["journal", "target"] {
+            let (temp, root, state) = fixture();
+            let mut command = Command::new(std::env::current_exe().unwrap());
+            command
+                .args([
+                    "--exact",
+                    "change::tests::recovery_process_child",
+                    "--nocapture",
+                ])
+                .env(
+                    "SKILLROSTER_RECOVERY_TEST_ROOT",
+                    fs::canonicalize(temp.path()).unwrap(),
+                )
+                .env("SKILLROSTER_RECOVERY_TEST_ROLE", checkpoint)
+                .stdout(Stdio::null());
+            let mut child = command.spawn().unwrap();
+            let deadline = Instant::now() + Duration::from_secs(30);
+            while !temp.path().join("checkpoint").exists() {
+                if let Some(status) = child.try_wait().unwrap() {
+                    panic!("child exited before {checkpoint}: {status}");
+                }
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("child did not reach {checkpoint}");
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            child.kill().unwrap();
+            let status = child.wait().unwrap();
+            assert!(!status.success());
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                assert_eq!(status.signal(), Some(libc::SIGKILL));
+            }
+            assert_eq!(root.join("target.md").exists(), checkpoint == "target");
+            let before = journals(&state).unwrap();
+            assert_eq!(before.len(), 1);
+            let receipt_path = state
+                .join("receipts")
+                .join(format!("{}.json", before[0].id));
+            let journal_bytes = fs::read(&receipt_path).unwrap();
+            command.env("SKILLROSTER_RECOVERY_TEST_ROLE", "restart");
+            let status = command.status().unwrap();
+            assert!(status.success());
+            assert_eq!(fs::read(receipt_path).unwrap(), journal_bytes);
+            if checkpoint == "target" {
+                assert_eq!(
+                    fs::read_to_string(root.join("target.md")).unwrap(),
+                    "published before injected barrier failure"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn unsupported_atomic_rename_is_rejected_before_mutation_or_receipt() {
         let (_temp, root, state) = fixture();
         let target = root.join("not-created.md");
@@ -4396,6 +4611,123 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn replacement_undo_refuses_permission_drift() {
+        use std::os::unix::fs::PermissionsExt;
+        let (_temp, root, state) = fixture();
+        let target = root.join("target");
+        fs::write(&target, "original").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o600)).unwrap();
+        let input = serde_json::json!({"schema_version":1,"scan_id":"scan_1","operations":[{
+            "kind":"replace_file","target":target,"content":"replacement","expected_fingerprint":fingerprint(&target).unwrap()
+        }]}).to_string();
+        let plan = prepare(
+            &input,
+            &PrepareContext {
+                approved_roots: vec![root],
+                state_dir: state,
+                operation_policy: OperationPolicy::TestOnly,
+            },
+        )
+        .unwrap();
+        let applied = apply(&plan).unwrap();
+        assert!(applied.verification_passed);
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o400)).unwrap();
+        let undone = undo(&applied.receipt).unwrap();
+        assert_eq!(undone.receipt.status, ReceiptStatus::RecoveryRequired);
+        assert_eq!(fs::read_to_string(&target).unwrap(), "replacement");
+        assert_eq!(
+            fs::metadata(target).unwrap().permissions().mode() & 0o777,
+            0o400
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recursive_copy_preserves_readonly_directory_mode_after_copying_children() {
+        use std::os::unix::fs::PermissionsExt;
+        let (_temp, root, state) = fixture();
+        let source = root.join("source");
+        let target = root.join("target");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("file"), "retained").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o500)).unwrap();
+        let anchored = open_anchored_fs(&[root], &state, &SystemDirectorySync).unwrap();
+        anchored.copy_tree(&source, &target).unwrap();
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o500
+        );
+        assert_eq!(fs::read_to_string(target.join("file")).unwrap(), "retained");
+        // Only release the two test-owned readonly directories for fixture cleanup.
+        fs::set_permissions(source, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::set_permissions(target, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn copy_and_replace_refuse_extended_attributes_without_losing_original() {
+        use std::os::fd::AsRawFd;
+        for kind in ["copy", "replace_file"] {
+            let (_temp, root, state) = fixture();
+            let source = root.join("source.md");
+            let target = root.join("copy.md");
+            fs::write(&source, "original").unwrap();
+            let file = File::open(&source).unwrap();
+            let name = c"user.skillroster-test";
+            let value = b"user metadata";
+            #[cfg(target_os = "linux")]
+            let result = unsafe {
+                libc::fsetxattr(
+                    file.as_raw_fd(),
+                    name.as_ptr(),
+                    value.as_ptr().cast(),
+                    value.len(),
+                    0,
+                )
+            };
+            #[cfg(target_os = "macos")]
+            let result = unsafe {
+                libc::fsetxattr(
+                    file.as_raw_fd(),
+                    name.as_ptr(),
+                    value.as_ptr().cast(),
+                    value.len(),
+                    0,
+                    0,
+                )
+            };
+            assert_eq!(result, 0, "fixture xattr: {}", io::Error::last_os_error());
+            let operation = if kind == "copy" {
+                serde_json::json!({"kind":kind,"source":source,"target":target,"expected_fingerprint":fingerprint(&source).unwrap()})
+            } else {
+                serde_json::json!({"kind":kind,"target":source,"content":"replacement","expected_fingerprint":fingerprint(&source).unwrap()})
+            };
+            let input =
+                serde_json::json!({"schema_version":1,"scan_id":"scan_1","operations":[operation]})
+                    .to_string();
+            let plan = prepare(
+                &input,
+                &PrepareContext {
+                    approved_roots: vec![root],
+                    state_dir: state,
+                    operation_policy: OperationPolicy::TestOnly,
+                },
+            )
+            .unwrap();
+            match apply(&plan) {
+                Err(error) => assert!(error.message.contains("metadata"), "{error}"),
+                Ok(outcome) => assert!(
+                    !outcome.verification_passed,
+                    "silently discarded extended metadata"
+                ),
+            }
+            assert_eq!(fs::read_to_string(&source).unwrap(), "original");
+            assert!(!target.exists());
+        }
+    }
+
     #[cfg(windows)]
     #[test]
     fn replace_and_undo_preserve_readonly_state() {
@@ -4511,7 +4843,7 @@ mod tests {
         fs::set_permissions(&source, fs::Permissions::from_mode(0o600)).unwrap();
         let anchored = open_anchored_fs(&[root], &state, &SystemDirectorySync).unwrap();
 
-        anchored.copy_file(&source, &staged).unwrap();
+        anchored.copy_tree(&source, &staged).unwrap();
 
         assert_eq!(
             fs::metadata(&staged).unwrap().permissions().mode() & 0o077,
@@ -4540,7 +4872,7 @@ mod tests {
         });
         let anchored = open_anchored_fs(&[root], &state, &SystemDirectorySync).unwrap();
 
-        let error = anchored.copy_file(&source, &target).unwrap_err();
+        let error = anchored.copy_tree(&source, &target).unwrap_err();
 
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         assert_eq!(

--- a/src/copy_metadata.rs
+++ b/src/copy_metadata.rs
@@ -1,0 +1,420 @@
+//! Metadata boundary for copy-based mutations. Unsupported observable metadata
+//! is refused, not silently discarded. All inspection uses retained handles.
+
+use std::fs::{File, Permissions};
+use std::io;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CopyMetadata {
+    permissions: Permissions,
+    #[cfg(unix)]
+    uid: u32,
+    #[cfg(unix)]
+    gid: u32,
+    #[cfg(target_os = "macos")]
+    provenance: Option<Vec<u8>>,
+    #[cfg(windows)]
+    security: windows::Security,
+}
+
+fn unsupported(message: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!("unsupported copy metadata: {message}"),
+    )
+}
+
+pub(crate) enum CopyDestination<'a> {
+    Preserve,
+    PrivateBackup,
+    Restore(Option<&'a str>),
+}
+
+impl CopyMetadata {
+    pub(crate) fn windows_security(&self) -> Option<String> {
+        #[cfg(windows)]
+        {
+            Some(self.security.0.clone())
+        }
+        #[cfg(not(windows))]
+        {
+            None
+        }
+    }
+
+    pub(crate) fn for_destination(
+        &self,
+        file: &File,
+        purpose: CopyDestination<'_>,
+    ) -> io::Result<Self> {
+        #[cfg(windows)]
+        {
+            let mut result = self.clone();
+            match purpose {
+                CopyDestination::Preserve => {}
+                CopyDestination::PrivateBackup => {
+                    crate::state_security::secure_opened_file(file)?;
+                    result.security = windows::Security::read(file)?;
+                }
+                CopyDestination::Restore(security) => {
+                    result.security = windows::Security(security.ok_or_else(|| unsupported(
+                        "legacy Windows Receipt has no original owner/group/DACL evidence"))?.to_owned());
+                }
+            }
+            result.validate_destination(file)?;
+            Ok(result)
+        }
+        #[cfg(not(windows))]
+        {
+            if let CopyDestination::Restore(security) = purpose {
+                let _ = security;
+            }
+            self.validate_destination(file)?;
+            Ok(self.clone())
+        }
+    }
+
+    pub(crate) fn validate_destination(&self, file: &File) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            validate_unix_extensions(file)?;
+            if file.metadata()?.uid() != self.uid {
+                return Err(unsupported("copy would change file ownership"));
+            }
+        }
+        #[cfg(windows)]
+        {
+            windows::validate_extensions(file)?;
+            self.security.apply_to(file)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn read(file: &File) -> io::Result<Self> {
+        let metadata = file.metadata()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            validate_unix_extensions(file)?;
+            // A non-owner may not be able to enumerate protected metadata.
+            // Do not treat its absence from a listing as permission to discard it.
+            if metadata.uid() != unsafe { libc::geteuid() } {
+                return Err(unsupported("source is not owned by the current user"));
+            }
+            Ok(Self {
+                permissions: metadata.permissions(),
+                uid: metadata.uid(),
+                gid: metadata.gid(),
+                #[cfg(target_os = "macos")]
+                provenance: macos_provenance(file)?,
+            })
+        }
+        #[cfg(windows)]
+        {
+            windows::validate_extensions(file)?;
+            Ok(Self {
+                permissions: metadata.permissions(),
+                security: windows::Security::read(file)?,
+            })
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = metadata;
+            Err(unsupported("platform inspection is unavailable"))
+        }
+    }
+
+    pub(crate) fn permissions(&self) -> cap_std::fs::Permissions {
+        cap_std::fs::Permissions::from_std(self.permissions.clone())
+    }
+
+    pub(crate) fn apply_to(&self, file: &File) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            use std::os::unix::fs::MetadataExt;
+            validate_unix_extensions(file)?;
+            let current = file.metadata()?;
+            if current.uid() != self.uid {
+                return Err(unsupported("copy would change file ownership"));
+            }
+            if current.gid() != self.gid {
+                // SAFETY: retained writable destination handle; uid=-1 leaves
+                // its owner unchanged. Failure precedes destructive publication.
+                if unsafe { libc::fchown(file.as_raw_fd(), !0, self.gid) } != 0 {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+        }
+        #[cfg(windows)]
+        self.security.apply_to(file)?;
+        file.set_permissions(self.permissions.clone())?;
+        self.verify(file)
+    }
+
+    pub(crate) fn verify(&self, file: &File) -> io::Result<()> {
+        if Self::read(file)? == *self {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "copy metadata changed while its handle was retained",
+            ))
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn validate_unix_extensions(file: &File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    // SAFETY: size zero queries the list length without dereferencing a buffer.
+    #[cfg(target_os = "linux")]
+    let length = unsafe { libc::flistxattr(file.as_raw_fd(), std::ptr::null_mut(), 0) };
+    #[cfg(target_os = "macos")]
+    let length = unsafe { libc::flistxattr(file.as_raw_fd(), std::ptr::null_mut(), 0, 0) };
+    if length < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    #[cfg(target_os = "linux")]
+    if length != 0 {
+        return Err(unsupported(
+            "extended attributes or POSIX ACLs require a metadata-preserving external workflow",
+        ));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // Current macOS automatically attaches provenance to ordinary new
+        // files. Permit only this OS attribute, and compare its exact bytes in
+        // CopyMetadata::verify; never remove it or overwrite it through a path.
+        if length != 0 {
+            let mut names = [0_u8; 64];
+            let read = unsafe {
+                libc::flistxattr(file.as_raw_fd(), names.as_mut_ptr().cast(), names.len(), 0)
+            };
+            if read < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if &names[..read as usize] != b"com.apple.provenance\0" {
+                return Err(unsupported(
+                    "extended attributes require a metadata-preserving external workflow",
+                ));
+            }
+        }
+        use std::ffi::c_void;
+        use std::os::macos::fs::MetadataExt;
+        unsafe extern "C" {
+            fn acl_get_fd_np(fd: libc::c_int, kind: libc::c_int) -> *mut c_void;
+            fn acl_get_entry(
+                acl: *mut c_void,
+                entry_id: libc::c_int,
+                entry: *mut *mut c_void,
+            ) -> libc::c_int;
+            fn acl_free(acl: *mut c_void) -> libc::c_int;
+        }
+        // macOS extended ACLs are separate from listxattr. A successful first
+        // entry returns zero; an empty ACL returns -1/EINVAL (Darwin contract).
+        let acl = unsafe { acl_get_fd_np(file.as_raw_fd(), 0x100) };
+        if acl.is_null() {
+            // Darwin filesec_get_property(FILESEC_ACL) returns ENOENT when
+            // this retained object has no ACL property (Libc/acl_file.c).
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ENOENT) {
+                return Err(error);
+            }
+        } else {
+            let mut entry = std::ptr::null_mut();
+            let result = unsafe { acl_get_entry(acl, 0, &mut entry) };
+            let error = io::Error::last_os_error();
+            unsafe { acl_free(acl) };
+            if result == 0 {
+                return Err(unsupported("macOS extended ACL"));
+            }
+            if error.raw_os_error() != Some(libc::EINVAL) {
+                return Err(error);
+            }
+        }
+        if file.metadata()?.st_flags() != 0 {
+            return Err(unsupported("macOS file flags"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn macos_provenance(file: &File) -> io::Result<Option<Vec<u8>>> {
+    use std::os::fd::AsRawFd;
+    let mut bytes = [0_u8; 4096];
+    // SAFETY: the retained descriptor and bounded writable buffer are valid.
+    let length = unsafe {
+        libc::fgetxattr(
+            file.as_raw_fd(),
+            c"com.apple.provenance".as_ptr(),
+            bytes.as_mut_ptr().cast(),
+            bytes.len(),
+            0,
+            0,
+        )
+    };
+    if length < 0 {
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ENOATTR) {
+            return Ok(None);
+        }
+        return Err(error);
+    }
+    Ok(Some(bytes[..length as usize].to_vec()))
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+fn validate_unix_extensions(_file: &File) -> io::Result<()> {
+    Err(unsupported(
+        "extended metadata inspection is unavailable on this Unix platform",
+    ))
+}
+
+#[cfg(windows)]
+mod windows;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_posix_acl_is_refused_and_retained() {
+        use std::os::fd::AsRawFd;
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("file");
+        fs::write(&path, "original").unwrap();
+        let file = File::open(&path).unwrap();
+        // Linux POSIX ACL xattr version 2: owner, named user, group, mask, other.
+        let mut acl = 2_u32.to_le_bytes().to_vec();
+        for (tag, permissions, id) in [
+            (1_u16, 6_u16, u32::MAX),
+            (2, 4, 1),
+            (4, 4, u32::MAX),
+            (16, 4, u32::MAX),
+            (32, 0, u32::MAX),
+        ] {
+            acl.extend_from_slice(&tag.to_le_bytes());
+            acl.extend_from_slice(&permissions.to_le_bytes());
+            acl.extend_from_slice(&id.to_le_bytes());
+        }
+        let name = c"system.posix_acl_access";
+        // SAFETY: the fixture-owned descriptor, name and value buffer are valid.
+        assert_eq!(
+            unsafe {
+                libc::fsetxattr(
+                    file.as_raw_fd(),
+                    name.as_ptr(),
+                    acl.as_ptr().cast(),
+                    acl.len(),
+                    0,
+                )
+            },
+            0,
+            "{}",
+            io::Error::last_os_error()
+        );
+        assert!(
+            CopyMetadata::read(&file)
+                .unwrap_err()
+                .to_string()
+                .contains("ACL")
+        );
+        let mut retained = [0_u8; 128];
+        let length = unsafe {
+            libc::fgetxattr(
+                file.as_raw_fd(),
+                name.as_ptr(),
+                retained.as_mut_ptr().cast(),
+                retained.len(),
+            )
+        };
+        assert_eq!(length as usize, acl.len());
+        assert_eq!(&retained[..acl.len()], &acl);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn different_owner_is_refused_without_changing_destination() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("file");
+        fs::write(&path, "original").unwrap();
+        let file = File::open(&path).unwrap();
+        let original = CopyMetadata::read(&file).unwrap();
+        let mut wrong_owner = original.clone();
+        wrong_owner.uid = wrong_owner.uid.wrapping_add(1);
+        assert!(wrong_owner.apply_to(&file).is_err());
+        assert_eq!(CopyMetadata::read(&file).unwrap(), original);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_extended_acl_is_refused_and_retained() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("file");
+        fs::write(&path, "original").unwrap();
+        assert!(
+            std::process::Command::new("chmod")
+                .args(["+a", "everyone allow read"])
+                .arg(&path)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let file = File::open(&path).unwrap();
+        let error = CopyMetadata::read(&file).unwrap_err();
+        assert!(error.to_string().contains("extended ACL"), "{error}");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "original");
+        // The refusal does not clear the ACL, so a second read still refuses.
+        assert!(CopyMetadata::read(&file).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_named_stream_is_refused_without_removing_it() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("file");
+        fs::write(&path, "original").unwrap();
+        let stream = path.with_file_name("file:metadata");
+        fs::write(&stream, "retained stream").unwrap();
+        let error = CopyMetadata::read(&File::open(&path).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("named data streams"), "{error}");
+        assert_eq!(fs::read_to_string(stream).unwrap(), "retained stream");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_custom_dacl_does_not_get_replaced_by_destination_defaults() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        let destination = temp.path().join("destination");
+        fs::write(&source, "original").unwrap();
+        fs::write(&destination, "").unwrap();
+        let grant = format!("{}:(F)", std::env::var("USERNAME").unwrap());
+        assert!(
+            std::process::Command::new("icacls")
+                .arg(&source)
+                .args(["/inheritance:r", "/grant:r", &grant])
+                .status()
+                .unwrap()
+                .success()
+        );
+        let original = CopyMetadata::read(&File::open(&source).unwrap()).unwrap();
+        let target = File::options()
+            .read(true)
+            .write(true)
+            .open(&destination)
+            .unwrap();
+        assert!(original.apply_to(&target).is_err());
+        assert_eq!(
+            CopyMetadata::read(&File::open(&source).unwrap()).unwrap(),
+            original
+        );
+        assert_eq!(fs::read(destination).unwrap(), b"");
+    }
+}

--- a/src/copy_metadata.rs
+++ b/src/copy_metadata.rs
@@ -125,6 +125,7 @@ impl CopyMetadata {
         }
     }
 
+    #[cfg(unix)]
     pub(crate) fn permissions(&self) -> cap_std::fs::Permissions {
         cap_std::fs::Permissions::from_std(self.permissions.clone())
     }

--- a/src/copy_metadata/windows.rs
+++ b/src/copy_metadata/windows.rs
@@ -1,0 +1,156 @@
+use super::{File, io, unsupported};
+use std::mem::{size_of, zeroed};
+use std::os::windows::fs::MetadataExt;
+use std::os::windows::io::AsRawHandle;
+use std::ptr::null_mut;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Authorization::{
+    ConvertSecurityDescriptorToStringSecurityDescriptorW, GetSecurityInfo, SDDL_REVISION_1,
+    SE_FILE_OBJECT,
+};
+use windows_sys::Win32::Security::{
+    DACL_SECURITY_INFORMATION, GROUP_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct Security(pub(super) String);
+
+impl Security {
+    pub(super) fn read(file: &File) -> io::Result<Self> {
+        let flags =
+            OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION;
+        let mut descriptor = null_mut();
+        // SAFETY: file is live; all requested components are returned in the
+        // allocated descriptor, which is released on every subsequent path.
+        let status = unsafe {
+            GetSecurityInfo(
+                file.as_raw_handle().cast(),
+                SE_FILE_OBJECT,
+                flags,
+                null_mut(),
+                null_mut(),
+                null_mut(),
+                null_mut(),
+                &mut descriptor,
+            )
+        };
+        if status != 0 {
+            return Err(io::Error::from_raw_os_error(status as i32));
+        }
+        let mut text = null_mut();
+        let mut length = 0;
+        let success = unsafe {
+            ConvertSecurityDescriptorToStringSecurityDescriptorW(
+                descriptor,
+                SDDL_REVISION_1,
+                flags,
+                &mut text,
+                &mut length,
+            )
+        };
+        let error = io::Error::last_os_error();
+        unsafe { LocalFree(descriptor.cast()) };
+        if success == 0 {
+            return Err(error);
+        }
+        let result = if length > 128 * 1024 {
+            Err(unsupported(
+                "Windows security descriptor exceeds inspection bound",
+            ))
+        } else {
+            // SAFETY: conversion allocated length UTF-16 code units.
+            let units = unsafe { std::slice::from_raw_parts(text, length as usize) };
+            String::from_utf16(units.strip_suffix(&[0]).unwrap_or(units))
+                .map(Self)
+                .map_err(|_| unsupported("invalid Windows security descriptor encoding"))
+        };
+        unsafe { LocalFree(text.cast()) };
+        result
+    }
+
+    pub(super) fn apply_to(&self, file: &File) -> io::Result<()> {
+        // Never broaden a private recovery file's DACL to imitate a source.
+        // A copy is supported only when its owner/group/DACL (including
+        // inheritance control) already exactly match the source snapshot.
+        if Self::read(file)? == *self {
+            Ok(())
+        } else {
+            Err(unsupported(
+                "destination owner, group or DACL differs from source",
+            ))
+        }
+    }
+}
+
+pub(super) fn validate_extensions(file: &File) -> io::Result<()> {
+    use windows_sys::Wdk::Storage::FileSystem::{
+        FILE_EA_INFORMATION, FileEaInformation, NtQueryInformationFile,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_ARCHIVE, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_NORMAL,
+        FILE_ATTRIBUTE_READONLY, FileStreamInfo, GetFileInformationByHandleEx,
+    };
+    use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
+    let allowed = FILE_ATTRIBUTE_ARCHIVE
+        | FILE_ATTRIBUTE_DIRECTORY
+        | FILE_ATTRIBUTE_NORMAL
+        | FILE_ATTRIBUTE_READONLY;
+    if file.metadata()?.file_attributes() & !allowed != 0 {
+        return Err(unsupported(
+            "Windows attributes beyond ordinary/readonly file metadata",
+        ));
+    }
+    // SAFETY: both structures are initialized writable output storage; the
+    // synchronous retained file handle stays live for the native query.
+    let mut status: IO_STATUS_BLOCK = unsafe { zeroed() };
+    let mut ea: FILE_EA_INFORMATION = unsafe { zeroed() };
+    let result = unsafe {
+        NtQueryInformationFile(
+            file.as_raw_handle().cast(),
+            &mut status,
+            (&mut ea as *mut FILE_EA_INFORMATION).cast(),
+            size_of::<FILE_EA_INFORMATION>() as u32,
+            FileEaInformation,
+        )
+    };
+    if result < 0 {
+        return Err(unsupported(&format!(
+            "Windows EA inspection failed: NTSTATUS {result:#x}"
+        )));
+    }
+    if ea.EaSize != 0 {
+        return Err(unsupported("Windows extended attributes"));
+    }
+    // One unnamed data stream is the only supported stream layout. The query
+    // fails closed if the complete stream list will not fit this fixed bound.
+    let mut storage = vec![0_u64; 8192];
+    let success = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle().cast(),
+            FileStreamInfo,
+            storage.as_mut_ptr().cast(),
+            (storage.len() * size_of::<u64>()) as u32,
+        )
+    };
+    if success == 0 {
+        let error = io::Error::last_os_error();
+        // Directories can legitimately have no streams (ERROR_HANDLE_EOF).
+        if file.metadata()?.is_dir() && error.raw_os_error() == Some(38) {
+            return Ok(());
+        }
+        return Err(error);
+    }
+    let bytes =
+        unsafe { std::slice::from_raw_parts(storage.as_ptr().cast::<u8>(), storage.len() * 8) };
+    let next = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+    let name_length = u32::from_le_bytes(bytes[4..8].try_into().unwrap()) as usize;
+    let expected = "::$DATA"
+        .encode_utf16()
+        .flat_map(u16::to_le_bytes)
+        .collect::<Vec<_>>();
+    // FILE_STREAM_INFO.StreamName starts at offset 24, independent of padding.
+    if next != 0 || name_length != expected.len() || bytes[24..24 + expected.len()] != expected {
+        return Err(unsupported("Windows named data streams"));
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod app;
 mod bootstrap;
 pub mod change;
 pub mod cli;
+mod copy_metadata;
 mod durable_fs;
 pub mod harness;
 pub mod model;

--- a/src/query.rs
+++ b/src/query.rs
@@ -17,6 +17,7 @@ pub const UNKNOWN_ARCHIVE_FINDING_TITLE: &str = "Archive candidacy is unknown";
 
 const SEMANTIC_SHARED_TERM_PREVIEW_LIMIT: usize = 20;
 const SEMANTIC_SHARED_TERM_CHARACTER_LIMIT: usize = 64;
+const SEMANTIC_CANDIDATE_LIMIT: usize = 25;
 const TASK_EXCLUSION_MARKERS: &[&str] = &["do not", "不要", "也不要"];
 const TASK_EXCLUSION_COORDINATORS: &[&str] = &["but", "and", "yet", "但是", "不过", "但"];
 const TASK_EXCLUSION_CONTEXT_TOKENS: &[&str] = &["code", "代码"];
@@ -1320,7 +1321,7 @@ fn usage_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     }
 }
 
-fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, usize) {
+fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, usize, usize) {
     for (skill_id, placements) in placements_by_skill(scan) {
         let Some(skill) = scan.skills.iter().find(|skill| skill.id == skill_id) else {
             continue;
@@ -1389,7 +1390,17 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, u
         .iter()
         .map(|skill| normalize_skill_name(&skill.name))
         .collect::<Vec<_>>();
-    let mut candidates = Vec::new();
+    let mut candidates = Vec::with_capacity(SEMANTIC_CANDIDATE_LIMIT);
+    let mut candidate_peak = 0;
+    let compare = |left: &(f64, &ScannedSkill, &ScannedSkill),
+                   right: &(f64, &ScannedSkill, &ScannedSkill)| {
+        right
+            .0
+            .partial_cmp(&left.0)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| left.1.id.cmp(&right.1.id))
+            .then_with(|| left.2.id.cmp(&right.2.id))
+    };
     let mut pair_comparison_count = 0usize;
     for (index, left) in scan.skills.iter().enumerate() {
         let left_tokens = &vocabularies[index];
@@ -1402,24 +1413,31 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, u
                 continue;
             }
             let right_tokens = &vocabularies[right_index];
-            let Some(basis) = semantic_overlap_basis_from_tokens(left_tokens, right_tokens) else {
+            let intersection_count = left_tokens.intersection(right_tokens).count();
+            if intersection_count < 3 {
                 continue;
-            };
-            let similarity = basis.score;
+            }
+            // Selection needs only a score. Full shared-term previews belong to
+            // the on-demand Finding detail, not every pair in the inventory.
+            let union_count = left_tokens.len() + right_tokens.len() - intersection_count;
+            let similarity = intersection_count as f64 / union_count as f64;
             if similarity >= 0.45 {
-                candidates.push((similarity, left, right));
+                let candidate = (similarity, left, right);
+                // Insert after equal keys, retaining the old stable-sort order.
+                // Discard the worst entry before insertion, never retaining >25.
+                let position = candidates
+                    .partition_point(|existing| compare(existing, &candidate) != Ordering::Greater);
+                if position < SEMANTIC_CANDIDATE_LIMIT {
+                    if candidates.len() == SEMANTIC_CANDIDATE_LIMIT {
+                        candidates.pop();
+                    }
+                    candidates.insert(position, candidate);
+                    candidate_peak = candidate_peak.max(candidates.len());
+                }
             }
         }
     }
-    candidates.sort_by(|left, right| {
-        right
-            .0
-            .partial_cmp(&left.0)
-            .unwrap_or(Ordering::Equal)
-            .then_with(|| left.1.id.cmp(&right.1.id))
-            .then_with(|| left.2.id.cmp(&right.2.id))
-    });
-    for (similarity, left, right) in candidates.into_iter().take(25) {
+    for (similarity, left, right) in candidates {
         push_finding(
             findings,
             FindingKind::SemanticOverlapCandidate,
@@ -1439,7 +1457,7 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, u
             EvidenceQuality::Inferred,
         );
     }
-    (vocabularies.len(), pair_comparison_count)
+    (vocabularies.len(), pair_comparison_count, candidate_peak)
 }
 
 fn physical_source_identity(
@@ -3249,7 +3267,7 @@ mod tests {
 
     #[test]
     fn semantic_overlap_work_stays_bounded_for_a_realistic_inventory() {
-        let (_, mut scan) = fixture();
+        let (root, mut scan) = fixture();
         let representative = scan.skills[0].clone();
         let shared_body = std::iter::repeat_n(
             "shared architecture workflow browser database agent skill governance local evidence",
@@ -3271,10 +3289,12 @@ mod tests {
         scan.usage.clear();
 
         let mut findings = Vec::new();
-        let (vocabulary_count, pair_comparison_count) = overlap_findings(&scan, &mut findings);
+        let (vocabulary_count, pair_comparison_count, candidate_peak) =
+            overlap_findings(&scan, &mut findings);
 
         assert_eq!(vocabulary_count, 193);
         assert_eq!(pair_comparison_count, 193 * 192 / 2);
+        assert!(candidate_peak <= 25, "retained {candidate_peak} candidates");
         assert_eq!(
             findings
                 .iter()
@@ -3282,6 +3302,103 @@ mod tests {
                 .count(),
             25
         );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    #[ignore = "explicit scale measurement; not a machine-dependent timing gate"]
+    fn semantic_overlap_scale_measurement() {
+        let count = std::env::var("SKILLROSTER_BENCH_SKILLS")
+            .unwrap_or_else(|_| "1000".into())
+            .parse::<usize>()
+            .unwrap();
+        assert!([193, 1000, 5000].contains(&count));
+        let (root, mut scan) = fixture();
+        let representative = scan.skills[0].clone();
+        let body = "shared architecture workflow browser database agent governance local evidence "
+            .repeat(20);
+        scan.skills = (0..count)
+            .map(|index| {
+                let mut skill = representative.clone();
+                skill.id = format!("scale-{index:05}");
+                skill.name = skill.id.clone();
+                skill.content_digest = skill.id.clone();
+                skill.normalized_text = format!("{body} unique-{index:05}");
+                skill
+            })
+            .collect();
+        scan.placements.clear();
+        scan.usage.clear();
+        let start = std::time::Instant::now();
+        let mut findings = Vec::new();
+        let (vocabularies, pairs, retained) = overlap_findings(&scan, &mut findings);
+        let elapsed = start.elapsed();
+        assert_eq!(vocabularies, count);
+        assert_eq!(pairs, count * (count - 1) / 2);
+        assert_eq!(findings.len(), 25);
+        println!(
+            "skills={count} pairs={pairs} retained_candidates={retained} analysis_ms={}",
+            elapsed.as_millis()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn bounded_overlap_matches_full_sort_oracle() {
+        let (root, mut scan) = fixture();
+        let representative = scan.skills[0].clone();
+        for count in [0, 1, 7, 60, 120] {
+            scan.skills = (0..count)
+                .map(|index| {
+                    let mut skill = representative.clone();
+                    skill.id = format!("oracle-{:03}", (index * 37) % 127);
+                    skill.name = format!("variant-{}", index / 2);
+                    skill.content_digest = format!("digest-{}", index / 3);
+                    skill.metadata.description = None;
+                    skill.normalized_text = (0..24)
+                        .filter(|term| (term + index) % (index % 5 + 2) != 0)
+                        .map(|term| format!("term{term}"))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    skill
+                })
+                .collect();
+            scan.placements.clear();
+            scan.usage.clear();
+            let mut expected = Vec::new();
+            for (index, left) in scan.skills.iter().enumerate() {
+                for right in scan.skills.iter().skip(index + 1) {
+                    if normalize_skill_name(&left.name) == normalize_skill_name(&right.name)
+                        || left.content_digest == right.content_digest
+                    {
+                        continue;
+                    }
+                    if let Some(basis) = semantic_overlap_basis(left, right) {
+                        if basis.score >= 0.45 {
+                            expected.push((basis.score, vec![left.id.clone(), right.id.clone()]));
+                        }
+                    }
+                }
+            }
+            expected.sort_by(|left, right| {
+                right
+                    .0
+                    .partial_cmp(&left.0)
+                    .unwrap()
+                    .then(left.1.cmp(&right.1))
+            });
+            expected.truncate(25);
+            let mut findings = Vec::new();
+            let (_, _, peak) = overlap_findings(&scan, &mut findings);
+            assert!(peak <= 25);
+            assert_eq!(findings.len(), expected.len());
+            for (actual, (score, mut ids)) in findings.iter().zip(expected) {
+                ids.sort();
+                assert_eq!(actual.affected_skill_ids, ids);
+                assert!(actual.summary.contains(&format!("Jaccard {score:.2}")));
+            }
+        }
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Problem and value
Keep large-inventory overlap candidate memory bounded, add concrete storage-error/restart evidence, and stop silently discarding unsupported observable metadata during copy-based mutation.

## Changes
- Preserve stable Top-25 output with a full-sort oracle; remove unused per-pair explanation allocation. Record 193/1,000/5,000-Skill optimized measurements and correct the nonexistent five-second test claim.
- Add one-shot/persistent ENOSPC/EIO directory-barrier tests and killed-child/fresh-process recovery refusal tests. Explicitly distinguish these from physical power-loss certification.
- Inspect copy metadata through retained handles. Preserve owner/group/modes, finalize directory permissions after children, and fail closed for unsupported observable xattrs/ACLs/streams. Windows private replacement backups retain private DACLs and save original security evidence in the Receipt.
- Replacement Undo checks observable metadata drift. Document the legacy Windows replacement-Receipt evidence boundary.

## Verification
- Local macOS: bash scripts/ci-full-check.sh passed (strict Clippy, formatting, Rust suites, 152 Node tests, documentation surface checks).
- git diff --check passed.
- Cross-platform CI and independent Standards/Spec reviews pending; merge only after review/fix and exact-head green checks.

## Scope
Original dirty checkout is untouched. No tag, public Release, Homebrew mutation, historical asset deletion, or user-pilot action is included here. Historical assets remain tracked separately in #55.

Closes #370
Closes #371
Closes #372