### PR TITLE
fix: disclose truncation of semantic overlap candidates

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -128,6 +128,8 @@ routing-vocabulary Jaccard score, counts, and shared-term preview. Complete
 Skill bodies stay at the returned local paths. The calling Agent or person owns
 the semantic conclusion, and no Plan action is suggested from this evidence.
 
+Reports disclose semantic overlap candidate bounds as `semantic_overlap_candidates`: the total qualifying pair count, the retained count (at most 25), and whether candidates were truncated. These are analysis-wide bounds, independent of Finding filters or pagination, and appear in both JSON views and terminal summaries and Finding lists. Cached reports without these bounds are regenerated from the same Snapshot; a new Scan is not required.
+
 ### 4.3 Library and Rosters
 
 The Library is logical and does not require moving every Skill. Each discovered Skill begins as Observed. After approval it may become:

--- a/src/app.rs
+++ b/src/app.rs
@@ -2580,6 +2580,7 @@ fn report_command(
         "findings": compact_findings,
         "finding_rollups": finding_rollups,
         "category_counts": report.category_counts,
+        "semantic_overlap_candidates": report.semantic_overlap_candidates,
         "files_changed": false
     });
     store.save_report(
@@ -4627,6 +4628,7 @@ fn paged_finding_report(
         "matched_finding_count": total,
         "finding_rollups": report_finding_rollups(report),
         "category_counts": report["category_counts"],
+        "semantic_overlap_candidates": report["semantic_overlap_candidates"],
         "filters": {
             "category": category.map(ReportCategory::id),
             "severity": severity.map(ReportSeverity::id)
@@ -4707,6 +4709,7 @@ fn compact_report(report: &Value) -> Value {
         "findings": compact_findings,
         "finding_rollups": report_finding_rollups(report),
         "category_counts": report["category_counts"],
+        "semantic_overlap_candidates": report["semantic_overlap_candidates"],
         "files_changed": false
     })
 }
@@ -11011,6 +11014,31 @@ mod recovery_tests {
         assert_eq!(rollups[0]["finding_count"], 2);
         assert_eq!(rollups[0]["affected_skill_count"], 2);
         assert_eq!(rollups[0]["affected_placement_count"], 3);
+    }
+
+    #[test]
+    fn report_views_preserve_semantic_overlap_candidate_bounds() {
+        let report = json!({
+            "findings": [],
+            "category_counts": {},
+            "semantic_overlap_candidates": {
+                "candidate_count": 31,
+                "returned_count": 25,
+                "truncated": true
+            }
+        });
+
+        let compact = compact_report(&report);
+        assert_eq!(
+            compact["semantic_overlap_candidates"],
+            report["semantic_overlap_candidates"]
+        );
+
+        let paged = paged_finding_report(&report, None, None, 20, 0);
+        assert_eq!(
+            paged["semantic_overlap_candidates"],
+            report["semantic_overlap_candidates"]
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2484,7 +2484,10 @@ fn report_command(
     let (scan_id, scan): (ScanId, ScanResult) = latest_scan(store)?;
     require_content_identity(&scan)?;
     if let Some(existing) = store.latest_report()? {
-        if existing.scan_id == scan_id && report_supports_source_confirmation_kind(&existing) {
+        if existing.scan_id == scan_id
+            && report_supports_source_confirmation_kind(&existing)
+            && existing.summary["semantic_overlap_candidates"].is_object()
+        {
             return Ok(select_report_view(&existing.summary, request));
         }
     }

--- a/src/present.rs
+++ b/src/present.rs
@@ -494,6 +494,25 @@ fn report(value: &Value, lines: &mut Vec<String>, width: usize) {
             }
         }
     }
+    if let Some(candidates) = value
+        .get("semantic_overlap_candidates")
+        .filter(|candidates| candidates["candidate_count"].as_u64().unwrap_or_default() > 0)
+    {
+        let qualifier = if candidates["truncated"].as_bool().unwrap_or(false) {
+            " · bounded"
+        } else {
+            ""
+        };
+        fact(
+            lines,
+            "Semantic candidates",
+            format!(
+                "{} of {} returned{qualifier}",
+                text(candidates, "returned_count"),
+                text(candidates, "candidate_count")
+            ),
+        );
+    }
     if let Some(counts) = value.get("category_counts").and_then(Value::as_object) {
         lines.push(String::new());
         lines.push("  Category totals".into());
@@ -2373,6 +2392,11 @@ mod tests {
                     "affected_placement_count": 0
                 }
             ],
+            "semantic_overlap_candidates": {
+                "candidate_count": 317,
+                "returned_count": 25,
+                "truncated": true
+            },
             "category_counts": {"layout": 1, "overlap": 1, "lifecycle": 1, "usage": 1}
         });
         for width in [60, 80, 120] {
@@ -2396,6 +2420,8 @@ mod tests {
                 "110 ×",
                 "110 Skills",
                 "561 placements",
+                "Semantic candidates",
+                "25 of 317 returned · bounded",
                 "Category totals",
             ] {
                 assert!(output.contains(expected), "{expected} missing at {width}");

--- a/src/present.rs
+++ b/src/present.rs
@@ -494,6 +494,21 @@ fn report(value: &Value, lines: &mut Vec<String>, width: usize) {
             }
         }
     }
+    semantic_overlap_bounds(value, lines);
+    if let Some(counts) = value.get("category_counts").and_then(Value::as_object) {
+        lines.push(String::new());
+        lines.push("  Category totals".into());
+        for (category, count) in counts {
+            lines.push(format!("  {category:<12} {count}"));
+        }
+    }
+    lines.extend(summary(
+        "Read-only · no Agent files changed",
+        "Review evidence before planning changes",
+    ));
+}
+
+fn semantic_overlap_bounds(value: &Value, lines: &mut Vec<String>) {
     if let Some(candidates) = value
         .get("semantic_overlap_candidates")
         .filter(|candidates| candidates["candidate_count"].as_u64().unwrap_or_default() > 0)
@@ -513,17 +528,6 @@ fn report(value: &Value, lines: &mut Vec<String>, width: usize) {
             ),
         );
     }
