### PR TITLE
feat: expose finding decision facts

### DIFF
--- a/docs/cli-ux-spec.md
+++ b/docs/cli-ux-spec.md
@@ -99,7 +99,11 @@ Lead with four counts: independent Skills, placements, default exposure, and obs
 Agent callers use selector-free `report --json` by default; `--summary` is an
 explicit alias. The compact payload
 contains those four metrics, total Finding count, category totals, and at most
-three complete Finding summaries. When the Agent needs another category or an
+three complete Finding summaries. Each Finding summary also states the affected
+Agent IDs, whether it has a deterministic next step (`plan_available`,
+`review_required`, `blocked`, or `read_only`), and whether an applied change can
+be undone (`undo_after_apply`, `manual_only`, or `not_governable`). These are
+bounded facts, not a semantic claim that the Skill is useful or safe. When the Agent needs another category or an
 exhaustive selection surface, it uses `report --findings --json`, optionally
 filtered by one `--category` and one `--severity`. That mode returns compact
 Finding summaries plus `page.next_offset`; it never suggests planning before a
@@ -122,9 +126,11 @@ per-Agent selection preview and the semantic `finding_roster_changes` shape;
 complete placement and Roster changes remain CLI-owned. An escaping-link Finding returns observed targets and a required
 trust decision instead of a Plan suggestion.
 
-Human Finding output shows the issue, severity, affected counts, bounded paths,
-and any required trust decision. It must not render a Finding as an empty
-aggregate report.
+Human Finding output shows the issue, severity, affected counts, affected
+Agents, actionability, reversibility, bounded paths, and any required trust
+decision. It must not render a Finding as an empty aggregate report. Finding
+lists show the same three decision facts in a shortened line so a person can
+decide which item to open next without reading every detail.
 
 Human `report --findings` output shows the matching range, active filters,
 stable IDs, impact counts, and next offset. Every line remains bounded at 60,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -138,7 +138,7 @@ skillroster setup --json
 
 Published CLI v1.8.45 bundles Bootstrap content version 1.8.29.
 The source tree is **v1.8.45**.
-Its bundled Bootstrap content version is 1.8.46. CLI and Bootstrap versions can
+Its bundled Bootstrap content version is 1.8.49. CLI and Bootstrap versions can
 differ intentionally when CLI behavior changes without changing the Bootstrap
 instructions.
 In Setup JSON, `cli_version` identifies the executable and

--- a/docs/product-brief.md
+++ b/docs/product-brief.md
@@ -91,6 +91,8 @@ A record of an applied plan containing enough information to verify the result a
 - SQLite with FTS5 for local inventory, evidence, and search.
 - Adapter boundary per agent harness.
 - JSON output for agent callers; concise terminal output for people.
-- One thin bootstrap Skill that teaches agents when to call the CLI.
+- One thin bootstrap Skill that teaches agents when to call the CLI. Its runtime
+  boundary is documented in [the Bootstrap boundary decision](research/agent-skill-governance-and-routing.md),
+  while product presentation and evaluation rules stay outside the Skill.
 
 The normative requirements, command contract, privacy rules, and completion gates live in [product-spec.md](product-spec.md). Domain terms are defined in the repository's [CONTEXT.md](../CONTEXT.md).

--- a/docs/research/agent-skill-governance-and-routing.md
+++ b/docs/research/agent-skill-governance-and-routing.md
@@ -66,6 +66,23 @@ blocker，Bootstrap 只规定如何保留 TASK、调用 CLI、验证 envelope �
 本轮没有证据证明缺少一个重复的 “Agent Brief” 命令或新的摘要层；除非未来
 明确指出某个缺失的机器字段，否则不新增该命令。
 
+## Bootstrap 边界决策（2026-09-09）
+
+本轮对 Bootstrap 的新增指引做了一次收敛。Bootstrap 是本地工具的运行时
+接缝，不是 SkillRoster 的产品说明书，也不是替宿主 Harness 规定通用工作法。
+它只保留会改变安全决策的内容：何时调用 CLI、如何保留原始任务、如何验证
+JSON、如何处理 typed blocker，以及 Plan、Apply、Receipt 的权限边界。
+
+`affected_agents`、`actionability` 和 `reversibility` 是 CLI 返回的事实。Bootstrap
+可以要求 Agent 原样传递并据此避免越权，但不应把它们变成价值分数、永久的
+模型匹配或固定的展示顺序。用户当前“值得先处理什么”的判断属于当前对话；
+四个核心指标、前三项 Finding、完整 usage 分类和各类 Plan 展示规则属于产品
+UX 与验收文档。
+
+因此，一次盲测能证明指引是否改变了 Agent 的调用和表达行为，但不能单独
+证明这些产品方法论应该长期写进 Skill。后续模型或 Harness 变化时，应重新
+评估行为；不要把一次 Bootstrap 的成功当成跨模型的永久结论。
+
 ### 大型 Skill 检索论文：可借鉴的问题，不可直接搬来的架构
 
 | 来源与证据级别 | 研究对象及直接结果 | 对 SkillRoster 的启示 | 非转移边界 |

--- a/skill/skillroster/SKILL.md
+++ b/skill/skillroster/SKILL.md
@@ -9,7 +9,7 @@ description: >
   third-party Skills or migrating, distributing, synchronizing, or repairing shared
   Skill-manager directories.
 metadata:
-  bootstrap-version: "1.8.46"
+  bootstrap-version: "1.8.49"
   skillroster-routing-triggers: "route task to local Skill; inventory installed Agent Skills; analyze duplicate or unused Agent Skills; govern a Skill Roster; prepare or apply approved Skill Plan; create or undo Skill Receipt"
 ---
 
@@ -27,10 +27,20 @@ command uses explicit `--json`. Validate `schema_version` and `ok` before using
   applies. Search below when a specialized Skill would help; otherwise proceed
   with the Agent's normal tools and the user's task.
 
