### PR TITLE
release: record v1.8.45 publication

### DIFF
--- a/Formula/skillroster.rb
+++ b/Formula/skillroster.rb
@@ -2,8 +2,8 @@ class Skillroster < Formula
   desc "Local skill governance for AI agents"
   homepage "https://github.com/tt-a1i/skillroster"
   url "https://github.com/tt-a1i/skillroster.git",
-      revision: "c79b08346552814b6b4438a4f87964f9ab9a06a0"
-  version "1.8.44"
+      revision: "25b39ebc279b5af5ae44c9c3cf9266da532eb693"
+  version "1.8.45"
   license "Apache-2.0"
 
   depends_on "rust" => :build
@@ -13,7 +13,7 @@ class Skillroster < Formula
   end
 
   test do
-    assert_match "skillroster 1.8.44", shell_output("#{bin}/skillroster --version")
+    assert_match "skillroster 1.8.45", shell_output("#{bin}/skillroster --version")
     assert_match "One library. The right roster for every agent.", shell_output("#{bin}/skillroster --help")
   end
 end

--- a/README.en.md
+++ b/README.en.md
@@ -217,7 +217,7 @@ instead of pretending the adapters are interchangeable.
 
 ## Project status
 
-Public release v1.8.44 implements the complete local governance loop. Every
+Public release v1.8.45 implements the complete local governance loop. Every
 Agent continuation stays bound to the SkillRoster executable that emitted it
 instead of silently handing control to an older version on `PATH`. The loop
 includes discovery, normalized inventory, conservative usage evidence, bounded
@@ -225,7 +225,7 @@ reporting, local retrieval, immutable planning, Apply/Undo, recovery, lifecycle
 controls, and eight direct agent adapters.
 
 - [Latest release](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.44 release and platform evidence](docs/acceptance/release-v1.8.44-candidate.md)
+- [v1.8.45 release and platform evidence](docs/acceptance/release-v1.8.45-candidate.md)
 - [Acceptance ledger](docs/acceptance.md)
 - [Product brief](docs/product-brief.md)
 - [Canonical vocabulary](CONTEXT.md)

--- a/README.md
+++ b/README.md
@@ -204,14 +204,14 @@ SkillRoster 会报告这些边界，不会假设所有 Adapter 都一样。
 
 ## 项目状态
 