-    if let Some(counts) = value.get("category_counts").and_then(Value::as_object) {
-        lines.push(String::new());
-        lines.push("  Category totals".into());
-        for (category, count) in counts {
-            lines.push(format!("  {category:<12} {count}"));
-        }
-    }
-    lines.extend(summary(
-        "Read-only · no Agent files changed",
-        "Review evidence before planning changes",
-    ));
 }
 
 fn finding_list(value: &Value, lines: &mut Vec<String>, width: usize) {
@@ -537,6 +541,7 @@ fn finding_list(value: &Value, lines: &mut Vec<String>, width: usize) {
     };
     fact(lines, "Finding page", range);
     fact(lines, "All Findings", text(value, "finding_count"));
+    semantic_overlap_bounds(value, lines);
     let category = value["filters"]["category"].as_str();
     let severity = value["filters"]["severity"].as_str();
     if category.is_some() || severity.is_some() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -311,7 +311,15 @@ pub struct Report {
     pub metrics: PrimaryMetrics,
     pub findings: Vec<Finding>,
     pub category_counts: BTreeMap<String, usize>,
+    pub semantic_overlap_candidates: SemanticOverlapCandidates,
     pub files_changed: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SemanticOverlapCandidates {
+    pub candidate_count: usize,
+    pub returned_count: usize,
+    pub truncated: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -566,7 +574,7 @@ pub fn build_report(scan: &ScanResult) -> Report {
     layout_findings(scan, &mut findings);
     exposure_findings(scan, &mut findings);
     usage_findings(scan, &mut findings);
-    overlap_findings(scan, &mut findings);
+    let semantic_overlap_candidates = overlap_findings(scan, &mut findings);
     routing_findings(scan, &mut findings);
     lifecycle_findings(scan, &mut findings);
     prioritize_report_findings(&mut findings, 3);
@@ -581,6 +589,7 @@ pub fn build_report(scan: &ScanResult) -> Report {
         metrics,
         findings,
         category_counts,
+        semantic_overlap_candidates,
         files_changed: false,
     }
 }
@@ -1321,7 +1330,7 @@ fn usage_findings(scan: &ScanResult, findings: &mut Vec<Finding>) {
     }
 }
 
-fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, usize, usize) {
+fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> SemanticOverlapCandidates {
     for (skill_id, placements) in placements_by_skill(scan) {
         let Some(skill) = scan.skills.iter().find(|skill| skill.id == skill_id) else {
             continue;
@@ -1391,7 +1400,6 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, u
         .map(|skill| normalize_skill_name(&skill.name))
         .collect::<Vec<_>>();
     let mut candidates = Vec::with_capacity(SEMANTIC_CANDIDATE_LIMIT);
-    let mut candidate_peak = 0;
     let compare = |left: &(f64, &ScannedSkill, &ScannedSkill),
                    right: &(f64, &ScannedSkill, &ScannedSkill)| {
         right
@@ -1401,11 +1409,10 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, u
             .then_with(|| left.1.id.cmp(&right.1.id))
             .then_with(|| left.2.id.cmp(&right.2.id))
     };
-    let mut pair_comparison_count = 0usize;
+    let mut candidate_count = 0usize;
     for (index, left) in scan.skills.iter().enumerate() {
         let left_tokens = &vocabularies[index];
         for (right_index, right) in scan.skills.iter().enumerate().skip(index + 1) {
-            pair_comparison_count = pair_comparison_count.saturating_add(1);
             if normalized_names[index] == normalized_names[right_index] {
                 continue;
             }
@@ -1422,6 +1429,7 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, u
             let union_count = left_tokens.len() + right_tokens.len() - intersection_count;
             let similarity = intersection_count as f64 / union_count as f64;
             if similarity >= 0.45 {
+                candidate_count = candidate_count.saturating_add(1);
                 let candidate = (similarity, left, right);
                 // Insert after equal keys, retaining the old stable-sort order.
                 // Discard the worst entry before insertion, never retaining >25.
@@ -1432,11 +1440,11 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, u
                         candidates.pop();
                     }
                     candidates.insert(position, candidate);
-                    candidate_peak = candidate_peak.max(candidates.len());
                 }
             }
         }
     }
+    let returned_count = candidates.len();
     for (similarity, left, right) in candidates {
         push_finding(
             findings,
@@ -1457,7 +1465,11 @@ fn overlap_findings(scan: &ScanResult, findings: &mut Vec<Finding>) -> (usize, u
             EvidenceQuality::Inferred,
         );
     }
-    (vocabularies.len(), pair_comparison_count, candidate_peak)
+    SemanticOverlapCandidates {
+        candidate_count,
+        returned_count,
+        truncated: candidate_count > returned_count,
+    }
 }
 
 fn physical_source_identity(
@@ -3233,6 +3245,9 @@ mod tests {
                     && finding.affected_skill_ids.contains(&candidate_id)
             })
             .unwrap();
+        assert_eq!(report.semantic_overlap_candidates.candidate_count, 1);
+        assert_eq!(report.semantic_overlap_candidates.returned_count, 1);
+        assert!(!report.semantic_overlap_candidates.truncated);
         assert_eq!(finding.evidence_quality, EvidenceQuality::Inferred);
         assert!(finding.summary.contains("review-only candidate evidence"));
         assert!(finding.summary.contains("not a confirmed duplicate"));
@@ -3289,12 +3304,11 @@ mod tests {
         scan.usage.clear();
 
         let mut findings = Vec::new();
-        let (vocabulary_count, pair_comparison_count, candidate_peak) =
-            overlap_findings(&scan, &mut findings);
+        let candidates = overlap_findings(&scan, &mut findings);
 
-        assert_eq!(vocabulary_count, 193);
-        assert_eq!(pair_comparison_count, 193 * 192 / 2);
-        assert!(candidate_peak <= 25, "retained {candidate_peak} candidates");
+        assert_eq!(candidates.candidate_count, 193 * 192 / 2);
+        assert_eq!(candidates.returned_count, 25);
+        assert!(candidates.truncated);
         assert_eq!(
             findings
                 .iter()
@@ -3331,13 +3345,16 @@ mod tests {
         scan.usage.clear();
         let start = std::time::Instant::now();
         let mut findings = Vec::new();
-        let (vocabularies, pairs, retained) = overlap_findings(&scan, &mut findings);
+        let candidates = overlap_findings(&scan, &mut findings);
         let elapsed = start.elapsed();
-        assert_eq!(vocabularies, count);
-        assert_eq!(pairs, count * (count - 1) / 2);
+        assert_eq!(candidates.candidate_count, count * (count - 1) / 2);
+        assert_eq!(candidates.returned_count, 25);
+        assert!(candidates.truncated);
         assert_eq!(findings.len(), 25);
         println!(
-            "skills={count} pairs={pairs} retained_candidates={retained} analysis_ms={}",
+            "skills={count} candidates={} retained_candidates={} analysis_ms={}",
+            candidates.candidate_count,
+            candidates.returned_count,
             elapsed.as_millis()
         );
         fs::remove_dir_all(root).unwrap();
@@ -3387,10 +3404,13 @@ mod tests {
                     .unwrap()
                     .then(left.1.cmp(&right.1))
             });
+            let candidate_count = expected.len();
             expected.truncate(25);
             let mut findings = Vec::new();
-            let (_, _, peak) = overlap_findings(&scan, &mut findings);
-            assert!(peak <= 25);
+            let candidates = overlap_findings(&scan, &mut findings);
+            assert_eq!(candidates.candidate_count, candidate_count);
+            assert_eq!(candidates.returned_count, expected.len());
+            assert_eq!(candidates.truncated, candidate_count > expected.len());
             assert_eq!(findings.len(), expected.len());
             for (actual, (score, mut ids)) in findings.iter().zip(expected) {
                 ids.sort();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13825,3 +13825,89 @@ fn historical_finding_detail_exposes_current_continuity_by_placement() {
         "latest_report_stale"
     );
 }
+
+#[test]
+fn report_refreshes_legacy_overlap_bounds_and_discloses_them_in_finding_lists() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    for index in 0..10 {
+        let root = home.join(format!(".claude/skills/example-{index}"));
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("SKILL.md"),
+            format!("---\nname: example-{index}\ndescription: shared architecture workflow database governance evidence\n---\nSkill {index}\n"),
+        ).unwrap();
+    }
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+    ];
+    json_output(&run(&[&common[..], &["scan", "--json"]].concat(), None));
+    let first = json_output(&run(&[&common[..], &["report", "--json"]].concat(), None));
+    let bounds = json!({"candidate_count": 45, "returned_count": 25, "truncated": true});
+    assert_eq!(first["result"]["semantic_overlap_candidates"], bounds);
+
+    // Simulate a report persisted before the bounds field existed, without
+    // rescanning or changing any Skill files.
+    let database = rusqlite::Connection::open(state.join("skillroster.db")).unwrap();
+    let original_id = first["result"]["report_id"].as_str().unwrap();
+    let stored: String = database
+        .query_row(
+            "SELECT summary_json FROM reports WHERE id = ?1",
+            [original_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut legacy: Value = serde_json::from_str(&stored).unwrap();
+    legacy
+        .as_object_mut()
+        .unwrap()
+        .remove("semantic_overlap_candidates");
+    database
+        .execute(
+            "UPDATE reports SET summary_json = ?1 WHERE id = ?2",
+            rusqlite::params![legacy.to_string(), original_id],
+        )
+        .unwrap();
+    drop(database);
+
+    let refreshed = json_output(&run(&[&common[..], &["report", "--json"]].concat(), None));
+    assert_ne!(
+        refreshed["result"]["report_id"],
+        first["result"]["report_id"]
+    );
+    assert_eq!(
+        refreshed["result"]["snapshot_id"],
+        first["result"]["snapshot_id"]
+    );
+    assert_eq!(refreshed["result"]["semantic_overlap_candidates"], bounds);
+    let cached = json_output(&run(&[&common[..], &["report", "--json"]].concat(), None));
+    assert_eq!(
+        cached["result"]["report_id"],
+        refreshed["result"]["report_id"]
+    );
+
+    let list_args = [
+        "report",
+        "--findings",
+        "--category",
+        "overlap",
+        "--limit",
+        "100",
+    ];
+    let page = json_output(&run(&[&common[..], &list_args, &["--json"]].concat(), None));
+    assert_eq!(page["result"]["semantic_overlap_candidates"], bounds);
+    for width in [60, 80, 120] {
+        let output = run_with_columns(&[&common[..], &list_args].concat(), width);
+        assert!(output.status.success());
+        let rendered = String::from_utf8(output.stdout).unwrap();
+        assert!(rendered.contains("Semantic candidates"), "{rendered}");
+        assert!(
+            rendered.contains("25 of 45 returned · bounded"),
+            "{rendered}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem and value

Fixes #377. Semantic overlap analysis retains at most 25 candidate pairs, but previously did not disclose how many qualified. Users and Agents could mistake the retained findings for a complete analysis result.

## Changes

- Return `semantic_overlap_candidates` with the total qualifying pair count, retained count, and truncation flag in report JSON, including compact and paginated views.
- Show these analysis-wide bounds in terminal summaries and Finding lists, independently of filters and pagination.
- Regenerate cached reports missing the bounds from the same Snapshot, while continuing to reuse current reports.
- Document the contract and cover counting, ordering parity, view preservation, terminal rendering, and legacy-cache refresh with regression tests.

Candidate ordering, the 25-candidate limit, Plan semantics, and Skill file operations are unchanged.

## Validation

At `bc00492b4235a882a6656f4a60f512abea05fade`, `bash scripts/ci-full-check.sh` passed locally on macOS, including formatting, strict Clippy, all Rust test targets, 152 Node harness tests, and documentation/installation checks. The scale measurement test remains intentionally ignored.

The CLI regression uses 10 Skills producing 45 candidates and verifies `25 of 45 returned · bounded` at terminal widths 60, 80, and 120. It also simulates a persisted legacy report and verifies that bounds are regenerated without rescanning, then cached normally.

GitHub CI passed on Linux x86_64, Windows x86_64, macOS arm64, and macOS x86_64; Change scope and CI gate also passed. Run: https://github.com/tt-a1i/skillroster/actions/runs/34010663505