+SkillRoster is a local lookup and governance bridge, not a replacement for the
+host Agent's Harness. Its contract is the CLI and its JSON; the host still
+decides whether a Skill is listed, activated, or enforced. Do not call it for
+ordinary work that needs no specialized procedure.
+
 ## Find a specialized Skill
 
 Use this search before relying on a Skill that is absent from the visible
 catalog. Read-only task context may inform whether a search is useful.
+
+Find searches the latest completed local Snapshot, not only the default catalog.
+It may return an On-demand, provider, or source-only Skill. Loading one returns
+verified instructions to the caller; it does not activate, install, expose,
+endorse, or establish success for the user's task.
 
 1. Keep the complete user message as `TASK`, byte-for-byte in its original
    language, including paths, limits, and output requirements. Do not summarize,
@@ -53,6 +63,14 @@ catalog. Read-only task context may inform whether a search is useful.
 6. Follow the loaded instructions and perform the original task. Treat
    `task_success: not_evaluated` literally; only the task's own evidence can
    establish success.
+
+If Find returns `snapshot_required`, execute its returned `scan` action only when
+both `mutates` and `requires_confirmation` are false, then retry the identical
+Find call with the same `TASK` and `HINT`. The Scan changes SkillRoster's local
+Snapshot, not Agent or Skill files. If either flag says otherwise, ask the user
+first; these flags do not authorize a material change. For any other typed
+blocker, read `references/routing.md` and follow its bounded branch; execute a
+returned action only when one is present.
 
 If the result is empty or clearly from another domain, retry at most once. Keep `TASK`
 unchanged; refine the existing hint, or add one capability hint when the first

--- a/skill/skillroster/references/governance.md
+++ b/skill/skillroster/references/governance.md
@@ -5,18 +5,19 @@
 Run `skillroster scan --summary --json`, then the bounded
 `skillroster report --json`. Use full `scan --json` only for deliberate root or
 coverage diagnostics.
-Use `finding_rollups` for complete group scale and the selected findings for the
-first decisions. Use `report --findings --limit 20 --json`, optionally narrowed
-by one category or severity, only when enumeration is needed. Follow
-`page.next_offset` while that decision remains open. Reserve `report --full`
-for deliberate exhaustive export.
+Use `finding_rollups` for group scale and the selected Findings for the first
+decisions. Use `report --findings --limit 20 --json`, optionally narrowed by
+category or severity, only when enumeration is needed. Follow `page.next_offset`
+while that decision remains open. Reserve `report --full` for deliberate
+exhaustive export; do not make extra calls just to satisfy a fixed presentation
+template.
 
-The initial diagnosis is complete when the bounded Report supplies the four
-core metrics, selected Findings, complete rollups, coverage, and a primary next
-action. Stop there. If one exact fact required to explain that primary action is
-absent, make one `report --finding` call for it. Help, status, Finding
-enumeration, other Finding drills, and full detail belong to a later user
-question; they are not initial-diagnosis checks.
+For each selected Finding, pass through these CLI facts without widening their
+scope: `affected_agents` is the observed Agent set, `actionability` describes
+what the CLI can support now, and `reversibility` describes the recovery path
+of a possible applied change. They constrain the next safe action; they are not
+a value score, and `reversibility` is not permission to Apply. Use the user's
+goal and the available evidence to decide what deserves attention.
 
 Usage evidence is five-stage and conservative. Read `session_coverage` before
 describing it. `sampled_agents` support bounded observed events;
@@ -119,19 +120,17 @@ Never infer a parent, sibling, descendant, alias, or wildcard.
 
 ## Present
 
-Show one bounded viewport with a one-sentence diagnosis and exactly these four
-core metrics: independent Skill count, placement count, default exposure, and
-observed-use count. Show the three highest-priority Findings plus compact
-rollups for the complete scale of every Finding group. Prioritize
-recommendations and keep each typed count's field meaning and unit. A Finding
-describes current affected scale: canonical candidates, physical sources,
-logical placements, default exposure, and relinks are distinct facts. Do not
-derive deletion or reduction counts from them. State measurable before/after
+Present a compact, evidence-backed first view using the report's available
+metrics, selected Findings, rollups, and typed safety facts. Include
+`affected_agents`, `actionability`, and `reversibility` when they are present,
+and keep each count's field meaning and unit. Do not derive deletion or
+reduction counts from current Finding scale. State measurable before/after
 impact only from a validated Plan, and actual impact only from its Receipt.
-Include uncertainties, evidence quality, safety risks, and whether confirmation
-is required. Name one primary next action. For a proposed change, include its
-measurable before/after impact, `change_summary`, operation groups, affected
-facts, uncertainty, reversibility, canonical deletion count, and Plan ID. Use
-`plan --show PLAN_ID --json` only when an exact operation, path, selection, or
-complete ID list is required. State explicitly that inspection and planning
-changed no Agent files.
+Include uncertainty, evidence quality, safety risks, and whether confirmation is
+required. Choose a primary next action when the evidence supports one; expand
+the view when the user's question or an unresolved decision requires it. For a
+proposed change, include its measurable before/after impact,
+`change_summary`, operation groups, affected facts, uncertainty,
+reversibility, canonical deletion count, and Plan ID. Use `plan --show PLAN_ID
+--json` only when an exact operation, path, selection, or complete ID list is
+required. State explicitly that inspection and planning changed no Agent files.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2304,6 +2304,8 @@ fn report_command(
                 .and_then(Value::as_array)
                 .cloned()
                 .unwrap_or_default();
+            let full_affected_skill_ids = affected_skill_ids.clone();
+            let full_affected_placement_ids = affected_placement_ids.clone();
             let affected_placement_id_set = affected_placement_ids
                 .iter()
                 .filter_map(Value::as_str)
@@ -2470,6 +2472,12 @@ fn report_command(
                 }),
             );
             add_finding_resolution(object, &observed_link_targets);
