### PR TITLE
ci: restore automatic Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "website/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy website
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Upload website artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Problem

The public site at https://tt-a1i.github.io/skillroster/ returns GitHub Pages 404. The repository API reports has_pages=false, while main still contains website/index.html. The latest successful Pages deployment was 2026-08-25 from a stale gh-pages branch.

## Fix

Add an official GitHub Actions Pages workflow that deploys only main/website, on website or workflow changes and manual dispatch. All actions are pinned to complete commit SHAs. Permissions are limited to contents:read, pages:write and id-token:write; checkout credentials are not persisted.

After exact-head review and CI, create the Pages site with build_type=workflow, merge with SHA guard, verify the deployment, require HTTP 200 and live bytes equal to main website/index.html, then inspect the real page in a browser.

## Checks

- YAML parsed successfully
- change-scope self-test passed
- git diff --check passed
- Standards review: 0 findings
- Spec review pending

This replaces neither source history nor the existing gh-pages branch. It does not change the CLI, release assets, Homebrew or user data.