-公开版本 v1.8.44 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
+公开版本 v1.8.45 已实现完整的本地治理闭环；每一步 Agent 续接都会绑定到
 生成该续接指令的 SkillRoster 可执行文件，不会被 `PATH` 中的旧版本静默接管。
 能力包括发现、标准化 Inventory、保守的
 使用证据、有边界的报告、本地检索、不可变 Plan、Apply/Undo、恢复、生命周期控制，
 以及 8 个直接 Agent Adapter。
 
 - [最新版本](https://github.com/tt-a1i/skillroster/releases/latest)
-- [v1.8.44 发布与平台证据](docs/acceptance/release-v1.8.44-candidate.md)
+- [v1.8.45 发布与平台证据](docs/acceptance/release-v1.8.45-candidate.md)
 - [验收记录](docs/acceptance.md)
 - [产品简介](docs/product-brief.md)
 - [统一术语](CONTEXT.md)

--- a/docs/acceptance/release-v1.8.45-candidate.md
+++ b/docs/acceptance/release-v1.8.45-candidate.md
@@ -1,8 +1,7 @@
-# SkillRoster v1.8.45 candidate
+# SkillRoster v1.8.45 release receipt
 
-This is source preparation, not a published release receipt. The public
-release and Homebrew Formula remain v1.8.44. No v1.8.45 tag, public Release,
-or Homebrew update is established by this document.
+The public CLI release is v1.8.45. This record separates source review, the
+candidate build, the formal tag build, public downloads and Homebrew acceptance.
 
 ## User-visible changes
 
@@ -19,6 +18,9 @@ or Homebrew update is established by this document.
   Recursive copies finalize directory modes after copying children; Windows
   copy handles retain directory rename protection. Replace/Undo retain their
   mode/readonly guarantees and refuse observable metadata drift.
+- Upgrade guidance now verifies which executable the Agent actually resolves
+  after a package upgrade, and preserves recoverable backups when an older
+  standalone binary shadows the intended installation.
 
 The exact platform metadata matrix, unsupported layouts, experiment setup,
 and regression limitations are in [hardening evidence](../hardening-evidence.md)
@@ -48,20 +50,98 @@ That head passed the complete local gate: 341 unit tests, 8 acceptance tests,
 archive documentation-surface checks. Its
 [PR CI](https://github.com/tt-a1i/skillroster/actions/runs/33754750269)
 passed Linux x86_64, Windows x86_64, both macOS architectures, and CI gate
-using Rust 1.85. This evidence belongs to the fix head, not to an as-yet
-unverified candidate build or future tag.
+using Rust 1.85. This evidence belongs to the fix head; candidate and final-tag
+acceptance are separately recorded below.
 
-## Remaining publication gates
+## Candidate and exact release source
 
-- Verify and review this version-preparation change at its exact commit.
-- Build candidate archives with the exact-SHA strict gate, four platform
-  jobs, and WSL2 smoke; independently verify checksums, README, and LICENSE.
-- Resolve [historical asset policy #55](https://github.com/tt-a1i/skillroster/issues/55).
-  The 21-release / 168-attachment inventory and backup are complete, but
-  retirement versus repackaging still requires a decision. No historical
-  attachment has been removed or replaced by this preparation.
-- Publish the final tag and GitHub Release, update Homebrew from verified
-  source/artifact checksums, and read back public installation results.
+[PR #374](https://github.com/tt-a1i/skillroster/pull/374) prepared version
+1.8.45 at exact head `c762843258a4da52f19d539930e53da0a6de6dd2`, with
+zero remaining findings in independent Standards and Spec reviews. Its
+[PR CI](https://github.com/tt-a1i/skillroster/actions/runs/33756007597)
+passed; it merged as `25b39ebc279b5af5ae44c9c3cf9266da532eb693`.
+The [exact-main CI](https://github.com/tt-a1i/skillroster/actions/runs/33756481903)
+and [candidate workflow](https://github.com/tt-a1i/skillroster/actions/runs/33756507766)
+passed at that source revision. Candidate acceptance included four archives,
+adjacent checksums, source-identical README/LICENSE, WSL2 and isolated macOS
+arm64 governance smoke. Candidate hashes are not reused as final tag hashes.
 
-Independent user-pilot work is outside this round. Version preparation does
-not change the user's installed binary, state, Agent files, or Skill library.
+Upgrade-path documentation is independently reviewed in
+[PR #369](https://github.com/tt-a1i/skillroster/pull/369).
+
+## Published release
+
+Annotated tag `v1.8.45` has tag object
+`c1197c16fb6b6ef98acece486348089e27c9af69` and resolves to source
+`25b39ebc279b5af5ae44c9c3cf9266da532eb693`.
+The [tag workflow](https://github.com/tt-a1i/skillroster/actions/runs/33759099791)
+passed all six jobs: strict exact-SHA validation with Rust 1.85, four platform
+builds/portability tests/governance smokes, and WSL2.
+
+The public [GitHub Release](https://github.com/tt-a1i/skillroster/releases/tag/v1.8.45)
+was published on 2026-09-03 and contains exactly four archives and four adjacent
+checksum files:
+
+| Target | SHA-256 |
+| --- | --- |
+| `aarch64-apple-darwin` | `cc6f0b89a49a3dcd2e6df56af6384640a6210e5e474d299be299f6e2b421c2c0` |
+| `x86_64-apple-darwin` | `b719159e7333bbace83e287c5667c7d6505514bbf9765237f48f68d37c1be59e` |
+| `x86_64-unknown-linux-gnu` | `6b2d5252666531c613b8e77aa075b03952bfa90aab9697400d2eaaf61ff1dfb1` |
+| `x86_64-pc-windows-msvc` | `dce739c302438c386348628324a8b20639b42aae1eb66b363dcadcabdc986dee` |
+
+Every archive has only its expected binary, README and LICENSE under the
+versioned directory/path prefix. Tar archives include an explicit directory
+entry; the Windows ZIP has three prefixed payload entries. README and LICENSE
+bytes match the exact source. All eight files were independently downloaded
+without authentication from the public Release URLs and matched the validated
+tag artifacts byte-for-byte, including GitHub's reported asset digests.
+
+Installing from the immutable Git tag with `cargo install --locked` into an
+isolated temporary prefix reported 1.8.45 and passed the release governance
+smoke. Both the macOS arm64 tag archive binary and the anonymously downloaded
+public archive binary passed that smoke independently.
+These checks exercise Setup/Apply/Undo, clear recovery state, a synthetic
+retained-ID collision and stable repeat Scan; they use no real Skill library.
+
+## Homebrew
+
+The official [tap PR #19](https://github.com/tt-a1i/homebrew-skillroster/pull/19)
+updated the Formula at exact head
+`ac4d03a91d167f80b08f3e9d24382cd13d2f36f2`, with zero findings from
+independent Standards and Spec reviews. Its
+[test-bot run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33759373293)
+built, installed and tested macOS arm64 and Linux x86_64 bottles. The
+[SHA-guarded pr-pull run](https://github.com/tt-a1i/homebrew-skillroster/actions/runs/33761488909)
+was dispatched from tap `main@7b7d445a7f43f30ab16602c997c3f1cc1f9ae864`
+with that exact PR head. It published the bottles, closed the PR without a
+regular merge commit, and advanced tap main through Formula commit
+`db3af585e92d2894ecdc237cfe679f158b37f181` and bottle commit
+`7107873827cd3ea8e1ec2a2dd93172b478d60371`.
+
+The Formula uses the actual v1.8.45 source archive SHA-256
+`bd1c065cfcccc1bce5e8749864de63120e96f2757355487e857f6acf1ef4ea77`.
+The public [bottle release](https://github.com/tt-a1i/homebrew-skillroster/releases/tag/skillroster-1.8.45)
+contains:
+
+| Bottle | SHA-256 |
+| --- | --- |
+| `arm64_tahoe` | `d9a1a5091c6c81d208743a50d99b4daf4481849967254476703ca11c664155fe` |
+| `x86_64_linux` | `f85bf30512892d5362f0f73e5cdc355d85dba91abcc67887846531d43df9e2c2` |
+
+Both bottles were anonymously downloaded and matched the public Formula and
+GitHub asset digests. The extracted arm64 bottle reported 1.8.45 and passed the
+full isolated release governance smoke. This did not install or upgrade the
+user's Homebrew package. Linux bottle installation and runtime test evidence
+comes from test-bot; it was not executed on the local macOS host.
+
+## Boundaries
+
+- Historical [asset policy #55](https://github.com/tt-a1i/skillroster/issues/55)
+  is tracked separately from this release. The 21-release / 168-attachment
+  inventory and backup are complete. No historical attachment was deleted or
+  replaced; old-asset disposition is not claimed as completed by this release.
+- Independent user-pilot work is outside this round.
+- WSL2 uses the Linux archive. WSL1 mutation remains fail-closed; native Linux
+  arm64 and Windows arm64 artifacts are not included.
+- Publication does not change the user's installed binary, state, Agent files
+  or Skill library. Installation smoke uses temporary prefixes and state.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ SkillRoster stores inventory, evidence, plans, receipts, and configuration on
 the local machine. Installation does not connect it to a hosted service or
 upload Skill contents or agent session history.
 
-The current public release is **v1.8.44**. Its Formula, annotated tag, four
+The current public release is **v1.8.45**. Its Formula, annotated tag, four
 platform archives, and adjacent checksums are public.
 
 WSL users need WSL2 and should use the Linux archive. WSL1 lacks the atomic
@@ -34,7 +34,7 @@ On macOS or Linux, the archive contains a versioned directory. Extract it and
 install the binary from that directory (not from the current directory):
 
 ```sh
-SKILLROSTER_VERSION=1.8.44
+SKILLROSTER_VERSION=1.8.45
 SKILLROSTER_TARGET=aarch64-apple-darwin # choose from the table above
 tar -xzf "skillroster-${SKILLROSTER_VERSION}-${SKILLROSTER_TARGET}.tar.gz"
 mkdir -p "$HOME/.local/bin"
@@ -49,7 +49,7 @@ Agent, then restart that Agent so future sessions can resolve `skillroster`.
 
 On Windows, compare `Get-FileHash .\skillroster-*.zip -Algorithm SHA256` with
 the checksum file. Extract the archive, open its versioned directory, then
-place `skillroster.exe` in a directory on `PATH`. Every release archive also
+place `skillroster.exe` in a directory on `PATH`. Every current release archive also
 contains `README.md` and the complete Apache-2.0 `LICENSE` distributed with the
 binary.
 
@@ -59,7 +59,7 @@ Rust 1.85 or newer is required. For an immutable release tag:
 
 ```sh
 cargo install --locked --git https://github.com/tt-a1i/skillroster.git \
-  --tag v1.8.44 skillroster
+  --tag v1.8.45 skillroster
 ```
 
 For a local checkout, run `cargo install --locked --path .`. Confirm the
@@ -136,7 +136,7 @@ skillroster scan --summary --json
 skillroster setup --json
 ```
 
-Published CLI v1.8.44 bundles Bootstrap content version 1.8.29.
+Published CLI v1.8.45 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.45**.
 Its bundled Bootstrap content version is 1.8.29. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap

--- a/website/index.html
+++ b/website/index.html
@@ -1451,7 +1451,7 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Homebrew</h3>
-        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.44 · MACOS &amp; LINUX</div>
+        <div class="sub">OFFICIAL TAP · CURRENT RELEASE v1.8.45 · MACOS &amp; LINUX</div>
         <div class="code-block">
           <div><span class="prompt">$</span>brew install tt-a1i/skillroster/skillroster</div>
           <button class="copy-btn" data-copy="brew install tt-a1i/skillroster/skillroster">COPY</button>
@@ -1460,12 +1460,12 @@ footer { overflow: hidden; }
       <div class="install-card spot">
         <div class="term-bar"><i></i><i></i><i></i><span>TERMINAL</span></div>
         <h3>Cargo</h3>
-        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.44 · ANY PLATFORM</div>
+        <div class="sub">IMMUTABLE CURRENT RELEASE · v1.8.45 · ANY PLATFORM</div>
         <div class="code-block">
           <div><span class="prompt">$</span>cargo install --locked \</div>
           <div>&nbsp;&nbsp;--git https://github.com/tt-a1i/skillroster.git \</div>
-          <div>&nbsp;&nbsp;--tag v1.8.44 skillroster</div>
-          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.44 skillroster">COPY</button>
+          <div>&nbsp;&nbsp;--tag v1.8.45 skillroster</div>
+          <button class="copy-btn" data-copy="cargo install --locked --git https://github.com/tt-a1i/skillroster.git --tag v1.8.45 skillroster">COPY</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Record the completed v1.8.45 publication and align both READMEs, installation guide, website source and source-pinned Formula. Release tag c1197c16fb6b6ef98acece486348089e27c9af69 resolves to 25b39ebc279b5af5ae44c9c3cf9266da532eb693. Tag run 33759099791 passed all six jobs. All eight public attachments were anonymously downloaded and matched the tag artifacts. Cargo tag installation, public macOS archive and macOS Homebrew bottle passed isolated governance smoke. Homebrew PR tt-a1i/homebrew-skillroster#19 passed both bottle tests and was published by SHA-guarded run 33761488909, advancing tap main to 7107873827cd3ea8e1ec2a2dd93172b478d60371. No runtime/Bootstrap/schema change, no user install/state mutation. Historical assets remain separate under #55; this PR does not close it or claim cleanup. Standards review is clean; Spec review and exact-head CI are required before merge.