+            refresh_finding_decision_facts(
+                object,
+                &scan,
+                &full_affected_skill_ids,
+                &full_affected_placement_ids,
+            );
             object.insert(
                 "detail".into(),
                 json!({
@@ -2489,6 +2497,7 @@ fn report_command(
     if let Some(existing) = store.latest_report()? {
         if existing.scan_id == scan_id
             && report_supports_source_confirmation_kind(&existing)
+            && report_supports_finding_decision_fields(&existing)
             && existing.summary["semantic_overlap_candidates"].is_object()
             && (scan.native_visibility.is_none()
                 || existing.summary["native_visibility"].is_object())
@@ -2520,30 +2529,11 @@ fn report_command(
             })
         })
         .collect::<Result<Vec<_>>>()?;
-    let compact_findings = report
-        .findings
+    let full_findings = findings
         .iter()
-        .zip(&findings)
-        .map(|(finding, stored)| {
-            json!({
-                "id": stored.id,
-                "kind": stored.details["kind"],
-                "category": finding.category,
-                "severity": finding.severity,
-                "title": finding.title,
-                "summary": finding.summary,
-                "evidence_quality": finding.evidence_quality,
-                "evidence_ids": stored.evidence_ids,
-                "affected_skill_ids": finding.affected_skill_ids,
-                "affected_placement_ids": finding.affected_placement_ids,
-                "affected_skill_count": finding.affected_skill_ids.len(),
-                "affected_placement_count": finding.affected_placement_ids.len(),
-                "impact": finding_impact(finding),
-                "coverage": finding_coverage(finding, &scan)
-            })
-        })
+        .map(|stored| stored.details.clone())
         .collect::<Vec<_>>();
-    let finding_rollups = finding_rollups(&compact_findings);
+    let finding_rollups = finding_rollups(&full_findings);
     let session_coverage = json!({
         "supported_agents": AgentKind::ALL.len(),
         "roots_present_agents": report.metrics.agents_with_session_roots,
@@ -2586,7 +2576,7 @@ fn report_command(
                 }
             }
         },
-        "findings": compact_findings,
+        "findings": full_findings,
         "finding_rollups": finding_rollups,
         "category_counts": report.category_counts,
         "semantic_overlap_candidates": report.semantic_overlap_candidates,
@@ -2618,6 +2608,265 @@ fn report_supports_source_confirmation_kind(report: &ReportRecord) -> bool {
                 || finding.get("kind").and_then(Value::as_str)
                     == Some(crate::query::FindingKind::EscapingLinkSourceConfirmation.as_str())
         })
+}
+
+fn report_supports_finding_decision_fields(report: &ReportRecord) -> bool {
+    let Some(findings) = report.summary["findings"].as_array() else {
+        return false;
+    };
+    findings.iter().all(|finding| {
+        finding.get("affected_agents").is_some_and(Value::is_array)
+            && finding
+                .get("actionability")
+                .and_then(Value::as_str)
+                .is_some()
+            && finding
+                .get("reversibility")
+                .and_then(Value::as_str)
+                .is_some()
+    })
+}
+
+#[derive(Clone, Copy)]
+struct FindingDecisionState {
+    actionability: &'static str,
+    reversibility: &'static str,
+}
+
+fn finding_decision_state(
+    kind: Option<crate::query::FindingKind>,
+    affected_placement_ids: &[String],
+    scan: &ScanResult,
+) -> FindingDecisionState {
+    use crate::query::FindingKind;
+
+    match kind {
+        Some(FindingKind::ExactDuplicatePlacements) => {
+            let placement_ids = affected_placement_ids
+                .iter()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>();
+            let affected = scan
+                .placements
+                .iter()
+                .filter(|placement| placement_ids.contains(placement.id.as_str()))
+                .collect::<Vec<_>>();
+            let all_mutable =
+                !affected.is_empty() && affected.iter().all(|placement| placement.is_mutable());
+            let canonical_candidate = affected
+                .iter()
+                .any(|placement| placement_owns_physical_source(placement));
+            if all_mutable && canonical_candidate {
+                FindingDecisionState {
+                    actionability: "plan_available",
+                    reversibility: "undo_after_apply",
+                }
+            } else {
+                FindingDecisionState {
+                    actionability: "blocked",
+                    reversibility: "not_governable",
+                }
+            }
+        }
+        Some(
+            FindingKind::SameNameDivergentContent
+            | FindingKind::DeclaredIdentityDivergentContent
+            | FindingKind::LargeDefaultRoster
+            | FindingKind::SemanticOverlapCandidate
+            | FindingKind::MissingRoutingMetadata
+            | FindingKind::UnknownProvenance
+            | FindingKind::UpstreamDriftUnverified
+            | FindingKind::SourceVersionDivergence
+            | FindingKind::ManagementStateReview
+            | FindingKind::StaleArchiveCandidates
+            | FindingKind::DeclaredNameDirectoryMismatch,
+        ) => FindingDecisionState {
+            actionability: "review_required",
+            reversibility: "manual_only",
+        },
+        Some(
+            FindingKind::ConfiguredRootsInaccessible
+            | FindingKind::ConfiguredRootsBounded
+            | FindingKind::IncompletePackageFingerprints
+            | FindingKind::BrokenSkillLinks
+            | FindingKind::EscapingLinkSourceConfirmation,
+        ) => FindingDecisionState {
+            actionability: "blocked",
+            reversibility: "not_governable",
+        },
+        Some(
+            FindingKind::FiveStageUsageEvidence
+            | FindingKind::UsageCoverageIncomplete
+            | FindingKind::ExecutableScriptsPresent
+            | FindingKind::ArchiveCandidacyUnknown,
+        )
+        | None => FindingDecisionState {
+            actionability: "read_only",
+            reversibility: "not_governable",
+        },
+    }
+}
+
+fn finding_affected_agents(
+    kind: Option<crate::query::FindingKind>,
+    affected_skill_ids: &[String],
+    affected_placement_ids: &[String],
+    scan: &ScanResult,
+) -> Vec<String> {
+    let skill_ids = affected_skill_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let placement_ids = affected_placement_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let mut agents = BTreeSet::<&'static str>::new();
+
+    for placement in &scan.placements {
+        let matches = placement_ids.contains(placement.id.as_str())
+            || (placement_ids.is_empty() && skill_ids.contains(placement.skill_id.as_str()));
+        if matches {
+            if let Some(agent) = placement.agent {
+                agents.insert(agent.id());
+            }
+        }
+    }
+
+    match kind {
+        Some(crate::query::FindingKind::FiveStageUsageEvidence) => {
+            for usage in &scan.usage {
+                if skill_ids.is_empty() || skill_ids.contains(usage.skill_id.as_str()) {
+                    agents.insert(usage.agent.id());
+                }
+            }
+            for coverage in &scan.coverage {
+                agents.insert(coverage.agent.id());
+            }
+        }
+        Some(crate::query::FindingKind::UsageCoverageIncomplete)
+        | Some(crate::query::FindingKind::ArchiveCandidacyUnknown) => {
+            for coverage in &scan.coverage {
+                if !coverage.denominator_is_reliable() {
+                    agents.insert(coverage.agent.id());
+                }
+            }
+        }
+        Some(crate::query::FindingKind::ConfiguredRootsInaccessible) => {
+            for root in &scan.roots {
+                if root.kind == crate::scan::RootKind::Skills
+                    && root.status == crate::scan::RootStatus::Inaccessible
+                {
+                    if let Some(agent) = root.agent {
+                        agents.insert(agent.id());
+                    }
+                }
+            }
+        }
+        Some(crate::query::FindingKind::ConfiguredRootsBounded) => {
+            for root in &scan.roots {
+                if root.kind == crate::scan::RootKind::Skills
+                    && root.status == crate::scan::RootStatus::Included
+                    && !root.discovery_complete
+                {
+                    if let Some(agent) = root.agent {
+                        agents.insert(agent.id());
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    agents.into_iter().map(str::to_owned).collect()
+}
+
+fn finding_decision_facts(
+    kind: Option<crate::query::FindingKind>,
+    affected_skill_ids: &[String],
+    affected_placement_ids: &[String],
+    scan: &ScanResult,
+    planning: Option<&Value>,
+    resolution: Option<&Value>,
+    comparison: Option<&Value>,
+) -> (Vec<String>, FindingDecisionState) {
+    let affected_agents =
+        finding_affected_agents(kind, affected_skill_ids, affected_placement_ids, scan);
+    let mut state = finding_decision_state(kind, affected_placement_ids, scan);
+
+    if let Some(planning) = planning {
+        if planning["supported"].as_bool() == Some(true) {
+            state = FindingDecisionState {
+                actionability: "plan_available",
+                reversibility: "undo_after_apply",
+            };
+        } else if planning.get("supported").is_some() {
+            state = FindingDecisionState {
+                actionability: "blocked",
+                reversibility: "not_governable",
+            };
+        }
+    }
+    if let Some(resolution) = resolution {
+        match resolution["decision"].as_str() {
+            Some("choose_same_name_variant") => {
+                state = FindingDecisionState {
+                    actionability: "review_required",
+                    reversibility: "manual_only",
+                };
+            }
+            Some("confirm_trusted_source_roots") => {
+                state = FindingDecisionState {
+                    actionability: "blocked",
+                    reversibility: "not_governable",
+                };
+            }
+            _ => {}
+        }
+    }
+    if let Some(comparison) = comparison {
+        if comparison["decision"].as_str() == Some("compare_skill_meaning") {
+            state = FindingDecisionState {
+                actionability: "review_required",
+                reversibility: "manual_only",
+            };
+        }
+    }
+    (affected_agents, state)
+}
+
+fn refresh_finding_decision_facts(
+    object: &mut serde_json::Map<String, Value>,
+    scan: &ScanResult,
+    affected_skill_ids: &[Value],
+    affected_placement_ids: &[Value],
+) {
+    let skill_ids = affected_skill_ids
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let placement_ids = affected_placement_ids
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let kind = crate::query::finding_kind_from_stored_value(
+        object.get("kind"),
+        object.get("title").and_then(Value::as_str).unwrap_or(""),
+    );
+    let (affected_agents, state) = finding_decision_facts(
+        kind,
+        &skill_ids,
+        &placement_ids,
+        scan,
+        object.get("planning"),
+        object.get("resolution"),
+        object.get("comparison"),
+    );
+    object.insert("affected_agents".into(), json!(affected_agents));
+    object.insert("actionability".into(), json!(state.actionability));
+    object.insert("reversibility".into(), json!(state.reversibility));
 }
 
 fn add_finding_resolution(
@@ -4484,7 +4733,7 @@ fn select_report_view(report: &Value, request: ReportRequest<'_>) -> Value {
 }
 
 fn compact_finding_summary(finding: &Value) -> Value {
-    json!({
+    let mut compact = json!({
         "id": finding["id"],
         "kind": finding["kind"],
         "category": finding["category"],
@@ -4497,7 +4746,15 @@ fn compact_finding_summary(finding: &Value) -> Value {
         "affected_placement_count": finding["affected_placement_count"],
         "impact": finding["impact"],
         "coverage": finding["coverage"]
-    })
+    });
+    if let Some(object) = compact.as_object_mut() {
+        for key in ["affected_agents", "actionability", "reversibility"] {
+            if let Some(value) = finding.get(key) {
+                object.insert(key.to_owned(), value.clone());
+            }
+        }
+    }
+    compact
 }
 
 struct FindingRollup {
@@ -4508,6 +4765,7 @@ struct FindingRollup {
     finding_count: usize,
     skill_ids: BTreeSet<String>,
     placement_ids: BTreeSet<String>,
+    agent_ids: BTreeSet<String>,
 }
 
 fn finding_rollups(findings: &[Value]) -> Vec<Value> {
@@ -4531,6 +4789,7 @@ fn finding_rollups(findings: &[Value]) -> Vec<Value> {
                     finding_count: 0,
                     skill_ids: BTreeSet::new(),
                     placement_ids: BTreeSet::new(),
+                    agent_ids: BTreeSet::new(),
                 });
                 rollups.len() - 1
             });
@@ -4552,6 +4811,14 @@ fn finding_rollups(findings: &[Value]) -> Vec<Value> {
         {
             rollup.placement_ids.insert(id.to_owned());
         }
+        for id in finding["affected_agents"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+        {
+            rollup.agent_ids.insert(id.to_owned());
+        }
     }
     rollups
         .into_iter()
@@ -4562,7 +4829,9 @@ fn finding_rollups(findings: &[Value]) -> Vec<Value> {
                 "title": rollup.title,
                 "finding_count": rollup.finding_count,
                 "affected_skill_count": rollup.skill_ids.len(),
-                "affected_placement_count": rollup.placement_ids.len()
+                "affected_placement_count": rollup.placement_ids.len(),
+                "affected_agents": rollup.agent_ids,
+                "affected_agent_count": rollup.agent_ids.len()
             })
         })
         .collect()
@@ -4736,6 +5005,15 @@ fn finding_json(
     evidence_ids: &[EvidenceId],
     scan: &ScanResult,
 ) -> Value {
+    let (affected_agents, decision) = finding_decision_facts(
+        Some(finding.kind),
+        &finding.affected_skill_ids,
+        &finding.affected_placement_ids,
+        scan,
+        None,
+        None,
+        None,
+    );
     let mut value = json!({
         "id": id,
         "kind": finding.kind,
@@ -4747,6 +5025,11 @@ fn finding_json(
         "evidence_ids": evidence_ids,
         "affected_skill_ids": finding.affected_skill_ids,
         "affected_placement_ids": finding.affected_placement_ids,
+        "affected_skill_count": finding.affected_skill_ids.len(),
+        "affected_placement_count": finding.affected_placement_ids.len(),
+        "affected_agents": affected_agents,
+        "actionability": decision.actionability,
+        "reversibility": decision.reversibility,
         "impact": finding_impact(finding),
         "coverage": finding_coverage(finding, scan),
         "files_changed": false
@@ -8425,6 +8708,69 @@ const LEGACY_COMPLETE_BOOTSTRAP_PACKAGES: &[BootstrapPackageManifest<'static>] =
             ),
         ],
     },
+    BootstrapPackageManifest {
+        version: "1.8.46",
+        file_digests: &[
+            (
+                "SKILL.md",
+                "8e6a7eacea3aea3fa7c11f6f1d73af06f5ca8b98cd287ab82004acd7b0fa938b",
+            ),
+            (
+                "references/routing.md",
+                "58bd0140cf31ebf89b7ffbc9d0d6f5013096897e666c436b8bf703ce45abd3cf",
+            ),
+            (
+                "references/governance.md",
+                "0aff10c04ef8aaa6fc19b119aa5e7b723fe7ae01f1bf72a569d0b02b7cdec5ad",
+            ),
+            (
+                "references/mutation.md",
+                "b6614b2e0c52f1b84df1562462810b0fdfe03fabac0da75f8bde26693bb43589",
+            ),
+        ],
+    },
+    BootstrapPackageManifest {
+        version: "1.8.47",
+        file_digests: &[
+            (
+                "SKILL.md",
+                "01f346450b239524658f1082e701144c396119ac0ef0278739928c5d797253a0",
+            ),
+            (
+                "references/routing.md",
+                "58bd0140cf31ebf89b7ffbc9d0d6f5013096897e666c436b8bf703ce45abd3cf",
+            ),
+            (
+                "references/governance.md",
+                "0aff10c04ef8aaa6fc19b119aa5e7b723fe7ae01f1bf72a569d0b02b7cdec5ad",
+            ),
+            (
+                "references/mutation.md",
+                "b6614b2e0c52f1b84df1562462810b0fdfe03fabac0da75f8bde26693bb43589",
+            ),
+        ],
+    },
+    BootstrapPackageManifest {
+        version: "1.8.48",
+        file_digests: &[
+            (
+                "SKILL.md",
+                "9b95e854f583f646b5aac0d2d839d249cd78651d9fb47a386f9c4d0c513a9e77",
+            ),
+            (
+                "references/routing.md",
+                "58bd0140cf31ebf89b7ffbc9d0d6f5013096897e666c436b8bf703ce45abd3cf",
+            ),
+            (
+                "references/governance.md",
+                "b121cfdbc3050efedbf2a603b2c7b61632285ea61a686204fcc855aeb115169e",
+            ),
+            (
+                "references/mutation.md",
+                "b6614b2e0c52f1b84df1562462810b0fdfe03fabac0da75f8bde26693bb43589",
+            ),
+        ],
+    },
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -11969,26 +12315,32 @@ mod recovery_tests {
 
     #[test]
     fn released_complete_bootstrap_manifest_is_exact_and_recognized() {
-        let manifest = LEGACY_COMPLETE_BOOTSTRAP_PACKAGES
-            .iter()
-            .find(|package| package.version == "1.8.23")
-            .unwrap();
-        let observed = BOOTSTRAP_PACKAGE_FILES
-            .iter()
-            .map(|file| {
-                manifest
-                    .file_digests
-                    .iter()
-                    .find(|(relative_path, _)| *relative_path == file.relative_path)
-                    .map(|(_, digest)| (*digest).to_owned())
-            })
-            .collect::<Vec<_>>();
+        let observed_for = |version: &str| {
+            let manifest = LEGACY_COMPLETE_BOOTSTRAP_PACKAGES
+                .iter()
+                .find(|package| package.version == version)
+                .unwrap();
+            BOOTSTRAP_PACKAGE_FILES
+                .iter()
+                .map(|file| {
+                    manifest
+                        .file_digests
+                        .iter()
+                        .find(|(relative_path, _)| *relative_path == file.relative_path)
+                        .map(|(_, digest)| (*digest).to_owned())
+                })
+                .collect::<Vec<_>>()
+        };
 
-        assert_eq!(
-            legacy_bootstrap_package_version(&observed, LEGACY_COMPLETE_BOOTSTRAP_PACKAGES),
-            Some("1.8.23")
-        );
+        for version in ["1.8.23", "1.8.46", "1.8.47", "1.8.48"] {
+            let observed = observed_for(version);
+            assert_eq!(
+                legacy_bootstrap_package_version(&observed, LEGACY_COMPLETE_BOOTSTRAP_PACKAGES),
+                Some(version)
+            );
+        }
 
+        let observed = observed_for("1.8.23");
         let mut mixed = observed;
         mixed[2] = Some(current_bootstrap_package()[2].1.clone());
         assert_eq!(

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn content_version_comes_from_the_bundled_skill_frontmatter() {
-        assert_eq!(content_version(), Some("1.8.46"));
+        assert_eq!(content_version(), Some("1.8.49"));
     }
 
     #[test]

--- a/src/present.rs
+++ b/src/present.rs
@@ -462,6 +462,9 @@ fn report(value: &Value, lines: &mut Vec<String>, width: usize) {
                 text(finding, "category"),
                 text(finding, "title")
             ));
+            if let Some(decision) = finding_decision_line(finding, width.saturating_sub(4)) {
+                lines.push(format!("    {decision}"));
+            }
         }
         if findings.is_empty() {
             lines.push("  none".into());
@@ -610,6 +613,9 @@ fn finding_list(value: &Value, lines: &mut Vec<String>, width: usize) {
                 "{detail_prefix}{}",
                 middle_truncate(&detail, width.saturating_sub(display_width(detail_prefix)))
             ));
+            if let Some(decision) = finding_decision_line(finding, width.saturating_sub(7)) {
+                lines.push(format!("{detail_prefix}{decision}"));
+            }
         }
         if items.is_empty() {
             lines.push("  none".into());
@@ -639,6 +645,27 @@ fn finding_report(value: &Value, lines: &mut Vec<String>, width: usize) {
         format!("{} · {}", text(value, "severity"), text(value, "category")),
     );
     fact(lines, "Evidence quality", text(value, "evidence_quality"));
+    if value.get("affected_agents").is_some() {
+        let agents = value
+            .get("affected_agents")
+            .and_then(Value::as_array)
+            .map(|agents| {
+                agents
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|agents| !agents.is_empty())
+            .unwrap_or_else(|| vec!["none".into()]);
+        fact_items(lines, "Affected Agents", agents, width);
+    }
+    if value.get("actionability").is_some() {
+        fact(lines, "Actionability", text(value, "actionability"));
+    }
+    if value.get("reversibility").is_some() {
+        fact(lines, "Reversibility", text(value, "reversibility"));
+    }
     fact(
         lines,
         "Affected",
@@ -762,6 +789,41 @@ fn finding_report(value: &Value, lines: &mut Vec<String>, width: usize) {
             "Use --full only when exact complete records are needed",
         ));
     }
+}
+
+fn finding_decision_line(value: &Value, width: usize) -> Option<String> {
+    let actionability = value.get("actionability").and_then(Value::as_str)?;
+    let reversibility = value.get("reversibility").and_then(Value::as_str)?;
+    let actionability_label = match actionability {
+        "plan_available" => "plan",
+        "review_required" => "review",
+        "blocked" => "blocked",
+        "read_only" => "read-only",
+        other => other,
+    };
+    let reversibility_label = match reversibility {
+        "undo_after_apply" => "undo",
+        "manual_only" => "manual",
+        "not_governable" => "not governed",
+        other => other,
+    };
+    let agents = value
+        .get("affected_agents")
+        .and_then(Value::as_array)
+        .map(|agents| {
+            agents
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|agents| !agents.is_empty())
+        .unwrap_or_else(|| "none".into());
+    let prefix = format!("Action: {actionability_label} · Undo: {reversibility_label} · Agents: ");
+    Some(format!(
+        "{prefix}{}",
+        middle_truncate(&agents, width.saturating_sub(display_width(&prefix)).max(1))
+    ))
 }
 
 fn finding_evidence_paths(value: &Value, lines: &mut Vec<String>, width: usize) {

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -497,6 +497,71 @@ fn all_eight_agent_fixtures_discover_one_skill_and_all_five_usage_stages() {
 }
 
 #[test]
+fn all_eight_agent_roots_share_the_cli_find_load_contract() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let contents = "---\nname: shared-workbook\ndescription: Create standalone spreadsheet workbooks\n---\nShared cross-agent fixture.\n";
+
+    for roots in known_agent_roots(&home) {
+        let skill = roots.skill_roots[0].join("shared-workbook");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), contents).unwrap();
+    }
+
+    let scanned = cli_json(&home, &state, &["scan"], None);
+    assert_eq!(scanned["result"]["skill_count"], 1);
+    assert_eq!(scanned["result"]["placement_count"], 8);
+
+    let loaded = cli_json(
+        &home,
+        &state,
+        &[
+            "find",
+            "--hint",
+            "create a standalone spreadsheet workbook",
+            "--load",
+            "--limit",
+            "1",
+            "--",
+            "制作一个独立的电子表格工作簿",
+        ],
+        None,
+    );
+    let mut expected_agents = AgentKind::ALL
+        .into_iter()
+        .map(|agent| agent.id())
+        .collect::<Vec<_>>();
+    expected_agents.sort_unstable();
+    let actual_agents = loaded["result"]["matches"][0]["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|agent| agent.as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(actual_agents, expected_agents);
+    assert_eq!(loaded["result"]["matches"][0]["rank"], 1);
+    assert_eq!(
+        loaded["result"]["ranking_strategy"],
+        "task_hint_reciprocal_rank_fusion"
+    );
+    let skill = &loaded["result"]["loaded_skill"];
+    assert_eq!(skill["selection"]["rank"], 1);
+    assert_eq!(skill["content"]["complete"], true);
+    assert_eq!(skill["verification"]["identity_matches_snapshot"], true);
+    assert_eq!(
+        skill["verification"]["entrypoint_digest_matches_snapshot"],
+        true
+    );
+    assert_eq!(
+        skill["verification"]["package_fingerprint_matches_snapshot"],
+        true
+    );
+    assert_eq!(skill["task_success"], "not_evaluated");
+    assert_eq!(loaded["result"]["files_changed"], false);
+}
+
+#[test]
 fn reports_reuse_one_snapshot_but_scope_finding_ids_to_each_new_report() {
     let temp = TempDir::new().unwrap();
     let home = temp.path().join("home");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -436,8 +436,8 @@ fn skill_evidence_id(database: &rusqlite::Connection, snapshot_id: &str, skill_i
 
 fn assert_setup_versions(output: &Value) {
     assert_eq!(output["result"]["cli_version"], env!("CARGO_PKG_VERSION"));
-    assert_eq!(output["result"]["bootstrap_content_version"], "1.8.46");
-    assert_eq!(output["result"]["bootstrap_version"], "1.8.46");
+    assert_eq!(output["result"]["bootstrap_content_version"], "1.8.49");
+    assert_eq!(output["result"]["bootstrap_version"], "1.8.49");
 }
 
 #[cfg(unix)]
@@ -3806,6 +3806,9 @@ fn same_name_divergent_finding_keeps_variant_paths_and_requires_a_choice() {
         .unwrap();
     assert_eq!(finding["affected_skill_count"], 2);
     assert_eq!(finding["affected_placement_count"], 2);
+    assert_eq!(finding["affected_agents"], json!(["claude-code", "codex"]));
+    assert_eq!(finding["actionability"], "review_required");
+    assert_eq!(finding["reversibility"], "manual_only");
     let finding_id = finding["id"].as_str().unwrap();
 
     let linked_find = json_output(&run(
@@ -5320,7 +5323,7 @@ fn setup_requires_a_choice_before_replacing_a_modified_bootstrap_skill() {
     assert_setup_versions(&current);
     assert_eq!(
         current["result"]["targets"][0]["installed_version"],
-        "1.8.46"
+        "1.8.49"
     );
 
     let undone = json_output(&run(
@@ -5523,7 +5526,7 @@ fn setup_upgrades_released_bootstrap_packages_and_undo_restores_every_file() {
         assert_eq!(current["result"]["state"], "up_to_date");
         assert_eq!(
             current["result"]["targets"][0]["installed_version"],
-            "1.8.46"
+            "1.8.49"
         );
 
         let receipt_id = applied["result"]["receipt_id"].as_str().unwrap();
@@ -7101,6 +7104,75 @@ fn json_failure_is_one_parseable_document() {
     assert_eq!(invalid_value["command"], "cli");
     assert_eq!(invalid_value["error"]["code"], "invalid_cli_arguments");
     assert!(invalid.stderr.is_empty());
+}
+
+#[test]
+fn find_load_recovers_from_a_missing_snapshot_without_changing_agent_files() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let skill = home.join(".codex/skills/.on-demand/workbook");
+    fs::create_dir_all(&skill).unwrap();
+    let contents = "---\nname: workbook\ndescription: Create standalone spreadsheet workbooks\n---\nHidden on-demand fixture.\n";
+    fs::write(skill.join("SKILL.md"), contents).unwrap();
+    let entrypoint = skill.join("SKILL.md");
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    let task = "帮我制作一个独立的电子表格工作簿";
+    let hint = "create a standalone spreadsheet workbook";
+    let find_args = ["find", "--hint", hint, "--load", "--limit", "1", "--", task];
+
+    let first = run(&[&common[..], &find_args].concat(), None);
+    assert!(!first.status.success());
+    assert!(first.stderr.is_empty());
+    let first: Value = serde_json::from_slice(&first.stdout).unwrap();
+    assert_eq!(first["ok"], false);
+    assert_eq!(first["error"]["code"], "snapshot_required");
+    assert_eq!(first["error"]["retryable"], true);
+    assert_eq!(first["suggested_actions"][0]["action"], "scan");
+    assert_eq!(first["suggested_actions"][0]["mutates"], false);
+    assert_eq!(
+        first["suggested_actions"][0]["requires_confirmation"],
+        false
+    );
+    assert_eq!(
+        first["suggested_actions"][0]["reason_code"],
+        "snapshot_required"
+    );
+    let before = fs::read(&entrypoint).unwrap();
+
+    let scanned = run_suggested_action(&first["suggested_actions"][0]);
+    let scanned = json_output(&scanned);
+    assert_eq!(scanned["result"]["files_changed"], false);
+    assert_eq!(scanned["result"]["placement_count"], 1);
+
+    let loaded = json_output(&run(&[&common[..], &find_args].concat(), None));
+    assert_eq!(loaded["result"]["task"], task);
+    assert_eq!(loaded["result"]["retrieval_hints"], json!([hint]));
+    assert_eq!(
+        loaded["result"]["ranking_strategy"],
+        "task_hint_reciprocal_rank_fusion"
+    );
+    let skill = &loaded["result"]["loaded_skill"];
+    assert_eq!(skill["selection"]["rank"], 1);
+    assert_eq!(skill["content"]["complete"], true);
+    assert_eq!(skill["verification"]["identity_matches_snapshot"], true);
+    assert_eq!(
+        skill["verification"]["entrypoint_digest_matches_snapshot"],
+        true
+    );
+    assert_eq!(
+        skill["verification"]["package_fingerprint_matches_snapshot"],
+        true
+    );
+    assert_eq!(skill["task_success"], "not_evaluated");
+    assert_eq!(loaded["result"]["files_changed"], false);
+    assert_eq!(fs::read(entrypoint).unwrap(), before);
 }
 
 #[test]
@@ -8778,6 +8850,12 @@ fn exact_duplicate_finding_prepares_library_plan_from_semantic_choices() {
     ));
     let planning = &detail["result"]["planning"];
     assert_eq!(planning["supported"], true);
+    assert_eq!(
+        detail["result"]["affected_agents"],
+        json!(["claude-code", "codex"])
+    );
+    assert_eq!(detail["result"]["actionability"], "plan_available");
+    assert_eq!(detail["result"]["reversibility"], "undo_after_apply");
     assert!(
         detail["suggested_actions"]
             .as_array()
@@ -8958,6 +9036,118 @@ fn exact_duplicate_finding_prepares_library_plan_from_semantic_choices() {
             .iter()
             .all(|action| action["action"] != "plan")
     );
+}
+
+#[test]
+fn messy_report_surfaces_agent_actionability_and_reversibility() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let state = temp.path().join("state");
+    let codex_root = home.join(".codex/skills");
+    let claude_root = home.join(".claude/skills");
+    let shared = "---\nname: shared\ndescription: shared capability\n---\nshared body\n";
+    let choice_a = "---\nname: choice\ndescription: first variant\n---\nfirst body\n";
+    let choice_b = "---\nname: choice\ndescription: second variant\n---\nsecond body\n";
+    for (root, name, content) in [
+        (&codex_root, "shared", shared),
+        (&claude_root, "shared", shared),
+        (&codex_root, "choice", choice_a),
+        (&claude_root, "choice", choice_b),
+    ] {
+        let directory = root.join(name);
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(directory.join("SKILL.md"), content).unwrap();
+    }
+    for index in 0..52 {
+        let directory = codex_root.join(format!("filler-{index:02}"));
+        fs::create_dir_all(&directory).unwrap();
+        fs::write(
+            directory.join("SKILL.md"),
+            format!("---\nname: filler-{index:02}\n---\nfiller body {index}\n"),
+        )
+        .unwrap();
+    }
+
+    let common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+        "--json",
+    ];
+    json_output(&run(&[&common[..], &["scan"]].concat(), None));
+    let summary = json_output(&run(
+        &[&common[..], &["report", "--summary"]].concat(),
+        None,
+    ));
+    for finding in summary["result"]["findings"].as_array().unwrap() {
+        assert!(finding["affected_agents"].is_array());
+        assert!(finding["actionability"].is_string());
+        assert!(finding["reversibility"].is_string());
+    }
+
+    let findings = json_output(&run(
+        &[&common[..], &["report", "--findings"]].concat(),
+        None,
+    ));
+    let items = findings["result"]["items"].as_array().unwrap();
+    let duplicate = items
+        .iter()
+        .find(|finding| finding["title"] == "Exact duplicate Skill placements")
+        .unwrap();
+    assert_eq!(
+        duplicate["affected_agents"],
+        json!(["claude-code", "codex"])
+    );
+    assert_eq!(duplicate["actionability"], "plan_available");
+    assert_eq!(duplicate["reversibility"], "undo_after_apply");
+    let divergent = items
+        .iter()
+        .find(|finding| finding["title"] == "Same-name Skills have different content")
+        .unwrap();
+    assert_eq!(
+        divergent["affected_agents"],
+        json!(["claude-code", "codex"])
+    );
+    assert_eq!(divergent["actionability"], "review_required");
+    assert_eq!(divergent["reversibility"], "manual_only");
+
+    let duplicate_detail = json_output(&run(
+        &[
+            &common[..],
+            &["report", "--finding", duplicate["id"].as_str().unwrap()],
+        ]
+        .concat(),
+        None,
+    ));
+    assert_eq!(
+        duplicate_detail["result"]["affected_agents"],
+        json!(["claude-code", "codex"])
+    );
+    assert_eq!(
+        duplicate_detail["result"]["actionability"],
+        "plan_available"
+    );
+    assert_eq!(
+        duplicate_detail["result"]["reversibility"],
+        "undo_after_apply"
+    );
+
+    let human_common = [
+        "--home",
+        home.to_str().unwrap(),
+        "--state-dir",
+        state.to_str().unwrap(),
+    ];
+    let human = run(
+        &[&human_common[..], &["report", "--findings"]].concat(),
+        None,
+    );
+    assert!(human.status.success());
+    let human = String::from_utf8(human.stdout).unwrap();
+    assert!(human.contains("Action:"), "{human}");
+    assert!(human.contains("Undo:"), "{human}");
+    assert!(human.contains("Agents:"), "{human}");
 }
 
 #[test]


### PR DESCRIPTION
## Problem and value

Follow-up to #381. The CLI now reports the issue and affected counts, but callers still have to infer which Agent is affected, whether the Finding has a supported next step, and whether a possible change has an Undo path. Bootstrap package history also stopped at the previous local content version, which made intermediate complete packages harder to recognize during setup and recovery.

## Changes

- Add bounded `affected_agents`, `actionability`, and `reversibility` facts to Finding summaries, paginated lists, details, and human output; rollups add only deduplicated affected-Agent scope.
- Keep these as operational facts, not a usefulness, safety, quality, token, or value score.
- Preserve full Finding facts for stored reports while keeping default report views bounded.
- Add complete Bootstrap package manifests for 1.8.46, 1.8.47, and 1.8.48, advance the bundled content to 1.8.49, and test upgrade/Undo recognition.
- Add cross-Agent Find/Load, missing-Snapshot recovery, and messy-report acceptance coverage.
- Document the Bootstrap boundary and the new decision facts.
- Replace three Rust 1.85-incompatible `let` condition chains with equivalent stable control flow.

## Validation

Passed locally:

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
- Node syntax checks and the repository Node harness excluding Windows symlink-dependent cases: 122 passed, 14 skipped, 0 failed.
- `scripts/verify-readme-value.sh`
- `scripts/verify-installation-surface.sh`

The full local Node harness reports 133 passed, 14 skipped, and 5 failures because this Windows environment denies the test symlink creation (`EPERM`); those cases are isolated in the symlink-dependent Pi gate tests. Local `cargo clippy` and `cargo test` cannot reach the crate because this GNU Windows Rust environment has no `gcc.exe`/`dlltool.exe` for bundled SQLite and Windows dependencies. The full Rust, portability, and CI gate checks should be treated as required before merge.

The change is intentionally not presented as evidence of token savings, task-quality gains, or general usefulness.